### PR TITLE
fix: avoid eeebot compat import in system emitter

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 from pathlib import Path
 
-from eeebot.runtime.coordinator import run_self_evolving_cycle
+from nanobot.runtime.coordinator import run_self_evolving_cycle
 
 DEFAULT_RUNTIME_STATE_SOURCE = "host_control_plane"
 DEFAULT_RUNTIME_STATE_ROOT = Path("/var/lib/eeepc-agent/self-evolving-agent/state")

--- a/tests/test_system_emitter_app.py
+++ b/tests/test_system_emitter_app.py
@@ -1,0 +1,12 @@
+"""Regression tests for the minimal system health/emitter entrypoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_system_emitter_entrypoint_imports_nanobot_runtime_directly():
+    source = Path('app/main.py').read_text(encoding='utf-8')
+
+    assert 'from nanobot.runtime.coordinator import run_self_evolving_cycle' in source
+    assert 'from eeebot.runtime.coordinator import run_self_evolving_cycle' not in source


### PR DESCRIPTION
## Summary
- change the eeepc system health/emitter entrypoint to import `run_self_evolving_cycle` from `nanobot.runtime.coordinator` directly
- avoid routing the minimal `/opt/eeepc-agent` emitter through the `eeebot` compatibility package, whose eager aliases require gateway/agent optional deps in older environments
- preserve existing `eeebot` compatibility alias behavior and tests

## Issues
Fixes #221
Unblocks retry of #220 for #210 privileged host-emitter rollout.

## Test plan
- `python3 -m pytest tests/test_system_emitter_app.py tests/test_eeebot_imports.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Results
- system emitter + eeebot imports: `37 passed`
- root suite: `614 passed, 5 skipped`
- dashboard suite: `76 passed`

## Delegated review
APPROVED: the entrypoint bypasses the eeebot eager-import path while preserving existing alias behavior.
