### PR TITLE
fix: materialize subagent results and enforce runtime parity gates

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1,5 +1,6 @@
 """Minimal durable self-evolving runtime coordinator."""
 import asyncio
+import hashlib
 import json
 import math
 import os
@@ -153,17 +154,26 @@ def _git_output(args: list[str], cwd: Path) -> str | None:
 
 
 def _runtime_source_fingerprint(workspace: Path) -> dict[str, Any]:
-    repo_root = workspace
-    while repo_root != repo_root.parent and not (repo_root / '.git').exists():
-        repo_root = repo_root.parent
-    commit = _git_output(['git', 'rev-parse', 'HEAD'], repo_root)
-    branch = _git_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], repo_root)
-    tree = _git_output(['git', 'rev-parse', 'HEAD^{tree}'], repo_root)
+    search_roots = [workspace, Path(__file__).resolve().parents[2], Path.cwd()]
+    for candidate_root in search_roots:
+        repo_root = candidate_root
+        while repo_root != repo_root.parent and not (repo_root / '.git').exists():
+            repo_root = repo_root.parent
+        if (repo_root / '.git').exists():
+            commit = _git_output(['git', 'rev-parse', 'HEAD'], repo_root)
+            branch = _git_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], repo_root)
+            tree = _git_output(['git', 'rev-parse', 'HEAD^{tree}'], repo_root)
+            return {
+                'source_repo_root': str(repo_root),
+                'source_commit': commit,
+                'source_branch': branch,
+                'source_tree': tree,
+            }
     return {
-        'source_repo_root': str(repo_root),
-        'source_commit': commit,
-        'source_branch': branch,
-        'source_tree': tree,
+        'source_repo_root': str(workspace),
+        'source_commit': None,
+        'source_branch': None,
+        'source_tree': None,
     }
 
 
@@ -2267,6 +2277,7 @@ async def run_self_evolving_cycle(
     )
 
     promotion_path = None
