### PR TITLE
fix: reconcile fresh live hadi authority

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -872,9 +872,23 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
             or bool(local_task)
         )
     )
+    live_hadi_handoff_selected_task = live_feedback.get('selected_task_id') if isinstance(live_feedback, dict) else None
+    live_hadi_handoff = (
+        all(artifacts.values())
+        and isinstance(live_feedback, dict)
+        and live_feedback.get('mode') in {'handoff_to_next_candidate', 'promote_review_followup', 'feedback_post_completion_handoff'}
+        and live_feedback.get('selection_source') in {'feedback_post_completion_handoff', 'feedback_review_to_execution'}
+        and _has_value(live_hadi_handoff_selected_task)
+        and str(live_hadi_handoff_selected_task) == str(live_task)
+    )
+    authority_resolution = None
+    canonical_task = local_task or live_task
     if local_task and live_task and str(local_task) not in str(live_task):
         if live_is_legacy_reward:
             reasons.append('legacy_live_reward_loop_current_task')
+        elif live_hadi_handoff:
+            authority_resolution = 'fresh_live_hadi_handoff'
+            canonical_task = live_task
         else:
             reasons.append('current_task_drift')
     missing = [key for key, present in artifacts.items() if not present]
@@ -888,8 +902,9 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         'missing_live_artifacts': missing,
         'local_current_task_id': local_task,
         'live_current_task_id': live_task,
-        'canonical_current_task_id': local_task or live_task,
+        'canonical_current_task_id': canonical_task,
         'live_task_selection_source': eeepc_plan.get('task_selection_source'),
+        'authority_resolution': authority_resolution,
     }
 
 

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -837,3 +837,43 @@ def test_api_system_exposes_eeepc_privileged_rollout_readiness_from_source_error
     assert readiness['source_errors']['outbox']['message'] == 'Permission denied'
     assert readiness['runtime_parity_state'] == 'legacy_reward_loop'
     assert readiness['next_issue'] == 210
+
+
+def test_runtime_parity_adopts_fresh_live_hadi_handoff_when_local_task_is_stale(tmp_path: Path) -> None:
+    from nanobot_ops_dashboard.app import _dashboard_runtime_parity
+
+    repo_root = tmp_path / 'nanobot'
+    state_root = repo_root / 'workspace' / 'state'
+    for rel in [
+        'hypotheses/backlog.json',
+        'credits/latest.json',
+        'control_plane/current_summary.json',
+        'self_evolution/current_state.json',
+    ]:
+        path = state_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{}', encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    parity = _dashboard_runtime_parity(
+        {
+            'current_task_id': 'analyze-last-failed-candidate',
+            'feedback_decision': {'mode': 'retire_terminal_selfevo_lane', 'selected_task_id': 'record-reward'},
+        },
+        {
+            'current_task_id': 'subagent-verify-materialized-improvement',
+            'task_selection_source': 'feedback_post_completion_handoff',
+            'feedback_decision': {
+                'mode': 'handoff_to_next_candidate',
+                'current_task_id': 'materialize-pass-streak-improvement',
+                'selected_task_id': 'subagent-verify-materialized-improvement',
+                'selection_source': 'feedback_post_completion_handoff',
+            },
+        },
+        cfg,
+    )
+
+    assert parity['state'] == 'healthy'
+    assert 'current_task_drift' not in parity['reasons']
+    assert parity['canonical_current_task_id'] == 'subagent-verify-materialized-improvement'
+    assert parity['authority_resolution'] == 'fresh_live_hadi_handoff'


### PR DESCRIPTION
## Summary
- Treat a fresh live eeepc HADI handoff as authoritative when local/repo task state is stale.
- Preserve raw local/live current-task evidence while setting `canonical_current_task_id` to the live handoff task.
- Add `authority_resolution = fresh_live_hadi_handoff` so the reconciliation is auditable instead of silently hiding drift.

## Issue
Fixes #229
Progresses #210

## Why
After #220/#226/#228, the live privileged host-control-plane is PASS and advanced to `subagent-verify-materialized-improvement` with:
- `feedback_decision.mode = handoff_to_next_candidate`
- `feedback_decision.selection_source = feedback_post_completion_handoff`
- `feedback_decision.selected_task_id = subagent-verify-materialized-improvement`

The local/repo snapshot was stale on `analyze-last-failed-candidate`, causing `/api/system.runtime_parity` to remain degraded with `current_task_drift` even though the live host had valid HADI follow-through evidence.

## Safety rule
The live task only wins when required local HADI artifacts exist and the live feedback handoff is explicit: selected task is present and equals the live current task.

## Test plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_runtime_parity_adopts_fresh_live_hadi_handoff_when_local_task_is_stale -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

## Results
- focused #229 test: `1 passed`
- dashboard suite: `77 passed`
- root suite: `616 passed, 5 skipped`
- delegated review: APPROVED
