### PR TITLE
fix: refresh observed selfevo product head

### DIFF
--- a/nanobot/runtime/autoevolve.py
+++ b/nanobot/runtime/autoevolve.py
@@ -40,6 +40,25 @@ def _self_evolution_root(workspace: Path) -> Path:
     return workspace / 'state' / 'self_evolution'
 
 
+def _observed_product_head(workspace: Path) -> dict[str, Any] | None:
+    repo_root = workspace.parent if workspace.name == 'workspace' else None
+    if repo_root is None or not (repo_root / '.git').exists():
+        return None
+    try:
+        commit = _git(repo_root, 'rev-parse', 'HEAD')
+    except Exception:
+        return None
+    if not commit:
+        return None
+    return {
+        'schema_version': 'observed-product-head-v1',
+        'commit': commit,
+        'source': 'git_rev_parse_head',
+        'repo_root': str(repo_root),
+        'observed_at_utc': datetime.now(timezone.utc).isoformat(),
+    }
+
+
 def derive_selfevo_branch_name(*, issue_number: int, source_task_id: str | None) -> str:
     raw = (source_task_id or 'self-evolution').lower()
     slug = re.sub(r'[^a-z0-9]+', '-', raw).strip('-') or 'self-evolution'
@@ -277,12 +296,15 @@ def write_guarded_evolution_state(workspace: Path) -> dict[str, Any]:
             return json.loads(path.read_text(encoding='utf-8'))
         except Exception:
             return None
+    observed_product_head = _observed_product_head(workspace)
     payload = {
         'schema_version': 'autoevolve-state-v1',
         'current_candidate': _load(root / 'candidates' / 'latest.json'),
         'latest_request': _load(root / 'requests' / 'latest.json'),
         'selfevo_issue': (_load(root / 'requests' / 'latest.json') or {}).get('selfevo_issue') if isinstance(_load(root / 'requests' / 'latest.json'), dict) else None,
         'selfevo_branch': (_load(root / 'requests' / 'latest.json') or {}).get('selfevo_branch') if isinstance(_load(root / 'requests' / 'latest.json'), dict) else None,
+        'observed_product_head': observed_product_head,
+        'product_head': observed_product_head.get('commit') if isinstance(observed_product_head, dict) else None,
         'last_apply': _load(root / 'runtime' / 'latest_apply.json'),
         'last_rollback': _load(root / 'runtime' / 'latest_rollback.json'),
         'last_failure_learning': _load(root / 'failure_learning' / 'latest.json'),

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -402,15 +402,18 @@ def _selfevo_current_proof_summary(cfg, guarded_evolution: dict | None, selfevo_
     compact_merge = _compact_merge(latest_merge)
     compact_pr = _compact_pr(latest_pr)
     current_candidate = current_state.get('current_candidate') if isinstance(current_state.get('current_candidate'), dict) else {}
+    observed_product_head = current_state.get('observed_product_head') if isinstance(current_state.get('observed_product_head'), dict) else {}
     product_head = _git_head(cfg.nanobot_repo_root)
     current_candidate_commit = current_candidate.get('commit') or current_state.get('current_candidate_commit')
     remote_head = current_state.get('remote_head')
-    state_commit = current_candidate_commit or remote_head
+    observed_product_head_commit = observed_product_head.get('commit') or current_state.get('product_head') or current_state.get('observed_product_head_commit')
+    state_commit = observed_product_head_commit or current_candidate_commit or remote_head
     state_fresh = bool(product_head and state_commit and product_head == state_commit)
     product_head_freshness = {
         'schema_version': 'selfevo-product-head-freshness-v1',
         'state': 'fresh' if state_fresh else ('unknown' if not product_head or not state_commit else 'stale'),
         'product_head': product_head,
+        'observed_product_head_commit': observed_product_head_commit,
         'current_candidate_commit': current_candidate_commit,
         'remote_head': remote_head,
         'state_commit': state_commit,

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -611,6 +611,62 @@ def test_api_system_exposes_selfevo_current_state_freshness_against_product_head
     assert freshness['state_fresh'] is False
 
 
+def test_api_system_treats_observed_product_head_as_fresh_without_rewriting_candidate(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    repo_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(['git', 'init', '-q'], cwd=repo_root, check=True)
+    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=repo_root, check=True)
+    subprocess.run(['git', 'config', 'user.name', 'Test User'], cwd=repo_root, check=True)
+    (repo_root / 'README.md').write_text('initial\n', encoding='utf-8')
+    subprocess.run(['git', 'add', 'README.md'], cwd=repo_root, check=True)
+    subprocess.run(['git', 'commit', '-q', '-m', 'initial'], cwd=repo_root, check=True)
+    stale_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo_root, text=True).strip()
+    (repo_root / 'README.md').write_text('new observed product head\n', encoding='utf-8')
+    subprocess.run(['git', 'commit', '-q', '-am', 'new observed product head'], cwd=repo_root, check=True)
+    product_head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo_root, text=True).strip()
+
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'control_plane').mkdir(parents=True, exist_ok=True)
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({'task_plan': {'current_task_id': 'task-1'}}), encoding='utf-8')
+    selfevo_dir = state_root / 'self_evolution'
+    selfevo_dir.mkdir(parents=True, exist_ok=True)
+    (selfevo_dir / 'current_state.json').write_text(json.dumps({
+        'state': 'running',
+        'current_candidate': {'commit': stale_commit},
+        'observed_product_head': {'commit': product_head, 'source': 'git_rev_parse_head'},
+    }), encoding='utf-8')
+    insert_collection(db, {
+        'collected_at': '2026-04-26T15:18:40Z',
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': '/workspace/state/reports/evolution-current.json',
+        'outbox_source': '/workspace/state/outbox/report.index.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({'current_plan': {'current_task_id': 'task-1'}, 'outbox': {'status': 'PASS'}}),
+    })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    system = _call_json(create_app(cfg), '/api/system')
+    freshness = system['selfevo_current_proof']['product_head_freshness']
+
+    assert freshness['state'] == 'fresh'
+    assert freshness['state_fresh'] is True
+    assert freshness['product_head'] == product_head
+    assert freshness['current_candidate_commit'] == stale_commit
+    assert freshness['observed_product_head_commit'] == product_head
+    assert freshness['state_commit'] == product_head
+
+
 def test_dashboard_apis_expose_canonical_live_proof_pointers(tmp_path: Path) -> None:
     project_root = tmp_path / 'dashboard'
     repo_root = tmp_path / 'nanobot'