+    promotion_provenance = None
     if promotion_candidate_id:
         promotions_dir.mkdir(parents=True, exist_ok=True)
         promotion_record = {
@@ -2375,8 +2386,47 @@ async def run_self_evolving_cycle(
         current_task_id=current_plan.get("current_task_id"),
         current_task_title=current_plan.get("current_task"),
     )
+    runtime_source = _runtime_source_fingerprint(workspace)
     if promotion_candidate_id and promotion_path is not None:
         final_artifact_path = current_plan.get("materialized_improvement_artifact_path") or ((current_plan.get("feedback_decision") or {}).get("artifact_path") if isinstance(current_plan.get("feedback_decision"), dict) else None)
+        promotion_artifact_id = promotion_candidate_id
+        promotion_artifact_version = cycle_id
+        promotion_release_channel = "self-evolving"
+        promotion_target_host_profile = "weak-host"
+        promotion_target_authority = "runtime-promotion-policy"
+        promotion_deployment_fingerprint_id = f"{promotion_candidate_id}:{cycle_id}"
+        promotion_build_recipe = {
+            "source_commit": runtime_source.get("source_commit"),
+            "origin_cycle_id": cycle_id,
+            "candidate_id": promotion_candidate_id,
+            "target_branch": "promote/self-evolving",
+            "artifact_path": final_artifact_path,
+            "release_channel": promotion_release_channel,
+        }
+        promotion_build_recipe_hash = hashlib.sha256(
+            json.dumps(promotion_build_recipe, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+        promotion_provenance = {
+            "source_commit": runtime_source.get("source_commit"),
+            "build_recipe_hash": promotion_build_recipe_hash,
+            "artifact_id": promotion_artifact_id,
+            "artifact_version": promotion_artifact_version,
+            "release_channel": promotion_release_channel,
+            "target_host_profile": promotion_target_host_profile,
+            "target_authority": promotion_target_authority,
+            "deployment_fingerprint": {
+                "deployment_fingerprint_id": promotion_deployment_fingerprint_id,
+                "artifact_id": promotion_artifact_id,
+                "artifact_version": promotion_artifact_version,
+                "release_channel": promotion_release_channel,
+                "target_host_profile": promotion_target_host_profile,
+                "target_authority": promotion_target_authority,
+            },
+            "rollback_evidence": {
+                "evidence_refs": [evidence_ref_id] if evidence_ref_id else [],
+                "rollback_plan": "Revert the candidate and keep host-local only.",
+            },
+        }
         final_promotion_record = {
             "schema_version": PROMOTION_RECORD_VERSION,
             "promotion_candidate_id": promotion_candidate_id,
@@ -2402,6 +2452,7 @@ async def run_self_evolving_cycle(
             "readiness_reasons": experiment.get("readiness_reasons"),
             "decision_record": "pending_operator_review_packet" if review_status == "ready_for_policy_review" else None,
             "accepted_record": None,
+            "promotion_provenance": promotion_provenance,
             "governance_packet": {
                 "review_packet_status": "pending_operator_review" if review_status == "ready_for_policy_review" else "not_ready",
                 "review_status": review_status,
@@ -2409,6 +2460,7 @@ async def run_self_evolving_cycle(
                 "source_artifact": final_artifact_path,
                 "readiness_checks": experiment.get("readiness_checks"),
                 "readiness_reasons": experiment.get("readiness_reasons"),
+                "promotion_provenance": promotion_provenance,
             },
         }
         promotion_path.write_text(json.dumps(final_promotion_record, indent=2, ensure_ascii=False), encoding="utf-8")
@@ -2541,6 +2593,7 @@ async def run_self_evolving_cycle(
             "candidate_path": str(promotion_path) if promotion_path else None,
             "review_status": review_status,
             "decision": decision,
+            "promotion_provenance": promotion_provenance,
         },
         "materialized_improvement_artifact_path": current_plan.get("materialized_improvement_artifact_path"),
     }

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -58,6 +58,9 @@ def _safe_runtime_config_operator_boost() -> dict[str, Any] | None:
         return None
 
 
+_PROVENANCE_PLACEHOLDER_VALUES = {'unknown', 'not_collected', 'local-build', 'placeholder', 'tbd', 'todo', 'n/a', 'na', 'none', 'null'}
+
+
 def _governance_coverage_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
     candidate_path = runtime.get('promotion_candidate_path')
     decision_record = runtime.get('promotion_decision_record')
@@ -85,6 +88,76 @@ def _governance_coverage_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
         'ownership_gaps': ownership_gaps,
         'due_reviews': due_reviews,
         'next_action': next_action,
+    }
+
+
+def _promotion_provenance_snapshot(promotion_data: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(promotion_data, dict):
+        return None
+    nested = promotion_data.get('promotion_provenance') if isinstance(promotion_data.get('promotion_provenance'), dict) else {}
+    deployment_fingerprint = nested.get('deployment_fingerprint') if isinstance(nested.get('deployment_fingerprint'), dict) else {}
+    rollback_evidence = nested.get('rollback_evidence') if nested.get('rollback_evidence') is not None else promotion_data.get('rollback_evidence')
+    source_commit = nested.get('source_commit') or promotion_data.get('source_commit')
+    build_recipe_hash = nested.get('build_recipe_hash') or promotion_data.get('build_recipe_hash')
+    artifact_id = nested.get('artifact_id') or promotion_data.get('artifact_id')
+    artifact_version = nested.get('artifact_version') or promotion_data.get('artifact_version')
+    release_channel = nested.get('release_channel') or promotion_data.get('release_channel')
+    target_host_profile = nested.get('target_host_profile') or promotion_data.get('target_host_profile')
+    target_authority = nested.get('target_authority') or promotion_data.get('target_authority')
+    deployment_fingerprint_id = (
+        deployment_fingerprint.get('deployment_fingerprint_id')
+        or nested.get('deployment_fingerprint_id')
+        or promotion_data.get('deployment_fingerprint_id')
+    )
+
+    def _missing(value: Any) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            return not normalized or normalized in _PROVENANCE_PLACEHOLDER_VALUES
+        if isinstance(value, (list, tuple, set, dict)):
+            return not bool(value)
+        return False
+
+    missing_fields = [
+        field_name
+        for field_name, value in {
+            'source_commit': source_commit,
+            'build_recipe_hash': build_recipe_hash,
+            'artifact_id': artifact_id,
+            'artifact_version': artifact_version,
+            'release_channel': release_channel,
+            'target_host_profile': target_host_profile,
+            'target_authority': target_authority,
+            'deployment_fingerprint_id': deployment_fingerprint_id,
+            'rollback_evidence': rollback_evidence,
+        }.items()
+        if _missing(value)
+    ]
+    status = 'ready' if not missing_fields else 'blocked'
+    blocking_reason = None if not missing_fields else f"missing_or_placeholder_provenance:{','.join(missing_fields)}"
+    return {
+        'status': status,
+        'blocking_reason': blocking_reason,
+        'source_commit': source_commit,
+        'build_recipe_hash': build_recipe_hash,
+        'artifact_id': artifact_id,
+        'artifact_version': artifact_version,
+        'release_channel': release_channel,
+        'target_host_profile': target_host_profile,
+        'target_authority': target_authority,
+        'deployment_fingerprint': {
+            **deployment_fingerprint,
+            'deployment_fingerprint_id': deployment_fingerprint_id,
+            'artifact_id': artifact_id,
+            'artifact_version': artifact_version,
+            'release_channel': release_channel,
+            'target_host_profile': target_host_profile,
+            'target_authority': target_authority,
+        },
+        'deployment_fingerprint_id': deployment_fingerprint_id,
+        'rollback_evidence': rollback_evidence,
     }
 
 
@@ -844,6 +917,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     promotion_readiness_checks = None
     promotion_readiness_reasons = None
     promotion_governance_packet = None
+    promotion_provenance = None
     credits_balance = None
     credits_delta = None
     credits_path = str(latest_credits) if latest_credits else None
@@ -966,6 +1040,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         promotion_governance_packet = promotion_data.get("governance_packet") or promotion_data.get("governancePacket") or promotion_governance_packet
         promotion_decision_record = promotion_data.get("decision_record") or promotion_data.get("decisionRecord") or promotion_decision_record
         promotion_accepted_record = promotion_data.get("accepted_record") or promotion_data.get("acceptedRecord") or promotion_accepted_record
+        promotion_provenance = _promotion_provenance_snapshot(promotion_data)
     elif isinstance(outbox_data, dict):
         promotion = outbox_data.get("promotion") if isinstance(outbox_data.get("promotion"), dict) else None
         if isinstance(promotion, dict):
@@ -1009,8 +1084,20 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
             'decision_record': promotion_decision_record,
             'accepted_record': promotion_accepted_record,
         }
-        if decision == 'accept' and review_status == 'reviewed' and promotion_accepted_record == 'present' and promotion_patch_bundle_path and Path(promotion_patch_bundle_path).exists():
-            promotion_replay_readiness = {'state': 'ready', 'reason': 'accepted_bundle_present'}
+        if (
+            decision == 'accept'
+            and review_status == 'reviewed'
+            and promotion_accepted_record == 'present'
+            and promotion_patch_bundle_path
+            and Path(promotion_patch_bundle_path).exists()
+        ):
+            if promotion_provenance and promotion_provenance.get('status') == 'ready':
+                promotion_replay_readiness = {'state': 'ready', 'reason': 'accepted_bundle_present_and_provenance_complete'}
+            else:
+                promotion_replay_readiness = {
+                    'state': 'blocked',
+                    'reason': (promotion_provenance or {}).get('blocking_reason') or 'provenance_missing_or_placeholder',
+                }
         elif decision == 'accept' and review_status == 'reviewed':
             promotion_replay_readiness = {'state': 'blocked', 'reason': 'patch_bundle_missing'}
         elif decision:
@@ -1048,6 +1135,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         "promotion_readiness_checks": promotion_readiness_checks,
         "promotion_readiness_reasons": promotion_readiness_reasons,
         "promotion_governance_packet": promotion_governance_packet,
+        "promotion_provenance": promotion_provenance,
         "promotion_replay_readiness": promotion_replay_readiness,
         "hypothesis_backlog_schema_version": hypothesis_backlog_schema_version,
         "runtime_status": runtime_status,
@@ -1223,6 +1311,7 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
     _render("Promotion schema", runtime.get("promotion_schema_version"))
     _render("Governance schema", runtime.get("governance_schema"))
     _render("Governance coverage", runtime.get("governance_coverage"))
+    _render("Promotion provenance", runtime.get("promotion_provenance"))
     _render("Promotion candidate path", runtime.get("promotion_candidate_path"))
     _render("Promotion decision record", runtime.get("promotion_decision_record"))
     _render("Promotion accepted record", runtime.get("promotion_accepted_record"))

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -114,8 +114,19 @@ def _material_progress_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
         or (selfevo_state.get('last_issue_lifecycle') if isinstance(selfevo_state, dict) else None)
         or (runtime.get('promotion_replay_readiness') or {}).get('state') == 'ready'
     )
+    latest_subagent_result = subagent_rollup.get('latest_result') if isinstance(subagent_rollup.get('latest_result'), dict) else {}
+    latest_subagent_status = latest_subagent_result.get('status') if isinstance(latest_subagent_result, dict) else None
+    subagent_terminal_count = int(subagent_rollup.get('count_completed', 0) or subagent_rollup.get('completed_result_count', 0) or 0)
+    subagent_blocked_count = int(subagent_rollup.get('blocked_result_count', 0) or 0)
+    subagent_only_blocked = bool(
+        latest_subagent_status == 'blocked'
+        and subagent_blocked_count >= subagent_terminal_count
+        and subagent_terminal_count > 0
+    )
     consumed_subagent_result = bool(
-        subagent_rollup.get('count_completed', 0) or subagent_rollup.get('completed_result_count', 0) or _present(subagent_rollup.get('latest_result'))
+        (subagent_terminal_count or _present(latest_subagent_result))
+        and latest_subagent_status not in {'blocked', 'failed', 'error'}
+        and not subagent_only_blocked
     )
     promotion_evidence_artifact = bool(
         _present(runtime.get('promotion_artifact_path'))
@@ -150,7 +161,11 @@ def _material_progress_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
         {
             'kind': 'consumed_subagent_result',
             'present': consumed_subagent_result,
-            'reason': 'subagent_result_consumed' if consumed_subagent_result else 'subagent_result_missing',
+            'reason': (
+                'subagent_result_consumed'
+                if consumed_subagent_result
+                else ('subagent_result_blocked' if subagent_only_blocked else 'subagent_result_missing')
+            ),
             'evidence': {
                 'subagent_rollup_state': subagent_rollup.get('state'),
                 'completed_result_count': subagent_rollup.get('completed_result_count') or subagent_rollup.get('count_completed'),
@@ -894,16 +909,16 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
             task_obj = (result_obj or {}).get("task") if isinstance((result_obj or {}).get("task"), dict) else None
             goal_context = (task_obj or {}).get("goal_context") if isinstance((task_obj or {}).get("goal_context"), dict) else None
             subagent_rollup = (goal_context or {}).get("subagent_rollup") if isinstance(goal_context, dict) else None
-            subagent_rollup_from_files = _subagent_rollup_snapshot(
-                state_root=state_root,
-                current_task_id=current_task_id,
-                current_task_title=(task_plan.get("current_task") if isinstance(task_plan, dict) else None),
-            )
+        subagent_rollup_from_files = _subagent_rollup_snapshot(
+            state_root=state_root,
+            current_task_id=current_task_id,
+            current_task_title=(task_plan.get("current_task") if isinstance(task_plan, dict) else None),
+        )
         if subagent_rollup is None:
             subagent_rollup = subagent_rollup_from_files
         elif isinstance(subagent_rollup_from_files, dict) and (
-            subagent_rollup_from_files.get('result_count')
-            or subagent_rollup.get('state') in {'stale', 'missing'}
+            subagent_rollup_from_files.get("result_count")
+            or subagent_rollup.get("state") in {"stale", "missing"}
         ):
             subagent_rollup = subagent_rollup_from_files
         capability_gate = report_data.get("capability_gate") if isinstance(report_data.get("capability_gate"), dict) else None

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -660,38 +660,65 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             payload = _json_file(path)
             status = payload.get('request_status') or payload.get('status') or 'queued'
             age = max(0, int(now - path.stat().st_mtime))
-            effective_status = 'stale' if status in {'queued', 'pending'} and age >= stale_after_seconds else status
             requests.append({
                 'path': str(path),
                 'task_id': payload.get('task_id'),
                 'cycle_id': payload.get('cycle_id'),
                 'profile': payload.get('profile'),
-                'status': effective_status,
+                'status': status,
                 'request_status': status,
                 'age_seconds': age,
                 'source_artifact': payload.get('source_artifact'),
             })
     results: list[dict] = []
+    results_by_request_path: dict[str, dict] = {}
+    results_by_cycle_id: dict[str, dict] = {}
+    results_by_task_id: dict[str, dict] = {}
     if result_dir.exists():
         for path in sorted(result_dir.glob('*.json'), key=lambda p: p.stat().st_mtime, reverse=True):
             payload = _json_file(path)
-            results.append({
+            result = {
                 'path': str(path),
+                'request_path': payload.get('request_path'),
                 'task_id': payload.get('task_id'),
                 'cycle_id': payload.get('cycle_id'),
                 'status': payload.get('status') or payload.get('result_status') or 'completed',
+                'terminal_reason': payload.get('terminal_reason') or payload.get('reason'),
                 'age_seconds': max(0, int(now - path.stat().st_mtime)),
-            })
-    stale_count = sum(1 for item in requests if item.get('status') == 'stale')
+            }
+            results.append(result)
+            if result.get('request_path'):
+                results_by_request_path.setdefault(str(result['request_path']), result)
+            if result.get('cycle_id'):
+                results_by_cycle_id.setdefault(str(result['cycle_id']), result)
+            if result.get('task_id'):
+                results_by_task_id.setdefault(str(result['task_id']), result)
+    for request in requests:
+        materialized_result = (
+            results_by_request_path.get(str(request.get('path')))
+            or (results_by_cycle_id.get(str(request.get('cycle_id'))) if request.get('cycle_id') else None)
+            or (results_by_task_id.get(str(request.get('task_id'))) if request.get('task_id') else None)
+        )
+        if isinstance(materialized_result, dict):
+            request['status'] = str(materialized_result.get('status') or 'completed').lower()
+            request['materialized_result_path'] = materialized_result.get('path')
+            request['materialized_result_status'] = materialized_result.get('status')
+            if materialized_result.get('terminal_reason'):
+                request['terminal_reason'] = materialized_result.get('terminal_reason')
+        elif request.get('request_status') in {'queued', 'pending'} and request.get('age_seconds', 0) >= stale_after_seconds:
+            request['status'] = 'stale'
+    stale_count = sum(1 for item in requests if item.get('request_status') in {'queued', 'pending'} and not item.get('materialized_result_path') and item.get('age_seconds', 0) >= stale_after_seconds)
+    queued_count = sum(1 for item in requests if item.get('request_status') in {'queued', 'pending'} and not item.get('materialized_result_path'))
+    blocked_count = sum(1 for item in results if str(item.get('status') or '').lower() in {'blocked', 'terminal_blocked'})
+    result_count = len(results)
     rollup = _subagent_rollup_snapshot(state_root=state_root)
     if isinstance(rollup, dict):
         stale_count = int(rollup.get('stale_request_count') or 0)
         queued_count = int(rollup.get('queued_request_count') or 0)
-        result_count = int(rollup.get('completed_result_count') or rollup.get('result_count') or 0)
+        result_count = int(rollup.get('completed_result_count') or rollup.get('result_count') or result_count)
+        blocked_count = int(rollup.get('blocked_result_count') or blocked_count)
         state = rollup.get('state') or ('stale' if stale_count else ('available' if requests or results else 'empty'))
     else:
-        queued_count = sum(1 for item in requests if item.get('request_status') in {'queued', 'pending'})
-        result_count = len(results)
         state = 'stale' if stale_count else ('available' if requests or results else 'empty')
     return {
         'schema_version': 'subagent-visibility-v1',
@@ -703,6 +730,7 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             'stale_request_count': stale_count,
             'queued_request_count': queued_count,
             'result_count': result_count,
+            'blocked_result_count': blocked_count,
             'state': state,
         },
     }

--- a/ops/dashboard/src/nanobot_ops_dashboard/collector.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/collector.py
@@ -353,6 +353,7 @@ def _repo_events(runtime: dict[str, Any]) -> list[dict[str, Any]]:
                 'readiness_checks': runtime.get('promotion_readiness_checks'),
                 'readiness_reasons': runtime.get('promotion_readiness_reasons'),
                 'governance_packet': runtime.get('promotion_governance_packet'),
+                'provenance': runtime.get('promotion_provenance'),
             },
         })
     return events

--- a/ops/dashboard/tests/test_app.py
+++ b/ops/dashboard/tests/test_app.py
@@ -923,6 +923,72 @@ def test_app_reports_missing_report_source_and_pending_cadence(tmp_path: Path):
     assert 'cadence not yet established' in deployments_body
 
 
+def test_app_api_subagents_prefers_materialized_blocked_result_over_stale_queued_request(tmp_path: Path):
+    root = tmp_path / 'dashboard'
+    db = root / 'data' / 'db.sqlite3'
+    init_db(db)
+
+    repo_root = tmp_path / 'nanobot'
+    state_root = repo_root / 'workspace' / 'state'
+    request_dir = state_root / 'subagents' / 'requests'
+    result_dir = state_root / 'subagents' / 'results'
+    request_dir.mkdir(parents=True)
+    result_dir.mkdir(parents=True)
+
+    request_path = request_dir / 'request-cycle-173.json'
+    request_path.write_text(
+        json.dumps(
+            {
+                'schema_version': 'subagent-request-v1',
+                'request_status': 'queued',
+                'task_id': 'subagent-verify-materialized-improvement',
+                'cycle_id': 'cycle-173',
+                'profile': 'research_only',
+                'source_artifact': 'workspace/state/improvements/materialized-cycle-173.json',
+            },
+            ensure_ascii=False,
+        ),
+        encoding='utf-8',
+    )
+    stale_at = time.time() - 4 * 3600
+    os.utime(request_path, (stale_at, stale_at))
+
+    result_path = result_dir / 'result-cycle-173.json'
+    result_path.write_text(
+        json.dumps(
+            {
+                'schema_version': 'subagent-result-v1',
+                'request_path': str(request_path),
+                'task_id': 'subagent-verify-materialized-improvement',
+                'cycle_id': 'cycle-173',
+                'status': 'blocked',
+                'terminal_reason': 'local_executor_unavailable',
+                'summary': 'Subagent request terminalized as blocked because no local executor is available',
+            },
+            ensure_ascii=False,
+        ),
+        encoding='utf-8',
+    )
+
+    app = create_app(_cfg(tmp_path, db))
+
+    status, body = _call_app(app, '/api/subagents')
+    assert status.startswith('200')
+    payload = json.loads(body)
+    summary = payload['summary']
+    assert summary['state'] == 'completed'
+    assert summary['stale_request_count'] == 0
+    assert summary['queued_request_count'] == 0
+    assert summary['result_count'] == 1
+    assert summary['blocked_result_count'] == 1
+    assert payload['subagent_rollup']['blocked_result_count'] == 1
+    assert payload['requests'][0]['request_status'] == 'queued'
+    assert payload['requests'][0]['status'] == 'blocked'
+    assert payload['requests'][0]['materialized_result_status'] == 'blocked'
+    assert payload['requests'][0]['materialized_result_path'] == str(result_path)
+    assert payload['results'][0]['status'] == 'blocked'
+
+
 def test_app_subagents_handles_missing_telemetry(tmp_path: Path):
     root = tmp_path / 'dashboard'
     db = root / 'data' / 'db.sqlite3'

--- a/tests/test_ci_dashboard_parity_gate.py
+++ b/tests/test_ci_dashboard_parity_gate.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from wsgiref.util import setup_testing_defaults
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ops" / "dashboard" / "src"))
+
+from nanobot_ops_dashboard.app import create_app  # noqa: E402
+from nanobot_ops_dashboard.config import DashboardConfig  # noqa: E402
+from nanobot_ops_dashboard.storage import init_db  # noqa: E402
+
+
+def _call_json(app, path: str) -> dict:
+    captured: dict[str, object] = {}
+
+    def start_response(status, headers):
+        captured["status"] = status
+        captured["headers"] = headers
+
+    environ: dict[str, object] = {}
+    setup_testing_defaults(environ)
+    environ["PATH_INFO"] = path
+    body = b"".join(app(environ, start_response)).decode("utf-8")
+    assert str(captured["status"]).startswith("200"), body
+    return json.loads(body)
+
+
+def test_ci_dashboard_subagent_gate_reconciles_blocked_materialized_result(tmp_path: Path) -> None:
+    project_root = tmp_path / "dashboard"
+    repo_root = tmp_path / "nanobot"
+    db = tmp_path / "dashboard.sqlite3"
+    init_db(db)
+    state_root = repo_root / "workspace" / "state"
+    request_dir = state_root / "subagents" / "requests"
+    result_dir = state_root / "subagents" / "results"
+    request_dir.mkdir(parents=True)
+    result_dir.mkdir(parents=True)
+    request_path = request_dir / "request-cycle-ci.json"
+    request_path.write_text(
+        json.dumps({"schema_version": "subagent-request-v1", "request_status": "queued", "task_id": "same-task", "cycle_id": "cycle-ci"}),
+        encoding="utf-8",
+    )
+    result_path = result_dir / "result-cycle-ci.json"
+    result_path.write_text(
+        json.dumps({"schema_version": "subagent-result-v1", "status": "blocked", "task_id": "same-task", "cycle_id": "cycle-ci", "request_path": str(request_path)}),
+        encoding="utf-8",
+    )
+    old = time.time() - 3 * 3600
+    os.utime(request_path, (old, old))
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host="eeepc", eeepc_ssh_key=tmp_path / "missing-key", eeepc_state_root="/state")
+
+    payload = _call_json(create_app(cfg), "/api/subagents")
+
+    assert payload["summary"]["state"] == "completed"
+    assert payload["summary"]["stale_request_count"] == 0
+    assert payload["summary"]["queued_request_count"] == 0
+    assert payload["summary"]["blocked_result_count"] == 1
+    assert payload["requests"][0]["status"] == "blocked"
+    assert payload["requests"][0]["materialized_result_path"] == str(result_path)

