### PR TITLE
test: cover autonomy audit truth gaps

### DIFF
--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from wsgiref.util import setup_testing_defaults
+
+from nanobot_ops_dashboard.app import create_app
+from nanobot_ops_dashboard.config import DashboardConfig
+from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
+
+
+def _call_json(app, path: str) -> dict:
+    captured = {}
+
+    def start_response(status, headers):
+        captured['status'] = status
+        captured['headers'] = headers
+
+    environ = {}
+    setup_testing_defaults(environ)
+    environ['PATH_INFO'] = path
+    environ['QUERY_STRING'] = ''
+    body = b''.join(app(environ, start_response)).decode('utf-8')
+    assert captured['status'].startswith('200'), body
+    return json.loads(body)
+
+
+def test_dashboard_truth_prefers_current_summary_and_flags_stale_legacy_active_execution(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'control_plane').mkdir(parents=True, exist_ok=True)
+    (project_root / 'control').mkdir(parents=True, exist_ok=True)
+
+    current_summary = {
+        'task_plan': {
+            'current_task': 'Use one bounded subagent-assisted review to verify the materialized improvement artifact',
+            'current_task_id': 'subagent-verify-materialized-improvement',
+            'feedback_decision': {'mode': 'execute_queued_revert', 'selection_source': 'feedback_discard_revert_followthrough'},
+            'task_selection_source': 'feedback_discard_revert_followthrough',
+            'selected_tasks': 'Use one bounded subagent-assisted review [task_id=subagent-verify-materialized-improvement]',
+        },
+        'runtime_source': {'source': 'workspace_state'},
+    }
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps(current_summary), encoding='utf-8')
+    active_exec_path = project_root / 'control' / 'active_execution.json'
+    active_exec_path.write_text(json.dumps({
+        'live_task': {'title': 'Record cycle reward', 'repo_root': '/home/ozand/herkoot/Projects/nanobot-ops-dashboard'},
+        'has_actually_executing_task': True,
+    }), encoding='utf-8')
+    old = time.time() - 72 * 3600
+    os.utime(active_exec_path, (old, old))
+
+    raw = {
+        'current_plan': current_summary['task_plan'],
+        'outbox': {'status': 'PASS'},
+    }
+    insert_collection(db, {
+        'collected_at': '2026-04-24T07:30:00Z',
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': '/workspace/state/reports/evolution-current.json',
+        'outbox_source': '/workspace/state/outbox/report.index.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps(raw),
+    })
+    upsert_event(db, {
+        'collected_at': '2026-04-24T07:25:00Z',
+        'source': 'repo',
+        'event_type': 'cycle',
+        'identity_key': 'cycle-1',
+        'title': 'goal-bootstrap',
+        'status': 'PASS',
+        'detail_json': '{}',
+    })
+    upsert_event(db, {
+        'collected_at': '2026-04-24T07:30:00Z',
+        'source': 'repo',
+        'event_type': 'cycle',
+        'identity_key': 'cycle-2',
+        'title': 'goal-bootstrap',
+        'status': 'PASS',
+        'detail_json': '{}',
+    })
+
+    cfg = DashboardConfig(
+        project_root=project_root,
+        nanobot_repo_root=repo_root,
+        db_path=db,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root='/state',
+    )
+    app = create_app(cfg)
+
+    analytics = _call_json(app, '/api/analytics')['analytics']
+    assert analytics['current_streak']['status'] == 'PASS'
+    assert analytics['current_streak']['length'] == 2
+
+    plan = _call_json(app, '/api/plan')
+    assert plan['feedback_decision']['mode'] == 'execute_queued_revert'
+    assert plan['task_selection_source'] == 'feedback_discard_revert_followthrough'
+    assert 'subagent-verify-materialized-improvement' in plan['selected_tasks_text']
+
+    system = _call_json(app, '/api/system')
+    control = system['control_plane']
+    assert control['current_task'] == current_summary['task_plan']['current_task']
+    assert control['current_blocker'] != 'Record cycle reward'
+    assert control['active_execution']['staleness']['state'] == 'stale'
+    assert control['active_execution']['legacy_path_reference_detected'] is True

