### PR TITLE
fix: reconcile live pass streak authority

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -881,6 +881,16 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         and _has_value(live_hadi_handoff_selected_task)
         and str(live_hadi_handoff_selected_task) == str(live_task)
     )
+    live_pass_streak_switch = (
+        all(artifacts.values())
+        and isinstance(live_feedback, dict)
+        and live_feedback.get('mode') == 'retire_goal_artifact_pair'
+        and live_feedback.get('retire_goal_artifact_pair') is True
+        and live_feedback.get('current_task_id') == 'record-reward'
+        and live_feedback.get('selection_source') == 'feedback_pass_streak_switch'
+        and _has_value(live_hadi_handoff_selected_task)
+        and str(live_hadi_handoff_selected_task) == str(live_task)
+    )
     authority_resolution = None
     canonical_task = local_task or live_task
     if local_task and live_task and str(local_task) not in str(live_task):
@@ -888,6 +898,9 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
             reasons.append('legacy_live_reward_loop_current_task')
         elif live_hadi_handoff:
             authority_resolution = 'fresh_live_hadi_handoff'
+            canonical_task = live_task
+        elif live_pass_streak_switch:
+            authority_resolution = 'fresh_live_pass_streak_switch'
             canonical_task = live_task
         else:
             reasons.append('current_task_drift')

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -877,3 +877,45 @@ def test_runtime_parity_adopts_fresh_live_hadi_handoff_when_local_task_is_stale(
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'subagent-verify-materialized-improvement'
     assert parity['authority_resolution'] == 'fresh_live_hadi_handoff'
+
+
+def test_runtime_parity_adopts_fresh_live_pass_streak_switch_when_local_task_is_stale(tmp_path: Path) -> None:
+    from nanobot_ops_dashboard.app import _dashboard_runtime_parity
+
+    repo_root = tmp_path / 'nanobot'
+    state_root = repo_root / 'workspace' / 'state'
+    for rel in [
+        'hypotheses/backlog.json',
+        'credits/latest.json',
+        'control_plane/current_summary.json',
+        'self_evolution/current_state.json',
+    ]:
+        path = state_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{}', encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    parity = _dashboard_runtime_parity(
+        {
+            'current_task_id': 'analyze-last-failed-candidate',
+            'feedback_decision': {'mode': 'fresh_failure_learning_repair', 'selected_task_id': 'analyze-last-failed-candidate'},
+        },
+        {
+            'current_task_id': 'inspect-pass-streak',
+            'task_selection_source': 'feedback_pass_streak_switch',
+            'feedback_decision': {
+                'mode': 'retire_goal_artifact_pair',
+                'current_task_id': 'record-reward',
+                'selected_task_id': 'inspect-pass-streak',
+                'selection_source': 'feedback_pass_streak_switch',
+                'retire_goal_artifact_pair': True,
+                'strong_pass_count': 3,
+            },
+        },
+        cfg,
+    )
+
+    assert parity['state'] == 'healthy'
+    assert 'current_task_drift' not in parity['reasons']
+    assert parity['canonical_current_task_id'] == 'inspect-pass-streak'
+    assert parity['authority_resolution'] == 'fresh_live_pass_streak_switch'


### PR DESCRIPTION
## Summary
- Reconcile fresh live pass-streak switch authority when local/repo task state is stale.
- Preserve raw local/live current-task ids while setting `canonical_current_task_id` to the live selected task and `authority_resolution = fresh_live_pass_streak_switch`.

## Issue
Fixes #234
Progresses #210

## Why
After #233 synchronized failure-learning evidence, live eeepc advanced to:
- `current_task_id = inspect-pass-streak`
- `feedback_decision.mode = retire_goal_artifact_pair`
- `feedback_decision.current_task_id = record-reward`
- `feedback_decision.selected_task_id = inspect-pass-streak`
- `feedback_decision.selection_source = feedback_pass_streak_switch`

Dashboard still treated this as generic `current_task_drift` because local state was stale on `analyze-last-failed-candidate`.

## Safety rule
The live pass-streak task only wins when required artifacts exist and the live feedback is explicit:
- mode is `retire_goal_artifact_pair`,
- `retire_goal_artifact_pair = true`,
- previous/current feedback task is `record-reward`,
- selection source is `feedback_pass_streak_switch`,
- selected task is present and equals the live current task.

## Test plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_runtime_parity_adopts_fresh_live_pass_streak_switch_when_local_task_is_stale -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

## Results
- focused #234 regression: `1 passed`
- dashboard suite: `78 passed`
- root suite: `617 passed, 5 skipped`
- delegated review: APPROVED
