### PR TITLE
fix: advance self-improvement follow-through lanes

### DIFF
--- a/nanobot/runtime/autoevolve.py
+++ b/nanobot/runtime/autoevolve.py
@@ -242,12 +242,50 @@ def create_candidate_release(repo_root: Path, workspace: Path, remote_name: str 
     return record
 
 
+def write_candidate_blocked_status(workspace: Path, candidate_record: dict[str, Any], reason: str) -> dict[str, Any]:
+    workspace = workspace.resolve()
+    root = _self_evolution_root(workspace)
+    runtime_dir = root / 'runtime'
+    stale = reason == 'remote_commit_not_visible'
+    payload = {
+        'schema_version': 'autoevolve-blocked-v1',
+        'ok': False,
+        'status': 'blocked',
+        'reason': reason,
+        'candidate_id': candidate_record.get('candidate_id'),
+        'commit': candidate_record.get('commit'),
+        'remote_name': candidate_record.get('remote_name'),
+        'branch': candidate_record.get('branch'),
+        'remote_head': candidate_record.get('remote_head'),
+        'remote_commit_visible': bool(candidate_record.get('remote_commit_visible')),
+        'clean_worktree': bool(candidate_record.get('clean_worktree')),
+        'stale_candidate': stale,
+        'recommended_next_action': (
+            'regenerate candidate from current remote-visible branch head before apply'
+            if stale else
+            'clean tracked worktree before creating/applying candidate'
+        ),
+    }
+    _write_json(runtime_dir / 'latest_blocked.json', payload)
+    if stale:
+        marked = dict(candidate_record)
+        marked['status'] = 'stale'
+        marked['stale_reason'] = reason
+        marked['recommended_next_action'] = payload['recommended_next_action']
+        candidates_dir = root / 'candidates'
+        _write_json(candidates_dir / 'latest.json', marked)
+    write_guarded_evolution_state(workspace)
+    return payload
+
+
 def apply_candidate_release(workspace: Path, candidate_record: dict[str, Any]) -> dict[str, Any]:
     workspace = workspace.resolve()
     root = _self_evolution_root(workspace)
     if not candidate_record.get('clean_worktree'):
+        write_candidate_blocked_status(workspace, candidate_record, 'dirty_worktree')
         raise ValueError('candidate release must come from a clean tracked worktree')
     if not candidate_record.get('remote_commit_visible'):
+        write_candidate_blocked_status(workspace, candidate_record, 'remote_commit_not_visible')
         raise ValueError('candidate release commit must be visible on remote before apply')
     runtime_dir = root / 'runtime'
     releases_dir = runtime_dir / 'releases'

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -255,7 +255,39 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
     selection_source = "recorded_current_task"
     mode = "stable"
     reason = ""
-    if current_task_id == "inspect-pass-streak":
+
+    latest_experiment = _safe_read_json(goals_dir.parent / "experiments" / "latest.json")
+    latest_experiment_task_id = latest_experiment.get("current_task_id") if isinstance(latest_experiment, dict) else None
+    latest_experiment_revert_queued = (
+        isinstance(latest_experiment, dict)
+        and latest_experiment.get("outcome") == "discard"
+        and latest_experiment.get("revert_required") is True
+        and latest_experiment.get("revert_status") == "queued"
+        and latest_experiment_task_id == current_task_id
+    )
+
+    if latest_experiment_revert_queued:
+        mode = "execute_queued_revert"
+        reason = "latest experiment discarded the active lane and queued revert follow-through"
+        for task in task_records:
+            task_id = task.get("task_id") or task.get("taskId")
+            if task_id in {None, current_task_id, "record-reward"}:
+                continue
+            if (task.get("status") or "pending") in {"pending", "active"}:
+                selected_task = task
+                selection_source = "feedback_discard_revert_followthrough"
+                break
+        if selected_task is None:
+            selected_task = {
+                "task_id": "execute-queued-revert",
+                "title": "Handle queued revert for discarded experiment lane",
+                "status": "active",
+                "kind": "remediation",
+                "discarded_task_id": current_task_id,
+                "experiment_id": latest_experiment.get("experiment_id") if isinstance(latest_experiment, dict) else None,
+            }
+            selection_source = "feedback_discard_revert_generated"
+    elif current_task_id == "inspect-pass-streak":
         followup_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == "materialize-pass-streak-improvement"), None)
         if followup_task is not None:
             decision = {
@@ -276,9 +308,31 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                 "selected_task_label": _render_task_selection(followup_task),
             }
             return decision
