### PR TITLE
fix: reconcile plan task text with runtime canonical task

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2366,13 +2366,14 @@ def create_app(cfg: DashboardConfig):
                 _has_value(runtime_canonical_task_id)
                 and runtime_canonical_task_id != canonical_current_task_id
                 and 'current_task_drift' not in runtime_reasons
-                and 'legacy_live_reward_loop_current_task' in runtime_reasons
                 and (
-                    runtime_canonical_task_id in str(canonical_current_task or '')
+                    'legacy_live_reward_loop_current_task' in runtime_reasons
+                    or runtime_canonical_task_id in str(canonical_current_task or '')
                     or runtime_canonical_task_id == _selected_task_id(task_truth.get('selected_tasks'))
                 )
             ):
                 canonical_current_task_id = runtime_canonical_task_id
+                canonical_current_task = runtime_canonical_task_id
                 runtime_reconciled_current_task_id = True
             canonical_task_plan = dict(task_truth['task_plan'])
             if _has_value(canonical_current_task_id) and (
@@ -2381,7 +2382,10 @@ def create_app(cfg: DashboardConfig):
                 or canonical_current_task_id == _selected_task_id(canonical_task_plan.get('selected_tasks'))
             ):
                 canonical_task_plan['current_task_id'] = canonical_current_task_id
-            if _has_value(canonical_current_task) and not _has_value(canonical_task_plan.get('current_task')):
+            if _has_value(canonical_current_task) and (
+                not _has_value(canonical_task_plan.get('current_task'))
+                or runtime_reconciled_current_task_id
+            ):
                 canonical_task_plan['current_task'] = canonical_current_task
             if plan_latest:
                 for source_key, target_key in (


### PR DESCRIPTION
## Summary
- reconcile stale `/api/plan.current_task` text when runtime canonical task evidence selects a different task id
- force nested `task_plan.current_task` together with `task_plan.current_task_id` after runtime reconciliation
- strengthen regression so task id, title, and selected task metadata are all stale `record-reward` before reconciliation

## Chat-visible error analysis
- Duplicate patch patterns/stale-file warnings were from non-unique `old_string` matches; fix was continued with targeted context and test verification.
- Live API did respond after #199, but proof showed ids were canonical while text stayed stale: `current_task=record-reward` with `current_task_id=analyze-last-failed-candidate`.
- Focused #200 regression reproduced the root cause: runtime reconciliation required canonical id to already appear in task text/selected_tasks, so fully stale text prevented reconciliation.

## Issues
Fixes #200

Related:
- #188
- #189
- #190
- #191
- #193
- #194
- #196
- #198

## Test plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_api_plan_reconciles_mixed_task_plan_id_with_runtime_canonical_task -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

## Review
- Delegated review: APPROVED.
