### PR TITLE
fix: expose hypothesis dynamics stagnation

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1067,7 +1067,7 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     }
 
 
-def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None) -> dict:
+def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None, hypothesis_dynamics: dict | None = None) -> dict:
     reasons: list[str] = []
     state_root = cfg.nanobot_repo_root / 'workspace' / 'state'
     recent = analytics.get('recent_status_sequence') or []
@@ -1113,6 +1113,9 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     if runtime_parity_is_blocking and not runtime_can_be_historical:
         reasons.append('runtime_parity_blocked')
     ambition_utilization = ambition_utilization if isinstance(ambition_utilization, dict) else {}
+    hypothesis_dynamics = hypothesis_dynamics if isinstance(hypothesis_dynamics, dict) else {}
+    if hypothesis_dynamics.get('state') == 'stagnant':
+        reasons.append('hypothesis_dynamics_stagnant')
     historical_reasons: list[str] = []
     if material_allows_healthy:
         stale_after_material_progress = {'same_task_streak', 'discarded_experiment', 'suppressed_reward', 'terminal_noop'}
@@ -1125,7 +1128,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
         if runtime_parity_is_blocking and runtime_can_be_historical:
             historical_reasons.append('runtime_parity_blocked')
         reasons = blocking_reasons
-    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized'}) else 'healthy')
+    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant'}) else 'healthy')
     return {
         'schema_version': 'autonomy-verdict-v1',
         'state': status,
@@ -1828,6 +1831,145 @@ def _discover_hypotheses_visibility(cfg: DashboardConfig) -> dict:
     }
 
 
