### PR TITLE
fix: deepen autonomous runtime followthrough

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from nanobot.runtime.coordinator import run_self_evolving_cycle
@@ -21,6 +24,25 @@ def _prime_runtime_defaults() -> None:
     os.environ.setdefault("NANOBOT_RUNTIME_STATE_ROOT", str(DEFAULT_RUNTIME_STATE_ROOT))
 
 
+def _write_strong_reflection_artifact(*, state_root: Path, workspace: Path, summary: str) -> Path:
+    """Persist durable strong-reflection evidence for dashboard and audits."""
+    reflection_dir = state_root / "strong_reflection"
+    reflection_dir.mkdir(parents=True, exist_ok=True)
+    recorded_at = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "schema_version": "strong-reflection-run-v1",
+        "recorded_at_utc": recorded_at,
+        "workspace": str(workspace),
+        "summary": summary,
+        "mode": "strong-reflection",
+    }
+    latest = reflection_dir / "latest.json"
+    latest.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    history = reflection_dir / f"reflection-{recorded_at.replace(':', '').replace('+', 'Z')}.json"
+    history.write_text(json.dumps({**payload, "latest_path": str(latest)}, indent=2, ensure_ascii=False), encoding="utf-8")
+    return latest
+
+
 def main() -> int:
     previous_source = os.environ.get("NANOBOT_RUNTIME_STATE_SOURCE")
     previous_root = os.environ.get("NANOBOT_RUNTIME_STATE_ROOT")
@@ -36,6 +58,10 @@ def main() -> int:
                 execute_turn=_execute_turn,
             )
         )
+        if any(arg == "strong-reflection" for arg in sys.argv[1:]):
+            state_root = Path(os.environ.get("NANOBOT_RUNTIME_STATE_ROOT", str(workspace / "state"))).expanduser()
+            artifact_path = _write_strong_reflection_artifact(state_root=state_root, workspace=workspace, summary=summary)
+            print(f"Strong reflection artifact persisted: {artifact_path}")
         print(summary)
         return 0
     finally:

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -33,7 +33,9 @@ class SubagentManager:
         web_search_config: "WebSearchConfig | None" = None,
         web_proxy: str | None = None,
         exec_config: "ExecToolConfig | None" = None,
+        subagent_config: Any | None = None,
         restrict_to_workspace: bool = False,
+        max_running: int | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -44,6 +46,9 @@ class SubagentManager:
         self.web_search_config = web_search_config or WebSearchConfig()
         self.web_proxy = web_proxy
         self.exec_config = exec_config or ExecToolConfig()
+        self.subagent_config = subagent_config
+        configured_max_running = getattr(subagent_config, "max_running", None)
+        self.max_running = int(max_running or configured_max_running or 1)
         self.restrict_to_workspace = restrict_to_workspace
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
@@ -59,11 +64,14 @@ class SubagentManager:
         origin_channel: str = "cli",
         origin_chat_id: str = "direct",
         session_key: str | None = None,
+        **runtime_options: Any,
     ) -> str:
         """Spawn a subagent to execute a task in the background."""
         task_id = str(uuid.uuid4())[:8]
         display_label = label or task[:30] + ("..." if len(task) > 30 else "")
         origin = {"channel": origin_channel, "chat_id": origin_chat_id, "session_key": session_key}
