### PR TITLE
fix: keep stale subagent retirement on repair lane

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1382,7 +1382,7 @@ def _build_task_plan_snapshot(
                 "failure_learning": latest_failure_learning,
                 "terminal_selfevo_issue": terminal_selfevo_issue,
             }
-        elif terminal_selfevo_issue is not None:
+        elif terminal_selfevo_issue is not None and current_task_id != "subagent-verify-materialized-improvement":
             for task in tasks:
                 if task.get("task_id") == "analyze-last-failed-candidate":
                     task["status"] = "done"
@@ -1426,6 +1426,20 @@ def _build_task_plan_snapshot(
                 task['status'] = 'pending' if task.get('task_id') != 'analyze-last-failed-candidate' and task.get('status') == 'active' else task.get('status')
             repair_task['status'] = 'active'
             current_task_id = 'analyze-last-failed-candidate'
+            feedback_decision = {
+                "mode": "fresh_failure_learning_repair",
+                "reason": "fresh failure-learning evidence remains the stronger repair lane than stale subagent bookkeeping",
+                "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
+                "current_task_id": recorded_current_task_id,
+                "current_task_class": _task_action_class(recorded_current_task_id),
+                "selected_task_id": "analyze-last-failed-candidate",
+                "selected_task_class": _task_action_class("analyze-last-failed-candidate"),
+                "selection_source": "feedback_stale_subagent_retire_to_failure_learning" if recorded_current_task_id == "subagent-verify-materialized-improvement" else "generated_from_failure_learning",
+                "selected_task_title": "Analyze the last failed self-evolution candidate before retrying mutation",
+                "selected_task_label": "Analyze the last failed self-evolution candidate before retrying mutation [task_id=analyze-last-failed-candidate]",
+                "failure_learning": latest_failure_learning,
+                "terminal_selfevo_issue": terminal_selfevo_issue,
+            }
     generated_candidates = _derive_generated_candidates(
         goals_dir=goals_dir,
         result_status=result_status,
@@ -1533,30 +1547,54 @@ def _build_task_plan_snapshot(
         )
     )
     if should_retire_subagent_lane:
+        subagent_retirement_target_id = "record-reward"
+        subagent_retirement_target_title = "Record cycle reward"
+        subagent_retirement_selection_source = "feedback_terminal_noop_retire" if latest_noop.get("status") == "terminal_noop" else "feedback_stale_subagent_retire"
+        if failure_learning_is_fresh and isinstance(latest_failure_learning, dict):
+            subagent_retirement_target_id = "analyze-last-failed-candidate"
+            subagent_retirement_target_title = "Analyze the last failed self-evolution candidate before retrying mutation"
+            subagent_retirement_selection_source = "feedback_stale_subagent_retire_to_failure_learning"
         for task in tasks:
             if task.get("task_id") == "subagent-verify-materialized-improvement":
                 task["status"] = "blocked" if subagent_lane_health.get("state") == "stale" else "done"
                 task["terminal_reason"] = "terminal_noop_or_no_material_change"
-            elif task.get("task_id") == "record-reward":
+            elif task.get("task_id") == subagent_retirement_target_id:
                 task["status"] = "active"
+                if subagent_retirement_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
+                    task["selection_source"] = subagent_retirement_selection_source
+                    task["failed_candidate_id"] = latest_failure_learning.get("candidate_id")
+                    task["failed_commit"] = latest_failure_learning.get("failed_commit")
+                    task["health_reasons"] = latest_failure_learning.get("health_reasons")
             elif task.get("status") == "active":
                 task["status"] = "pending"
-        if not any(task.get("task_id") == "record-reward" for task in tasks):
-            tasks.append({"task_id": "record-reward", "title": "Record cycle reward", "status": "active"})
-        current_task_id = "record-reward"
+        if not any(task.get("task_id") == subagent_retirement_target_id for task in tasks):
+            task_payload = {"task_id": subagent_retirement_target_id, "title": subagent_retirement_target_title, "status": "active"}
+            if subagent_retirement_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
+                task_payload.update({
+                    "kind": "review",
+                    "acceptance": "produce a bounded explanation of the failed candidate and one safer follow-up mutation idea",
+                    "selection_source": subagent_retirement_selection_source,
+                    "failed_candidate_id": latest_failure_learning.get("candidate_id"),
+                    "failed_commit": latest_failure_learning.get("failed_commit"),
+                    "health_reasons": latest_failure_learning.get("health_reasons"),
+                })
+            tasks.append(task_payload)
+        current_task_id = subagent_retirement_target_id
         feedback_decision = {
             "mode": "retire_terminal_noop_lane" if latest_noop.get("status") == "terminal_noop" else "retire_stale_subagent_lane",
             "reason": "subagent verification lane reached a terminal no-op/discard/stale state and must not keep producing PASS-only telemetry",
             "current_task_id": "subagent-verify-materialized-improvement",
             "current_task_class": _task_action_class("subagent-verify-materialized-improvement"),
-            "selected_task_id": "record-reward",
-            "selected_task_class": _task_action_class("record-reward"),
-            "selection_source": "feedback_terminal_noop_retire" if latest_noop.get("status") == "terminal_noop" else "feedback_stale_subagent_retire",
-            "selected_task_title": "Record cycle reward",
-            "selected_task_label": "Record cycle reward [task_id=record-reward]",
+            "selected_task_id": subagent_retirement_target_id,
+            "selected_task_class": _task_action_class(subagent_retirement_target_id),
+            "selection_source": subagent_retirement_selection_source,
+            "selected_task_title": subagent_retirement_target_title,
+            "selected_task_label": f"{subagent_retirement_target_title} [task_id={subagent_retirement_target_id}]",
             "latest_noop": latest_noop if latest_noop else None,
             "subagent_lane_health": subagent_lane_health,
         }
+        if subagent_retirement_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
+            feedback_decision["failure_learning"] = latest_failure_learning
     task_counts = {
         "total": len(tasks),
         "done": sum(1 for task in tasks if task["status"] == "done"),

--- a/tests/test_live_followthrough_drift.py
+++ b/tests/test_live_followthrough_drift.py
@@ -64,3 +64,70 @@ def test_retired_record_reward_does_not_mask_fresh_failure_learning_even_with_te
     report = _read_json(sorted((tmp_path / 'state' / 'reports').glob('evolution-*.json'))[-1])
     assert report['current_task_id'] == 'analyze-last-failed-candidate'
     assert report['feedback_decision']['selection_source'] == 'feedback_fresh_failure_learning_after_reward_retirement'
+
+
+def test_stale_subagent_lane_retirement_prefers_fresh_failure_learning_over_record_reward(tmp_path: Path):
+    approvals_dir = tmp_path / 'state' / 'approvals'
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 27, 2, 30, tzinfo=timezone.utc)
+    (approvals_dir / 'apply.ok').write_text(json.dumps({'expires_at_utc': expires_at.isoformat(), 'ttl_minutes': 120}), encoding='utf-8')
+
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'subagent-verify-materialized-improvement',
+        'tasks': [
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+            {'task_id': 'subagent-verify-materialized-improvement', 'title': 'Use one bounded subagent-assisted review to verify the materialized improvement artifact', 'status': 'active', 'kind': 'review'},
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'pending', 'kind': 'review'},
+        ],
+        'feedback_decision': {
+            'mode': 'handoff_to_next_candidate',
+            'current_task_id': 'materialize-pass-streak-improvement',
+            'selected_task_id': 'subagent-verify-materialized-improvement',
+            'selection_source': 'feedback_post_completion_handoff',
+        },
+    }), encoding='utf-8')
+
+    learning_dir = tmp_path / 'state' / 'self_evolution' / 'failure_learning'
+    learning_dir.mkdir(parents=True, exist_ok=True)
+    (learning_dir / 'latest.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-live-bad',
+        'failed_commit': 'deadbeef',
+        'health_reasons': ['stale_report'],
+        'learning_summary': 'Fresh failure learning remains the stronger repair lane.',
+    }), encoding='utf-8')
+
+    runtime_dir = tmp_path / 'state' / 'self_evolution' / 'runtime'
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / 'latest_issue_lifecycle.json').write_text(json.dumps({
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'selfevo_branch': 'fix/issue-42-analyze-last-failed-candidate',
+        'selfevo_issue': {'number': 42, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+    }), encoding='utf-8')
+
+    # The discarded/no-material-change experiment is the live condition that used
+    # to retire the subagent lane by reactivating record-reward.
+    experiments_dir = tmp_path / 'state' / 'experiments'
+    experiments_dir.mkdir(parents=True, exist_ok=True)
+    (experiments_dir / 'latest.json').write_text(json.dumps({
+        'outcome': 'discard',
+        'revert_status': 'skipped_no_material_change',
+    }), encoding='utf-8')
+
+    execute = AsyncMock(return_value='agent completed bounded work')
+    now = expires_at - timedelta(minutes=15)
+    asyncio.run(run_self_evolving_cycle(workspace=tmp_path, tasks='check open tasks', execute_turn=execute, now=now))
+
+    current = _read_json(tmp_path / 'state' / 'goals' / 'current.json')
+    assert current['current_task_id'] == 'analyze-last-failed-candidate'
+    assert current['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'
+    assert current['feedback_decision']['selection_source'] == 'feedback_stale_subagent_retire_to_failure_learning'
+
+    report = _read_json(sorted((tmp_path / 'state' / 'reports').glob('evolution-*.json'))[-1])
+    assert report['current_task_id'] == 'analyze-last-failed-candidate'
+    assert report['feedback_decision']['mode'] == 'fresh_failure_learning_repair'


### PR DESCRIPTION
## Summary
- Prevent stale subagent-lane retirement from falling back to `record-reward` when fresh failure-learning evidence is available.
- Keep `analyze-last-failed-candidate` as the current task in that case and emit explicit repair feedback metadata.
- Add a regression for the live #231 shape: stale subagent lane + discarded/no-material experiment + fresh failure learning.

## Issue
Fixes #231
Progresses #210

## Why
After #229, live eeepc was PASS but emitted:
- `current_task_id = record-reward`
- `feedback_decision.mode = retire_stale_subagent_lane`
- `feedback_decision.current_task_id = subagent-verify-materialized-improvement`
- `feedback_decision.selected_task_id = record-reward`

This reintroduced runtime parity drift against local canonical `analyze-last-failed-candidate`.

## Fix
When fresh failure learning exists and the active lane is `subagent-verify-materialized-improvement`, terminal/stale subagent retirement now targets the stronger repair lane:
- `current_task_id = analyze-last-failed-candidate`
- `selected_task_id = analyze-last-failed-candidate`
- `selection_source = feedback_stale_subagent_retire_to_failure_learning`
- `mode = fresh_failure_learning_repair`

## Test plan
- `python3 -m pytest tests/test_live_followthrough_drift.py tests/test_autonomy_stagnation_followthrough.py tests/test_failure_learning_feedback.py tests/test_noncore_continue.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

## Results
- focused related suite: `11 passed`
- root suite: `617 passed, 5 skipped`
- dashboard suite: `77 passed`
- delegated review: APPROVED
