### PR TITLE
fix: retire terminal selfevo lanes before continuation

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1346,6 +1346,7 @@ def _build_task_plan_snapshot(
     latest_failure_learning = _latest_failure_learning(workspace)
     failure_learning_is_fresh = isinstance(latest_failure_learning, dict) and isinstance(latest_failure_learning.get('_age_seconds'), int) and latest_failure_learning.get('_age_seconds') <= 3600
     terminal_selfevo_issue = resolve_terminal_selfevo_issue(workspace=workspace, source_task_id='analyze-last-failed-candidate')
+    terminal_selfevo_retired = False
     recorded_feedback_decision_for_repair = recorded_task_plan.get('feedback_decision') if 'recorded_task_plan' in locals() and isinstance(recorded_task_plan, dict) and isinstance(recorded_task_plan.get('feedback_decision'), dict) else {}
     recorded_reward_retirement = (
         isinstance(recorded_feedback_decision_for_repair, dict)
@@ -1359,7 +1360,33 @@ def _build_task_plan_snapshot(
         and recorded_feedback_decision_for_repair.get('selected_task_id') == 'record-reward'
         and recorded_feedback_decision_for_repair.get('selection_source') == 'feedback_complete_active_lane'
     )
-    if isinstance(latest_failure_learning, dict) and (current_task_id == "record-reward" or failure_learning_is_fresh):
+    if terminal_selfevo_issue is not None and current_task_id == "analyze-last-failed-candidate":
+        for task in tasks:
+            if task.get("task_id") == "analyze-last-failed-candidate":
+                task["status"] = "done"
+                task["terminal_reason"] = terminal_selfevo_issue.get("terminal_status") or "terminal_selfevo_issue"
+            elif task.get("task_id") == "record-reward":
+                task["status"] = "active"
+            elif task.get("status") == "active":
+                task["status"] = "pending"
+        if not any(task.get("task_id") == "record-reward" for task in tasks):
+            tasks.append({"task_id": "record-reward", "title": "Record cycle reward", "status": "active"})
+        current_task_id = "record-reward"
+        feedback_decision = {
+            "mode": "retire_terminal_selfevo_lane",
+            "reason": "latest self-evolution issue reached a terminal merged/closed or terminal no-op state; do not recreate analyze-last-failed-candidate",
+            "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
+            "current_task_id": "analyze-last-failed-candidate",
+            "current_task_class": _task_action_class("analyze-last-failed-candidate"),
+            "selected_task_id": "record-reward",
+            "selected_task_class": _task_action_class("record-reward"),
+            "selection_source": "feedback_terminal_selfevo_retire",
+            "selected_task_title": "Record cycle reward",
+            "selected_task_label": "Record cycle reward [task_id=record-reward]",
+            "terminal_selfevo_issue": terminal_selfevo_issue,
+        }
+        terminal_selfevo_retired = True
+    elif isinstance(latest_failure_learning, dict) and (current_task_id == "record-reward" or failure_learning_is_fresh) and not terminal_selfevo_retired:
         if (recorded_reward_retirement and failure_learning_is_fresh) or recorded_complete_lane_to_reward:
             repair_source = 'fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'stale_complete_lane_record_reward_repair'
             repair_selection_source = 'feedback_fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'feedback_complete_active_lane_to_failure_learning'

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -129,6 +129,65 @@ def test_terminal_selfevo_lane_is_retired_when_latest_issue_lifecycle_closed(tmp
     assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
 
 
+def test_terminal_selfevo_lane_is_retired_before_continuing_active_analyze_lane(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    (state_root / 'self_evolution' / 'failure_learning').mkdir(parents=True)
+    (goals / 'current.json').write_text(json.dumps({
+        'current_task_id': 'analyze-last-failed-candidate',
+        'tasks': [
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'active'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+        ],
+    }), encoding='utf-8')
+    failure_learning_path = state_root / 'self_evolution' / 'failure_learning' / 'latest.json'
+    failure_learning_path.write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-stale',
+        'failed_commit': 'cafebabe',
+        'health_reasons': ['stale_report'],
+    }), encoding='utf-8')
+    stale_time = time.time() - 3 * 3600
+    os.utime(failure_learning_path, (stale_time, stale_time))
+    (state_root / 'self_evolution' / 'runtime' / 'latest_issue_lifecycle.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-issue-lifecycle-v1',
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'issue_number': 61,
+        'pr_number': 62,
+        'selfevo_branch': 'fix/issue-61-analyze-last-failed-candidate',
+        'selfevo_issue': {'number': 61, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+        'source_task_id': 'analyze-last-failed-candidate',
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-retire-analyze',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.0}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard', 'revert_status': 'skipped_no_material_change'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.0,
+        feedback_decision=None,
+        goals_dir=goals,
+    )
+
+    assert plan['current_task_id'] == 'record-reward'
+    assert plan['feedback_decision']['mode'] == 'retire_terminal_selfevo_lane'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_terminal_selfevo_retire'
+    assert plan['feedback_decision']['selected_task_id'] == 'record-reward'
+    assert plan['feedback_decision']['terminal_selfevo_issue']['terminal_status'] == 'terminal_merged'
+    assert plan['feedback_decision']['terminal_selfevo_issue']['selfevo_issue']['number'] == 61
+    assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
+
+
 def test_subagent_lane_health_marks_stale_queued_request(tmp_path: Path) -> None:
     state_root = tmp_path / 'state'
     req_dir = state_root / 'subagents' / 'requests'


### PR DESCRIPTION
Fixes #251.

Summary:
- retire terminal self-evolution analyze-last-failed-candidate lanes before generic active non-core continuation
- add regression for stale failure-learning + terminal merged selfevo lifecycle

Verification:
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py -k 'terminal_selfevo_lane_is_retired_before_continuing_active_analyze_lane' -q
- python3 -m pytest tests/test_live_followthrough_drift.py -q
- python3 -m pytest tests -q -> 624 passed, 5 skipped