--- a/tests/test_promotion_workflow.py
+++ b/tests/test_promotion_workflow.py
@@ -40,6 +40,42 @@ def _create_pass_candidate(tmp_path: Path) -> tuple[dict, str]:
     return candidate, candidate_id
 
 
+def _write_promotion_candidate(
+    tmp_path: Path,
+    candidate_id: str,
+    provenance: dict,
+) -> Path:
+    promotions_dir = tmp_path / "state" / "promotions"
+    promotions_dir.mkdir(parents=True)
+    candidate_path = promotions_dir / f"{candidate_id}.json"
+    payload = {
+        "schema_version": "promotion-record-v1",
+        "promotion_candidate_id": candidate_id,
+        "origin_cycle_id": f"cycle-{candidate_id}",
+        "candidate_created_utc": "2026-04-18T11:45:00Z",
+        "origin_host": "local-workspace",
+        "source_paths": ["state/reports/evolution-cycle.json"],
+        "target_repo": "ozand/nanobot",
+        "target_branch": "promote/self-evolving",
+        "review_status": "ready_for_policy_review",
+        "decision": "accept",
+        "decision_reason": "ready to validate provenance gate",
+        "artifact_path": str(promotions_dir / f"{candidate_id}.artifact.json"),
+        "decision_record": "pending_operator_review_packet",
+        "accepted_record": None,
+        "promotion_provenance": provenance,
+        "governance_packet": {
+            "review_packet_status": "pending_operator_review",
+            "review_status": "ready_for_policy_review",
+            "decision": "accept",
+            "source_artifact": str(promotions_dir / f"{candidate_id}.artifact.json"),
+            "promotion_provenance": provenance,
+        },
+    }
+    candidate_path.write_text(json.dumps(payload), encoding="utf-8")
+    return candidate_path
+
+
 def test_accept_review_writes_decision_trail_and_accepted_record(tmp_path):
     candidate, candidate_id = _create_pass_candidate(tmp_path)
 