+def _selected_hypothesis_terminal_evidence(cfg: DashboardConfig) -> tuple[dict | None, dict | None]:
+    state_root = cfg.nanobot_repo_root / 'workspace' / 'state' / 'self_evolution'
+    current_state = _json_file(state_root / 'current_state.json')
+    latest_noop = _json_file(state_root / 'runtime' / 'latest_noop.json')
+    issue = current_state.get('selfevo_issue') if isinstance(current_state.get('selfevo_issue'), dict) else latest_noop.get('selfevo_issue') if isinstance(latest_noop.get('selfevo_issue'), dict) else None
+    pr = current_state.get('last_pr') if isinstance(current_state.get('last_pr'), dict) else latest_noop.get('pr') if isinstance(latest_noop.get('pr'), dict) else None
+    return issue, pr
+
+
+def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibility: dict, credits_visibility: dict, cfg: DashboardConfig) -> dict:
+    visibility = hypotheses_visibility if isinstance(hypotheses_visibility, dict) else {}
+    selected_id = visibility.get('selected_hypothesis_id')
+    selected_title = visibility.get('selected_hypothesis_title')
+    selected_score = visibility.get('selected_hypothesis_score')
+    selected_wsjf = visibility.get('selected_hypothesis_wsjf')
+
+    def _matches_selected(row: dict) -> bool:
+        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        task_id = detail.get('current_task_id') or row.get('title')
+        hypothesis_id = detail.get('selected_hypothesis_id') or detail.get('hypothesis_id') or task_id
+        if _has_value(selected_id):
+            return str(task_id) == str(selected_id) or str(hypothesis_id) == str(selected_id)
+        if _has_value(selected_title):
+            return str(row.get('title') or task_id) == str(selected_title)
+        return False
+
+    ordered_cycles = sorted(cycles or [], key=lambda row: _coerce_timestamp(row.get('collected_at')) or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+    matched_cycles = [row for row in ordered_cycles if _matches_selected(row)]
+    if matched_cycles:
+        reference_dt = _coerce_timestamp(matched_cycles[0].get('collected_at')) or datetime.now(timezone.utc)
+    elif ordered_cycles:
+        reference_dt = _coerce_timestamp(ordered_cycles[0].get('collected_at')) or datetime.now(timezone.utc)
+    else:
+        reference_dt = datetime.now(timezone.utc)
+    window_start = reference_dt - timedelta(hours=24)
+
+    window_cycles = []
+    for row in matched_cycles:
+        ts = _coerce_timestamp(row.get('collected_at'))
+        if ts is not None and ts >= window_start:
+            window_cycles.append(row)
+
+    run_streak = 0
+    for row in ordered_cycles:
+        ts = _coerce_timestamp(row.get('collected_at'))
+        if ts is None or ts < window_start:
+            break
+        if _matches_selected(row):
+            run_streak += 1
+        else:
+            break
+
+    def _cycle_outcome(row: dict) -> str | None:
+        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
+        return experiment.get('outcome') or detail.get('outcome') or row.get('status')
+
+    def _cycle_budget_used(row: dict) -> dict:
+        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        budget_used = detail.get('budget_used') if isinstance(detail.get('budget_used'), dict) else {}
+        if not budget_used:
+            experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
+            budget_used = experiment.get('budget_used') if isinstance(experiment.get('budget_used'), dict) else {}
+        if not budget_used and isinstance(detail.get('current_plan'), dict):
+            budget_used = detail['current_plan'].get('budget_used') if isinstance(detail['current_plan'].get('budget_used'), dict) else {}
+        return budget_used if isinstance(budget_used, dict) else {}
+
+    outcome_counts = {'discard': 0, 'pass': 0, 'block': 0, 'other': 0}
+    budget_sum = {'requests': 0, 'tool_calls': 0, 'subagents': 0, 'elapsed_seconds': 0}
+    for row in window_cycles:
+        outcome = str(_cycle_outcome(row) or 'other').lower()
+        if outcome not in outcome_counts:
+            outcome = 'other'
+        outcome_counts[outcome] += 1
+        budget_used = _cycle_budget_used(row)
+        for key in budget_sum:
+            try:
+                budget_sum[key] += int(budget_used.get(key) or 0)
+            except Exception:
+                continue
+
+    reward_gate = credits_visibility.get('current', {}).get('reward_gate') if isinstance(credits_visibility.get('current'), dict) else {}
+    if not isinstance(reward_gate, dict):
+        reward_gate = {}
+    terminal_issue, terminal_pr = _selected_hypothesis_terminal_evidence(cfg)
+    state = 'stagnant' if (
+        run_count := len(window_cycles)
+    ) and run_streak >= 5 and outcome_counts['discard'] == run_count and reward_gate.get('status') == 'suppressed' and (terminal_issue or terminal_pr) else 'healthy'
+    reasons: list[str] = []
+    if run_count:
+        if run_streak >= 5:
+            reasons.append('selected_hypothesis_repetition')
+        if outcome_counts['discard'] == run_count:
+            reasons.append('discard_only_selected_hypothesis')
+        if reward_gate.get('status') == 'suppressed':
+            reasons.append('suppressed_reward_gate')
+        if terminal_issue or terminal_pr:
+            reasons.append('terminal_selfevo_issue_present')
+    if state == 'stagnant':
+        reasons.insert(0, 'selected_hypothesis_stagnant')
+
+    return {
+        'schema_version': 'hypothesis-dynamics-v1',
+        'state': state,
+        'reasons': reasons,
+        'selected_hypothesis_id': str(selected_id) if _has_value(selected_id) else None,
+        'selected_hypothesis_title': str(selected_title) if _has_value(selected_title) else None,
+        'selected_hypothesis_score': selected_score,
+        'selected_hypothesis_score_text': _hypothesis_score_text(selected_score),
+        'selected_hypothesis_wsjf': selected_wsjf,
+        'selected_hypothesis_wsjf_text': _wsjf_text(selected_wsjf),
+        'run_count': run_count,
+        'run_streak': run_streak,
+        'window_hours': 24,
+        'last_24h': {
+            'window_hours': 24,
+            'total_runs': run_count,
+            'discard_count': outcome_counts['discard'],
+            'pass_count': outcome_counts['pass'],
+            'block_count': outcome_counts['block'],
+            'other_count': outcome_counts['other'],
+            'budget_used_sum': budget_sum,
+            'reward_gate': {
+                'status': reward_gate.get('status'),
+                'reason': reward_gate.get('reason'),
+            },
+            'terminal_selfevo_issue': terminal_issue,
+            'terminal_selfevo_pr': terminal_pr,
+            'latest_outcome': _cycle_outcome(window_cycles[0]) if window_cycles else None,
+        },
+        'reward_gate': {
+            'status': reward_gate.get('status'),
+            'reason': reward_gate.get('reason'),
+        },
+        'terminal_selfevo_issue': terminal_issue,
+        'terminal_selfevo_pr': terminal_pr,
+    }
+
+
 def _plan_snapshot_from_row(row) -> dict:
     item = dict(row)
     raw = _json_loads_dict(item.get('raw_json'))
@@ -2485,6 +2627,13 @@ def create_app(cfg: DashboardConfig):
         strong_reflection_freshness = _strong_reflection_freshness(cfg, now)
         analytics['ambition_utilization'] = ambition_utilization
         analytics['strong_reflection_freshness'] = strong_reflection_freshness
+        hypothesis_dynamics = _selected_hypothesis_diagnostics(
+            cycles=cycles,
+            hypotheses_visibility=hypotheses_visibility,
+            credits_visibility=credits_visibility,
+            cfg=cfg,
+        )
+        hypotheses_visibility = {**hypotheses_visibility, 'selected_hypothesis_diagnostics': hypothesis_dynamics}
         autonomy_verdict = _autonomy_verdict(
             analytics=analytics,
             plan_latest=plan_latest,
@@ -2494,8 +2643,10 @@ def create_app(cfg: DashboardConfig):
             material_progress=control_plane.get('material_progress') if isinstance(control_plane, dict) else None,
             runtime_parity=runtime_parity,
             ambition_utilization=ambition_utilization,
+            hypothesis_dynamics=hypothesis_dynamics,
         )
         analytics['runtime_parity'] = runtime_parity
+        analytics['hypothesis_dynamics'] = hypothesis_dynamics
         analytics['autonomy_verdict'] = autonomy_verdict
         if isinstance(control_plane, dict):
             control_plane = dict(control_plane)
@@ -2503,6 +2654,7 @@ def create_app(cfg: DashboardConfig):
             control_plane['runtime_parity'] = runtime_parity
             control_plane['ambition_utilization'] = ambition_utilization
             control_plane['strong_reflection_freshness'] = strong_reflection_freshness
+            control_plane['hypothesis_dynamics'] = hypothesis_dynamics
             control_plane['autonomy_verdict'] = autonomy_verdict
 
         request_source = query.get('source', [''])[0]
@@ -2890,6 +3042,7 @@ def create_app(cfg: DashboardConfig):
                 'material_progress': _material_progress_summary(control_plane.get('material_progress') if isinstance(control_plane, dict) else None),
                 'autonomy_verdict': autonomy_verdict,
                 'runtime_parity': runtime_parity,
+                'hypothesis_dynamics': hypothesis_dynamics,
                 'ambition_utilization': ambition_utilization,
                 'strong_reflection_freshness': strong_reflection_freshness,
                 'eeepc_privileged_rollout_readiness': eeepc_privileged_rollout_readiness,

--- a/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
+++ b/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
@@ -75,6 +75,110 @@ def _write_control_plane_summary(project_root: Path, *, material_progress: dict 
     path.write_text(json.dumps(summary), encoding='utf-8')
 
 
+def _seed_hypothesis_backlog(repo_root: Path, *, selected_id: str, selected_title: str, selected_score: int = 100) -> Path:
+    backlog = repo_root / 'workspace' / 'state' / 'hypotheses' / 'backlog.json'
+    backlog.parent.mkdir(parents=True, exist_ok=True)
+    backlog.write_text(json.dumps({
+        'schema_version': 'hypotheses-backlog-v1',
+        'model': 'HADI',
+        'selected_hypothesis_id': selected_id,
+        'selected_hypothesis_title': selected_title,
+        'selected_hypothesis_score': selected_score,
+        'entries': [
+            {
+                'hypothesis_id': f'hypothesis-{selected_id}',
+                'title': selected_title,
+                'bounded_priority_score': selected_score,
+                'selection_status': 'selected',
+                'execution_spec': {
+                    'goal': 'goal-bootstrap',
+                    'task': selected_title,
+                    'acceptance': 'surface current stagnation evidence for the selected hypothesis',
+                    'budget': {'requests': 1, 'tool_calls': 2, 'subagents': 0},
+                },
+                'wsjf': {'score': 24.0},
+                'hadi': {
+                    'hypothesis': selected_title,
+                    'action': 'inspect current stagnation evidence and expose it in the dashboard APIs',
+                },
+            },
+            {
+                'hypothesis_id': 'hypothesis-record-reward',
+                'title': 'Record cycle reward',
+                'bounded_priority_score': 70,
+                'selection_status': 'backlog',
+                'execution_spec': {
+                    'goal': 'goal-bootstrap',
+                    'task': 'Record cycle reward',
+                    'acceptance': 'complete the current lane and persist the reward evidence',
+                    'budget': {'requests': 1, 'tool_calls': 2, 'subagents': 0},
+                },
+                'wsjf': {'score': 14.0},
+                'hadi': {
+                    'hypothesis': 'Record cycle reward',
+                    'action': 'publish durable evidence for the finished lane',
+                },
+            },
+        ],
+    }), encoding='utf-8')
+    return backlog
+
+
+def _seed_selected_hypothesis_cycle(db: Path, idx: int, task_id: str, *, outcome: str = 'discard') -> None:
+    stamp = f'2026-04-24T13:{idx:02d}:00Z'
+    raw = {
+        'current_plan': {
+            'current_task_id': task_id,
+            'current_task': 'Analyze the last failed self-evolution candidate before retrying mutation',
+            'selected_tasks': 'Analyze the last failed self-evolution candidate [task_id=analyze-last-failed-candidate]',
+            'task_selection_source': 'generated_from_failure_learning',
+            'feedback_decision': {
+                'mode': 'handoff_to_next_candidate',
+                'selected_task_id': task_id,
+                'selected_task_title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+                'selection_source': 'generated_from_failure_learning',
+            },
+            'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+            'experiment': {
+                'outcome': outcome,
+                'revert_status': 'skipped_no_material_change',
+                'revert_required': True,
+            },
+        },
+        'outbox': {'status': 'PASS'},
+    }
+    insert_collection(db, {
+        'collected_at': stamp,
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': f'/workspace/state/reports/evolution-{idx}.json',
+        'outbox_source': '/workspace/state/outbox/latest.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps(raw),
+    })
+    upsert_event(db, {
+        'collected_at': stamp,
+        'source': 'repo',
+        'event_type': 'cycle',
+        'identity_key': f'cycle-stagnant-{idx}',
+        'title': task_id,
+        'status': 'PASS',
+        'detail_json': json.dumps({
+            'current_task_id': task_id,
+            'selected_hypothesis_id': task_id,
+            'outcome': outcome,
+            'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+        }),
+    })
+
+
 def test_api_subagents_returns_json_with_stale_queued_request(tmp_path: Path) -> None:
     project_root = tmp_path / 'dashboard'
     repo_root = tmp_path / 'nanobot'
@@ -181,6 +285,100 @@ def test_dashboard_api_surfaces_shared_autonomy_verdict_and_material_progress(tm
     assert plan['material_progress']['available'] is True
     assert experiments['material_progress']['state'] == 'proven'
     assert experiments['material_progress']['available'] is True
+
+
+def test_dashboard_api_surfaces_selected_hypothesis_diagnostics_and_hypothesis_dynamics(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'experiments').mkdir(parents=True)
+    (state_root / 'credits').mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    (state_root / 'control_plane').mkdir(parents=True)
+    _seed_hypothesis_backlog(
+        repo_root,
+        selected_id='analyze-last-failed-candidate',
+        selected_title='Analyze the last failed self-evolution candidate before retrying mutation',
+        selected_score=100,
+    )
+    _write_control_plane_summary(
+        project_root,
+        task_plan={
+            'current_task_id': 'analyze-last-failed-candidate',
+            'current_task': 'Analyze the last failed self-evolution candidate before retrying mutation',
+        },
+    )
+    for idx in range(5):
+        _seed_selected_hypothesis_cycle(db, idx, 'analyze-last-failed-candidate')
+    (state_root / 'experiments' / 'latest.json').write_text(json.dumps({
+        'outcome': 'discard',
+        'revert_required': True,
+        'revert_status': 'skipped_no_material_change',
+    }), encoding='utf-8')
+    (state_root / 'credits' / 'latest.json').write_text(json.dumps({
+        'delta': 0.0,
+        'reward_gate': {
+            'status': 'suppressed',
+            'reason': 'discarded_experiment_unresolved_revert',
+        },
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'runtime' / 'latest_noop.json').write_text(json.dumps({
+        'status': 'terminal_noop',
+        'selfevo_issue': {
+            'number': 61,
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/61',
+            'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+        },
+        'pr': {
+            'number': 62,
+            'url': 'https://github.com/ozand/eeebot-self-evolving/pull/62',
+            'title': 'Terminal self-evolution lane closure',
+        },
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'current_state.json').write_text(json.dumps({
+        'selfevo_issue': {
+            'number': 61,
+            'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/61',
+        },
+        'last_pr': {
+            'number': 62,
+            'title': 'Terminal self-evolution lane closure',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/pull/62',
+        },
+    }), encoding='utf-8')
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+    app = create_app(cfg)
+
+    hypotheses = _call_json(app, '/api/hypotheses')
+    system = _call_json(app, '/api/system')
+
+    diagnostics = hypotheses['selected_hypothesis_diagnostics']
+    assert diagnostics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
+    assert diagnostics['run_count'] == 5
+    assert diagnostics['run_streak'] == 5
+    assert diagnostics['last_24h']['total_runs'] == 5
+    assert diagnostics['last_24h']['discard_count'] == 5
+    assert diagnostics['last_24h']['budget_used_sum']['requests'] == 5
+    assert diagnostics['last_24h']['budget_used_sum']['tool_calls'] == 10
+    assert diagnostics['last_24h']['reward_gate']['status'] == 'suppressed'
+    assert diagnostics['last_24h']['reward_gate']['reason'] == 'discarded_experiment_unresolved_revert'
+    assert diagnostics['terminal_selfevo_issue']['number'] == 61
+    assert diagnostics['terminal_selfevo_pr']['number'] == 62
+
+    hypothesis_dynamics = system['hypothesis_dynamics']
+    assert hypothesis_dynamics['state'] == 'stagnant'
+    assert hypothesis_dynamics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
+    assert hypothesis_dynamics['run_count'] == 5
+    assert hypothesis_dynamics['run_streak'] == 5
+    assert hypothesis_dynamics['last_24h']['discard_count'] == 5
+    assert hypothesis_dynamics['last_24h']['reward_gate']['reason'] == 'discarded_experiment_unresolved_revert'
+    assert hypothesis_dynamics['terminal_selfevo_issue']['number'] == 61
+    assert hypothesis_dynamics['terminal_selfevo_pr']['number'] == 62
+    assert 'hypothesis_dynamics_stagnant' in system['autonomy_verdict']['reasons']
+    assert system['autonomy_verdict']['state'] == 'stagnant'
 
 
 def test_dashboard_api_surfaces_unavailable_material_progress_when_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #253.

Summary:
- add selected_hypothesis_diagnostics to /api/hypotheses
- add hypothesis_dynamics to /api/system, analytics, and control-plane context
- include hypothesis_dynamics_stagnant in autonomy verdict when repeated hypothesis/discard/suppressed reward/terminal lane evidence is active

Verification:
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_autonomy_stagnation_dashboard.py -q -> 11 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 85 passed