### PR TITLE
feat: add eeepc privileged rollout preflight

### DIFF
--- a/scripts/eeepc_privileged_rollout_preflight.py
+++ b/scripts/eeepc_privileged_rollout_preflight.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+DEFAULT_STATE_ROOT = "/var/lib/eeepc-agent/self-evolving-agent/state"
+DEFAULT_NANOBOT = "/home/opencode/.venvs/nanobot/bin/nanobot"
+DEFAULT_OPENCODE_HOME = "/home/opencode"
+
+
+def run_command(args: Sequence[str], timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def _ssh_args(host: str, remote_command: str, *, key: str | None = None) -> list[str]:
+    args = ["ssh", "-F", str(Path.home() / ".ssh" / "config")]
+    if key:
+        args.extend(["-i", key, "-o", "IdentitiesOnly=yes"])
+    args.extend(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, remote_command])
+    return args
+
+
+def _quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _ssh(host: str, remote_command: str, *, key: str | None = None, timeout: int = 20) -> dict[str, Any]:
+    proc = run_command(_ssh_args(host, remote_command, key=key), timeout=timeout)
+    return {
+        "ok": proc.returncode == 0,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+        "command": remote_command,
+    }
+
+
+def _read_latest_report(host: str, state_root: str, *, key: str | None = None) -> tuple[str | None, dict[str, Any] | None, dict[str, Any] | None]:
+    reports_glob = f"{_quote(state_root)}/reports/evolution-*.json"
+    path_result = _ssh(host, f"sh -lc {_quote(f'ls -1t {reports_glob} 2>/dev/null | head -n 1')}", key=key)
+    report_path = path_result["stdout"].splitlines()[0] if path_result["ok"] and path_result["stdout"] else None
+    if not report_path:
+        return None, None, path_result
+    cat_result = _ssh(host, f"cat {_quote(report_path)}", key=key)
+    if not cat_result["ok"]:
+        return report_path, None, cat_result
+    try:
+        return report_path, json.loads(cat_result["stdout"]), None
+    except json.JSONDecodeError as exc:
+        return report_path, None, {"ok": False, "message": str(exc), "stage": "parse_latest_report", "path": report_path}
+
+
+def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str | None = None, nanobot_path: str = DEFAULT_NANOBOT, opencode_home: str = DEFAULT_OPENCODE_HOME) -> dict[str, Any]:
+    collected_at = datetime.now(timezone.utc).isoformat()
+    ssh_probe = _ssh(host, "hostname; whoami; id", key=key)
+    blockers: list[str] = []
+    checks: dict[str, Any] = {"ssh": ssh_probe}
+    if not ssh_probe["ok"]:
+        blockers.append("ssh_reachability")
+        return {
+            "schema_version": "eeepc-privileged-rollout-preflight-v1",
+            "collected_at_utc": collected_at,
+            "host": host,
+            "state_root": state_root,
+            "state": "blocked_unreachable",
+            "ready": False,
+            "blocked_capabilities": blockers,
+            "checks": checks,
+            "latest_report": None,
+        }
+
+    sudo = _ssh(host, "sudo -n true", key=key)
+    opencode_home_check = _ssh(host, f"test -x {_quote(nanobot_path)} && test -x {_quote(opencode_home)}", key=key)
+    outbox = _ssh(host, f"test -r {_quote(state_root + '/outbox/report.index.json')}", key=key)
+    goals = _ssh(host, f"test -r {_quote(state_root + '/goals/registry.json')}", key=key)
+    checks.update({
+        "sudo_noninteractive": sudo,
+        "opencode_nanobot_executable": opencode_home_check,
+        "read_authority_outbox": outbox,
+        "read_goal_registry": goals,
+    })
+    if not sudo["ok"]:
+        blockers.append("sudo_noninteractive")
+    if not opencode_home_check["ok"]:
+        blockers.append("execute_opencode_nanobot")
+    if not outbox["ok"]:
+        blockers.append("read_authority_outbox")
+    if not goals["ok"]:
+        blockers.append("read_goal_registry")
+
+    report_path, report_payload, report_error = _read_latest_report(host, state_root, key=key)
+    latest_report = None
+    if report_payload:
+        latest_report = {
+            "path": report_path,
+            "result_status": report_payload.get("result_status") or report_payload.get("status"),
+            "goal_id": report_payload.get("goal_id") or ((report_payload.get("goal") or {}).get("goal_id") if isinstance(report_payload.get("goal"), dict) else None),
+            "feedback_decision_present": report_payload.get("feedback_decision") is not None,
+            "selected_tasks": report_payload.get("selected_tasks"),
+            "task_selection_source": report_payload.get("task_selection_source"),
+        }
+    checks["latest_readable_report"] = {"path": report_path, "ok": bool(report_payload), "error": report_error}
+
+    state = "ready" if not blockers else ("partial_report_only" if latest_report else "blocked_privileged_access")
+    if blockers:
+        state = "blocked_privileged_access"
+    return {
+        "schema_version": "eeepc-privileged-rollout-preflight-v1",
+        "collected_at_utc": collected_at,
+        "host": host,
+        "state_root": state_root,
+        "state": state,
+        "ready": not blockers,
+        "blocked_capabilities": sorted(set(blockers)),
+        "available_partial_proof": "latest_readable_report" if latest_report else None,
+        "checks": checks,
+        "latest_report": latest_report,
+        "does_not_mutate_host": True,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Emit a JSON eeepc privileged rollout preflight artifact without mutating the host.")
+    parser.add_argument("--host", default="eeepc")
+    parser.add_argument("--state-root", default=DEFAULT_STATE_ROOT)
+    parser.add_argument("--ssh-key", default=str(Path.home() / ".ssh" / "id_ed25519_eeepc"))
+    parser.add_argument("--nanobot-path", default=DEFAULT_NANOBOT)
+    parser.add_argument("--opencode-home", default=DEFAULT_OPENCODE_HOME)
+    parser.add_argument("--json", action="store_true", help="Accepted for explicitness; output is always JSON.")
+    args = parser.parse_args(argv)
+    payload = build_preflight(host=args.host, state_root=args.state_root, key=args.ssh_key, nanobot_path=args.nanobot_path, opencode_home=args.opencode_home)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_eeepc_privileged_rollout_preflight.py
+++ b/tests/test_eeepc_privileged_rollout_preflight.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / 'scripts' / 'eeepc_privileged_rollout_preflight.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('eeepc_privileged_rollout_preflight', SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_preflight_reports_blocked_privileged_access_with_latest_readable_report(monkeypatch):
+    module = _load_module()
+    state_root = '/var/lib/eeepc-agent/self-evolving-agent/state'
+    latest_report = f'{state_root}/reports/evolution-20260426T172155Z-cycle-18a55ab2ec15.json'
+    report_payload = {
+        'result_status': 'PASS',
+        'goal_id': 'goal-bootstrap',
+        'feedback_decision': None,
+        'selected_tasks': 'Record cycle reward [task_id=record-reward]',
+        'task_selection_source': 'recorded_current_task',
+    }
+
+    def fake_run(args, timeout=20):
+        command = args[-1]
+        if command == 'hostname; whoami; id':
+            return subprocess.CompletedProcess(args, 0, 'debian\nozand\nuid=1000(ozand)\n', '')
+        if command == 'sudo -n true':
+            return subprocess.CompletedProcess(args, 1, '', 'sudo: a password is required\n')
+        if command.startswith('test -x '):
+            return subprocess.CompletedProcess(args, 1, '', '')
+        if 'outbox/report.index.json' in command:
+            return subprocess.CompletedProcess(args, 1, '', '')
+        if 'goals/registry.json' in command:
+            return subprocess.CompletedProcess(args, 1, '', '')
+        if '/reports/evolution-*.json' in command:
+            return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
+        if command == f'cat {latest_report}':
+            return subprocess.CompletedProcess(args, 0, json.dumps(report_payload), '')
+        raise AssertionError(command)
+
+    monkeypatch.setattr(module, 'run_command', fake_run)
+
+    payload = module.build_preflight(host='eeepc', state_root=state_root, key='/tmp/key')
+
+    assert payload['schema_version'] == 'eeepc-privileged-rollout-preflight-v1'
+    assert payload['state'] == 'blocked_privileged_access'
+    assert payload['ready'] is False
+    assert payload['does_not_mutate_host'] is True
+    assert payload['available_partial_proof'] == 'latest_readable_report'
+    assert payload['latest_report']['path'] == latest_report
+    assert payload['latest_report']['result_status'] == 'PASS'
+    assert payload['latest_report']['goal_id'] == 'goal-bootstrap'
+    assert payload['latest_report']['feedback_decision_present'] is False
+    assert payload['latest_report']['selected_tasks'] == 'Record cycle reward [task_id=record-reward]'
+    assert payload['latest_report']['task_selection_source'] == 'recorded_current_task'
+    assert set(payload['blocked_capabilities']) == {
+        'sudo_noninteractive',
+        'execute_opencode_nanobot',
+        'read_authority_outbox',
+        'read_goal_registry',
+    }
+
+
+def test_preflight_main_always_exits_zero_for_auditable_blocked_state(monkeypatch, capsys):
+    module = _load_module()
+    monkeypatch.setattr(module, 'build_preflight', lambda **kwargs: {
+        'schema_version': 'eeepc-privileged-rollout-preflight-v1',
+        'state': 'blocked_privileged_access',
+        'ready': False,
+    })
+
+    assert module.main(['--host', 'eeepc', '--ssh-key', '/tmp/key', '--json']) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['state'] == 'blocked_privileged_access'
+
+
+def test_preflight_reports_ready_when_all_privileged_checks_pass(monkeypatch):
+    module = _load_module()
+    state_root = '/var/lib/eeepc-agent/self-evolving-agent/state'
+    latest_report = f'{state_root}/reports/evolution-ready.json'
+    report_payload = {'result_status': 'PASS', 'goal_id': 'goal-bootstrap', 'feedback_decision': {'selected_task_id': 'task-1'}}
+
+    def fake_run(args, timeout=20):
+        command = args[-1]
+        if command in {'hostname; whoami; id', 'sudo -n true'}:
+            return subprocess.CompletedProcess(args, 0, 'ok\n', '')
+        if command.startswith('test -x ') or command.startswith('test -r '):
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if '/reports/evolution-*.json' in command:
+            return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
+        if command == f'cat {latest_report}':
+            return subprocess.CompletedProcess(args, 0, json.dumps(report_payload), '')
+        raise AssertionError(command)
+
+    monkeypatch.setattr(module, 'run_command', fake_run)
+
+    payload = module.build_preflight(host='eeepc', state_root=state_root, key='/tmp/key')
+
+    assert payload['state'] == 'ready'
+    assert payload['ready'] is True
+    assert payload['blocked_capabilities'] == []
+    assert payload['latest_report']['feedback_decision_present'] is True
+
+
+def test_preflight_reports_blocked_unreachable_without_running_privileged_checks(monkeypatch):
+    module = _load_module()
+    commands = []
+
+    def fake_run(args, timeout=20):
+        commands.append(args[-1])
+        return subprocess.CompletedProcess(args, 255, '', 'host unreachable')
+
+    monkeypatch.setattr(module, 'run_command', fake_run)
+
+    payload = module.build_preflight(host='eeepc', state_root='/state', key='/tmp/key')
+
+    assert payload['state'] == 'blocked_unreachable'
+    assert payload['ready'] is False
+    assert payload['blocked_capabilities'] == ['ssh_reachability']
+    assert commands == ['hostname; whoami; id']
+
+
+def test_preflight_quotes_user_supplied_remote_paths(monkeypatch):
+    module = _load_module()
+    commands = []
+    injected_state_root = "/state; touch /tmp/SHOULD_NOT_EXIST"
+    injected_nanobot = "/bin/nanobot; touch /tmp/SHOULD_NOT_EXIST"
+    injected_home = "/home/opencode; touch /tmp/SHOULD_NOT_EXIST"
+
+    def fake_run(args, timeout=20):
+        command = args[-1]
+        commands.append(command)
+        if command == 'hostname; whoami; id':
+            return subprocess.CompletedProcess(args, 0, 'ok\n', '')
+        return subprocess.CompletedProcess(args, 1, '', '')
+
+    monkeypatch.setattr(module, 'run_command', fake_run)
+
+    module.build_preflight(
+        host='eeepc',
+        state_root=injected_state_root,
+        key='/tmp/key',
+        nanobot_path=injected_nanobot,
+        opencode_home=injected_home,
+    )
+
+    joined = '\n'.join(commands)
+    assert "'/state; touch /tmp/SHOULD_NOT_EXIST'" in joined
+    assert "'/bin/nanobot; touch /tmp/SHOULD_NOT_EXIST'" in joined
+    assert "'/home/opencode; touch /tmp/SHOULD_NOT_EXIST'" in joined
+    assert 'test -r /state; touch /tmp/SHOULD_NOT_EXIST' not in joined
+    assert 'test -x /bin/nanobot; touch /tmp/SHOULD_NOT_EXIST' not in joined


### PR DESCRIPTION
## Summary
- add `scripts/eeepc_privileged_rollout_preflight.py`, a no-mutation JSON artifact for #210 privileged rollout readiness
- checks SSH reachability, non-interactive sudo, opencode Nanobot executability, readable authority indexes, and latest readable report proof
- exits 0 even when readiness is blocked so the JSON artifact is auditable
- hardens remote command construction with shell quoting for user-supplied paths
- covers blocked, ready, unreachable, and command-injection regression cases

## Issues
Fixes #216
Progresses #210 by making the privileged handoff deterministic and auditable without performing host mutation.

## Test plan
- `python3 -m pytest tests/test_eeepc_privileged_rollout_preflight.py -q`
- `python3 -m pytest tests/test_eeepc_privileged_rollout_runbooks.py tests/test_eeepc_privileged_rollout_preflight.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Delegated review
- Initial review requested changes for shell-command injection risk and missing ready/unreachable/injection tests.
- Follow-up review APPROVED after quoting fixes and expanded tests.