+        active_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == current_task_id), None)
+        if active_task is not None and strong_pass_count >= GOAL_ROTATION_STREAK_LIMIT:
+            return {
+                "mode": "continue_active_lane",
+                "reason": "active inspect-pass-streak review lane remains bounded when the repeated PASS signature belongs to a prior lane",
+                "reward_value": reward_value,
+                "current_task_id": current_task_id,
+                "current_task_class": current_task_class,
+                "repeat_block_count": repeat_block_count,
+                "repeat_block_failure_class": repeat_block_failure_class,
+                "goal_artifact_signature": list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+                "strong_pass_count": strong_pass_count,
+                "retire_goal_artifact_pair": False,
+                "selected_task_id": current_task_id,
+                "selected_task_class": _task_action_class(current_task_id),
+                "selection_source": "feedback_continue_active_lane",
+                "selected_task_title": active_task.get("title") or active_task.get("summary") or current_task_id,
+                "selected_task_label": _render_task_selection(active_task),
+            }
     elif current_task_id and current_task_id not in CORE_TASK_IDS:
         active_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == current_task_id), None)
-        if active_task is not None:
+        if (
+            active_task is not None
+            and not (strong_pass_signature is not None and strong_pass_count >= GOAL_ROTATION_STREAK_LIMIT)
+        ):
             return {
                 "mode": "continue_active_lane",
                 "reason": "active non-core lane remains the best bounded next step",
@@ -297,7 +351,9 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                 "selected_task_label": _render_task_selection(active_task),
             }
 
-    if repeat_block_failure_class and repeat_block_count >= REPEATED_BLOCK_LIMIT:
+    if mode != "stable" and selected_task is not None:
+        pass
+    elif repeat_block_failure_class and repeat_block_count >= REPEATED_BLOCK_LIMIT:
         mode = "force_remediation"
         reason = f"repeated BLOCK on {repeat_block_failure_class}; force remediation"
         preferred_classes = ["verification", "remediation", "diagnostic"]
@@ -324,19 +380,14 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
         mode = "retire_goal_artifact_pair"
         reason = "goal/artifact PASS streak reached retirement threshold; deprioritize the pair next cycle"
         if current_task_id and current_task_id not in CORE_TASK_IDS:
-            selected_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == current_task_id), None)
-            if selected_task is not None:
-                selection_source = "feedback_continue_active_lane"
-                mode = "continue_active_lane"
-                reason = "active richer lane remains the best bounded next step"
-                for task in task_records:
-                    task_id = task.get("task_id") or task.get("taskId")
-                    if task_id == "materialize-pass-streak-improvement":
-                        selected_task = task
-                        selection_source = "feedback_review_to_execution"
-                        mode = "promote_review_followup"
-                        reason = "active inspect-pass-streak review produced a concrete bounded follow-up candidate"
-                        break
+            for task in task_records:
+                task_id = task.get("task_id") or task.get("taskId")
+                if task_id == "materialize-pass-streak-improvement":
+                    selected_task = task
+                    selection_source = "feedback_review_to_execution"
+                    mode = "promote_review_followup"
+                    reason = "active inspect-pass-streak review produced a concrete bounded follow-up candidate"
+                    break
         if selected_task is None:
             preferred_ids = ["inspect-pass-streak"]
             for preferred_id in preferred_ids:

--- a/scripts/guarded_self_evolve.py
+++ b/scripts/guarded_self_evolve.py
@@ -17,6 +17,7 @@ from nanobot.runtime.autoevolve import (
     health_check_release,
     merge_selfevo_pr,
     rollback_release,
+    write_candidate_blocked_status,
     write_failure_learning_artifact,
     write_guarded_evolution_state,
 )
@@ -68,6 +69,16 @@ try:
     )
     commit_result = commit_and_push_self_evolution(repo_root=repo_root, message=commit_message, remote_name=source_remote_name, branch=source_remote_branch)
     candidate = create_candidate_release(repo_root=repo_root, workspace=workspace, remote_name=source_remote_name, branch=source_remote_branch)
