### PR TITLE
feat: expose next task separately in plan api

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2397,14 +2397,25 @@ def create_app(cfg: DashboardConfig):
                     value = plan_latest.get(source_key)
                     if _has_value(value) and value != 'unknown':
                         canonical_task_plan.setdefault(target_key, value)
+            feedback_decision = (plan_latest['feedback_decision'] if plan_latest and plan_latest.get('feedback_decision') else producer_plan.get('feedback_decision'))
+            if not isinstance(feedback_decision, dict):
+                feedback_decision = {}
+            next_task_id = feedback_decision.get('selected_task_id') or feedback_decision.get('selectedTaskId')
+            next_task_title = feedback_decision.get('selected_task_title') or feedback_decision.get('selectedTaskTitle')
+            next_task_label = feedback_decision.get('selected_task_label') or feedback_decision.get('selectedTaskLabel')
+            next_task_source = feedback_decision.get('selection_source') or feedback_decision.get('selectionSource')
             payload = {
                 'current_plan': plan_latest,
                 'current_plan_source': plan_latest['source'] if plan_latest else None,
                 'current_task_id': canonical_current_task_id,
                 'current_task': canonical_current_task,
                 'task_plan': canonical_task_plan,
+                'next_task_id': next_task_id,
+                'next_task_title': next_task_title,
+                'next_task_label': next_task_label,
+                'next_task_source': next_task_source,
                 'selected_task_title': (plan_latest['selected_task_title'] if plan_latest and plan_latest.get('selected_task_title') else producer_feedback.get('selected_task_title') or producer_feedback.get('selected_task_label')),
-                'feedback_decision': (plan_latest['feedback_decision'] if plan_latest and plan_latest.get('feedback_decision') else producer_plan.get('feedback_decision')),
+                'feedback_decision': feedback_decision,
                 'task_selection_source': (plan_latest['task_selection_source'] if plan_latest and plan_latest.get('task_selection_source') else producer_plan.get('task_selection_source') or producer_feedback.get('selection_source')),
                 'selected_tasks_text': (plan_latest['selected_tasks_text'] if plan_latest and plan_latest.get('selected_tasks_text') and plan_latest.get('selected_tasks_text') != 'unknown' else _selected_tasks_text(producer_plan.get('selected_tasks') or producer_feedback.get('selected_task_label') or producer_feedback.get('selected_task_title'))),
                 'plan_history_count': len(plan_history),

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -489,6 +489,72 @@ def test_api_plan_reconciles_mixed_task_plan_id_with_runtime_canonical_task(tmp_
     assert plan['task_plan']['current_task'] == 'analyze-last-failed-candidate'
 
 
+def test_api_plan_exposes_next_task_selection_separately_from_current_task(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'control_plane').mkdir(parents=True, exist_ok=True)
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({
+        'task_plan': {
+            'current_task_id': 'analyze-last-failed-candidate',
+            'current_task': 'analyze-last-failed-candidate',
+            'task_selection_source': 'feedback_terminal_selfevo_retire',
+            'feedback_decision': {
+                'mode': 'retire_terminal_selfevo_lane',
+                'current_task_id': 'analyze-last-failed-candidate',
+                'selected_task_id': 'record-reward',
+                'selected_task_title': 'Record cycle reward',
+                'selected_task_label': 'Record cycle reward [task_id=record-reward]',
+                'selection_source': 'feedback_terminal_selfevo_retire',
+            },
+        },
+        'runtime_source': {'source': 'workspace_state'},
+    }), encoding='utf-8')
+    insert_collection(db, {
+        'collected_at': '2026-04-26T15:18:40Z',
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': '/workspace/state/reports/evolution-current.json',
+        'outbox_source': '/workspace/state/outbox/report.index.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({
+            'current_plan': {
+                'current_task_id': 'analyze-last-failed-candidate',
+                'current_task': 'analyze-last-failed-candidate',
+                'task_selection_source': 'feedback_terminal_selfevo_retire',
+                'feedback_decision': {
+                    'mode': 'retire_terminal_selfevo_lane',
+                    'current_task_id': 'analyze-last-failed-candidate',
+                    'selected_task_id': 'record-reward',
+                    'selected_task_title': 'Record cycle reward',
+                    'selected_task_label': 'Record cycle reward [task_id=record-reward]',
+                    'selection_source': 'feedback_terminal_selfevo_retire',
+                },
+            },
+            'outbox': {'status': 'PASS'},
+        }),
+    })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    plan = _call_json(create_app(cfg), '/api/plan')
+
+    assert plan['current_task_id'] == 'analyze-last-failed-candidate'
+    assert plan['current_task'] == 'analyze-last-failed-candidate'
+    assert plan['next_task_id'] == 'record-reward'
+    assert plan['next_task_title'] == 'Record cycle reward'
+    assert plan['next_task_label'] == 'Record cycle reward [task_id=record-reward]'
+    assert plan['next_task_source'] == 'feedback_terminal_selfevo_retire'
+
+
 def test_dashboard_apis_expose_canonical_live_proof_pointers(tmp_path: Path) -> None:
     project_root = tmp_path / 'dashboard'
     repo_root = tmp_path / 'nanobot'


### PR DESCRIPTION
## Summary
- expose selected next-task metadata separately from canonical current-task metadata in `/api/plan`
- add `next_task_id`, `next_task_title`, `next_task_label`, and `next_task_source`
- preserve existing current-task fields and compatibility fields

## Issues
Fixes #203

## Test plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_api_plan_exposes_next_task_selection_separately_from_current_task -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

## Delegated review
- APPROVED: no blocking issues.