+        if runtime_options:
+            origin["runtime_options"] = {key: value for key, value in runtime_options.items() if value is not None}
         correlation_context = self._build_subagent_correlation_context()
         self._write_subagent_telemetry(
             task_id,

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -143,11 +143,22 @@ class MCPServerConfig(Base):
     tool_timeout: int = 30  # seconds before a tool call is cancelled
     enabled_tools: list[str] = Field(default_factory=lambda: ["*"])  # Only register these tools; accepts raw MCP names or wrapped mcp_<server>_<tool> names; ["*"] = all tools; [] = no tools
 
+class SubagentToolConfig(Base):
+    """Subagent execution tool configuration.
+
+    Kept under tools.subagent for compatibility with deployed eeepc bridge
+    scripts that tune concurrency separately from the in-process manager.
+    """
+
+    max_running: int = 1
+
+
 class ToolsConfig(Base):
     """Tools configuration."""
 
     web: WebToolsConfig = Field(default_factory=WebToolsConfig)
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
+    subagent: SubagentToolConfig = Field(default_factory=SubagentToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1499,7 +1499,7 @@ def _build_task_plan_snapshot(
                 task["status"] = "pending"
         combined_candidates = [candidate for candidate in combined_candidates if candidate.get("task_id") not in {"inspect-pass-streak", "materialize-pass-streak-improvement"}]
         next_candidate = next((candidate for candidate in combined_candidates if candidate.get("task_id") == "subagent-verify-materialized-improvement"), None)
-        if next_candidate is not None:
+        if next_candidate is not None and not isinstance(latest_failure_learning, dict):
             for task in tasks:
                 if task.get("task_id") == next_candidate.get("task_id"):
                     task["status"] = "active"
@@ -1520,20 +1520,55 @@ def _build_task_plan_snapshot(
                 "artifact_path": materialized_improvement_artifact_path,
             }
         else:
-            current_task_id = "record-reward"
+            completion_target_id = "record-reward"
+            completion_target_title = "Record cycle reward"
+            completion_selection_source = "feedback_complete_active_lane"
+            completion_reason = "materialized improvement artifact written; richer execution lane completed"
+            if isinstance(latest_failure_learning, dict):
+                completion_target_id = "analyze-last-failed-candidate"
+                completion_target_title = "Analyze the last failed self-evolution candidate before retrying mutation"
+                completion_selection_source = "feedback_complete_active_lane_to_failure_learning"
+                completion_reason = "materialized improvement artifact written, but fresh failure-learning evidence remains the next non-bookkeeping lane"
+            for task in tasks:
+                if task.get("task_id") == completion_target_id:
+                    task["status"] = "active"
+                    if completion_target_id == "analyze-last-failed-candidate":
+                        task["selection_source"] = completion_selection_source
+                        task["failed_candidate_id"] = latest_failure_learning.get("candidate_id") if isinstance(latest_failure_learning, dict) else None
+                        task["failed_commit"] = latest_failure_learning.get("failed_commit") if isinstance(latest_failure_learning, dict) else None
+                        task["health_reasons"] = latest_failure_learning.get("health_reasons") if isinstance(latest_failure_learning, dict) else None
+                elif task.get("task_id") == "record-reward":
+                    task["status"] = "pending" if completion_target_id != "record-reward" else "active"
+                elif task.get("status") == "active":
+                    task["status"] = "pending"
+            if not any(task.get("task_id") == completion_target_id for task in tasks):
+                task_payload = {"task_id": completion_target_id, "title": completion_target_title, "status": "active"}
+                if completion_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
+                    task_payload.update({
+                        "kind": "review",
+                        "acceptance": "produce a bounded explanation of the failed candidate and one safer follow-up mutation idea",
+                        "selection_source": completion_selection_source,
+                        "failed_candidate_id": latest_failure_learning.get("candidate_id"),
+                        "failed_commit": latest_failure_learning.get("failed_commit"),
+                        "health_reasons": latest_failure_learning.get("health_reasons"),
+                    })
+                tasks.append(task_payload)
+            current_task_id = completion_target_id
             feedback_decision = {
                 "mode": "complete_active_lane",
-                "reason": "materialized improvement artifact written; richer execution lane completed",
+                "reason": completion_reason,
                 "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
                 "current_task_id": "materialize-pass-streak-improvement",
                 "current_task_class": _task_action_class("materialize-pass-streak-improvement"),
-                "selected_task_id": "record-reward",
-                "selected_task_class": _task_action_class("record-reward"),
-                "selection_source": "feedback_complete_active_lane",
-                "selected_task_title": "Record cycle reward",
-                "selected_task_label": "Record cycle reward [task_id=record-reward]",
+                "selected_task_id": completion_target_id,
+                "selected_task_class": _task_action_class(completion_target_id),
+                "selection_source": completion_selection_source,
+                "selected_task_title": completion_target_title,
+                "selected_task_label": f"{completion_target_title} [task_id={completion_target_id}]",
                 "artifact_path": materialized_improvement_artifact_path,
             }
+            if completion_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
+                feedback_decision["failure_learning"] = latest_failure_learning
         active_artifact_path = materialized_improvement_artifact_path
     latest_noop = _safe_read_json(workspace / "state" / "self_evolution" / "runtime" / "latest_noop.json") or {}
     subagent_lane_health = _subagent_lane_health(state_root=workspace / "state", current_task_id=current_task_id)

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -921,7 +921,110 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
     }
 
 
-def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None) -> dict:
+def _strong_reflection_freshness(cfg: DashboardConfig, now: datetime) -> dict:
+    path = cfg.nanobot_repo_root / 'workspace' / 'state' / 'strong_reflection' / 'latest.json'
+    payload = _json_file(path)
+    if not payload:
+        return {
+            'schema_version': 'strong-reflection-freshness-v1',
+            'state': 'missing',
+            'available': False,
+            'path': str(path),
+            'reason': 'strong_reflection_latest_missing',
+        }
+    recorded_at = payload.get('recorded_at_utc')
+    ts = _parse_timestamp(recorded_at) if recorded_at else None
+    age = max(0, int((now.astimezone(timezone.utc) - ts).total_seconds())) if ts is not None else None
+    state = 'fresh' if isinstance(age, int) and age <= 8 * 3600 else 'stale'
+    return {
+        'schema_version': 'strong-reflection-freshness-v1',
+        'state': state,
+        'available': True,
+        'path': str(path),
+        'recorded_at_utc': recorded_at,
+        'age_seconds': age,
+        'summary': payload.get('summary'),
+        'mode': payload.get('mode'),
+    }
+
+
+def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dict, subagent_visibility: dict | None = None) -> dict:
+    """Classify whether recent autonomous activity is substantive or shallow.
+
+    PASS cycles alone are not enough: repeated discarded cycles with almost no
+    tool/subagent/time usage are active telemetry, not ambitious self-development.
+    """
+    recent = analytics.get('recent_status_sequence') or []
+    low_budget_discard_count = 0
+    inspected = 0
+    total_requests = 0
+    total_tool_calls = 0
+    total_subagents = 0
+    total_elapsed = 0
+    repeated_tasks: list[str] = []
+    for row in recent[:20]:
+        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
+        budget_used = detail.get('budget_used') if isinstance(detail.get('budget_used'), dict) else experiment.get('budget_used') if isinstance(experiment.get('budget_used'), dict) else {}
+        if not isinstance(budget_used, dict):
+            budget_used = {}
+        outcome = experiment.get('outcome') or detail.get('outcome')
+        task_id = detail.get('current_task_id') or row.get('title')
+        if task_id:
+            repeated_tasks.append(str(task_id))
+        requests = int(budget_used.get('requests') or 0)
+        tool_calls = int(budget_used.get('tool_calls') or 0)
+        subagents = int(budget_used.get('subagents') or 0)
+        elapsed = int(budget_used.get('elapsed_seconds') or 0)
+        total_requests += requests
+        total_tool_calls += tool_calls
+        total_subagents += subagents
+        total_elapsed += elapsed
+        inspected += 1
+        if outcome == 'discard' and requests <= 1 and tool_calls <= 2 and subagents == 0 and elapsed <= 1:
+            low_budget_discard_count += 1
+    current_experiment = experiment_visibility.get('current_experiment') if isinstance(experiment_visibility, dict) else {}
+    current_budget_used = current_experiment.get('budget_used') if isinstance(current_experiment, dict) and isinstance(current_experiment.get('budget_used'), dict) else {}
+    current_outcome = current_experiment.get('outcome') if isinstance(current_experiment, dict) else None
+    if inspected == 0 and isinstance(current_budget_used, dict):
+        inspected = 1
+        total_requests = int(current_budget_used.get('requests') or 0)
+        total_tool_calls = int(current_budget_used.get('tool_calls') or 0)
+        total_subagents = int(current_budget_used.get('subagents') or 0)
+        total_elapsed = int(current_budget_used.get('elapsed_seconds') or 0)
+        if current_outcome == 'discard' and total_requests <= 1 and total_tool_calls <= 2 and total_subagents == 0 and total_elapsed <= 1:
+            low_budget_discard_count = 1
+    same_task_streak = len(repeated_tasks) >= 5 and len(set(repeated_tasks[:5])) == 1
+    bridge_summary = subagent_visibility if isinstance(subagent_visibility, dict) else {}
+    reasons: list[str] = []
+    if low_budget_discard_count >= 5:
+        reasons.append('low_budget_discard_streak')
+    if same_task_streak:
+        reasons.append('same_task_streak')
+    if inspected >= 5 and total_subagents == 0:
+        reasons.append('subagents_unused')
+    if inspected >= 5 and total_tool_calls <= inspected * 2:
+        reasons.append('tool_budget_underused')
+    state = 'underutilized' if reasons else 'substantive'
+    return {
+        'schema_version': 'ambition-utilization-v1',
+        'state': state,
+        'reasons': reasons,
+        'recent_window': inspected,
+        'low_budget_discard_count': low_budget_discard_count,
+        'budget_used_sum': {
+            'requests': total_requests,
+            'tool_calls': total_tool_calls,
+            'subagents': total_subagents,
+            'elapsed_seconds': total_elapsed,
+        },
+        'same_task_streak': same_task_streak,
+        'subagent_visibility_available': bool(bridge_summary),
+        'recommended_next_action': 'escalate_to_higher_ambition_lane_or_emit_precise_blocker' if state == 'underutilized' else None,
+    }
+
+
+def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None) -> dict:
     reasons: list[str] = []
     state_root = cfg.nanobot_repo_root / 'workspace' / 'state'
     recent = analytics.get('recent_status_sequence') or []