@@ -64,6 +100,8 @@ def test_accept_review_writes_decision_trail_and_accepted_record(tmp_path):
     assert latest["decision"] == "accept"
     runtime = load_runtime_state(tmp_path)
     assert runtime["promotion_replay_readiness"]["state"] == "ready"
+    assert runtime["promotion_provenance"]["status"] == "ready"
+    assert runtime["promotion_provenance"]["source_commit"]
     assert runtime["governance_coverage"]["state"] == "healthy"
     assert latest["schema_version"] == "promotion-record-v1"
 
@@ -83,6 +121,75 @@ def test_accept_review_writes_decision_trail_and_accepted_record(tmp_path):
     assert patch_bundle["promotion_candidate_id"] == candidate_id
     assert patch_bundle["target_branch"] == candidate["target_branch"]
     assert patch_bundle["evidence_refs"] == candidate["evidence_refs"]
+
+
+def test_placeholder_provenance_blocks_promotion_readiness(tmp_path):
+    candidate_id = "promotion-placeholder"
+    provenance = {
+        "source_commit": "unknown",
+        "build_recipe_hash": "local-build",
+        "artifact_id": "unknown",
+        "artifact_version": "unknown",
+        "release_channel": "unknown",
+        "target_host_profile": "unknown",
+        "target_authority": "unknown",
+        "deployment_fingerprint": {"deployment_fingerprint_id": "unknown"},
+        "rollback_evidence": [],
+    }
+    _write_promotion_candidate(tmp_path, candidate_id, provenance)
+
+    review_promotion_candidate(
+        workspace=tmp_path,
+        candidate_id=candidate_id,
+        decision="accept",
+        decision_reason="accepted for readiness gating check",
+    )
+
+    runtime = load_runtime_state(tmp_path)
+    assert runtime["promotion_candidate_id"] == candidate_id
+    assert runtime["promotion_provenance"]["status"] == "blocked"
+    assert runtime["promotion_replay_readiness"]["state"] == "blocked"
+    assert "missing_or_placeholder_provenance" in runtime["promotion_replay_readiness"]["reason"]
+
+
+def test_valid_provenance_surfaces_in_runtime_and_promotion_record(tmp_path):
+    candidate_id = "promotion-provenance"
+    provenance = {
+        "source_commit": "abc123def456",
+        "build_recipe_hash": "recipe-hash-123",
+        "artifact_id": "artifact-175",
+        "artifact_version": "1.0.0",
+        "release_channel": "stable",
+        "target_host_profile": "weak-host",
+        "target_authority": "runtime-promotion-policy",
+        "deployment_fingerprint": {
+            "deployment_fingerprint_id": "dfp-175",
+            "artifact_id": "artifact-175",
+            "artifact_version": "1.0.0",
+            "release_channel": "stable",
+            "target_host_profile": "weak-host",
+            "target_authority": "runtime-promotion-policy",
+        },
+        "rollback_evidence": {"evidence_refs": ["rollback-evidence-1"]},
+    }
+    _write_promotion_candidate(tmp_path, candidate_id, provenance)
+
+    review_promotion_candidate(
+        workspace=tmp_path,
+        candidate_id=candidate_id,
+        decision="accept",
+        decision_reason="validated provenance fields",
+    )
+
+    runtime = load_runtime_state(tmp_path)
+    assert runtime["promotion_candidate_id"] == candidate_id
+    assert runtime["promotion_provenance"]["status"] == "ready"
+    assert runtime["promotion_provenance"]["source_commit"] == "abc123def456"
+    assert runtime["promotion_provenance"]["deployment_fingerprint"]["deployment_fingerprint_id"] == "dfp-175"
+    assert runtime["promotion_replay_readiness"]["state"] == "ready"
+    assert runtime["promotion_summary"] == f"{candidate_id} | reviewed | accept"
+    latest = _read_json(tmp_path / "state" / "promotions" / "latest.json")
+    assert latest["promotion_provenance"]["artifact_id"] == "artifact-175"
 
 
 def test_reject_review_writes_decision_trail_without_accepted_record(tmp_path):

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -253,6 +253,8 @@ def test_cycle_writes_pass_report_when_gate_is_fresh(tmp_path):
     assert candidate["promotion_candidate_id"] == report["promotion_candidate_id"]
     assert candidate["origin_cycle_id"] == report["cycle_id"]
     assert candidate["target_branch"] == "promote/self-evolving"
