### PR TITLE
fix: expose autonomy verdict details in system api

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2809,6 +2809,8 @@ def create_app(cfg: DashboardConfig):
                 'material_progress': _material_progress_summary(control_plane.get('material_progress') if isinstance(control_plane, dict) else None),
                 'autonomy_verdict': autonomy_verdict,
                 'runtime_parity': runtime_parity,
+                'ambition_utilization': ambition_utilization,
+                'strong_reflection_freshness': strong_reflection_freshness,
                 'eeepc_privileged_rollout_readiness': eeepc_privileged_rollout_readiness,
                 'host_resources': dict(repo_latest).get('host_resources') if repo_latest else None,
                 'host_resources': (control_plane.get('host_resources') if isinstance(control_plane, dict) else None),

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -1003,3 +1003,40 @@ def test_runtime_parity_accepts_local_failure_learning_repair_over_stale_live_co
     assert result['reasons'] == []
     assert result['canonical_current_task_id'] == 'analyze-last-failed-candidate'
     assert result['authority_resolution'] == 'local_failure_learning_repair_over_stale_live_complete_lane'
+
+
+def test_api_system_exposes_ambition_and_strong_reflection_top_level(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    latest = state_root / 'strong_reflection' / 'latest.json'
+    latest.parent.mkdir(parents=True)
+    latest.write_text(json.dumps({
+        'schema_version': 'strong-reflection-run-v1',
+        'recorded_at_utc': '2026-04-27T20:00:00+00:00',
+        'summary': 'Self-evolving cycle PASS — evidence=e-system',
+        'mode': 'strong-reflection',
+    }), encoding='utf-8')
+    (state_root / 'goals').mkdir(parents=True, exist_ok=True)
+    (state_root / 'goals' / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'inspect-pass-streak',
+        'current_task': 'Inspect repeated PASS streak for a new bounded improvement',
+        'tasks': [],
+    }), encoding='utf-8')
+    cfg = DashboardConfig(
+        project_root=project_root,
+        nanobot_repo_root=repo_root,
+        db_path=db,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root='/state',
+    )
+
+    system = _call_json(create_app(cfg), '/api/system')
+
+    assert system['ambition_utilization']['schema_version'] == 'ambition-utilization-v1'
+    assert system['strong_reflection_freshness']['schema_version'] == 'strong-reflection-freshness-v1'
+    assert system['strong_reflection_freshness']['available'] is True


### PR DESCRIPTION
## Summary

Exposes the #238/#239 computed verdicts directly at `/api/system` top level so external proof queries do not need to infer them from nested dashboard context.

## Changes

- `/api/system.ambition_utilization` now returns the computed ambition/budget-utilization verdict.
- `/api/system.strong_reflection_freshness` now returns the computed strong-reflection artifact freshness verdict.
- Added regression coverage for both fields.

## Verification

- `python3 -m pytest tests -q`
  - `623 passed, 5 skipped`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
  - `82 passed`
- `git diff --check`
  - passed

Fixes #247
