### PR TITLE
fix: follow through after retired reward task

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1334,8 +1334,55 @@ def _build_task_plan_snapshot(
     latest_failure_learning = _latest_failure_learning(workspace)
     failure_learning_is_fresh = isinstance(latest_failure_learning, dict) and isinstance(latest_failure_learning.get('_age_seconds'), int) and latest_failure_learning.get('_age_seconds') <= 3600
     terminal_selfevo_issue = resolve_terminal_selfevo_issue(workspace=workspace, source_task_id='analyze-last-failed-candidate')
+    recorded_reward_retirement = (
+        'recorded_task_plan' in locals()
+        and isinstance(recorded_task_plan, dict)
+        and isinstance(recorded_task_plan.get('feedback_decision'), dict)
+        and recorded_task_plan['feedback_decision'].get('current_task_id') == 'record-reward'
+        and recorded_task_plan['feedback_decision'].get('retire_goal_artifact_pair') is True
+    )
     if isinstance(latest_failure_learning, dict) and (current_task_id == "record-reward" or failure_learning_is_fresh):
-        if terminal_selfevo_issue is not None:
+        if recorded_reward_retirement and failure_learning_is_fresh:
+            repair_task = next((task for task in tasks if task.get("task_id") == "analyze-last-failed-candidate"), None)
+            if repair_task is None:
+                repair_task = {
+                    'task_id': 'analyze-last-failed-candidate',
+                    'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+                    'status': 'active',
+                    'kind': 'review',
+                    'acceptance': 'produce a bounded explanation of the failed candidate and one safer follow-up mutation idea',
+                    'selection_source': 'fresh_failure_learning_after_reward_retirement',
+                    'failed_candidate_id': latest_failure_learning.get('candidate_id'),
+                    'failed_commit': latest_failure_learning.get('failed_commit'),
+                    'health_reasons': latest_failure_learning.get('health_reasons'),
+                }
+                tasks.append(repair_task)
+            for task in tasks:
+                if task.get('task_id') == 'analyze-last-failed-candidate':
+                    task['status'] = 'active'
+                    task['selection_source'] = 'fresh_failure_learning_after_reward_retirement'
+                    task['failed_candidate_id'] = latest_failure_learning.get('candidate_id')
+                    task['failed_commit'] = latest_failure_learning.get('failed_commit')
+                    task['health_reasons'] = latest_failure_learning.get('health_reasons')
+                elif task.get('status') == 'active':
+                    task['status'] = 'pending'
+            current_task_id = 'analyze-last-failed-candidate'
+            feedback_decision = {
+                "mode": "fresh_failure_learning_after_reward_retirement",
+                "reason": "fresh failure-learning evidence after a retired record-reward lane must be analyzed before returning to bookkeeping",
+                "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
+                "current_task_id": "record-reward",
+                "current_task_class": _task_action_class("record-reward"),
+                "retire_goal_artifact_pair": True,
+                "selected_task_id": "analyze-last-failed-candidate",
+                "selected_task_class": _task_action_class("analyze-last-failed-candidate"),
+                "selection_source": "feedback_fresh_failure_learning_after_reward_retirement",
+                "selected_task_title": "Analyze the last failed self-evolution candidate before retrying mutation",
+                "selected_task_label": "Analyze the last failed self-evolution candidate before retrying mutation [task_id=analyze-last-failed-candidate]",
+                "failure_learning": latest_failure_learning,
+                "terminal_selfevo_issue": terminal_selfevo_issue,
+            }
+        elif terminal_selfevo_issue is not None:
             for task in tasks:
                 if task.get("task_id") == "analyze-last-failed-candidate":
                     task["status"] = "done"

--- a/tests/test_live_followthrough_drift.py
+++ b/tests/test_live_followthrough_drift.py
@@ -1,0 +1,66 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from nanobot.runtime.coordinator import run_self_evolving_cycle
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def test_retired_record_reward_does_not_mask_fresh_failure_learning_even_with_terminal_selfevo(tmp_path: Path):
+    approvals_dir = tmp_path / 'state' / 'approvals'
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 27, 1, 0, tzinfo=timezone.utc)
+    (approvals_dir / 'apply.ok').write_text(json.dumps({'expires_at_utc': expires_at.isoformat(), 'ttl_minutes': 60}), encoding='utf-8')
+
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'record-reward',
+        'tasks': [{'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'}],
+        'feedback_decision': {
+            'mode': 'retire_goal_artifact_pair',
+            'current_task_id': 'record-reward',
+            'retire_goal_artifact_pair': True,
+            'selected_task_id': None,
+            'selection_source': 'recorded_current_task',
+        },
+    }), encoding='utf-8')
+
+    learning_dir = tmp_path / 'state' / 'self_evolution' / 'failure_learning'
+    learning_dir.mkdir(parents=True, exist_ok=True)
+    (learning_dir / 'latest.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-after-retired-record-reward',
+        'failed_commit': 'badc0de',
+        'health_reasons': ['current_task_drift'],
+        'learning_summary': 'Fresh failure after reward-loop retirement; analyze before returning to bookkeeping.',
+    }), encoding='utf-8')
+
+    runtime_dir = tmp_path / 'state' / 'self_evolution' / 'runtime'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / 'latest_issue_lifecycle.json').write_text(json.dumps({
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'selfevo_branch': 'fix/issue-19-analyze-last-failed-candidate',
+        'selfevo_issue': {'number': 19, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+    }), encoding='utf-8')
+
+    execute = AsyncMock(return_value='agent completed bounded work')
+    now = expires_at - timedelta(minutes=15)
+    asyncio.run(run_self_evolving_cycle(workspace=tmp_path, tasks='check open tasks', execute_turn=execute, now=now))
+
+    current = _read_json(tmp_path / 'state' / 'goals' / 'current.json')
+    assert current['current_task_id'] == 'analyze-last-failed-candidate'
+    assert current['feedback_decision']['mode'] == 'fresh_failure_learning_after_reward_retirement'
+    assert current['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'
+
+    report = _read_json(sorted((tmp_path / 'state' / 'reports').glob('evolution-*.json'))[-1])
+    assert report['current_task_id'] == 'analyze-last-failed-candidate'
+    assert report['feedback_decision']['selection_source'] == 'feedback_fresh_failure_learning_after_reward_retirement'


### PR DESCRIPTION
## Summary
- Fix live eeepc follow-through after a retired `record-reward` lane when fresh failure-learning evidence exists.
- A recorded `retire_goal_artifact_pair` for `record-reward` no longer lets terminal self-evolution retirement force the current task back to bookkeeping.
- Instead, fresh failure-learning now reactivates `analyze-last-failed-candidate` and emits explicit feedback metadata.

## Issues
Fixes #226
Progresses #210

## Test plan
- `python3 -m pytest tests/test_live_followthrough_drift.py -q` initially failed before the fix with `current_task_id == record-reward`.
- `python3 -m pytest tests/test_live_followthrough_drift.py tests/test_autonomy_stagnation_followthrough.py tests/test_runtime_coordinator.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Results
- focused follow-through/runtime suite: `33 passed`
- root suite: `616 passed, 5 skipped`
- dashboard suite: `76 passed`

## Delegated review
APPROVED: the fix correctly detects retired `record-reward` with fresh failure-learning and prevents drift back to bookkeeping.
