### PR TITLE
feat: write durable goal registry

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2642,6 +2642,32 @@ async def run_self_evolving_cycle(
         encoding="utf-8",
     )
 
+    goal_registry = {
+        "schema_version": "goal-registry-v1",
+        "active_goal_id": active_goal,
+        "goals": {
+            active_goal: {
+                "goal_id": active_goal,
+                "status": "active" if result_status != "ERROR" else "error",
+                "result_status": result_status,
+                "current_task_id": current_plan.get("current_task_id"),
+                "current_task": current_plan.get("current_task"),
+                "latest_report_path": str(report_path),
+                "latest_outbox_path": str(report_index_path),
+                "updated_at_utc": cycle_ended,
+            }
+        },
+        "current_task_id": current_plan.get("current_task_id"),
+        "current_task": current_plan.get("current_task"),
+        "latest_report_path": str(report_path),
+        "latest_outbox_path": str(report_index_path),
+        "updated_at_utc": cycle_ended,
+    }
+    (goals_dir / "registry.json").write_text(
+        json.dumps(goal_registry, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
     history_entry = {
         **current_plan,
         "schema_version": "task-history-v1",

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -423,6 +423,7 @@ def test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifac
     experiment = _read_json(tmp_path / "state" / "experiments" / "latest.json")
     report = _read_json(runtime["report_path"])
     report_index = _read_json(tmp_path / "state" / "outbox" / "report.index.json")
+    goal_registry = _read_json(goals_dir / "registry.json")
     control_summary = _read_json(tmp_path / "state" / "control_plane" / "current_summary.json")
 
     # Regression guard for #177: before the fix, the resolved decision from
@@ -450,6 +451,12 @@ def test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifac
     assert outbox["selected_tasks"] == "Record cycle reward [task_id=record-reward]"
     assert report["selected_tasks"] == "Record cycle reward [task_id=record-reward]"
     assert report_index["selected_tasks"] == "Record cycle reward [task_id=record-reward]"
+    assert goal_registry["schema_version"] == "goal-registry-v1"
+    assert goal_registry["active_goal_id"] == "goal-bootstrap"
+    assert goal_registry["current_task_id"] == "record-reward"
+    assert goal_registry["current_task"] == "Record cycle reward"
+    assert goal_registry["latest_report_path"] == str(runtime["report_path"])
+    assert goal_registry["latest_outbox_path"] == str(tmp_path / "state" / "outbox" / "report.index.json")
 
 
 def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):


### PR DESCRIPTION
## Summary
- write durable `workspace/state/goals/registry.json` from local self-evolving cycles
- include active goal, current task, latest report/outbox pointers, and update timestamp
- add regression coverage for registry creation and canonical pointers

## Issues
Fixes #204

## Test plan
- `python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_persists_recorded_feedback_decision_into_latest_authority_artifacts -q`
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_reward_authority_and_task_boundary.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Delegated review
- APPROVED: no blocking issues.