@@ -966,6 +1069,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     )
     if runtime_parity_is_blocking and not runtime_can_be_historical:
         reasons.append('runtime_parity_blocked')
+    ambition_utilization = ambition_utilization if isinstance(ambition_utilization, dict) else {}
     historical_reasons: list[str] = []
     if material_allows_healthy:
         stale_after_material_progress = {'same_task_streak', 'discarded_experiment', 'suppressed_reward', 'terminal_noop'}
@@ -978,7 +1082,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
         if runtime_parity_is_blocking and runtime_can_be_historical:
             historical_reasons.append('runtime_parity_blocked')
         reasons = blocking_reasons
-    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked'}) else 'healthy')
+    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized'}) else 'healthy')
     return {
         'schema_version': 'autonomy-verdict-v1',
         'state': status,
@@ -987,6 +1091,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
         'current_task_id': (plan_latest or {}).get('current_task_id') or (plan_latest or {}).get('current_task'),
         'pass_streak': analytics.get('current_streak'),
         'material_progress': material_progress or None,
+        'ambition_utilization': ambition_utilization or None,
     }
 
 
@@ -2215,6 +2320,7 @@ def create_app(cfg: DashboardConfig):
                     'source': row.get('source'),
                     'status': row.get('status'),
                     'title': row.get('title'),
