### PR TITLE
fix: force nested plan task id after runtime reconciliation

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2361,6 +2361,7 @@ def create_app(cfg: DashboardConfig):
             canonical_current_task = (_first_present(producer_plan, ('current_task', 'currentTask')) if isinstance(producer_plan, dict) else None) or (plan_latest.get('current_task') if plan_latest and plan_latest.get('current_task') else task_truth.get('current_task'))
             runtime_canonical_task_id = runtime_parity.get('canonical_current_task_id') if isinstance(runtime_parity, dict) else None
             runtime_reasons = runtime_parity.get('reasons') if isinstance(runtime_parity, dict) and isinstance(runtime_parity.get('reasons'), list) else []
+            runtime_reconciled_current_task_id = False
             if (
                 _has_value(runtime_canonical_task_id)
                 and runtime_canonical_task_id != canonical_current_task_id
@@ -2372,9 +2373,11 @@ def create_app(cfg: DashboardConfig):
                 )
             ):
                 canonical_current_task_id = runtime_canonical_task_id
+                runtime_reconciled_current_task_id = True
             canonical_task_plan = dict(task_truth['task_plan'])
             if _has_value(canonical_current_task_id) and (
                 not _has_value(canonical_task_plan.get('current_task_id'))
+                or runtime_reconciled_current_task_id
                 or canonical_current_task_id == _selected_task_id(canonical_task_plan.get('selected_tasks'))
             ):
                 canonical_task_plan['current_task_id'] = canonical_current_task_id

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -432,7 +432,7 @@ def test_api_plan_reconciles_mixed_task_plan_id_with_runtime_canonical_task(tmp_
     mixed_task_plan = {
         'current_task_id': 'record-reward',
         'current_task': 'analyze-last-failed-candidate',
-        'selected_tasks': 'Analyze the last failed self-evolution candidate [task_id=analyze-last-failed-candidate]',
+        'selected_tasks': 'Record cycle reward [task_id=record-reward]',
         'task_selection_source': 'recorded_current_task',
     }
     (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({


### PR DESCRIPTION
## Summary
- track when `/api/plan.current_task_id` is reconciled from runtime canonical evidence
- force nested `/api/plan.task_plan.current_task_id` to the same canonical id in that path
- strengthen regression so stale nested selected task metadata would otherwise keep `record-reward`

## Issues
Fixes #198

Related:
- #188
- #189
- #190
- #191
- #193
- #194
- #196

## Test plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_api_plan_reconciles_mixed_task_plan_id_with_runtime_canonical_task -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

## Review
- Delegated review: APPROVED.
