### PR TITLE
fix: normalize retired lane current task truth

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -238,6 +238,15 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
     current_task_class = _task_action_class(current_task_id if isinstance(current_task_id, str) else None)
     tasks = task_plan.get("tasks") if isinstance(task_plan.get("tasks"), list) else []
     task_records = [task for task in tasks if isinstance(task, dict)]
+    recorded_feedback_decision = task_plan.get("feedback_decision") if isinstance(task_plan.get("feedback_decision"), dict) else None
+    if (
+        isinstance(recorded_feedback_decision, dict)
+        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane"}
+        and recorded_feedback_decision.get("current_task_id") == current_task_id
+        and recorded_feedback_decision.get("selected_task_id")
+        and recorded_feedback_decision.get("selected_task_id") != current_task_id
+    ):
+        return recorded_feedback_decision
 
     repeat_block_failure_class = None
     repeat_block_count = 0
@@ -2505,6 +2514,8 @@ async def run_self_evolving_cycle(
         "approval_gate": approval_gate,
         "next_hint": next_hint,
         "summary": summary,
+        "current_task_id": current_plan.get("current_task_id"),
+        "current_task": current_plan.get("current_task"),
         "selected_tasks": selected_tasks,
         "task_selection_source": task_selection_source,
         "feedback_decision": resolved_feedback_decision,
@@ -2562,6 +2573,10 @@ async def run_self_evolving_cycle(
         "ok": result_status != "ERROR",
         "source": str(report_path),
         "status": result_status,
+        "current_task_id": current_plan.get("current_task_id"),
+        "current_task": current_plan.get("current_task"),
+        "selected_tasks": selected_tasks,
+        "task_selection_source": task_selection_source,
         "improvement_score": current_plan.get("reward_signal", {}).get("value") if isinstance(current_plan.get("reward_signal"), dict) else reward_signal["value"],
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -392,10 +392,10 @@ def test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifac
         json.dumps(
             {
                 "schema_version": "task-plan-v1",
-                "current_task_id": "record-reward",
+                "current_task_id": "analyze-last-failed-candidate",
                 "tasks": [
-                    {"task_id": "analyze-last-failed-candidate", "title": "Analyze the last failed self-evolution candidate", "status": "done"},
-                    {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+                    {"task_id": "analyze-last-failed-candidate", "title": "Analyze the last failed self-evolution candidate", "status": "active"},
+                    {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
                 ],
                 "feedback_decision": recorded_feedback_decision,
             }
@@ -422,6 +422,7 @@ def test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifac
     outbox = _read_json(tmp_path / "state" / "outbox" / "latest.json")
     experiment = _read_json(tmp_path / "state" / "experiments" / "latest.json")
     report = _read_json(runtime["report_path"])
+    report_index = _read_json(tmp_path / "state" / "outbox" / "report.index.json")
     control_summary = _read_json(tmp_path / "state" / "control_plane" / "current_summary.json")
 
     # Regression guard for #177: before the fix, the resolved decision from
@@ -432,6 +433,23 @@ def test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifac
     assert experiment["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
     assert report["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
     assert control_summary["task_plan"]["feedback_decision"]["mode"] == "retire_terminal_selfevo_lane"
+
+    # Regression guard for #178: after a terminal self-evolution lane is retired,
+    # every current-task surface must point to the selected follow-up lane. The
+    # retired/pre-plan task is kept only as diagnostic feedback_decision context.
+    assert current["current_task_id"] == "record-reward"
+    assert outbox["current_task_id"] == "record-reward"
+    assert experiment["current_task_id"] == "record-reward"
+    assert report["current_task_id"] == "record-reward"
+    assert report_index["current_task_id"] == "record-reward"
+    assert control_summary["task_plan"]["current_task_id"] == "record-reward"
+    assert control_summary["task_boundary"]["task_id"] == "record-reward"
+    assert control_summary["experiment"]["current_task_id"] == "record-reward"
+    assert report["feedback_decision"]["current_task_id"] == "analyze-last-failed-candidate"
+    assert report["feedback_decision"]["selected_task_id"] == "record-reward"
+    assert outbox["selected_tasks"] == "Record cycle reward [task_id=record-reward]"
+    assert report["selected_tasks"] == "Record cycle reward [task_id=record-reward]"
+    assert report_index["selected_tasks"] == "Record cycle reward [task_id=record-reward]"
 
 
 def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):


### PR DESCRIPTION
## Summary
- preserves already-resolved terminal lane retirement feedback decisions instead of recomputing them as continue-active-lane
- publishes canonical current_task_id/current_task on outbox/latest and report.index surfaces
- strengthens the runtime coordinator regression so goals/current, outbox/latest, experiments/latest, report, report.index, and control_plane/current_summary all point to the selected follow-up task after terminal selfevo retirement

## Verification
- RED observed first: `python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifacts -q` failed because feedback_decision was recomputed as `continue_active_lane`
- GREEN focused: `python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifacts -q` => 1 passed
- Focused suite: `python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py tests/test_failure_learning_feedback.py tests/test_self_improvement_followthrough.py -q` => 33 passed
- Full root suite: `python3 -m pytest tests -q` => 596 passed, 5 skipped
- Review subagent: APPROVED

Fixes #178
Refs #165 #167
