### PR TITLE
fix: expose dashboard live proof pointers

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -505,6 +505,8 @@ def _control_plane_summary(repo_latest, eeepc_latest, current_experiment, curren
         governance_enforcement = {'state': 'pending', 'reason': 'completion_unverified'}
     else:
         governance_enforcement = {'state': 'open', 'reason': 'no_verified_terminal_completion'}
+    producer_task_truth = _task_plan_truth(producer_summary.get('task_plan') if isinstance(producer_summary, dict) else None)
+    producer_current_task = producer_task_truth.get('current_task')
     experiment_source = producer_summary.get('experiment') if isinstance(producer_summary, dict) and producer_summary.get('experiment') else current_experiment
     experiment_truth = _experiment_truth_summary(experiment_source)
     live_task = active_exec.get('live_task') if isinstance(active_exec, dict) and isinstance(active_exec.get('live_task'), dict) else {}
@@ -525,7 +527,7 @@ def _control_plane_summary(repo_latest, eeepc_latest, current_experiment, curren
         'eeepc_status': (eeepc_latest or {}).get('status'),
         'approval': approval,
         'current_blocker': None if ((isinstance(producer_summary.get('task_plan'), dict) and producer_summary.get('task_plan', {}).get('current_task')) or (repo_latest or {}).get('current_task')) else current_blocker,
-        'current_task': (producer_summary.get('task_plan') or {}).get('current_task') or (repo_latest or {}).get('current_task'),
+        'current_task': producer_current_task or (repo_latest or {}).get('current_task'),
         'producer_summary': producer_summary if isinstance(producer_summary, dict) else {},
         'blocker_summary': (producer_summary.get('blocker_summary') if isinstance(producer_summary, dict) else None) or {
             'schema_version': 'blocker-summary-v1',
@@ -733,6 +735,9 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             'blocked_result_count': blocked_count,
             'state': state,
         },
+        'latest_request': requests[0] if requests else ((rollup or {}).get('latest_request') if isinstance(rollup, dict) else None),
+        'latest_result': results[0] if results else ((rollup or {}).get('latest_result') if isinstance(rollup, dict) else None),
+        'latest_telemetry': (rollup or {}).get('latest_telemetry') if isinstance(rollup, dict) else None,
     }
 
 
@@ -2299,6 +2304,8 @@ def create_app(cfg: DashboardConfig):
                 'plan_history_count': len(plan_history),
                 'recent_plan_history': plan_history[:10],
                 'material_progress': material_progress,
+                'runtime_parity': runtime_parity,
+                'autonomy_verdict': autonomy_verdict,
             }
             body = json.dumps(payload, ensure_ascii=False, indent=2).encode('utf-8')
             start_response('200 OK', [('Content-Type', 'application/json; charset=utf-8')])
@@ -2319,6 +2326,8 @@ def create_app(cfg: DashboardConfig):
                 'credits': credits_visibility,
                 'empty_state_reason': experiment_visibility['empty_state_reason'],
                 'material_progress': _material_progress_summary(control_plane.get('material_progress') if isinstance(control_plane, dict) else None),
+                'runtime_parity': runtime_parity,
+                'autonomy_verdict': autonomy_verdict,
             }
             body = json.dumps(payload, ensure_ascii=False, indent=2).encode('utf-8')
             start_response('200 OK', [('Content-Type', 'application/json; charset=utf-8')])