+    assert candidate["promotion_provenance"]["source_commit"]
+    assert candidate["promotion_provenance"]["deployment_fingerprint"]["deployment_fingerprint_id"].startswith(report["promotion_candidate_id"])
     assert candidate["evidence_refs"] == [report["evidence_ref_id"]]
 
     current = _read_json(tmp_path / "state" / "goals" / "current.json")

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1024,6 +1024,8 @@ def test_load_runtime_state_prefers_materialized_subagent_results_over_stale_out
     assert runtime["subagent_rollup"]["state"] == "completed"
     assert runtime["subagent_rollup"]["result_count"] == 1
     assert runtime["subagent_rollup"]["stale_request_count"] == 0
+    assert runtime["subagent_rollup"]["latest_request"]["status"] == "blocked"
+    assert runtime["subagent_rollup"]["latest_request"]["materialized_result_status"] == "blocked"
 
 
 def test_material_progress_does_not_treat_blocked_subagent_terminalization_as_healthy():

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1024,3 +1024,35 @@ def test_load_runtime_state_prefers_materialized_subagent_results_over_stale_out
     assert runtime["subagent_rollup"]["state"] == "completed"
     assert runtime["subagent_rollup"]["result_count"] == 1
     assert runtime["subagent_rollup"]["stale_request_count"] == 0