+                    'detail': row.get('detail'),
                 }
                 for row in cycles[:20]
             ],
@@ -2250,6 +2356,14 @@ def create_app(cfg: DashboardConfig):
                     'title': summary.get('goal_id') or 'unknown',
                     'artifact': summary.get('report_path'),
                 }]
+        ambition_utilization = _ambition_utilization_verdict(
+            analytics=analytics,
+            experiment_visibility=experiment_visibility,
+            subagent_visibility=subagent_visibility,
+        )
+        strong_reflection_freshness = _strong_reflection_freshness(cfg, now)
+        analytics['ambition_utilization'] = ambition_utilization
+        analytics['strong_reflection_freshness'] = strong_reflection_freshness
         autonomy_verdict = _autonomy_verdict(
             analytics=analytics,
             plan_latest=plan_latest,
@@ -2258,6 +2372,7 @@ def create_app(cfg: DashboardConfig):
             cfg=cfg,
             material_progress=control_plane.get('material_progress') if isinstance(control_plane, dict) else None,
             runtime_parity=runtime_parity,
+            ambition_utilization=ambition_utilization,
         )
         analytics['runtime_parity'] = runtime_parity
         analytics['autonomy_verdict'] = autonomy_verdict
@@ -2265,6 +2380,8 @@ def create_app(cfg: DashboardConfig):
             control_plane = dict(control_plane)
             control_plane['material_progress'] = _material_progress_summary(control_plane.get('material_progress'))
             control_plane['runtime_parity'] = runtime_parity