@@ -2364,6 +2373,9 @@ def create_app(cfg: DashboardConfig):
         if path == '/api/subagents':
             payload = {
                 **subagent_visibility,
+                'latest_request': subagent_visibility.get('latest_request'),
+                'latest_result': subagent_visibility.get('latest_result'),
+                'latest_telemetry': subagent_latest_event or subagent_visibility.get('latest_telemetry'),
                 'events': subagent_events,
                 'summary': {
                     **subagent_visibility.get('summary', {}),

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -228,3 +228,116 @@ def test_api_system_canonicalizes_stale_outbox_current_blocker_task_truth(tmp_pa
     assert blocker['stale_outbox_task_selection_source'] == 'recorded_current_task'
     assert blocker['task_truth_source'] == 'producer_summary.task_plan'
     assert control['blocker_summary']['current_task_id'] == current_summary['blocker_summary']['current_task_id']
+
+
+def test_dashboard_apis_expose_canonical_live_proof_pointers(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'control_plane').mkdir(parents=True, exist_ok=True)
+    (state_root / 'subagents' / 'requests').mkdir(parents=True, exist_ok=True)
+    (state_root / 'subagents' / 'results').mkdir(parents=True, exist_ok=True)
+
+    current_summary = {
+        'task_plan': {
+            'current_task_id': 'record-reward',
+            'selected_tasks': 'Record cycle reward [task_id=record-reward]',
+            'task_selection_source': 'recorded_current_task',
+            'feedback_decision': {
+                'mode': 'force_remediation',
+                'selected_task_id': 'record-reward',
+                'selection_source': 'recorded_current_task',
+            },
+        },
+        'material_progress': {
+            'schema_version': 'material-progress-v1',
+            'state': 'blocked',
+            'available': True,
+            'healthy_autonomy_allowed': False,
+            'proof_count': 0,
+            'proofs': [],
+            'qualifying_proofs': [],
+            'blocking_reason': 'no_qualifying_material_progress',
+        },
+        'runtime_source': {'source': 'workspace_state'},
+    }
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps(current_summary), encoding='utf-8')
+    request_path = state_root / 'subagents' / 'requests' / 'req-1.json'
+    result_path = state_root / 'subagents' / 'results' / 'res-1.json'
+    request_path.write_text(json.dumps({
+        'task_id': 'record-reward',
+        'task_title': 'Record cycle reward',
+        'cycle_id': 'cycle-179',
+        'status': 'queued',
+        'source_artifact': 'workspace/state/reports/evolution-current.json',
+    }), encoding='utf-8')
+    result_path.write_text(json.dumps({
+        'task_id': 'record-reward',
+        'task_title': 'Record cycle reward',
+        'cycle_id': 'cycle-179',
+        'status': 'completed',
+        'summary': 'materialized proof pointer',
+        'request_path': str(request_path),
+    }), encoding='utf-8')
+
+    raw_plan = {
+        'current_plan': current_summary['task_plan'],
+        'material_progress': current_summary['material_progress'],
+        'outbox': {'status': 'PASS'},
+    }
+    for source in ('repo', 'eeepc'):
+        insert_collection(db, {
+            'collected_at': '2026-04-24T07:30:00Z',
+            'source': source,
+            'status': 'PASS',
+            'active_goal': 'goal-bootstrap',
+            'approval_gate': None,
+            'gate_state': None,
+            'report_source': '/workspace/state/reports/evolution-current.json',
+            'outbox_source': '/workspace/state/outbox/report.index.json',
+            'artifact_paths_json': '[]',
+            'promotion_summary': None,
+            'promotion_candidate_path': None,
+            'promotion_decision_record': None,
+            'promotion_accepted_record': None,
+            'raw_json': json.dumps(raw_plan),
+        })
+    upsert_event(db, {
+        'collected_at': '2026-04-24T07:31:00Z',
+        'source': 'repo',
+        'event_type': 'subagent',
+        'identity_key': 'subagent-cycle-179',
+        'title': 'record-reward',
+        'status': 'PASS',
+        'detail_json': json.dumps({'cycle_id': 'cycle-179', 'report_path': str(result_path), 'origin': {'channel': 'runtime'}}),
+    })
+
+    cfg = DashboardConfig(
+        project_root=project_root,
+        nanobot_repo_root=repo_root,
+        db_path=db,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root='/state',
+    )
+    app = create_app(cfg)
+
+    system = _call_json(app, '/api/system')
+    assert system['control_plane']['current_task'] == 'record-reward'
+
+    plan = _call_json(app, '/api/plan')
+    assert plan['runtime_parity']['schema_version'] == 'runtime-parity-v1'
+    assert plan['autonomy_verdict']['schema_version'] == 'autonomy-verdict-v1'
+    assert plan['material_progress']['schema_version'] == 'material-progress-v1'
+
+    experiments = _call_json(app, '/api/experiments')
+    assert experiments['runtime_parity']['schema_version'] == 'runtime-parity-v1'
+    assert experiments['autonomy_verdict']['schema_version'] == 'autonomy-verdict-v1'
+    assert experiments['material_progress']['schema_version'] == 'material-progress-v1'
+
+    subagents = _call_json(app, '/api/subagents')
+    assert subagents['latest_request']['task_id'] == 'record-reward'
+    assert subagents['latest_result']['task_id'] == 'record-reward'
+    assert subagents['latest_telemetry']['title'] == 'record-reward'


### PR DESCRIPTION
## Summary
- adds canonical top-level runtime proof pointers to `/api/plan` and `/api/experiments`
- exposes `/api/subagents.latest_request`, `.latest_result`, and `.latest_telemetry` as first-class live proof pointers
- makes `/api/system.control_plane.current_task` fall back to `current_task_id` while preserving the existing current_blocker stale-outbox regression behavior

## TDD / Verification
- RED observed first: `python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_dashboard_apis_expose_canonical_live_proof_pointers -q` failed because `/api/system.control_plane.current_task` was `None` when only `current_task_id` existed
- GREEN focused: `python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_dashboard_apis_expose_canonical_live_proof_pointers -q` => 1 passed
- Dashboard focused: `python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py ops/dashboard/tests/test_app.py -q` => 17 passed
- Dashboard suite: `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q` => 63 passed
- Root suite: `python3 -m pytest tests -q` => 596 passed, 5 skipped
- Review subagent: APPROVED

Fixes #179
Refs #165 #166 #167 #180 #183
