### PR TITLE
fix: load failure learning from runtime state root

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -995,22 +995,34 @@ def _derive_mutation_lane(*, current_task_id: str | None, selected_tasks: str | 
 
 
 def _latest_failure_learning(workspace: Path) -> dict[str, Any] | None:
-    path = workspace / 'state' / 'self_evolution' / 'failure_learning' / 'latest.json'
-    if not path.exists():
-        return None
+    candidate_paths = []
     try:
-        data = json.loads(path.read_text(encoding='utf-8'))
+        candidate_paths.append(_resolve_runtime_state_root(workspace) / 'self_evolution' / 'failure_learning' / 'latest.json')
     except Exception:
-        return None
-    if not isinstance(data, dict):
-        return None
-    try:
-        mtime = path.stat().st_mtime
-        age_seconds = max(0, int(datetime.now(timezone.utc).timestamp() - mtime))
-    except Exception:
-        age_seconds = None
-    data['_age_seconds'] = age_seconds
-    return data
+        pass
+    candidate_paths.append(workspace / 'state' / 'self_evolution' / 'failure_learning' / 'latest.json')
+    seen: set[Path] = set()
+    for path in candidate_paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding='utf-8'))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        try:
+            mtime = path.stat().st_mtime
+            age_seconds = max(0, int(datetime.now(timezone.utc).timestamp() - mtime))
+        except Exception:
+            age_seconds = None
+        data['_age_seconds'] = age_seconds
+        data['_source_path'] = str(path)
+        return data
+    return None
 
 
 def _derive_generated_candidates(

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -275,3 +275,25 @@ def test_stale_complete_lane_record_reward_revives_failure_learning(tmp_path: Pa
     assert plan['feedback_decision']['mode'] == 'stale_complete_lane_record_reward_repair'
     assert plan['feedback_decision']['selection_source'] == 'feedback_complete_active_lane_to_failure_learning'
     assert plan['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'
+
+
+def test_failure_learning_uses_resolved_runtime_state_root(tmp_path: Path, monkeypatch) -> None:
+    from nanobot.runtime.coordinator import _latest_failure_learning
+
+    workspace = tmp_path / 'release'
+    workspace.mkdir()
+    runtime_state = tmp_path / 'host-state'
+    failure_dir = runtime_state / 'self_evolution' / 'failure_learning'
+    failure_dir.mkdir(parents=True)
+    (failure_dir / 'latest.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'host-control-plane-candidate',
+        'failed_commit': 'abc123',
+    }), encoding='utf-8')
+    monkeypatch.setenv('NANOBOT_RUNTIME_STATE_ROOT', str(runtime_state))
+
+    result = _latest_failure_learning(workspace)
+
+    assert result is not None
+    assert result['candidate_id'] == 'host-control-plane-candidate'
+    assert result['_source_path'] == str(failure_dir / 'latest.json')


### PR DESCRIPTION
## Summary

Completes the live #244 root-cause repair. The first #245 slice detected stale `complete_active_lane -> record-reward`, but live deployment still missed host failure-learning evidence because `_latest_failure_learning()` read only `workspace/state/...` while eeepc runs with a resolved host-control-plane state root under `/var/lib/eeepc-agent/self-evolving-agent/state`.

## Fix

- `_latest_failure_learning(workspace)` now checks the resolved runtime state root first via `_resolve_runtime_state_root(workspace)`.
- Falls back to legacy `workspace/state/...` for local compatibility.
- Annotates returned evidence with `_source_path` for proof/debuggability.

## Regression

Added a test that sets `NANOBOT_RUNTIME_STATE_ROOT` and proves failure-learning is loaded from that host-control-plane root instead of the release workspace.

## Verification

- `python3 -m pytest tests -q`
  - `623 passed, 5 skipped`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
  - `81 passed`
- `git diff --check`
  - passed

Fixes #244
