### PR TITLE
fix: reconcile plan task identity with runtime canonical task

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2359,8 +2359,24 @@ def create_app(cfg: DashboardConfig):
             task_truth = _task_plan_truth(producer_plan)
             canonical_current_task_id = task_truth.get('current_task_id') or (plan_latest.get('current_task_id') if plan_latest else None)
             canonical_current_task = (_first_present(producer_plan, ('current_task', 'currentTask')) if isinstance(producer_plan, dict) else None) or (plan_latest.get('current_task') if plan_latest and plan_latest.get('current_task') else task_truth.get('current_task'))
+            runtime_canonical_task_id = runtime_parity.get('canonical_current_task_id') if isinstance(runtime_parity, dict) else None
+            runtime_reasons = runtime_parity.get('reasons') if isinstance(runtime_parity, dict) and isinstance(runtime_parity.get('reasons'), list) else []
+            if (
+                _has_value(runtime_canonical_task_id)
+                and runtime_canonical_task_id != canonical_current_task_id
+                and 'current_task_drift' not in runtime_reasons
+                and 'legacy_live_reward_loop_current_task' in runtime_reasons
+                and (
+                    runtime_canonical_task_id in str(canonical_current_task or '')
+                    or runtime_canonical_task_id == _selected_task_id(task_truth.get('selected_tasks'))
+                )
+            ):
+                canonical_current_task_id = runtime_canonical_task_id
             canonical_task_plan = dict(task_truth['task_plan'])
-            if _has_value(canonical_current_task_id) and not _has_value(canonical_task_plan.get('current_task_id')):
+            if _has_value(canonical_current_task_id) and (
+                not _has_value(canonical_task_plan.get('current_task_id'))
+                or canonical_current_task_id == _selected_task_id(canonical_task_plan.get('selected_tasks'))
+            ):
                 canonical_task_plan['current_task_id'] = canonical_current_task_id
             if _has_value(canonical_current_task) and not _has_value(canonical_task_plan.get('current_task')):
                 canonical_task_plan['current_task'] = canonical_current_task

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -421,6 +421,74 @@ def test_api_plan_prefers_canonical_task_plan_truth_over_latest_snapshot_current
     assert plan['task_plan']['selected_tasks'] == 'Analyze the last failed self-evolution candidate [task_id=analyze-last-failed-candidate]'
 
 
+def test_api_plan_reconciles_mixed_task_plan_id_with_runtime_canonical_task(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'control_plane').mkdir(parents=True, exist_ok=True)
+
+    mixed_task_plan = {
+        'current_task_id': 'record-reward',
+        'current_task': 'analyze-last-failed-candidate',
+        'selected_tasks': 'Analyze the last failed self-evolution candidate [task_id=analyze-last-failed-candidate]',
+        'task_selection_source': 'recorded_current_task',
+    }
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({
+        'task_plan': mixed_task_plan,
+        'runtime_source': {'source': 'workspace_state'},
+    }), encoding='utf-8')
+
+    repo_raw = {
+        'current_plan': {
+            'current_task_id': 'analyze-last-failed-candidate',
+            'current_task': 'analyze-last-failed-candidate',
+            'selected_tasks': 'Analyze the last failed self-evolution candidate [task_id=analyze-last-failed-candidate]',
+            'task_selection_source': 'generated_from_failure_learning',
+            'feedback_decision': {'mode': 'handoff_to_next_candidate'},
+        },
+        'outbox': {'status': 'PASS'},
+    }
+    live_raw = {
+        'current_plan': {
+            'current_task_id': 'record-reward',
+            'current_task': 'Record cycle reward',
+            'selected_tasks': 'Record cycle reward [task_id=record-reward]',
+            'task_selection_source': 'recorded_current_task',
+        },
+        'outbox': {'status': 'PASS'},
+    }
+    for source, raw in (('repo', repo_raw), ('eeepc', live_raw)):
+        insert_collection(db, {
+            'collected_at': '2026-04-24T07:30:00Z',
+            'source': source,
+            'status': 'PASS',
+            'active_goal': 'goal-bootstrap',
+            'approval_gate': None,
+            'gate_state': None,
+            'report_source': '/workspace/state/reports/evolution-current.json',
+            'outbox_source': '/workspace/state/outbox/report.index.json',
+            'artifact_paths_json': '[]',
+            'promotion_summary': None,
+            'promotion_candidate_path': None,
+            'promotion_decision_record': None,
+            'promotion_accepted_record': None,
+            'raw_json': json.dumps(raw),
+        })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+    app = create_app(cfg)
+
+    system = _call_json(app, '/api/system')
+    plan = _call_json(app, '/api/plan')
+
+    assert system['runtime_parity']['canonical_current_task_id'] == 'analyze-last-failed-candidate'
+    assert plan['current_task_id'] == 'analyze-last-failed-candidate'
+    assert plan['task_plan']['current_task_id'] == 'analyze-last-failed-candidate'
+    assert plan['current_task'] == 'analyze-last-failed-candidate'
+    assert plan['task_plan']['current_task'] == 'analyze-last-failed-candidate'
+
+
 def test_dashboard_apis_expose_canonical_live_proof_pointers(tmp_path: Path) -> None:
     project_root = tmp_path / 'dashboard'
     repo_root = tmp_path / 'nanobot'


### PR DESCRIPTION
## Summary
- reconcile mixed `/api/plan` task id/title authority using classified runtime canonical task evidence
- keep top-level and nested `/api/plan` current task ids equal after normalization
- preserve runtime parity raw evidence for stale live `record-reward`

## Issues
Fixes #196

Related:
- #188
- #189
- #190
- #191
- #193
- #194

## Test plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_api_plan_reconciles_mixed_task_plan_id_with_runtime_canonical_task -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

## Review
- Delegated review: APPROVED.
