### PR TITLE
fix: persist resolved runtime feedback decision

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2331,17 +2331,19 @@ async def run_self_evolving_cycle(
             feedback_decision=feedback_decision,
         ),
     )
-    effective_feedback_decision = current_plan.get("feedback_decision") if isinstance(current_plan.get("feedback_decision"), dict) else feedback_decision
+    current_plan_feedback_decision = current_plan.get("feedback_decision") if isinstance(current_plan.get("feedback_decision"), dict) else None
+    resolved_feedback_decision = current_plan_feedback_decision or (feedback_decision if isinstance(feedback_decision, dict) else None)
+    if resolved_feedback_decision is None and isinstance(recorded_task_plan, dict) and isinstance(recorded_task_plan.get("feedback_decision"), dict):
+        resolved_feedback_decision = recorded_task_plan.get("feedback_decision")
     effective_current_task_id = current_plan.get("current_task_id")
     experiment["current_task_id"] = effective_current_task_id
-    if effective_feedback_decision is not None:
-        experiment["feedback_decision"] = effective_feedback_decision
+    if resolved_feedback_decision is not None:
+        experiment["feedback_decision"] = resolved_feedback_decision
     experiment["reward_signal"] = current_plan.get("reward_signal") if isinstance(current_plan.get("reward_signal"), dict) else reward_signal
-    persisted_feedback_decision = effective_feedback_decision if isinstance(effective_feedback_decision, dict) else recorded_task_plan.get("feedback_decision") if isinstance(recorded_task_plan, dict) and isinstance(recorded_task_plan.get("feedback_decision"), dict) else None
-    if persisted_feedback_decision is not None:
-        current_plan["feedback_decision"] = persisted_feedback_decision
-        if not current_plan.get("materialized_improvement_artifact_path") and persisted_feedback_decision.get("artifact_path"):
-            current_plan["materialized_improvement_artifact_path"] = persisted_feedback_decision.get("artifact_path")
+    if resolved_feedback_decision is not None and not isinstance(current_plan_feedback_decision, dict):
+        current_plan["feedback_decision"] = resolved_feedback_decision
+        if not current_plan.get("materialized_improvement_artifact_path") and resolved_feedback_decision.get("artifact_path"):
+            current_plan["materialized_improvement_artifact_path"] = resolved_feedback_decision.get("artifact_path")
     artifact_paths = [str(report_path)] if execution_response and result_status == "PASS" else []
     if current_plan.get("materialized_improvement_artifact_path"):
         artifact_path = current_plan.get("materialized_improvement_artifact_path")
@@ -2487,7 +2489,7 @@ async def run_self_evolving_cycle(
         "next_hint": next_hint,
         "bounded_apply": bounded_apply,
         "promotion_execute": promotion_execute,
-        "feedback_decision": effective_feedback_decision,
+        "feedback_decision": resolved_feedback_decision,
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
         "experiment": experiment,
@@ -2505,7 +2507,7 @@ async def run_self_evolving_cycle(
         "summary": summary,
         "selected_tasks": selected_tasks,
         "task_selection_source": task_selection_source,
-        "feedback_decision": effective_feedback_decision,
+        "feedback_decision": resolved_feedback_decision,
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
         "experiment": experiment,
@@ -2564,7 +2566,7 @@ async def run_self_evolving_cycle(
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
         "experiment": experiment,
-        "feedback_decision": effective_feedback_decision,
+        "feedback_decision": resolved_feedback_decision,
         "goal": {
             "goal_id": active_goal,
             "text": active_goal,

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -364,6 +364,76 @@ def test_cycle_prefers_recorded_current_task_from_existing_plan(tmp_path):
     assert outbox["task_selection_source"] == "recorded_current_task"
 
 
+def test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifacts(tmp_path):
+    approvals_dir = tmp_path / "state" / "approvals"
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)
+    (approvals_dir / "apply.ok").write_text(
+        json.dumps({"expires_at_utc": expires_at.isoformat(), "ttl_minutes": 60}),
+        encoding="utf-8",
+    )
+
+    goals_dir = tmp_path / "state" / "goals"
+    goals_dir.mkdir(parents=True)
+    recorded_feedback_decision = {
+        "mode": "retire_terminal_selfevo_lane",
+        "reason": "latest self-evolution issue reached a terminal merged/closed or terminal no-op state; do not recreate analyze-last-failed-candidate",
+        "reward_value": 1.0,
+        "current_task_id": "analyze-last-failed-candidate",
+        "current_task_class": "other",
+        "selected_task_id": "record-reward",
+        "selected_task_class": "execution",
+        "selection_source": "feedback_terminal_selfevo_retire",
+        "selected_task_title": "Record cycle reward",
+        "selected_task_label": "Record cycle reward [task_id=record-reward]",
+        "terminal_selfevo_issue": {"terminal_status": "merged"},
+    }
+    (goals_dir / "current.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "task-plan-v1",
+                "current_task_id": "record-reward",
+                "tasks": [
+                    {"task_id": "analyze-last-failed-candidate", "title": "Analyze the last failed self-evolution candidate", "status": "done"},
+                    {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+                ],
+                "feedback_decision": recorded_feedback_decision,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    execute = AsyncMock(return_value="agent completed bounded work")
+
+    summary = asyncio.run(
+        run_self_evolving_cycle(
+            workspace=tmp_path,
+            tasks="check open tasks",
+            execute_turn=execute,
+            now=expires_at - timedelta(minutes=30),
+        )
+    )
+
+    execute.assert_awaited_once()
+    assert "PASS" in summary
+
+    runtime = load_runtime_state(tmp_path)
+    current = _read_json(goals_dir / "current.json")
+    outbox = _read_json(tmp_path / "state" / "outbox" / "latest.json")
+    experiment = _read_json(tmp_path / "state" / "experiments" / "latest.json")
+    report = _read_json(runtime["report_path"])
+    control_summary = _read_json(tmp_path / "state" / "control_plane" / "current_summary.json")
+
+    # Regression guard for #177: before the fix, the resolved decision from
+    # goals/current.json stayed there while the authoritative latest artifacts
+    # were republished with feedback_decision=null.
+    assert current["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
+    assert outbox["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
+    assert experiment["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
+    assert report["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
+    assert control_summary["task_plan"]["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
+
+
 def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):
     approvals_dir = tmp_path / "state" / "approvals"
     approvals_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Resolve feedback_decision from the post-plan current plan or recorded task plan before publishing runtime artifacts.
- Propagate the resolved decision consistently into experiment, outbox, report, and control-plane task plan surfaces.
- Add regression coverage for the #177 live failure shape where goals/current.json had a HADI feedback decision but latest runtime artifacts republished null.

## Verification
- python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py -q => 28 passed
- python3 -m pytest tests -q => 596 passed, 5 skipped
- Spec review subagent found initial test gaps; fixed by asserting control-plane summary and documenting the null-republish regression.
- Code-quality review subagent: APPROVED.

Fixes #177
Refs #165