### PR TITLE
test: cover autonomy stagnation follow-through

### DIFF
--- a/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
+++ b/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from wsgiref.util import setup_testing_defaults
+
+from nanobot_ops_dashboard.app import create_app
+from nanobot_ops_dashboard.config import DashboardConfig
+from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
+
+
+def _call_json(app, path: str) -> dict:
+    captured = {}
+    def start_response(status, headers):
+        captured['status'] = status
+        captured['headers'] = headers
+    environ = {}
+    setup_testing_defaults(environ)
+    environ['PATH_INFO'] = path
+    environ['QUERY_STRING'] = ''
+    body = b''.join(app(environ, start_response)).decode('utf-8')
+    assert captured['status'].startswith('200'), body
+    return json.loads(body)
+
+
+def _seed_pass_cycle(db: Path, idx: int, task_id: str = 'subagent-verify-materialized-improvement') -> None:
+    stamp = f'2026-04-24T12:{idx:02d}:00Z'
+    raw = {
+        'current_plan': {
+            'current_task_id': task_id,
+            'current_task': task_id,
+            'feedback_decision': {'mode': 'handoff_to_next_candidate', 'selected_task_id': task_id},
+            'task_selection_source': 'feedback_review_to_execution',
+            'selected_tasks': f'{task_id} [task_id={task_id}]',
+        },
+        'outbox': {'status': 'PASS'},
+    }
+    insert_collection(db, {
+        'collected_at': stamp,
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': f'/workspace/state/reports/evolution-{idx}.json',
+        'outbox_source': '/workspace/state/outbox/latest.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps(raw),
+    })
+    upsert_event(db, {
+        'collected_at': stamp,
+        'source': 'repo',
+        'event_type': 'cycle',
+        'identity_key': f'cycle-{idx}',
+        'title': task_id,
+        'status': 'PASS',
+        'detail_json': json.dumps({'current_task_id': task_id}),
+    })
+
+
+def test_api_subagents_returns_json_with_stale_queued_request(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    req_dir = state_root / 'subagents' / 'requests'
+    req_dir.mkdir(parents=True)
+    req = req_dir / 'request-cycle-old.json'
+    req.write_text(json.dumps({'schema_version': 'subagent-request-v1', 'request_status': 'queued', 'task_id': 'subagent-verify-materialized-improvement'}), encoding='utf-8')
+    old = time.time() - 3 * 3600
+    os.utime(req, (old, old))
+    upsert_event(db, {
+        'collected_at': '2026-04-24T12:00:00Z',
+        'source': 'repo',
+        'event_type': 'subagent',
+        'identity_key': 'subagent-old',
+        'title': 'subagent verify',
+        'status': 'queued',
+        'detail_json': json.dumps({'task_id': 'subagent-verify-materialized-improvement'}),
+    })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    payload = _call_json(create_app(cfg), '/api/subagents')
+
+    assert payload['summary']['total_events'] == 1
+    assert payload['summary']['stale_request_count'] == 1
+    assert payload['requests'][0]['status'] == 'stale'
+    assert payload['requests'][0]['task_id'] == 'subagent-verify-materialized-improvement'
+
+
+def test_dashboard_autonomy_verdict_flags_pass_but_stagnant(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'experiments').mkdir(parents=True)
+    (state_root / 'credits').mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    for i in range(10):
+        _seed_pass_cycle(db, i)
+    (state_root / 'experiments' / 'latest.json').write_text(json.dumps({'outcome': 'discard', 'revert_status': 'skipped_no_material_change'}), encoding='utf-8')
+    (state_root / 'credits' / 'latest.json').write_text(json.dumps({'delta': 0.0, 'reward_gate': {'status': 'suppressed'}}), encoding='utf-8')
+    (state_root / 'self_evolution' / 'runtime' / 'latest_noop.json').write_text(json.dumps({'status': 'terminal_noop'}), encoding='utf-8')
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+    app = create_app(cfg)
+
+    analytics = _call_json(app, '/api/analytics')['analytics']
+    system = _call_json(app, '/api/system')
+
+    assert analytics['current_streak']['status'] == 'PASS'
+    assert analytics['autonomy_verdict']['state'] == 'stagnant'
+    assert 'same_task_streak' in analytics['autonomy_verdict']['reasons']
+    assert 'discarded_experiment' in analytics['autonomy_verdict']['reasons']
+    assert system['autonomy_verdict']['state'] == 'stagnant'
+
+
+def test_system_api_reports_legacy_reward_loop_parity(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    insert_collection(db, {
+        'collected_at': '2026-04-24T12:00:00Z',
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': None,
+        'outbox_source': None,
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({'current_plan': {'current_task_id': 'subagent-verify-materialized-improvement', 'feedback_decision': {'mode': 'handoff_to_next_candidate'}}}),
+    })
+    insert_collection(db, {
+        'collected_at': '2026-04-24T12:00:01Z',
+        'source': 'eeepc',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': None,
+        'outbox_source': None,
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({'current_plan': {'selected_tasks': 'Record cycle reward [task_id=record-reward]', 'task_selection_source': 'recorded_current_task', 'feedback_decision': None}}),
+    })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    system = _call_json(create_app(cfg), '/api/system')
+
+    assert system['runtime_parity']['state'] == 'legacy_reward_loop'
+    assert 'live_hadi_artifacts_missing' in system['runtime_parity']['reasons']

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from nanobot.runtime import autoevolve
+from nanobot.runtime.coordinator import (
+    _build_task_plan_snapshot,
+    _subagent_lane_health,
+)
+
+
+def test_terminal_noop_retire_decision_advances_repeated_subagent_lane(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    (goals / 'current.json').write_text(json.dumps({
+        'current_task_id': 'subagent-verify-materialized-improvement',
+        'tasks': [
+            {'task_id': 'subagent-verify-materialized-improvement', 'title': 'Verify materialized improvement', 'status': 'active'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+        ],
+        'feedback_decision': {'mode': 'handoff_to_next_candidate', 'selected_task_id': 'subagent-verify-materialized-improvement'},
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'runtime' / 'latest_noop.json').write_text(json.dumps({
+        'status': 'terminal_noop',
+        'selfevo_issue': {'number': 13},
+        'recommended_next_action': 'select a new bounded mutation or close the already terminal task',
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-noop',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.0}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard', 'revert_status': 'skipped_no_material_change'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.0,
+        feedback_decision={'mode': 'handoff_to_next_candidate', 'selected_task_id': 'subagent-verify-materialized-improvement'},
+        goals_dir=goals,
+    )
+
+    assert plan['current_task_id'] != 'subagent-verify-materialized-improvement'
+    assert plan['feedback_decision']['mode'] == 'retire_terminal_noop_lane'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_terminal_noop_retire'
+
+
+def test_subagent_lane_health_marks_stale_queued_request(tmp_path: Path) -> None:
+    state_root = tmp_path / 'state'
+    req_dir = state_root / 'subagents' / 'requests'
+    req_dir.mkdir(parents=True)
+    req = req_dir / 'request-cycle-old.json'
+    req.write_text(json.dumps({'request_status': 'queued', 'task_id': 'subagent-verify-materialized-improvement'}), encoding='utf-8')
+    old = time.time() - 3 * 3600
+    req.touch()
+    req.chmod(0o644)
+    import os
+    os.utime(req, (old, old))
+
+    health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+    assert health['state'] == 'stale'
+    assert health['stale_request_count'] == 1
+    assert health['recommended_action'] == 'retire_or_block_stale_subagent_lane'
+
+
+def test_issue_lifecycle_does_not_claim_closed_when_github_issue_open(tmp_path: Path) -> None:
+    record = autoevolve.write_issue_lifecycle_status(
+        workspace=tmp_path / 'workspace',
+        selfevo_issue={'number': 14, 'title': 'Inspect repeated PASS streak'},
+        selfevo_branch='chore/issue-14-inspect-pass-streak',
+        pr={'number': 15, 'state': 'MERGED', 'merged': True},
+        action='closed_after_merge',
+        github_issue_state='OPEN',
+    )
+
+    assert record['status'] == 'terminal_merged_issue_still_open'
+    assert record['linked_issue_action'] == 'still_open_after_merge'
+    assert record['github_issue_state'] == 'OPEN'
+    assert record['retry_allowed'] is True
+
+
+def test_runtime_parity_summary_classifies_legacy_reward_loop() -> None:
+    summary = autoevolve.runtime_parity_summary(
+        local_plan={'current_task_id': 'subagent-verify-materialized-improvement', 'feedback_decision': {'mode': 'handoff_to_next_candidate'}},
+        live_plan={'selected_tasks': 'Record cycle reward [task_id=record-reward]', 'task_selection_source': 'recorded_current_task', 'feedback_decision': None},
+        live_artifacts={'hypotheses_backlog': False, 'credits_latest': False, 'control_plane_current_summary': False, 'self_evolution_current_state': False},
+    )
+
+    assert summary['state'] == 'legacy_reward_loop'
+    assert 'live_feedback_decision_missing' in summary['reasons']
+    assert 'live_hadi_artifacts_missing' in summary['reasons']
+    assert summary['missing_live_artifacts'] == ['hypotheses_backlog', 'credits_latest', 'control_plane_current_summary', 'self_evolution_current_state']


### PR DESCRIPTION
## Summary
- Adds regression coverage for the live 5-hour autonomy audit gaps: stagnant `subagent-verify-materialized-improvement`, terminal no-op selector follow-through, GitHub issue lifecycle truth, eeepc legacy parity classification, `/api/subagents`, and PASS-but-stagnant dashboard verdicts.
- Product implementation is already present on canonical main via `e2555c4 autoevolve: bounded self-update`; this PR locks those fixes with focused root/dashboard tests.
- Confirms the live local cycle now retires the stale terminal-noop subagent lane to `record-reward` instead of continuing PASS-only telemetry.

## Issues
Fixes #153
Fixes #154
Fixes #155
Fixes #156
Fixes #157
Fixes #158

## Verification
- `PYTHONPATH=. python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_autonomy_audit_gap_fixes.py tests/test_runtime_coordinator.py tests/test_subagent_handoff.py tests/test_subagent_request_semantics.py -q` -> `27 passed in 0.92s`
- `cd ops/dashboard && PYTHONPATH=src python3 -m pytest tests/test_autonomy_stagnation_dashboard.py tests/test_dashboard_truth_audit_gaps.py tests/test_app.py -q` -> `16 passed in 21.65s`
- `PYTHONPATH=. python3 -m pytest -q` -> `583 passed, 5 skipped in 15.48s`
- `cd ops/dashboard && PYTHONPATH=src python3 -m pytest -q` -> `54 passed in 49.52s`

## Live proof
- Dashboard services restarted and active.
- `GET /api/subagents` -> JSON 200 with stale request summary (`stale_request_count=163`, `total_requests=174`).
- `GET /api/analytics` and `GET /api/system` -> `autonomy_verdict.state=stagnant` with reasons `same_task_streak`, `discarded_experiment`, `suppressed_reward`, `terminal_noop`.
- `GET /api/system` -> `runtime_parity.state=legacy_reward_loop`.
- One live local cycle with local state root retired the stuck lane:
  - before: `subagent-verify-materialized-improvement`
  - after: `current_task=record-reward`
  - feedback mode: `retire_terminal_noop_lane`
  - selection source: `feedback_terminal_noop_retire`
- Guarded self-evolution ran with `ok=True` after the lane retired.

## CI note
If GitHub Actions does not start, inspect annotations; recent runs have been blocked by an account-level billing lock rather than code/test failures.