+
+
+def test_material_progress_does_not_treat_blocked_subagent_terminalization_as_healthy():
+    runtime = {
+        "current_task_id": "inspect-pass-streak",
+        "experiment": {
+            "outcome": "discard",
+            "decision": "pending_policy_review",
+            "review_status": "pending_policy_review",
+            "revert_status": "skipped_no_material_change",
+        },
+        "subagent_rollup": {
+            "state": "completed",
+            "completed_result_count": 1,
+            "blocked_result_count": 1,
+            "latest_result": {
+                "path": "/workspace/state/subagents/results/result-cycle-1.json",
+                "status": "blocked",
+                "summary": "Subagent request terminalized as blocked because no local executor is available",
+            },
+            "active_task_id": "inspect-pass-streak",
+        },
+    }
+
+    progress = _material_progress_snapshot(runtime)
+
+    consumed = next(proof for proof in progress["proofs"] if proof["kind"] == "consumed_subagent_result")
+    assert consumed["present"] is False
+    assert consumed["reason"] == "subagent_result_blocked"
+    assert progress["state"] == "blocked"
+    assert progress["healthy_autonomy_allowed"] is False
+    assert progress["blocking_reason"] == "missing_current_material_progress"


### PR DESCRIPTION
## Summary
- Materializes queued subagent requests into durable result artifacts and teaches runtime/dashboard rollups to consume result files instead of stale embedded queue snapshots.
- Exposes runtime HADI/parity proof surfaces through dashboard system/analytics APIs and blocks healthy autonomy on degraded/legacy parity.
- Tightens material-progress semantics so healthy autonomy requires current qualifying proof and does not accept stale historic PRs, unaccepted promotion artifacts, or blocked subagent terminalizations as success.
- Reconciles `/api/subagents` with canonical materialized subagent rollup truth, including explicit blocked terminalization status.
- Adds a root-suite CI parity gate for dashboard subagent API reconciliation without requiring workflow-token scope.
- Adds bounded promotion provenance readiness: promotion readiness fail-closes on missing/placeholder provenance and surfaces provenance in runtime/promotion/dashboard collection paths.