--- a/tests/test_autoevolve_state.py
+++ b/tests/test_autoevolve_state.py
@@ -64,3 +64,23 @@ def test_write_guarded_evolution_state_aggregates_latest_artifacts(tmp_path: Pat
     assert payload['last_failure_learning']['candidate_id'] == 'candidate-bad'
     assert payload['latest_request']['request_id'] == 'request-1'
     assert latest['current_candidate']['candidate_id'] == 'candidate-1'
+
+
+def test_write_guarded_evolution_state_records_observed_product_head_without_rewriting_candidate(tmp_path: Path):
+    repo = tmp_path / 'repo'
+    _init_repo(repo)
+    workspace = repo / 'workspace'
+    state = workspace / 'state' / 'self_evolution'
+    (state / 'candidates').mkdir(parents=True, exist_ok=True)
+    stale_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip()
+    (repo / 'README.md').write_text('advanced product head\n', encoding='utf-8')
+    subprocess.run(['git', 'commit', '-q', '-am', 'advance product head'], cwd=repo, check=True)
+    product_head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip()
+    (state / 'candidates' / 'latest.json').write_text(json.dumps({'candidate_id': 'candidate-1', 'commit': stale_commit}), encoding='utf-8')
+
+    payload = write_guarded_evolution_state(workspace=workspace)
+
+    assert payload['current_candidate']['commit'] == stale_commit
+    assert payload['observed_product_head']['commit'] == product_head
+    assert payload['observed_product_head']['source'] == 'git_rev_parse_head'
+    assert payload['product_head'] == product_head


### PR DESCRIPTION
## Summary
- record an explicit observed product HEAD in `self_evolution/current_state.json` when local self-evolution state is refreshed from a repo workspace
- preserve `current_candidate.commit` provenance instead of rewriting it to a non-candidate product merge
- make `/api/system.selfevo_current_proof.product_head_freshness` treat an explicit observed product HEAD as the freshness authority while still exposing candidate commit

## Issues
Fixes #212
Progresses #210 by keeping the local/product proof fresh after the non-sudo readiness PR without falsely claiming privileged eeepc host-emitter parity.

## Test plan
- `python3 -m pytest tests/test_autoevolve_state.py::test_write_guarded_evolution_state_records_observed_product_head_without_rewriting_candidate -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_api_system_treats_observed_product_head_as_fresh_without_rewriting_candidate -q`
- `python3 -m pytest tests/test_autoevolve_state.py -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Delegated review
- APPROVED: reviewer confirmed candidate provenance remains visible and observed product HEAD freshness is honest.