+    if not candidate.get('clean_worktree'):
+        blocked = write_candidate_blocked_status(workspace, candidate, 'dirty_worktree')
+        result = {'ok': False, 'controlled_block': True, 'request': request, 'commit': commit_result, 'candidate': candidate, 'blocked': blocked, 'state': write_guarded_evolution_state(workspace)}
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        raise SystemExit(0)
+    if not candidate.get('remote_commit_visible'):
+        blocked = write_candidate_blocked_status(workspace, candidate, 'remote_commit_not_visible')
+        result = {'ok': False, 'controlled_block': True, 'request': request, 'commit': commit_result, 'candidate': candidate, 'blocked': blocked, 'state': write_guarded_evolution_state(workspace)}
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        raise SystemExit(0)
     apply_record = apply_candidate_release(workspace=workspace, candidate_record=candidate)
     if wait_seconds:
         time.sleep(wait_seconds)

--- a/tests/test_self_improvement_followthrough.py
+++ b/tests/test_self_improvement_followthrough.py
@@ -1,0 +1,114 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from nanobot.runtime.coordinator import _derive_feedback_decision, run_self_evolving_cycle
+from nanobot.runtime.autoevolve import write_candidate_blocked_status
+
+
+def _write_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding='utf-8')
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def _fresh_gate(workspace: Path):
+    expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)
+    _write_json(workspace / 'state' / 'approvals' / 'apply.ok', {'expires_at_utc': expires_at.isoformat(), 'ttl_minutes': 60})
+    return expires_at
+
+
+def test_repeated_pass_noncore_lane_retires_instead_of_continue_active_lane(tmp_path: Path):
+    goals_dir = tmp_path / 'state' / 'goals'
+    plan = {
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'analyze-last-failed-candidate',
+        'tasks': [
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'active', 'kind': 'review'},
+            {'task_id': 'subagent-verify-materialized-improvement', 'title': 'Use one bounded subagent-assisted review to verify the materialized improvement artifact', 'status': 'pending', 'kind': 'review'},
+            {'task_id': 'inspect-pass-streak', 'title': 'Inspect repeated PASS streak for a new bounded improvement', 'status': 'pending', 'kind': 'review'},
+        ],
+        'reward_signal': {'value': 1.2, 'source': 'materialized_improvement_artifact'},
+    }
+    _write_json(goals_dir / 'current.json', plan)
+    for idx in range(3):
+        _write_json(goals_dir / 'history' / f'cycle-pass-{idx}.json', {
+            'result_status': 'PASS',
+            'goal_id': 'goal-bootstrap',
+            'current_task_id': 'analyze-last-failed-candidate',
+        })
+
+    decision = _derive_feedback_decision(plan, goals_dir)
+
+    assert decision is not None
+    assert decision['mode'] == 'retire_goal_artifact_pair'
+    assert decision['selected_task_id'] != 'analyze-last-failed-candidate'
+    assert decision['selection_source'] == 'feedback_pass_streak_switch'
+    assert decision['retire_goal_artifact_pair'] is True
+
+
+def test_discard_revert_queued_forces_followthrough_away_from_discarded_lane(tmp_path: Path):
+    expires_at = _fresh_gate(tmp_path)
+    goals_dir = tmp_path / 'state' / 'goals'
+    _write_json(goals_dir / 'current.json', {
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'analyze-last-failed-candidate',
+        'tasks': [
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'active', 'kind': 'review'},
+            {'task_id': 'subagent-verify-materialized-improvement', 'title': 'Use one bounded subagent-assisted review to verify the materialized improvement artifact', 'status': 'pending', 'kind': 'review'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+        ],
+        'reward_signal': {'value': 1.2, 'source': 'materialized_improvement_artifact'},
+    })
+    _write_json(tmp_path / 'state' / 'experiments' / 'latest.json', {
+        'experiment_id': 'experiment-old',
+        'current_task_id': 'analyze-last-failed-candidate',
+        'outcome': 'discard',
+        'revert_required': True,
+        'revert_status': 'queued',
+        'metric_current': 1.2,
+        'metric_frontier': 2.0,
+        'result_status': 'PASS',
+    })
+
+    execute = AsyncMock(return_value='agent completed bounded work')
+    asyncio.run(run_self_evolving_cycle(workspace=tmp_path, tasks='check open tasks', execute_turn=execute, now=expires_at - timedelta(minutes=30)))
+
+    current = _read_json(tmp_path / 'state' / 'goals' / 'current.json')
+    decision = current.get('feedback_decision') or {}
+    assert decision.get('mode') == 'execute_queued_revert'
+    assert decision.get('selected_task_id') != 'analyze-last-failed-candidate'
+    assert current.get('current_task_id') != 'analyze-last-failed-candidate'
+
+
+def test_stale_candidate_blocked_status_is_durable_and_marks_latest_candidate_stale(tmp_path: Path):
+    workspace = tmp_path / 'workspace'
+    candidate = {
+        'schema_version': 'autoevolve-candidate-v1',
+        'candidate_id': 'candidate-stale',
+        'commit': 'abc123',
+        'remote_name': 'origin',
+        'branch': 'main',
+        'remote_head': 'def456',
+        'remote_commit_visible': False,
+        'clean_worktree': True,
+    }
+
+    blocked = write_candidate_blocked_status(workspace, candidate, 'remote_commit_not_visible')
+
+    assert blocked['status'] == 'blocked'
+    assert blocked['reason'] == 'remote_commit_not_visible'
+    assert blocked['stale_candidate'] is True
+    assert 'regenerate candidate' in blocked['recommended_next_action']
+    latest_blocked = _read_json(workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_blocked.json')
+    latest_candidate = _read_json(workspace / 'state' / 'self_evolution' / 'candidates' / 'latest.json')
+    current_state = _read_json(workspace / 'state' / 'self_evolution' / 'current_state.json')
+    assert latest_blocked['candidate_id'] == 'candidate-stale'
+    assert latest_candidate['status'] == 'stale'
+    assert latest_candidate['stale_reason'] == 'remote_commit_not_visible'
+    assert current_state['current_candidate']['status'] == 'stale'


### PR DESCRIPTION
## Summary
Fixes the three blockers found in the live self-improvement audit:

- fixes the selector loop that kept repeating one non-core active hypothesis after repeated PASS reports
- makes `outcome=discard` / `revert_status=queued` drive the next cycle away from the discarded lane
- makes guarded self-evolution write durable controlled blocked/stale-candidate status instead of only failing in the service journal

Closes #142.
Closes #143.
Closes #144.

## Implementation

### Selector / hypothesis follow-through
`nanobot/runtime/coordinator.py`

- loads latest experiment during feedback selection
- if the active task was discarded and revert is queued, selects a safe follow-through task instead of continuing the same lane
- prevents generic non-core `continue_active_lane` from bypassing repeated PASS retirement
- preserves the existing special `inspect-pass-streak` behavior where it should continue until an explicit follow-up exists, and still promotes `materialize-pass-streak-improvement` when generated

### Experiment discard/revert discipline
`nanobot/runtime/coordinator.py`

- adds `execute_queued_revert` feedback mode
- selects another pending bounded task or generates `execute-queued-revert` if no alternative exists
- updates current plan/current hypothesis away from the discarded task on the next cycle

### Guarded self-evolution controlled block
`nanobot/runtime/autoevolve.py`
`scripts/guarded_self_evolve.py`

- adds `write_candidate_blocked_status(...)`
- writes `state/self_evolution/runtime/latest_blocked.json`
- marks stale non-remote-visible candidate records in `state/self_evolution/candidates/latest.json`
- updates `state/self_evolution/current_state.json`
- guarded script exits 0 for controlled dirty/stale candidate blocks after writing truthful durable status

## Verification

Focused regression:

```text
PYTHONPATH=. python3 -m pytest tests/test_self_improvement_followthrough.py tests/test_active_lane_continue.py tests/test_review_to_candidate.py -q
5 passed in 0.62s
```

Full repository suite:

```text
PYTHONPATH=. python3 -m pytest -q
574 passed, 5 skipped in 15.34s
```

Live local selector verification against existing workspace state:

```text
SELECTED_TASKS_START
Use one bounded subagent-assisted review to verify the materialized improvement artifact [task_id=subagent-verify-materialized-improvement]
SELECTED_TASKS_END
{
  "current_task_id": "subagent-verify-materialized-improvement",
  "feedback_decision": {
    "mode": "execute_queued_revert",
    "reason": "latest experiment discarded the active lane and queued revert follow-through",
    "current_task_id": "analyze-last-failed-candidate",
    "strong_pass_count": 4,
    "selected_task_id": "subagent-verify-materialized-improvement",
    "selection_source": "feedback_discard_revert_followthrough"
  },
  "selected_hypothesis": "subagent-verify-materialized-improvement"
}
```

This proves the runtime no longer keeps selecting `analyze-last-failed-candidate` after the discard/revert/streak condition.

## GitHub Actions note
If GitHub Actions do not start, inspect check-run annotations. The previous PR had an account billing lock annotation: `The job was not started because your account is locked due to a billing issue.` Local test proof above is the authoritative verification for this patch if Actions are unavailable.