Refs #165
Refs #166
Refs #167
Refs #173
Refs #174
Refs #175

## Verification
- `python3 -m pytest tests -q` => `595 passed, 5 skipped`
- `(cd ops/dashboard && python3 -m pytest tests -q)` => `62 passed`
- Targeted #173 verification: dashboard subagent reconciliation tests passed; `/api/subagents` now links stale queued requests to durable blocked result artifacts.
- Targeted #174 verification: `tests/test_ci_dashboard_parity_gate.py` runs in the existing root CI path (`python -m pytest tests/ -v`) and passed locally.
- Targeted #175 verification: `python3 -m pytest tests/test_promotion_workflow.py tests/test_promotion_governance_packet.py tests/test_runtime_coordinator.py -q` => `29 passed`.

## Why this PR intentionally does not close #165-#167
Live audit at 2026-04-25T17:47Z still shows architecture gaps that require follow-up/live rollout work:
- `/api/system.runtime_parity.state=legacy_reward_loop` and live feedback/task parity is not healthy yet (#165 remains open).
- Latest subagent result is blocked because no local executor is available (#166 remains open until a real executor exists, even though stale/result API truth is now reconciled by #173).
- `/api/system.material_progress.state=blocked`, `healthy_autonomy_allowed=false`, `proof_count=0` (#167 remains open until there is a current qualifying material improvement proof).

## CI note
A direct workflow edit was rejected because the available GitHub token lacks `workflow` scope. The CI gate was therefore implemented as a root-suite pytest file under `tests/`, which is covered by the existing workflow. GitHub Actions may still fail to start because the account is locked due to billing; previous check-run annotation: `The job was not started because your account is locked due to a billing issue.`