--- a/tests/test_autonomy_audit_gap_fixes.py
+++ b/tests/test_autonomy_audit_gap_fixes.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime import autoevolve
+from nanobot.runtime.coordinator import _build_experiment_snapshot, _write_credits_ledger
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def test_noop_selfevo_export_writes_terminal_artifact_and_skips_pr(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    export_result = {
+        'ok': True,
+        'stdout_tail': 'exported-noop /tmp/selfevo main\n',
+        'publish_remote_branch': 'chore/issue-13-subagent-verify-materialized-improvement',
+        'publish_repo': 'ozand/eeebot-self-evolving',
+    }
+
+    terminal = autoevolve.write_noop_export_status(
+        workspace=workspace,
+        export_result=export_result,
+        selfevo_issue={'number': 13, 'title': 'Use one bounded subagent-assisted review'},
+        selfevo_branch='chore/issue-13-subagent-verify-materialized-improvement',
+        reason='exported_noop',
+    )
+
+    assert terminal['status'] == 'terminal_noop'
+    assert terminal['ok'] is True
+    assert terminal['pr_creation_allowed'] is False
+    assert terminal['reason'] == 'exported_noop'
+    assert 'skip PR creation' in terminal['recommended_next_action']
+    persisted = _read_json(workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_noop.json')
+    assert persisted['selfevo_issue']['number'] == 13
+    state = _read_json(workspace / 'state' / 'self_evolution' / 'current_state.json')
+    assert state['last_noop']['status'] == 'terminal_noop'
+
+
+def test_selfevo_already_merged_pr_marks_issue_lifecycle_terminal(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+
+    record = autoevolve.write_issue_lifecycle_status(
+        workspace=workspace,
+        selfevo_issue={'number': 14, 'title': 'Inspect repeated PASS streak'},
+        selfevo_branch='chore/issue-14-inspect-pass-streak',
+        pr={'number': 15, 'state': 'MERGED', 'merged': True, 'url': 'https://github.com/ozand/eeebot-self-evolving/pull/15'},
+        action='closed_after_merge',
+    )
+
+    assert record['status'] == 'terminal_merged'
+    assert record['issue_number'] == 14
+    assert record['pr_number'] == 15
+    assert record['retry_allowed'] is False
+    persisted = _read_json(workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_issue_lifecycle.json')
+    assert persisted['linked_issue_action'] == 'closed_after_merge'
+    state = _read_json(workspace / 'state' / 'self_evolution' / 'current_state.json')
+    assert state['last_issue_lifecycle']['status'] == 'terminal_merged'
+
+
+def test_discard_equal_metric_revert_terminalizes_as_no_material_change(tmp_path: Path) -> None:
+    experiment = _build_experiment_snapshot(
+        experiment_id='exp-no-change',
+        cycle_id='cycle-1',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        selected_tasks='Verify materialized artifact [task_id=subagent-verify-materialized-improvement]',
+        task_selection_source='feedback_discard_revert_followthrough',
+        cycle_started_utc='2026-04-24T00:00:00Z',
+        cycle_ended_utc='2026-04-24T00:01:00Z',
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        outbox_path=tmp_path / 'outbox.json',
+        promotion_candidate_id=None,
+        review_status=None,
+        decision=None,
+        reward_signal={'value': 1.2, 'source': 'materialized_improvement_artifact', 'result_status': 'PASS'},
+        feedback_decision={'selected_task_id': 'subagent-verify-materialized-improvement'},
+        previous_experiment={'metric_current': 2.0, 'metric_frontier': 2.0},
+        contract_path=tmp_path / 'contract.json',
+        revert_path=tmp_path / 'revert.json',
+    )
+
+    assert experiment['outcome'] == 'discard'
+    assert experiment['revert_required'] is True
+    assert experiment['revert_status'] == 'skipped_no_material_change'
+    assert experiment['revert']['terminal'] is True
+    assert experiment['revert']['reason'] == 'discarded telemetry did not produce a material file change to revert'
+
+
+def test_credits_zeroed_for_discarded_experiment_with_unresolved_or_noop_revert(tmp_path: Path) -> None:
+    credits = _write_credits_ledger(
+        credits_dir=tmp_path / 'credits',
+        cycle_id='cycle-discard',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        reward_signal={'value': 1.2, 'source': 'materialized_improvement_artifact', 'result_status': 'PASS'},
+        budget_used={'requests': 1, 'tool_calls': 1},
+        recorded_at_utc='2026-04-24T00:01:00Z',
+        experiment={'outcome': 'discard', 'revert_required': True, 'revert_status': 'queued'},
+    )
+
+    assert credits['delta'] == 0.0
+    assert credits['balance'] == 0.0
+    assert credits['reward_gate']['status'] == 'suppressed'
+    assert credits['reward_gate']['reason'] == 'discarded_experiment_unresolved_revert'
+
+
+def test_runtime_parity_summary_flags_missing_feedback_decision() -> None:
+    summary = autoevolve.runtime_parity_summary(
+        local_plan={'current_task_id': 'subagent-verify-materialized-improvement', 'feedback_decision': {'mode': 'execute_queued_revert'}},
+        live_plan={'current_task_id': 'record-reward', 'feedback_decision': None},
+    )
+
+    assert summary['state'] == 'degraded'
+    assert 'feedback_decision_missing_on_live' in summary['reasons']
+    assert summary['local_current_task_id'] == 'subagent-verify-materialized-improvement'
+    assert summary['live_current_task_id'] == 'record-reward'


### PR DESCRIPTION
## Summary
- Adds regression coverage for the post-audit autonomy/control-plane fixes that are already present in canonical main via `db37af8 autoevolve: bounded self-update`.
- Covers self-evolution no-op terminalization, issue lifecycle recording, discarded-experiment reward gating, terminal skipped reverts, local/live parity drift summaries, and dashboard stale-control truth surfaces.
- Provides durable proof for audit gap issues #146-#151 so future autonomous cycles cannot silently regress to PASS-only telemetry, stale dashboard blockers, or no-op PR hangs.

## Verification
- `PYTHONPATH=. python3 -m pytest tests/test_autonomy_audit_gap_fixes.py tests/test_runtime_coordinator.py -q` -> `20 passed in 0.81s`
- `cd ops/dashboard && PYTHONPATH=src python3 -m pytest tests/test_dashboard_truth_audit_gaps.py tests/test_app.py -q` -> `13 passed in 21.69s`
- `PYTHONPATH=. python3 -m pytest -q` -> `579 passed, 5 skipped in 15.42s`
- `cd ops/dashboard && PYTHONPATH=src python3 -m pytest -q` -> `51 passed in 54.19s`
- Dashboard services restarted and active: `nanobot-ops-dashboard-web.service`, `nanobot-ops-dashboard-collector.service`
- Live dashboard API proof after collection:
  - `/api/analytics 200`, PASS streak length `98`
  - `/api/plan 200`, current task `subagent-verify-materialized-improvement`, feedback decision present
  - `/api/system 200`, current task `subagent-verify-materialized-improvement`, execution state `completed`, blocker `None`
- Guarded self-evolution proof: returned controlled machine-readable block rather than hanging/failing silently: `controlled_block=True`, `reason=remote_commit_not_visible`, candidate id `candidate-20260424T084129Z-6978ff2634f4`.

Fixes #146
Fixes #147
Fixes #148
Fixes #149
Fixes #150
Fixes #151
