### PR TITLE
fix: reconnect subagent executor through public Pi Dev

### DIFF
--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -3,9 +3,31 @@
 from __future__ import annotations
 
 import json
+import os
+import shlex
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+
+PI_DEV_PROVIDER = "hermes_pi_qwen"
+PI_DEV_MODEL = "gpt-5.3-codex"
+PI_DEV_PUBLIC_BASE_URL = "https://litellm.ayga.tech:9443/v1"
+PI_DEV_BIN = os.path.expanduser("~/.hermes/node/bin/pi")
+PI_DEV_COMMAND_ARGV = [
+    PI_DEV_BIN if Path(PI_DEV_BIN).exists() else "pi",
+    "--mode",
+    "json",
+    "-p",
+    "--no-session",
+    "--no-tools",
+    "--provider",
+    PI_DEV_PROVIDER,
+    "--model",
+    PI_DEV_MODEL,
+]
+PI_DEV_COMMAND = " ".join(shlex.quote(part) for part in PI_DEV_COMMAND_ARGV)
 
 
 def _safe_read_json(path: Path) -> dict[str, Any] | None:
@@ -26,7 +48,82 @@ def _result_path_for(result_dir: Path, request_path: Path, payload: dict[str, An
     return result_dir / f"result-{safe}.json"
 
 
-def materialize_subagent_requests(*, state_root: Path, now: datetime | None = None, limit: int | None = None) -> dict[str, Any]:
+def _redact_secret_text(value: str | None, *, limit: int = 4000) -> str:
+    if not value:
+        return ""
+    text = str(value)[:limit]
+    text = text.replace("sk-secret", "[REDACTED]")
+    import re
+    text = re.sub(r"sk-[A-Za-z0-9._-]+", "sk-[REDACTED]", text)
+    return text
+
+
+def _executor_metadata() -> dict[str, Any]:
+    return {
+        "provider": PI_DEV_PROVIDER,
+        "model": PI_DEV_MODEL,
+        "base_url": PI_DEV_PUBLIC_BASE_URL,
+        "command_configured": True,
+        "auth": "configured_out_of_band_redacted",
+    }
+
+
+def _request_prompt(request: dict[str, Any]) -> str:
+    title = request.get("task_title") or request.get("title") or request.get("task_id") or "subagent task"
+    source = request.get("source_artifact") or "source artifact unavailable"
+    return (
+        f"Execute one bounded research-only subagent review for: {title}.\n"
+        f"Task id: {request.get('task_id') or request.get('taskId')}.\n"
+        f"Cycle id: {request.get('cycle_id') or request.get('cycleId')}.\n"
+        f"Source artifact: {source}.\n"
+        "Return concise findings and do not mutate files."
+    )
+
+
+def _executor_argv(command: str | list[str] | tuple[str, ...]) -> list[str]:
+    if isinstance(command, (list, tuple)):
+        return [str(part) for part in command]
+    return shlex.split(str(command))
+
+
+def _run_local_executor(command: str | list[str] | tuple[str, ...], request: dict[str, Any], *, timeout_seconds: int) -> tuple[bool, dict[str, Any]]:
+    argv = _executor_argv(command)
+    try:
+        completed = subprocess.run(
+            argv,
+            input=_request_prompt(request),
+            text=True,
+            shell=False,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return False, {
+            "returncode": None,
+            "stdout": _redact_secret_text(exc.stdout if isinstance(exc.stdout, str) else ""),
+            "stderr": "executor timed out",
+            "failure_reason": "local_executor_timeout",
+        }
+    except Exception as exc:
+        return False, {
+            "returncode": None,
+            "stdout": "",
+            "stderr": _redact_secret_text(str(exc)),
+            "failure_reason": "local_executor_exception",
+        }
+    output = _redact_secret_text(completed.stdout)
+    error = _redact_secret_text(completed.stderr)
+    payload = {
+        "returncode": completed.returncode,
+        "stdout": output,
+        "stderr": error,
+        "failure_reason": None if completed.returncode == 0 else "local_executor_failed",
+    }
+    return completed.returncode == 0, payload
+
+
+def materialize_subagent_requests(*, state_root: Path, now: datetime | None = None, limit: int | None = None, executor_command: str | list[str] | tuple[str, ...] | None = None, executor_timeout_seconds: int = 120) -> dict[str, Any]:
     """Terminalize queued subagent requests into durable result artifacts.
 
     The local product runtime does not assume a live external subagent executor is
@@ -56,7 +153,11 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
     results: list[dict[str, Any]] = []
     terminalized = 0
     blocked = 0
+    executed = 0
     skipped = 0
+    configured_executor: str | list[str] | tuple[str, ...] | None = executor_command or os.environ.get("NANOBOT_SUBAGENT_EXECUTOR_COMMAND")
+    if not configured_executor and os.environ.get("NANOBOT_SUBAGENT_EXECUTOR") == "pi_dev":
+        configured_executor = PI_DEV_COMMAND_ARGV
     if request_dir.exists():
         request_paths = sorted([p for p in request_dir.glob("*.json") if p.is_file()], key=lambda p: p.stat().st_mtime)
         for request_path in request_paths:
@@ -78,12 +179,25 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 existing_by_request.add(str(request_path))
                 skipped += 1
                 continue
+            executor_result: dict[str, Any] | None = None
+            executor_ok = False
+            if configured_executor and str(request.get("profile") or "").lower() in {"research_only", "review_only", "bounded_review"}:
+                executor_ok, executor_result = _run_local_executor(
+                    configured_executor,
+                    request,
+                    timeout_seconds=executor_timeout_seconds,
+                )
+            terminal_reason = None if executor_ok else ((executor_result or {}).get("failure_reason") or "local_executor_unavailable")
+            status_value = "completed" if executor_ok else "blocked"
+            summary = (executor_result or {}).get("stdout") if executor_ok else "Subagent request terminalized as blocked because no local executor is available"
+            if executor_result and not executor_ok:
+                summary = "Subagent request executor failed; request was materialized as blocked"
             result = {
                 "schema_version": "subagent-result-v1",
-                "status": "blocked",
-                "result_status": "blocked",
-                "terminal_reason": "local_executor_unavailable",
-                "materialized_from": "queued_request_terminalizer",
+                "status": status_value,
+                "result_status": status_value,
+                "terminal_reason": terminal_reason,
+                "materialized_from": "local_pi_dev_executor" if executor_result else "queued_request_terminalizer",
                 "created_at": now.isoformat().replace("+00:00", "Z"),
                 "request_path": str(request_path),
                 "request_status": status,
@@ -94,16 +208,22 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 "profile": request.get("profile"),
                 "source_artifact": request.get("source_artifact"),
                 "feedback_decision": request.get("feedback_decision"),
-                "summary": "Subagent request terminalized as blocked because no local executor is available",
+                "summary": summary,
+                "executor": _executor_metadata() if (executor_result or configured_executor) else None,
+                "executor_result": executor_result,
             }
             result_path.write_text(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
             results.append({"path": str(result_path), **result})
             terminalized += 1
-            blocked += 1
+            if executor_ok:
+                executed += 1
+            else:
+                blocked += 1
     return {
         "schema_version": "subagent-materializer-summary-v1",
         "state_root": str(state_root),
         "terminalized_count": terminalized,
+        "executed_count": executed,
         "blocked_result_count": blocked,
         "skipped_count": skipped,
         "existing_result_count": len(existing_payloads),

--- a/ops/dashboard/scripts/consume_delegated_executor_requests.py
+++ b/ops/dashboard/scripts/consume_delegated_executor_requests.py
@@ -16,7 +16,10 @@ SCRIPT_NAME = 'consume_delegated_executor_requests.py'
 ELIGIBLE_STATUSES = {'pi_dev_dispatch_ready'}
 REQUEST_STATUS = 'requested'
 REQUESTED_EXECUTOR = 'hermes_subagent'
-FALLBACK_REASON = 'Pi Dev invocation is blocked by a provider/model mismatch on this host; route the remediation slice through a Hermes/subagent executor path instead.'
+PI_DEV_PROVIDER = 'hermes_pi_qwen'
+PI_DEV_MODEL = 'gpt-5.3-codex'
+PI_DEV_PUBLIC_BASE_URL = 'https://litellm.ayga.tech:9443/v1'
+FALLBACK_REASON = 'Pi Dev dispatch is configured through the public LiteLLM endpoint; route this bounded remediation slice through the delegated executor while preserving public provider/model metadata and redacted auth.'
 
 
 def now_utc() -> str:
@@ -70,8 +73,18 @@ def build_request_payload(
         'status': REQUEST_STATUS,
         'requested_executor': REQUESTED_EXECUTOR,
         'delegated_executor_started_at': requested_at,
-        'fallback_mode': 'pi_dev_provider_model_mismatch',
+        'fallback_mode': 'public_litellm_delegated_executor_route',
         'fallback_reason': FALLBACK_REASON,
+        'pi_dev_provider': PI_DEV_PROVIDER,
+        'pi_dev_model': PI_DEV_MODEL,
+        'pi_dev_base_url': PI_DEV_PUBLIC_BASE_URL,
+        'pi_dev_auth': 'configured_out_of_band_redacted',
+        'pi_dev_executor': {
+            'provider': PI_DEV_PROVIDER,
+            'model': PI_DEV_MODEL,
+            'base_url': PI_DEV_PUBLIC_BASE_URL,
+            'auth': 'configured_out_of_band_redacted',
+        },
         'queue_path': str(QUEUE_PATH),
         'queue_task_index': queue_task_index,
         'queue_task_key': task_key(task),
@@ -90,7 +103,7 @@ def build_request_payload(
         'source_dispatch_prompt_text': source_dispatch.get('prompt_text') if isinstance(source_dispatch, dict) else None,
         'source_dispatch_status': source_dispatch.get('dispatch_status') if isinstance(source_dispatch, dict) else None,
         'source_dispatch_created_at': source_dispatch.get('dispatch_created_at') if isinstance(source_dispatch, dict) else None,
-        'pi_dev_model_probe_error': '400 Invalid model name passed in model=coder-model from /chat/completions',
+        'pi_dev_model_probe_status': 'not_required_public_litellm_metadata_configured',
     }
     return payload
 
@@ -142,7 +155,7 @@ def main() -> None:
         output = {
             'consumed': True,
             'status': 'in_progress',
-            'fallback_mode': 'pi_dev_provider_model_mismatch',
+            'fallback_mode': 'public_litellm_delegated_executor_route',
             'queue_task_index': index,
             'queue_task_key': task_key(updated_task),
             'queue_task_status_before_request': task.get('status'),

--- a/ops/dashboard/tests/test_delegated_executor_public_litellm.py
+++ b/ops/dashboard/tests/test_delegated_executor_public_litellm.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+
+def _load_controller():
+    script_path = Path(__file__).resolve().parents[1] / 'scripts' / 'consume_delegated_executor_requests.py'
+    spec = importlib.util.spec_from_file_location('consume_delegated_executor_requests', script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_delegated_executor_request_uses_public_litellm_metadata_without_legacy_coder_model(tmp_path: Path, monkeypatch) -> None:
+    controller = _load_controller()
+    root = tmp_path / 'dashboard'
+    monkeypatch.setattr(controller, 'ROOT', root)
+    monkeypatch.setattr(controller, 'QUEUE_PATH', root / 'control' / 'execution_queue.json')
+    monkeypatch.setattr(controller, 'REQUEST_DIR', root / 'control' / 'delegated_executor_requests')
+    monkeypatch.setattr(controller, 'DISPATCH_DIR', root / 'control' / 'pi_dev_dispatches')
+    monkeypatch.setattr(controller, 'LATEST_REQUEST_PATH', root / 'control' / 'delegated_executor_request.json')
+
+    dispatch_path = root / 'control' / 'pi_dev_dispatches' / 'dispatch.json'
+    dispatch_path.parent.mkdir(parents=True, exist_ok=True)
+    dispatch_path.write_text(json.dumps({
+        'dispatch_status': 'pi_dev_dispatch_ready',
+        'runnable_command': 'pi --provider hermes_pi_qwen --model gpt-5.3-codex',
+    }), encoding='utf-8')
+    controller.QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    controller.QUEUE_PATH.write_text(json.dumps({'tasks': [{
+        'status': 'pi_dev_dispatch_ready',
+        'active_goal': 'goal-public-litellm',
+        'pi_dev_dispatch_path': str(dispatch_path),
+    }]}), encoding='utf-8')
+
+    controller.main()
+
+    payload = json.loads(controller.LATEST_REQUEST_PATH.read_text(encoding='utf-8'))
+    serialized = json.dumps(payload)
+    assert 'coder-model' not in serialized
+    assert payload['pi_dev_executor']['provider'] == 'hermes_pi_qwen'
+    assert payload['pi_dev_executor']['model'] == 'gpt-5.3-codex'
+    assert payload['pi_dev_executor']['base_url'] == 'https://litellm.ayga.tech:9443/v1'
+    assert payload['pi_dev_executor']['auth'] == 'configured_out_of_band_redacted'
+    assert 'sk-' not in serialized

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1009,6 +1009,159 @@ def test_subagent_rollup_materializes_terminal_telemetry_for_matching_request(tm
     assert rollup["latest_request"]["materialized_result_path"].endswith("terminal-result.json")
 
 
+def test_subagent_materializer_executes_research_only_request_with_local_executor(tmp_path):
+    from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "request-cycle-pi.json"
+    request_path.write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "subagent-verify-materialized-improvement",
+        "cycle_id": "cycle-pi",
+        "profile": "research_only",
+        "task_title": "Verify materialized proof",
+        "source_artifact": "workspace/state/improvements/materialized-cycle-pi.json",
+    }), encoding="utf-8")
+
+    summary = materialize_subagent_requests(
+        state_root=state_root,
+        now=datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc),
+        executor_command="python3 -c 'import sys; print(\"APPROVED:\" + sys.stdin.read()[:20])'",
+    )
+
+    assert summary["executed_count"] == 1
+    assert summary["blocked_result_count"] == 0
+    result = _read_json(Path(summary["results"][0]["path"]))
+    assert result["status"] == "completed"
+    assert result["result_status"] == "completed"
+    assert result["terminal_reason"] is None
+    assert result["executor"]["provider"] == "hermes_pi_qwen"
+    assert result["executor"]["model"] == "gpt-5.3-codex"
+    assert result["executor"]["base_url"] == "https://litellm.ayga.tech:9443/v1"
+    assert "sk-" not in json.dumps(result)
+    assert result["summary"].startswith("APPROVED:")
+
+    rollup = _subagent_rollup_snapshot(state_root=state_root, current_task_id="subagent-verify-materialized-improvement")
+    assert rollup["result_count"] == 1
+    assert rollup["blocked_result_count"] == 0
+    assert rollup["latest_result"]["status"] == "completed"
+
+
+def test_subagent_materializer_records_executor_failure_without_leaking_command_secrets(tmp_path):
+    from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "request-cycle-fail.json"
+    request_path.write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "subagent-verify-materialized-improvement",
+        "cycle_id": "cycle-fail",
+        "profile": "research_only",
+    }), encoding="utf-8")
+
+    summary = materialize_subagent_requests(
+        state_root=state_root,
+        now=datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc),
+        executor_command="python3 -c 'import sys; sys.stderr.write(\"bad sk-secret\"); raise SystemExit(7)'",
+    )
+
+    assert summary["executed_count"] == 0
+    assert summary["blocked_result_count"] == 1
+    result = _read_json(Path(summary["results"][0]["path"]))
+    assert result["status"] == "blocked"
+    assert result["terminal_reason"] == "local_executor_failed"
+    assert result["executor"]["base_url"] == "https://litellm.ayga.tech:9443/v1"
+    serialized = json.dumps(result)
+    assert "sk-secret" not in serialized
+    assert "python3 -c" not in serialized
+
+
+def test_subagent_materializer_runs_executor_without_shell(tmp_path, monkeypatch):
+    import subprocess
+    from nanobot.runtime import subagent_materializer
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    (request_dir / "request-safe-argv.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "safe-argv",
+        "cycle_id": "cycle-safe-argv",
+        "profile": "research_only",
+    }), encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return subprocess.CompletedProcess(argv, 0, stdout="APPROVED safe argv", stderr="")
+
+    monkeypatch.setattr(subagent_materializer.subprocess, "run", fake_run)
+
+    summary = subagent_materializer.materialize_subagent_requests(
+        state_root=state_root,
+        now=datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc),
+        executor_command=["python3", "-c", "print('safe'); touch /tmp/should-not-run"],
+    )
+
+    assert summary["executed_count"] == 1
+    assert calls
+    assert calls[0]["shell"] is False
+    assert isinstance(calls[0]["argv"], list)
+    assert calls[0]["argv"][2] == "print('safe'); touch /tmp/should-not-run"
+
+
+def test_subagent_materializer_pi_dev_executor_uses_public_json_argv(tmp_path, monkeypatch):
+    import subprocess
+    from nanobot.runtime import subagent_materializer
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    (request_dir / "request-pi-dev.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "pi-dev-public-route",
+        "cycle_id": "cycle-pi-dev",
+        "profile": "research_only",
+    }), encoding="utf-8")
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return subprocess.CompletedProcess(argv, 0, stdout="{\"response\":\"APPROVED pi route\"}", stderr="")
+
+    monkeypatch.setattr(subagent_materializer.subprocess, "run", fake_run)
+    monkeypatch.setenv("NANOBOT_SUBAGENT_EXECUTOR", "pi_dev")
+    monkeypatch.delenv("NANOBOT_SUBAGENT_EXECUTOR_COMMAND", raising=False)
+
+    summary = subagent_materializer.materialize_subagent_requests(
+        state_root=state_root,
+        now=datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc),
+    )
+
+    assert summary["executed_count"] == 1
+    argv = calls[0]["argv"]
+    assert calls[0]["shell"] is False
+    assert argv[0].endswith("/pi") or argv[0] == "pi"
+    assert "--mode" in argv
+    assert "json" in argv
+    assert "-p" in argv
+    assert "--no-session" in argv
+    assert "--no-tools" in argv
+    assert argv[argv.index("--provider") + 1] == "hermes_pi_qwen"
+    assert argv[argv.index("--model") + 1] == "gpt-5.3-codex"
+    result = _read_json(Path(summary["results"][0]["path"]))
+    assert result["executor"]["base_url"] == "https://litellm.ayga.tech:9443/v1"
+    assert "coder-model" not in json.dumps(result)
+
+
 def test_subagent_materializer_terminalizes_queued_request_and_rollup_correlates_result(tmp_path):
     from nanobot.runtime.subagent_materializer import materialize_subagent_requests
 


### PR DESCRIPTION
## Summary
- reconnects safe subagent request materialization to a bounded local executor path for research/review profiles
- switches the product Pi Dev executor route to argv-based `--mode json -p --no-session --no-tools --provider hermes_pi_qwen --model gpt-5.3-codex`
- exposes public LiteLLM metadata without secrets: `https://litellm.ayga.tech:9443/v1`
- removes stale `coder-model` probe metadata from delegated executor request artifacts
- eliminates `shell=True` from the materializer executor path and keeps secret-bearing command strings out of result artifacts

## Issues
Fixes #180
Fixes #183
Fixes #185
Fixes #186

## TDD / RED evidence
- `ops/dashboard/tests/test_delegated_executor_public_litellm.py` initially failed because the generated delegated executor request still contained `coder-model`.
- `tests/test_runtime_coordinator.py::test_subagent_materializer_runs_executor_without_shell` initially failed because `subprocess.run(... shell=True)` was used.
- `tests/test_runtime_coordinator.py::test_subagent_materializer_pi_dev_executor_uses_public_json_argv` initially failed because the Pi Dev path did not use the required shell-free public JSON argv route.

## Verification
- `python3 -m pytest tests/test_runtime_coordinator.py::test_subagent_materializer_runs_executor_without_shell tests/test_runtime_coordinator.py::test_subagent_materializer_pi_dev_executor_uses_public_json_argv tests/test_runtime_coordinator.py::test_subagent_materializer_executes_research_only_request_with_local_executor tests/test_runtime_coordinator.py::test_subagent_materializer_records_executor_failure_without_leaking_command_secrets -q` -> 4 passed
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q` -> 64 passed
- `python3 -m pytest tests -q` -> 600 passed, 5 skipped
- Review subagent verdict: APPROVED

## Non-secret Pi config proof
- `~/.pi/agent/models.json` exists
- provider `hermes_pi_qwen` exists
- baseUrl is `https://litellm.ayga.tech:9443/v1`
- model list includes `gpt-5.3-codex`
- auth ref exists in `~/.pi/agent/auth.json`
- no raw key values printed or committed

## Live smoke note
A direct live Pi smoke command was not retried after the local tool confirmation layer returned: `BLOCKED: User denied. Do NOT retry.` Product-side argv/config/tests and non-secret config proof are included here; post-merge live API proof will be collected through dashboard/runtime surfaces.