+            control_plane['ambition_utilization'] = ambition_utilization
+            control_plane['strong_reflection_freshness'] = strong_reflection_freshness
             control_plane['autonomy_verdict'] = autonomy_verdict
 
         request_source = query.get('source', [''])[0]
@@ -2307,6 +2424,8 @@ def create_app(cfg: DashboardConfig):
             'current_budget': experiment_visibility['current_budget'],
             'current_reward_signal': experiment_visibility['current_reward_signal'],
             'current_reward_text': experiment_visibility['current_reward_text'],
+            'ambition_utilization': ambition_utilization,
+            'strong_reflection_freshness': strong_reflection_freshness,
             'credits_visibility': credits_visibility,
             'current_credits': credits_visibility['current'],
             'credits_history': credits_visibility['history'],

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -919,3 +919,46 @@ def test_runtime_parity_adopts_fresh_live_pass_streak_switch_when_local_task_is_
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'inspect-pass-streak'
     assert parity['authority_resolution'] == 'fresh_live_pass_streak_switch'
+
+
+def test_ambition_utilization_flags_low_budget_discard_streak() -> None:
+    from nanobot_ops_dashboard.app import _ambition_utilization_verdict
+
+    analytics = {
+        'recent_status_sequence': [
+            {
+                'status': 'PASS',
+                'title': 'analyze-last-failed-candidate',
+                'detail': {
+                    'current_task_id': 'analyze-last-failed-candidate',
+                    'experiment': {'outcome': 'discard'},
+                    'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+                },
+            }
+            for _ in range(6)
+        ]
+    }
+    verdict = _ambition_utilization_verdict(analytics=analytics, experiment_visibility={}, subagent_visibility={})
+    assert verdict['state'] == 'underutilized'
+    assert 'low_budget_discard_streak' in verdict['reasons']
+    assert 'subagents_unused' in verdict['reasons']
+
+
+def test_strong_reflection_freshness_exposes_latest_artifact(tmp_path: Path) -> None:
+    from datetime import datetime, timezone
+    from nanobot_ops_dashboard.app import _strong_reflection_freshness
+
+    repo_root = tmp_path / 'nanobot'
+    latest = repo_root / 'workspace' / 'state' / 'strong_reflection' / 'latest.json'
+    latest.parent.mkdir(parents=True)
+    latest.write_text(json.dumps({
+        'schema_version': 'strong-reflection-run-v1',
+        'recorded_at_utc': '2026-04-27T00:00:00+00:00',
+        'summary': 'Self-evolving cycle PASS — evidence=evidence-1',
+        'mode': 'strong-reflection',
+    }), encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing', eeepc_state_root='/state')
+    result = _strong_reflection_freshness(cfg, datetime(2026, 4, 27, 1, 0, tzinfo=timezone.utc))
+    assert result['state'] == 'fresh'
+    assert result['available'] is True
+    assert result['summary'].startswith('Self-evolving cycle PASS')

--- a/tests/test_app_main.py
+++ b/tests/test_app_main.py
@@ -1,0 +1,11 @@
+import json
+
+
+def test_strong_reflection_artifact_writer(tmp_path):
+    from app.main import _write_strong_reflection_artifact
+
+    path = _write_strong_reflection_artifact(state_root=tmp_path / 'state', workspace=tmp_path, summary='Self-evolving cycle PASS — evidence=e1')
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    assert payload['schema_version'] == 'strong-reflection-run-v1'
+    assert payload['mode'] == 'strong-reflection'
+    assert payload['summary'].endswith('e1')

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 
@@ -174,3 +175,53 @@ def test_runtime_parity_summary_classifies_legacy_reward_loop() -> None:
     assert 'live_feedback_decision_missing' in summary['reasons']
     assert 'live_hadi_artifacts_missing' in summary['reasons']
     assert summary['missing_live_artifacts'] == ['hypotheses_backlog', 'credits_latest', 'control_plane_current_summary', 'self_evolution_current_state']
+
+
+def test_complete_active_lane_prefers_failure_learning_over_record_reward(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    failure_dir = state_root / 'self_evolution' / 'failure_learning'
+    failure_dir.mkdir(parents=True)
+    artifact = state_root / 'materialized_improvements' / 'artifact.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{}', encoding='utf-8')
+    failure_path = failure_dir / 'latest.json'
+    failure_path.write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-ambitious',
+        'failed_commit': 'deadbeef',
+        'health_reasons': ['stale_report'],
+    }), encoding='utf-8')
+    old_time = time.time() - 7200
+    os.utime(failure_path, (old_time, old_time))
+    (goals / 'current.json').write_text(json.dumps({
+        'current_task_id': 'materialize-pass-streak-improvement',
+        'tasks': [
+            {'task_id': 'inspect-pass-streak', 'title': 'Inspect repeated PASS streak', 'status': 'done'},
+            {'task_id': 'materialize-pass-streak-improvement', 'title': 'Materialize one bounded improvement', 'status': 'active'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+        ],
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-complete-active',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {}, 'outcome': 'keep'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals,
+        materialized_improvement_artifact_path=str(artifact),
+    )
+
+    assert plan['current_task_id'] == 'analyze-last-failed-candidate'
+    assert plan['feedback_decision']['mode'] == 'complete_active_lane'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_complete_active_lane_to_failure_learning'
+    assert plan['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,7 @@
+
+
+def test_tools_config_exposes_subagent_compatibility_section():
+    from nanobot.config.schema import ToolsConfig
+
+    cfg = ToolsConfig()
+    assert cfg.subagent.max_running == 1

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -1,0 +1,21 @@
+
+
+def test_subagent_manager_accepts_deployed_bridge_compat_kwargs(tmp_path):
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    class Provider:
+        def get_default_model(self):
+            return 'test-model'
+
+    class SubagentCfg:
+        max_running = 3
+
+    manager = SubagentManager(
+        provider=Provider(),
+        workspace=tmp_path,
+        bus=MessageBus(),
+        subagent_config=SubagentCfg(),
+        max_running=2,
+    )
+    assert manager.max_running == 2


### PR DESCRIPTION
## Summary

Implements the #236-#239 autonomous-depth repair slice:

- #236: prevents completed rich execution lanes from falling back to shallow `record-reward` when failure-learning evidence exists.
- #237: restores deployed eeepc subagent bridge compatibility with product API/schema.
- #238: exposes machine-readable ambition/budget-utilization verdicts so PASS activity is not confused with substantive self-development.
- #239: persists and exposes strong-reflection run artifacts.

## Product changes

### #236 complete-active-lane drift

When `materialize-pass-streak-improvement` completes and no stronger HADI handoff should take authority, failure-learning evidence now selects:

- `current_task_id = analyze-last-failed-candidate`
- `feedback_decision.mode = complete_active_lane`
- `feedback_decision.selection_source = feedback_complete_active_lane_to_failure_learning`

instead of returning to `record-reward`.

### #237 subagent bridge compatibility

Adds product-side compatibility required by the deployed eeepc bridge:

- `ToolsConfig.subagent.max_running`
- `SubagentManager(..., subagent_config=..., max_running=...)`
- `SubagentManager.spawn(..., **runtime_options)` for bridge runtime metadata such as profile/mode/budget/escalation flags.

### #238 ambition/utilization dashboard verdict

Adds `/api/system` and `/api/analytics` surface:

- `ambition_utilization.schema_version = ambition-utilization-v1`
- `state = underutilized | substantive`
- reasons such as `low_budget_discard_streak`, `subagents_unused`, `tool_budget_underused`
- aggregate budget usage over recent cycles

This separates activity from meaningful autonomous effort.

### #239 strong-reflection persistence

`python -m app.main strong-reflection` now persists:

- `state/strong_reflection/latest.json`
- history artifact under `state/strong_reflection/reflection-*.json`

Dashboard exposes `strong_reflection_freshness` with freshness state, path, recorded time, age, mode, and summary.

## Verification

- `python3 -m pytest tests -q`
  - `621 passed, 5 skipped`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
  - `80 passed`
- `git diff --check`
  - passed

## Notes

A delegated review attempt was made, but the delegation backend was rate-limited (`model_cooldown`). The implementation was independently verified by the full product and dashboard test suites.

Fixes #236
Fixes #237
Fixes #238
Fixes #239
