### PR TITLE
fix: repair stale record reward authority

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1334,15 +1334,29 @@ def _build_task_plan_snapshot(
     latest_failure_learning = _latest_failure_learning(workspace)
     failure_learning_is_fresh = isinstance(latest_failure_learning, dict) and isinstance(latest_failure_learning.get('_age_seconds'), int) and latest_failure_learning.get('_age_seconds') <= 3600
     terminal_selfevo_issue = resolve_terminal_selfevo_issue(workspace=workspace, source_task_id='analyze-last-failed-candidate')
+    recorded_feedback_decision_for_repair = recorded_task_plan.get('feedback_decision') if 'recorded_task_plan' in locals() and isinstance(recorded_task_plan, dict) and isinstance(recorded_task_plan.get('feedback_decision'), dict) else {}
     recorded_reward_retirement = (
-        'recorded_task_plan' in locals()
-        and isinstance(recorded_task_plan, dict)
-        and isinstance(recorded_task_plan.get('feedback_decision'), dict)
-        and recorded_task_plan['feedback_decision'].get('current_task_id') == 'record-reward'
-        and recorded_task_plan['feedback_decision'].get('retire_goal_artifact_pair') is True
+        isinstance(recorded_feedback_decision_for_repair, dict)
+        and recorded_feedback_decision_for_repair.get('current_task_id') == 'record-reward'
+        and recorded_feedback_decision_for_repair.get('retire_goal_artifact_pair') is True
+    )
+    recorded_complete_lane_to_reward = (
+        isinstance(recorded_feedback_decision_for_repair, dict)
+        and recorded_feedback_decision_for_repair.get('mode') == 'complete_active_lane'
+        and recorded_feedback_decision_for_repair.get('current_task_id') == 'materialize-pass-streak-improvement'
+        and recorded_feedback_decision_for_repair.get('selected_task_id') == 'record-reward'
+        and recorded_feedback_decision_for_repair.get('selection_source') == 'feedback_complete_active_lane'
     )
     if isinstance(latest_failure_learning, dict) and (current_task_id == "record-reward" or failure_learning_is_fresh):
-        if recorded_reward_retirement and failure_learning_is_fresh:
+        if (recorded_reward_retirement and failure_learning_is_fresh) or recorded_complete_lane_to_reward:
+            repair_source = 'fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'stale_complete_lane_record_reward_repair'
+            repair_selection_source = 'feedback_fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'feedback_complete_active_lane_to_failure_learning'
+            repair_reason = (
+                'fresh failure-learning evidence after a retired record-reward lane must be analyzed before returning to bookkeeping'
+                if recorded_reward_retirement
+                else 'stale complete-active-lane record-reward authority must revive failure-learning analysis before bookkeeping'
+            )
+            repair_mode = 'fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'stale_complete_lane_record_reward_repair'
             repair_task = next((task for task in tasks if task.get("task_id") == "analyze-last-failed-candidate"), None)
             if repair_task is None:
                 repair_task = {
@@ -1351,7 +1365,7 @@ def _build_task_plan_snapshot(
                     'status': 'active',
                     'kind': 'review',
                     'acceptance': 'produce a bounded explanation of the failed candidate and one safer follow-up mutation idea',
-                    'selection_source': 'fresh_failure_learning_after_reward_retirement',
+                    'selection_source': repair_source,
                     'failed_candidate_id': latest_failure_learning.get('candidate_id'),
                     'failed_commit': latest_failure_learning.get('failed_commit'),
                     'health_reasons': latest_failure_learning.get('health_reasons'),
@@ -1360,7 +1374,7 @@ def _build_task_plan_snapshot(
             for task in tasks:
                 if task.get('task_id') == 'analyze-last-failed-candidate':
                     task['status'] = 'active'
-                    task['selection_source'] = 'fresh_failure_learning_after_reward_retirement'
+                    task['selection_source'] = repair_source
                     task['failed_candidate_id'] = latest_failure_learning.get('candidate_id')
                     task['failed_commit'] = latest_failure_learning.get('failed_commit')
                     task['health_reasons'] = latest_failure_learning.get('health_reasons')
@@ -1368,15 +1382,15 @@ def _build_task_plan_snapshot(
                     task['status'] = 'pending'
             current_task_id = 'analyze-last-failed-candidate'
             feedback_decision = {
-                "mode": "fresh_failure_learning_after_reward_retirement",
-                "reason": "fresh failure-learning evidence after a retired record-reward lane must be analyzed before returning to bookkeeping",
+                "mode": repair_mode,
+                "reason": repair_reason,
                 "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
                 "current_task_id": "record-reward",
                 "current_task_class": _task_action_class("record-reward"),
-                "retire_goal_artifact_pair": True,
+                "retire_goal_artifact_pair": bool(recorded_reward_retirement),
                 "selected_task_id": "analyze-last-failed-candidate",
                 "selected_task_class": _task_action_class("analyze-last-failed-candidate"),
-                "selection_source": "feedback_fresh_failure_learning_after_reward_retirement",
+                "selection_source": repair_selection_source,
                 "selected_task_title": "Analyze the last failed self-evolution candidate before retrying mutation",
                 "selected_task_label": "Analyze the last failed self-evolution candidate before retrying mutation [task_id=analyze-last-failed-candidate]",
                 "failure_learning": latest_failure_learning,

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -891,6 +891,22 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         and _has_value(live_hadi_handoff_selected_task)
         and str(live_hadi_handoff_selected_task) == str(live_task)
     )
+    local_complete_lane_failure_repair = (
+        all(artifacts.values())
+        and isinstance(local_feedback, dict)
+        and local_feedback.get('mode') in {'complete_active_lane', 'stale_complete_lane_record_reward_repair'}
+        and local_feedback.get('selection_source') == 'feedback_complete_active_lane_to_failure_learning'
+        and local_feedback.get('selected_task_id') == 'analyze-last-failed-candidate'
+        and str(local_task) == 'analyze-last-failed-candidate'
+    )
+    live_stale_complete_lane_reward = (
+        isinstance(live_feedback, dict)
+        and live_feedback.get('mode') == 'complete_active_lane'
+        and live_feedback.get('current_task_id') == 'materialize-pass-streak-improvement'
+        and live_feedback.get('selected_task_id') == 'record-reward'
+        and live_feedback.get('selection_source') == 'feedback_complete_active_lane'
+        and 'record-reward' in str(live_task or '')
+    )
     authority_resolution = None
     canonical_task = local_task or live_task
     if local_task and live_task and str(local_task) not in str(live_task):
@@ -902,6 +918,9 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         elif live_pass_streak_switch:
             authority_resolution = 'fresh_live_pass_streak_switch'
             canonical_task = live_task
+        elif local_complete_lane_failure_repair and live_stale_complete_lane_reward:
+            authority_resolution = 'local_failure_learning_repair_over_stale_live_complete_lane'
+            canonical_task = local_task
         else:
             reasons.append('current_task_drift')
     missing = [key for key, present in artifacts.items() if not present]

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -962,3 +962,44 @@ def test_strong_reflection_freshness_exposes_latest_artifact(tmp_path: Path) -> 
     assert result['state'] == 'fresh'
     assert result['available'] is True
     assert result['summary'].startswith('Self-evolving cycle PASS')
+
+
+def test_runtime_parity_accepts_local_failure_learning_repair_over_stale_live_complete_lane(tmp_path: Path) -> None:
+    from nanobot_ops_dashboard.app import _dashboard_runtime_parity
+
+    state = tmp_path / 'repo' / 'workspace' / 'state'
+    for rel in [
+        'hypotheses/backlog.json',
+        'credits/latest.json',
+        'control_plane/current_summary.json',
+        'self_evolution/current_state.json',
+    ]:
+        path = state / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{}', encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=tmp_path / 'repo', db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing', eeepc_state_root='/state')
+    repo_plan = {
+        'current_task_id': 'analyze-last-failed-candidate',
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'selection_source': 'feedback_complete_active_lane_to_failure_learning',
+            'selected_task_id': 'analyze-last-failed-candidate',
+        },
+    }
+    live_plan = {
+        'current_task_id': 'record-reward',
+        'task_selection_source': 'feedback_complete_active_lane',
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'current_task_id': 'materialize-pass-streak-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_complete_active_lane',
+        },
+    }
+
+    result = _dashboard_runtime_parity(repo_plan, live_plan, cfg)
+
+    assert result['state'] == 'healthy'
+    assert result['reasons'] == []
+    assert result['canonical_current_task_id'] == 'analyze-last-failed-candidate'
+    assert result['authority_resolution'] == 'local_failure_learning_repair_over_stale_live_complete_lane'

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -225,3 +225,53 @@ def test_complete_active_lane_prefers_failure_learning_over_record_reward(tmp_pa
     assert plan['feedback_decision']['mode'] == 'complete_active_lane'
     assert plan['feedback_decision']['selection_source'] == 'feedback_complete_active_lane_to_failure_learning'
     assert plan['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'
+
+
+def test_stale_complete_lane_record_reward_revives_failure_learning(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    failure_dir = state_root / 'self_evolution' / 'failure_learning'
+    failure_dir.mkdir(parents=True)
+    (failure_dir / 'latest.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-stale-live',
+        'failed_commit': 'badc0ffee',
+        'health_reasons': ['stale_report'],
+    }), encoding='utf-8')
+    (goals / 'current.json').write_text(json.dumps({
+        'current_task_id': 'record-reward',
+        'tasks': [
+            {'task_id': 'inspect-pass-streak', 'title': 'Inspect repeated PASS streak', 'status': 'done'},
+            {'task_id': 'materialize-pass-streak-improvement', 'title': 'Materialize improvement', 'status': 'done'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'},
+        ],
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'current_task_id': 'materialize-pass-streak-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_complete_active_lane',
+        },
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-stale-live-repair',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals,
+        materialized_improvement_artifact_path=None,
+    )
+
+    assert plan['current_task_id'] == 'analyze-last-failed-candidate'
+    assert plan['feedback_decision']['mode'] == 'stale_complete_lane_record_reward_repair'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_complete_active_lane_to_failure_learning'
+    assert plan['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'


### PR DESCRIPTION
## Summary

Repairs the post-#243 live-host stale authority shape where eeepc retained old `complete_active_lane -> record-reward` state while the local/product runtime had already learned to prefer failure-learning analysis.

## Changes

Runtime:
- Detects recorded stale complete-active-lane authority:
  - `feedback_decision.mode = complete_active_lane`
  - `feedback_decision.current_task_id = materialize-pass-streak-improvement`
  - `feedback_decision.selected_task_id = record-reward`
  - `feedback_decision.selection_source = feedback_complete_active_lane`
- When failure-learning evidence exists, revives:
  - `current_task_id = analyze-last-failed-candidate`
  - `feedback_decision.mode = stale_complete_lane_record_reward_repair`
  - `feedback_decision.selection_source = feedback_complete_active_lane_to_failure_learning`

Dashboard:
- Classifies local `feedback_complete_active_lane_to_failure_learning` over stale live `feedback_complete_active_lane -> record-reward` as a precise authority resolution:
  - `authority_resolution = local_failure_learning_repair_over_stale_live_complete_lane`
  - `canonical_current_task_id = analyze-last-failed-candidate`
  - no generic `current_task_drift`

## Verification

- `python3 -m pytest tests -q`
  - `622 passed, 5 skipped`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
  - `81 passed`
- `git diff --check`
  - passed

Fixes #244
