### PR TITLE
fix: refresh observed head after local cycle

### DIFF
--- a/scripts/run_local_cycle.sh
+++ b/scripts/run_local_cycle.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DEFAULT_GUARDED="/home/ozand/herkoot/Projects/nanobot/workspace/state/self_evolution/runtime/current"
-ROOT_FALLBACK_REPO="/home/ozand/herkoot/Projects/nanobot"
+ROOT_FALLBACK_REPO="${NANOBOT_REPO_ROOT:-/home/ozand/herkoot/Projects/nanobot}"
 ROOT="${NANOBOT_RUNTIME_ROOT:-$ROOT_DEFAULT_GUARDED}"
 if [[ ! -e "$ROOT" ]]; then
   ROOT="$ROOT_FALLBACK_REPO"
@@ -11,4 +11,17 @@ cd "$ROOT"
 export PYTHONPATH=.
 : "${NANOBOT_WORKSPACE:=/home/ozand/herkoot/Projects/nanobot/workspace}"
 : "${NANOBOT_RUNTIME_STATE_SOURCE:=workspace_state}"
-exec python3 app/main.py
+set +e
+python3 app/main.py
+cycle_status=$?
+set -e
+(
+  cd "$ROOT_FALLBACK_REPO"
+  PYTHONPATH="$ROOT_FALLBACK_REPO" python3 - <<'PY'
+import os
+from pathlib import Path
+from nanobot.runtime.autoevolve import write_guarded_evolution_state
+write_guarded_evolution_state(Path(os.environ['NANOBOT_WORKSPACE']))
+PY
+) || true
+exit "$cycle_status"

--- a/tests/test_run_local_cycle_refresh.py
+++ b/tests/test_run_local_cycle_refresh.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from test_autoevolve import _init_repo
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_run_local_cycle_refreshes_observed_product_head_after_runtime_exits(tmp_path: Path):
+    repo = tmp_path / 'repo'
+    _init_repo(repo)
+    workspace = repo / 'workspace'
+    app_dir = tmp_path / 'runtime' / 'app'
+    app_dir.mkdir(parents=True)
+    runtime_pkg = tmp_path / 'runtime' / 'nanobot' / 'runtime'
+    runtime_pkg.mkdir(parents=True)
+    (runtime_pkg.parent / '__init__.py').write_text('', encoding='utf-8')
+    (runtime_pkg / '__init__.py').write_text('', encoding='utf-8')
+    (runtime_pkg / 'autoevolve.py').write_text(
+        "def write_guarded_evolution_state(workspace):\n"
+        "    raise RuntimeError('stale pinned runtime writer should not be imported')\n",
+        encoding='utf-8',
+    )
+    (app_dir / 'main.py').write_text("print('dummy cycle PASS')\n", encoding='utf-8')
+    state = workspace / 'state' / 'self_evolution' / 'candidates'
+    state.mkdir(parents=True)
+    stale_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip()
+    (repo / 'README.md').write_text('advanced product head\n', encoding='utf-8')
+    subprocess.run(['git', 'commit', '-q', '-am', 'advance product head'], cwd=repo, check=True)
+    product_head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip()
+    (state / 'latest.json').write_text(json.dumps({'candidate_id': 'candidate-1', 'commit': stale_commit}), encoding='utf-8')
+    env = os.environ.copy()
+    env.update({
+        'NANOBOT_RUNTIME_ROOT': str(app_dir.parent),
+        'NANOBOT_REPO_ROOT': str(REPO_ROOT),
+        'NANOBOT_WORKSPACE': str(workspace),
+        'PYTHONPATH': str(REPO_ROOT),
+    })
+
+    result = subprocess.run([str(REPO_ROOT / 'scripts' / 'run_local_cycle.sh')], env=env, text=True, capture_output=True, check=True)
+
+    current_state = json.loads((workspace / 'state' / 'self_evolution' / 'current_state.json').read_text(encoding='utf-8'))
+    assert 'dummy cycle PASS' in result.stdout
+    assert current_state['current_candidate']['commit'] == stale_commit
+    assert current_state['observed_product_head']['commit'] == product_head
+    assert current_state['product_head'] == product_head
+
+
+def test_run_local_cycle_still_refreshes_observed_product_head_when_cycle_fails(tmp_path: Path):
+    repo = tmp_path / 'repo'
+    _init_repo(repo)
+    workspace = repo / 'workspace'
+    app_dir = tmp_path / 'runtime' / 'app'
+    app_dir.mkdir(parents=True)
+    (app_dir / 'main.py').write_text("raise SystemExit(7)\n", encoding='utf-8')
+    state = workspace / 'state' / 'self_evolution' / 'candidates'
+    state.mkdir(parents=True)
+    stale_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip()
+    (repo / 'README.md').write_text('advanced product head\n', encoding='utf-8')
+    subprocess.run(['git', 'commit', '-q', '-am', 'advance product head'], cwd=repo, check=True)
+    product_head = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=repo, text=True).strip()
+    (state / 'latest.json').write_text(json.dumps({'candidate_id': 'candidate-1', 'commit': stale_commit}), encoding='utf-8')
+    env = os.environ.copy()
+    env.update({
+        'NANOBOT_RUNTIME_ROOT': str(app_dir.parent),
+        'NANOBOT_REPO_ROOT': str(REPO_ROOT),
+        'NANOBOT_WORKSPACE': str(workspace),
+        'PYTHONPATH': str(REPO_ROOT),
+    })
+
+    result = subprocess.run([str(REPO_ROOT / 'scripts' / 'run_local_cycle.sh')], env=env, text=True, capture_output=True)
+
+    current_state = json.loads((workspace / 'state' / 'self_evolution' / 'current_state.json').read_text(encoding='utf-8'))
+    assert result.returncode == 7
+    assert current_state['current_candidate']['commit'] == stale_commit
+    assert current_state['observed_product_head']['commit'] == product_head


### PR DESCRIPTION
## Summary
- make `scripts/run_local_cycle.sh` refresh self-evolution `observed_product_head` using the product repo after the pinned runtime exits
- preserve original local-cycle exit status while still refreshing observed product HEAD on failures
- avoid stale pinned-runtime import precedence by running the refresh from the product repo with product `PYTHONPATH`
- add regression tests for stale pinned-runtime imports and nonzero cycle exits

## Issues
Fixes #212
Progresses #210 readiness proof by making the local/product side converge after product PR merges without falsely claiming privileged eeepc host-emitter parity.

## Test plan
- `python3 -m pytest tests/test_run_local_cycle_refresh.py -q`
- `python3 -m pytest tests/test_autoevolve_state.py tests/test_run_local_cycle_refresh.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Delegated review
- Initial review requested changes for import precedence and `set -e` failure handling.
- Follow-up review APPROVED after fixes and targeted verification.
