### PR TITLE
docs: add repo workflow guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Scope
+- This file is the root guidance for OpenCode sessions in this repo.
+- Keep changes small, focused, and compatible with the current runtime.
+
+## Source of truth
+- Trust executable sources first: `pyproject.toml`, `.github/workflows/ci.yml`, `bridge/package.json`, runtime code, and current git state.
+- Use `docs/README.md` as the docs index, especially for migration context and maintainer reading order.
+- For active rename execution context, prioritize migration docs linked from `docs/README.md` over stale assumptions in older notes.
+- Repository/GitHub operating rules live in `REPO_GITHUB_WORKFLOW_RULES.md`.
+
+## Repo identity and migration guardrails
+- This is the canonical `eeebot` repository; internals are being migrated from `nanobot` naming to `eeebot`.
+- Internal rename work is actively in progress on parallel branches; avoid broad mechanical renames or cross-cutting refactors unless the task is explicitly migration-scoped.
+- If your task touches files under rename churn, keep edits minimal and task-local; do not reintroduce legacy naming in newly added code unless compatibility requires it.
+- Packaging/CLI compatibility is currently dual-entrypoint; when touching packaging or CLI behavior, preserve both current scripts from `pyproject.toml` unless the task explicitly retires compatibility:
+  - `nanobot = "nanobot.cli.commands:app"`
+  - `eeebot = "nanobot.cli.eeebot:main"`
+- The WhatsApp bridge is the separate Node/TypeScript package in `bridge/`.
+
+## Working tree and branch safety
+- Do not do active work directly on `main`.
+- Start from fresh `origin/main`, create a task branch, and keep unrelated local edits isolated in a separate branch/worktree.
+- Preferred workflow for parallel/risky work: task branch + git worktree.
+- Before pulling, check for local modifications so remote changes are not mixed with unrelated local edits.
+- Assume concurrent rename edits may be landing nearby; rebase or merge frequently and avoid cleanup changes outside task scope.
+- Do not block or undo in-progress rename work by restoring legacy names purely for consistency; prefer incremental convergence toward `eeebot` naming.
+
+## Runtime and path gotchas
+- Runtime compatibility paths still default to `~/.nanobot` in current code.
+- `~/.eeebot` is only used as a fallback when it exists and `~/.nanobot` does not.
+- Docker and compose still use `nanobot` naming and commands in the current compatibility window.
+
+## Verified commands
+- Install dev dependencies: `pip install .[dev]`
+- Run full Python tests: `python -m pytest tests/ -v`
+- Run a focused test: `python -m pytest tests/<file>.py -k <pattern> -v`
+- Ruff is configured in `pyproject.toml`; use targeted checks when needed: `ruff check <path>`
+- Bridge build/typecheck: in `bridge/`, run `npm run build`
+- Bridge runtime requires Node `>=20`
+
+## CI reality
+- CI currently runs Python tests only, on Python `3.11`, `3.12`, and `3.13`.
+- CI installs `libolm-dev` and `build-essential` before tests; keep that in mind for env-sensitive failures.
+- There is no verified JS bridge CI job in this repo, so bridge changes should be manually validated with `npm run build`.
+
+## Security and operations
+- Never commit secrets, tokens, auth state, or files from local runtime directories.
+- Preserve security defaults from `SECURITY.md`: `allowFrom` protections, least-privilege execution, path protections, and localhost-only bridge assumptions unless the task explicitly changes them.
+- For recurring tasks/reminders, preserve the template guidance in `nanobot/templates/AGENTS.md`: prefer built-in cron tooling and use `HEARTBEAT.md` for periodic tasks rather than ad hoc reminder notes.
+
+## Change style
+- Prefer minimal, focused patches over broad rewrites.
+- Keep refactors scoped to task intent; avoid opportunistic rename churn.
+- When docs and code disagree, follow running behavior/config first, then update docs deliberately in the same task when appropriate.

--- a/REPO_GITHUB_WORKFLOW_RULES.md
+++ b/REPO_GITHUB_WORKFLOW_RULES.md
@@ -1,0 +1,48 @@
+# Repository and GitHub Workflow Rules
+
+## Purpose
+- This file defines mandatory repository/GitHub workflow rules to prevent local and remote changes from mixing in multi-contributor work.
+- Scope is workflow safety only; runtime and product behavior remain governed by `AGENTS.md`, `README.md`, and executable config.
+- Keep the workflow simple: isolate work, sync often, and do not mix unrelated changes.
+
+## Mandatory preflight
+- Before edits, pull, or branch switch, run `git status --short --branch` and `git fetch --all --prune`.
+- If the working tree is dirty, classify files as task-related vs unrelated; do not mix both in one branch or PR.
+- If unrelated local edits exist, move task work to a separate branch/worktree before continuing.
+- Record the intended base branch explicitly before creating a task branch.
+- Do not start active work directly on `main`.
+
+## Isolation rules
+- One task equals one branch.
+- Prefer `git worktree` for parallel or risky work so uncommitted state stays isolated.
+- Use branch names that encode intent, for example `feat/*`, `fix/*`, `docs/*`, `chore/*`.
+- Keep commits scoped to one concern; do not combine feature, refactor, docs, and workflow changes unless they are inseparable.
+- Do not include unrelated untracked files in commits.
+
+## Local and remote sync rules
+- Safe sync order: `fetch` -> verify clean or isolated tree -> update from base branch -> verify -> push branch.
+- Do not pull or rebase when unrelated local modifications are present.
+- If a branch diverges from remote and also has unrelated local edits, isolate first, then sync.
+- Push only task branches; do not push local scratch or backup branches unless that is the explicit goal.
+- Do not use destructive git operations on shared branches unless explicitly requested.
+
+## GitHub and todo alignment
+- Map each active branch or PR to a GitHub issue when the task is substantial enough to track.
+- Keep repository state and GitHub state in sync when task metadata, status, or supporting docs change materially.
+- Treat `todo.md` as an in-repo operator surface: update it only when the task actually changes its tracked work, status, or proof.
+- Do not create a second private backlog file for the same work.
+- If process rules or operator workflow change, document the operator impact briefly in the PR or companion docs.
+
+## PR and merge hygiene
+- Re-check `git diff <base>...HEAD` before opening a PR to confirm only intended changes are included.
+- If unrelated files appear in the branch, remove them before PR creation.
+- Run relevant local verification before opening or merging a PR.
+- Keep PRs small and reviewable; split oversized work into follow-up branches.
+- Prefer merge flows that preserve reviewability and do not hide conflict resolution.
+
+## Stop conditions
+- Stop if branch purpose becomes mixed across multiple independent concerns.
+- Stop if pull or rebase would combine unrelated local edits with remote updates.
+- Stop if task tracking is unclear enough to create drift between repo state and GitHub state.
+- Stop if secrets, auth state, or runtime files appear in staged changes.
+- When stopping, report the blocker and the recommended isolation or recovery path.


### PR DESCRIPTION
## Summary
- add root AGENTS.md with source-of-truth precedence, branch/worktree safety, and eeebot migration guardrails
- add REPO_GITHUB_WORKFLOW_RULES.md with mandatory preflight, isolation rules, safe sync order, and stop conditions for multi-contributor work
- document lightweight repo/GitHub coordination rules so agents do not mix local, remote, and in-progress rename work

## Test Plan
- [x] python -m pytest tests/test_eeebot_imports.py -v
- [x] git diff --name-status origin/main...HEAD
- [x] reviewed AGENTS.md and REPO_GITHUB_WORKFLOW_RULES.md contents on branch
