### PR TITLE
docs: fail closed eeepc privileged rollout readiness

### DIFF
--- a/docs/EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md
+++ b/docs/EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md
@@ -126,6 +126,8 @@ Verified real example from `eeepc`:
 - Do not auto-renew `apply.ok`
 - Keep TTL short and intentional
 - Treat this as operator-supervised bounded apply, not a permanent capability grant
+- Missing, unreadable, malformed, or expired approval must fail closed; never infer approval from dashboard health or from the existence of older PASS reports
+- A non-sudo readiness check may document that the gate is protected, but it must not claim the gate is valid unless the current `apply.ok` payload was read and its `expires_at_epoch` is in the future
 - If a cycle produces unexpected changes, remove or let the gate expire before rerunning
 
 ## Remove Or Let Expire

--- a/docs/EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md
+++ b/docs/EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md
@@ -91,6 +91,18 @@ Verification release rule:
 
 ## Verification Workflow
 
+### Non-sudo readiness boundary
+
+If the current operator context can SSH to `eeepc` but cannot run `sudo`, cannot access `/home/opencode`, or cannot read protected authority indexes, this runbook can only establish rollout readiness and partial live proof.
+
+In that mode, record the exact blockers and do not claim host-emitter parity. The known fail-closed signals are:
+- `sudo -n true` returns `a password is required`
+- direct SSH as `opencode` or `root` is denied
+- `/home/opencode/.venvs/nanobot/bin/nanobot` is inaccessible
+- `/var/lib/eeepc-agent/self-evolving-agent/state/outbox/report.index.json` or `goals/registry.json` are unreadable
+
+A non-sudo operator may still preserve limited live proof from the newest readable `reports/evolution-*.json`, but activation and authoritative parity verification remain privileged steps.
+
 ### Step 6 — run read-only verification against live host truth
 
 Use the verification release without switching the active runtime:

--- a/docs/plans/2026-04-16-eeepc-live-repair-approval-subagents.md
+++ b/docs/plans/2026-04-16-eeepc-live-repair-approval-subagents.md
@@ -52,6 +52,18 @@ Conclusion:
 
 ## Repair Strategy
 
+### Slice 0 — privileged readiness preflight
+
+Before installing or activating any host-side change, run a non-mutating readiness check and record what is actually proven.
+
+Ready for privileged rollout requires all of these:
+- `sudo` or equivalent privileged execution is available for `/var/lib/eeepc-agent/self-evolving-agent/state`
+- the opencode Nanobot venv can be executed through the intended service account or through `sudo env PYTHONPATH=... /home/opencode/.venvs/nanobot/bin/nanobot ...`
+- `outbox/report.index.json`, `goals/registry.json`, and the newest report can be read from the same authority root
+- side-by-side `nanobot status --runtime-state-source host_control_plane --runtime-state-root /var/lib/eeepc-agent/self-evolving-agent/state` reports concrete status, goal, approval, report, and outbox fields, not `unknown`
+
+If any of those are false, the slice remains a readiness/proof-preservation slice only. Do not claim HADI/follow-through host-emitter parity from readable reports alone; create or keep a privileged follow-up issue with exact blockers.
+
 ### Slice 1 — approval keeper
 
 Add a host service/timer that maintains a valid `apply.ok` window intentionally and repeatably.

--- a/tests/test_eeepc_privileged_rollout_runbooks.py
+++ b/tests/test_eeepc_privileged_rollout_runbooks.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_deploy_runbook_preserves_non_sudo_readiness_boundary():
+    text = (REPO_ROOT / "docs" / "EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md").read_text(encoding="utf-8")
+
+    assert "Non-sudo readiness boundary" in text
+    assert "do not claim host-emitter parity" in text
+    assert "sudo -n true" in text
+    assert "a password is required" in text
+    assert "newest readable `reports/evolution-*.json`" in text
+    assert "activation and authoritative parity verification remain privileged steps" in text
+
+
+def test_apply_gate_runbook_fails_closed_without_readable_current_gate():
+    text = (REPO_ROOT / "docs" / "EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md").read_text(encoding="utf-8")
+
+    assert "Do not auto-renew `apply.ok`" in text
+    assert "Missing, unreadable, malformed, or expired approval must fail closed" in text
+    assert "must not claim the gate is valid unless the current `apply.ok` payload was read" in text
+    assert "`expires_at_epoch` is in the future" in text
+
+
+def test_live_repair_plan_requires_privileged_preflight_before_parity_claim():
+    text = (REPO_ROOT / "docs" / "plans" / "2026-04-16-eeepc-live-repair-approval-subagents.md").read_text(encoding="utf-8")
+
+    assert "Slice 0 — privileged readiness preflight" in text
+    assert "Ready for privileged rollout requires all of these" in text
+    assert "the opencode Nanobot venv can be executed" in text
+    assert "outbox/report.index.json`, `goals/registry.json`, and the newest report can be read" in text
+    assert "not claim HADI/follow-through host-emitter parity from readable reports alone" in text


### PR DESCRIPTION
## Summary
- document the non-sudo boundary for eeepc privileged host-emitter rollout
- make apply-gate validity explicitly fail-closed when unreadable/missing/expired
- add a Slice 0 privileged readiness preflight before claiming HADI/follow-through parity
- add tests that pin the runbook safety contract

## Issue
Progresses #210 without falsely claiming host mutation while sudo/opencode access is unavailable.

## Test plan
- `python3 -m pytest tests/test_eeepc_privileged_rollout_runbooks.py -q`
- `python3 -m pytest tests/test_commands.py -k host_control_plane -q`
- `python3 -m pytest tests/test_promotion_workflow.py tests/test_autoevolve.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Delegated review
- APPROVED: reviewer confirmed the docs/tests preserve honesty about blocked privileged host parity and fail-closed rollout readiness.
