### PR TITLE
fix: hydrate hypothesis dynamics from reports

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1847,14 +1847,90 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
     selected_score = visibility.get('selected_hypothesis_score')
     selected_wsjf = visibility.get('selected_hypothesis_wsjf')
 
+    def _report_source_candidates(detail: dict) -> list[str]:
+        candidates: list[str] = []
+        for key in ('report_source', 'reportSource', 'report_path', 'reportPath'):
+            value = detail.get(key)
+            if _has_value(value):
+                candidates.append(str(value))
+        artifact_paths = detail.get('artifact_paths')
+        if isinstance(artifact_paths, str):
+            parsed = _json_loads_any(artifact_paths)
+            if isinstance(parsed, list):
+                artifact_paths = parsed
+        if isinstance(artifact_paths, list):
+            for artifact_path in artifact_paths:
+                if _has_value(artifact_path):
+                    candidates.append(str(artifact_path))
+        artifact_paths_json = detail.get('artifact_paths_json')
+        if isinstance(artifact_paths_json, str):
+            for artifact_path in _json_loads_list(artifact_paths_json):
+                if _has_value(artifact_path):
+                    candidates.append(str(artifact_path))
+        seen: set[str] = set()
+        ordered_candidates: list[str] = []
+        for candidate in candidates:
+            normalized = candidate.strip()
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                ordered_candidates.append(normalized)
+        return ordered_candidates
+
+    def _resolve_report_source_path(report_source: str) -> Path | None:
+        if not _has_value(report_source):
+            return None
+        text = str(report_source).strip()
+        stripped = text.lstrip('/\\')
+        candidates = [Path(text)]
+        if stripped:
+            candidates.extend([
+                cfg.nanobot_repo_root / stripped,
+                cfg.project_root / stripped,
+            ])
+        for path in candidates:
+            try:
+                if path.exists():
+                    return path
+            except Exception:
+                continue
+        return None
+
+    def _hydrate_cycle_detail(row: dict) -> dict:
+        detail = dict(row.get('detail')) if isinstance(row.get('detail'), dict) else {}
+        hydrated = dict(detail)
+        for report_source in _report_source_candidates(detail):
+            path = _resolve_report_source_path(report_source)
+            if path is None:
+                continue
+            payload = _json_file(path)
+            if not isinstance(payload, dict):
+                continue
+            hydrated.setdefault('report_source', report_source)
+            hydrated.setdefault('report_source_path', str(path))
+            hydrated.update(payload)
+            for key in ('current_plan', 'currentPlan', 'task_plan', 'taskPlan', 'plan'):
+                nested = payload.get(key)
+                if isinstance(nested, dict):
+                    hydrated.update(nested)
+            break
+        return hydrated
+
     def _matches_selected(row: dict) -> bool:
-        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
-        task_id = detail.get('current_task_id') or row.get('title')
-        hypothesis_id = detail.get('selected_hypothesis_id') or detail.get('hypothesis_id') or task_id
+        detail = _hydrate_cycle_detail(row)
+        task_id = _first_present(detail, ('current_task_id', 'currentTaskId', 'task_id', 'taskId')) or row.get('title')
+        hypothesis_id = _first_present(detail, ('selected_hypothesis_id', 'selectedHypothesisId', 'hypothesis_id', 'hypothesisId')) or task_id
+        title_candidates = [
+            row.get('title'),
+            detail.get('selected_hypothesis_title'),
+            detail.get('hypothesis_title'),
+            detail.get('current_task'),
+            detail.get('current_task_title'),
+            detail.get('title'),
+        ]
         if _has_value(selected_id):
             return str(task_id) == str(selected_id) or str(hypothesis_id) == str(selected_id)
         if _has_value(selected_title):
-            return str(row.get('title') or task_id) == str(selected_title)
+            return any(_has_value(candidate) and str(candidate) == str(selected_title) for candidate in title_candidates)
         return False
 
     ordered_cycles = sorted(cycles or [], key=lambda row: _coerce_timestamp(row.get('collected_at')) or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
@@ -1883,13 +1959,16 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
         else:
             break
 
+    def _cycle_detail(row: dict) -> dict:
+        return _hydrate_cycle_detail(row)
+
     def _cycle_outcome(row: dict) -> str | None:
-        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        detail = _cycle_detail(row)
         experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
         return experiment.get('outcome') or detail.get('outcome') or row.get('status')
 
     def _cycle_budget_used(row: dict) -> dict:
-        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        detail = _cycle_detail(row)
         budget_used = detail.get('budget_used') if isinstance(detail.get('budget_used'), dict) else {}
         if not budget_used:
             experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
@@ -1897,6 +1976,11 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
         if not budget_used and isinstance(detail.get('current_plan'), dict):
             budget_used = detail['current_plan'].get('budget_used') if isinstance(detail['current_plan'].get('budget_used'), dict) else {}
         return budget_used if isinstance(budget_used, dict) else {}
+
+    def _cycle_feedback_decision(row: dict):
+        detail = _cycle_detail(row)
+        feedback_decision = detail.get('feedback_decision')
+        return feedback_decision if isinstance(feedback_decision, dict) else feedback_decision
 
     outcome_counts = {'discard': 0, 'pass': 0, 'block': 0, 'other': 0}
     budget_sum = {'requests': 0, 'tool_calls': 0, 'subagents': 0, 'elapsed_seconds': 0}
@@ -1912,6 +1996,7 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
             except Exception:
                 continue
 
+    latest_cycle = window_cycles[0] if window_cycles else (matched_cycles[0] if matched_cycles else None)
     reward_gate = credits_visibility.get('current', {}).get('reward_gate') if isinstance(credits_visibility.get('current'), dict) else {}
     if not isinstance(reward_gate, dict):
         reward_gate = {}
@@ -1942,6 +2027,8 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
         'selected_hypothesis_score_text': _hypothesis_score_text(selected_score),
         'selected_hypothesis_wsjf': selected_wsjf,
         'selected_hypothesis_wsjf_text': _wsjf_text(selected_wsjf),
+        'selected_hypothesis_feedback_decision': _cycle_feedback_decision(latest_cycle) if latest_cycle else None,
+        'selected_hypothesis_experiment_outcome': _cycle_outcome(latest_cycle) if latest_cycle else None,
         'run_count': run_count,
         'run_streak': run_streak,
         'window_hours': 24,
@@ -1959,7 +2046,8 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
             },
             'terminal_selfevo_issue': terminal_issue,
             'terminal_selfevo_pr': terminal_pr,
-            'latest_outcome': _cycle_outcome(window_cycles[0]) if window_cycles else None,
+            'latest_outcome': _cycle_outcome(latest_cycle) if latest_cycle else None,
+            'latest_feedback_decision': _cycle_feedback_decision(latest_cycle) if latest_cycle else None,
         },
         'reward_gate': {
             'status': reward_gate.get('status'),

--- a/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
+++ b/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
@@ -124,7 +124,15 @@ def _seed_hypothesis_backlog(repo_root: Path, *, selected_id: str, selected_titl
     return backlog
 
 
-def _seed_selected_hypothesis_cycle(db: Path, idx: int, task_id: str, *, outcome: str = 'discard') -> None:
+def _seed_selected_hypothesis_cycle(
+    db: Path,
+    idx: int,
+    task_id: str,
+    *,
+    outcome: str = 'discard',
+    summary_only: bool = False,
+    repo_root: Path | None = None,
+) -> None:
     stamp = f'2026-04-24T13:{idx:02d}:00Z'
     raw = {
         'current_plan': {
@@ -147,6 +155,41 @@ def _seed_selected_hypothesis_cycle(db: Path, idx: int, task_id: str, *, outcome
         },
         'outbox': {'status': 'PASS'},
     }
+    report_source = f'/workspace/state/reports/evolution-{idx}.json'
+    if summary_only:
+        assert repo_root is not None
+        report_path = repo_root / 'workspace' / 'state' / 'reports' / f'evolution-{idx}.json'
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps({
+            'current_plan': {
+                'current_task_id': task_id,
+                'current_task': 'Analyze the last failed self-evolution candidate before retrying mutation',
+                'selected_hypothesis_id': task_id,
+                'hypothesis_id': task_id,
+                'feedback_decision': {
+                    'mode': 'handoff_to_next_candidate',
+                    'selected_task_id': task_id,
+                    'selected_task_title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+                    'selection_source': 'generated_from_failure_learning',
+                },
+                'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+                'experiment': {
+                    'outcome': outcome,
+                    'revert_status': 'skipped_no_material_change',
+                    'revert_required': True,
+                },
+            },
+            'experiment': {
+                'outcome': outcome,
+                'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+            },
+            'feedback_decision': {
+                'mode': 'handoff_to_next_candidate',
+                'selected_task_id': task_id,
+                'selected_task_title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+                'selection_source': 'generated_from_failure_learning',
+            },
+        }), encoding='utf-8')
     insert_collection(db, {
         'collected_at': stamp,
         'source': 'repo',
@@ -154,7 +197,7 @@ def _seed_selected_hypothesis_cycle(db: Path, idx: int, task_id: str, *, outcome
         'active_goal': 'goal-bootstrap',
         'approval_gate': None,
         'gate_state': None,
-        'report_source': f'/workspace/state/reports/evolution-{idx}.json',
+        'report_source': report_source,
         'outbox_source': '/workspace/state/outbox/latest.json',
         'artifact_paths_json': '[]',
         'promotion_summary': None,
@@ -163,19 +206,27 @@ def _seed_selected_hypothesis_cycle(db: Path, idx: int, task_id: str, *, outcome
         'promotion_accepted_record': None,
         'raw_json': json.dumps(raw),
     })
+    detail: dict[str, object]
+    if summary_only:
+        detail = {
+            'report_source': report_source,
+            'artifact_paths': [f'/workspace/state/reports/evolution-{idx}.json'],
+        }
+    else:
+        detail = {
+            'current_task_id': task_id,
+            'selected_hypothesis_id': task_id,
+            'outcome': outcome,
+            'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+        }
     upsert_event(db, {
         'collected_at': stamp,
         'source': 'repo',
         'event_type': 'cycle',
         'identity_key': f'cycle-stagnant-{idx}',
-        'title': task_id,
+        'title': 'summary-only cycle' if summary_only else task_id,
         'status': 'PASS',
-        'detail_json': json.dumps({
-            'current_task_id': task_id,
-            'selected_hypothesis_id': task_id,
-            'outcome': outcome,
-            'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
-        }),
+        'detail_json': json.dumps(detail),
     })
 
 
@@ -359,6 +410,102 @@ def test_dashboard_api_surfaces_selected_hypothesis_diagnostics_and_hypothesis_d
     assert diagnostics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
     assert diagnostics['run_count'] == 5
     assert diagnostics['run_streak'] == 5
+    assert diagnostics['last_24h']['total_runs'] == 5
+    assert diagnostics['last_24h']['discard_count'] == 5
+    assert diagnostics['last_24h']['budget_used_sum']['requests'] == 5
+    assert diagnostics['last_24h']['budget_used_sum']['tool_calls'] == 10
+    assert diagnostics['last_24h']['reward_gate']['status'] == 'suppressed'
+    assert diagnostics['last_24h']['reward_gate']['reason'] == 'discarded_experiment_unresolved_revert'
+    assert diagnostics['terminal_selfevo_issue']['number'] == 61
+    assert diagnostics['terminal_selfevo_pr']['number'] == 62
+
+    hypothesis_dynamics = system['hypothesis_dynamics']
+    assert hypothesis_dynamics['state'] == 'stagnant'
+    assert hypothesis_dynamics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
+    assert hypothesis_dynamics['run_count'] == 5
+    assert hypothesis_dynamics['run_streak'] == 5
+    assert hypothesis_dynamics['last_24h']['discard_count'] == 5
+    assert hypothesis_dynamics['last_24h']['reward_gate']['reason'] == 'discarded_experiment_unresolved_revert'
+    assert hypothesis_dynamics['terminal_selfevo_issue']['number'] == 61
+    assert hypothesis_dynamics['terminal_selfevo_pr']['number'] == 62
+    assert 'hypothesis_dynamics_stagnant' in system['autonomy_verdict']['reasons']
+    assert system['autonomy_verdict']['state'] == 'stagnant'
+
+
+def test_dashboard_api_hydrates_summary_only_cycle_detail_from_report_source(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'experiments').mkdir(parents=True)
+    (state_root / 'credits').mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    (state_root / 'control_plane').mkdir(parents=True)
+    _seed_hypothesis_backlog(
+        repo_root,
+        selected_id='analyze-last-failed-candidate',
+        selected_title='Analyze the last failed self-evolution candidate before retrying mutation',
+        selected_score=100,
+    )
+    _write_control_plane_summary(
+        project_root,
+        task_plan={
+            'current_task_id': 'analyze-last-failed-candidate',
+            'current_task': 'Analyze the last failed self-evolution candidate before retrying mutation',
+        },
+    )
+    for idx in range(5):
+        _seed_selected_hypothesis_cycle(db, idx, 'analyze-last-failed-candidate', summary_only=True, repo_root=repo_root)
+    (state_root / 'experiments' / 'latest.json').write_text(json.dumps({
+        'outcome': 'discard',
+        'revert_required': True,
+        'revert_status': 'skipped_no_material_change',
+    }), encoding='utf-8')
+    (state_root / 'credits' / 'latest.json').write_text(json.dumps({
+        'delta': 0.0,
+        'reward_gate': {
+            'status': 'suppressed',
+            'reason': 'discarded_experiment_unresolved_revert',
+        },
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'runtime' / 'latest_noop.json').write_text(json.dumps({
+        'status': 'terminal_noop',
+        'selfevo_issue': {
+            'number': 61,
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/61',
+            'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+        },
+        'pr': {
+            'number': 62,
+            'url': 'https://github.com/ozand/eeebot-self-evolving/pull/62',
+            'title': 'Terminal self-evolution lane closure',
+        },
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'current_state.json').write_text(json.dumps({
+        'selfevo_issue': {
+            'number': 61,
+            'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/61',
+        },
+        'last_pr': {
+            'number': 62,
+            'title': 'Terminal self-evolution lane closure',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/pull/62',
+        },
+    }), encoding='utf-8')
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+    app = create_app(cfg)
+
+    hypotheses = _call_json(app, '/api/hypotheses')
+    system = _call_json(app, '/api/system')
+
+    diagnostics = hypotheses['selected_hypothesis_diagnostics']
+    assert diagnostics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
+    assert diagnostics['run_count'] == 5
+    assert diagnostics['run_streak'] == 5
+    assert diagnostics['selected_hypothesis_experiment_outcome'] == 'discard'
+    assert diagnostics['selected_hypothesis_feedback_decision']['mode'] == 'handoff_to_next_candidate'
     assert diagnostics['last_24h']['total_runs'] == 5
     assert diagnostics['last_24h']['discard_count'] == 5
     assert diagnostics['last_24h']['budget_used_sum']['requests'] == 5


### PR DESCRIPTION
Fixes #257.

Summary:
- hydrates summary-only cycle event rows from referenced report_source/artifact_paths JSON
- counts selected hypothesis run_count/run_streak from full cycle report payloads
- preserves/hydrates experiment outcome, budget, and feedback decision for diagnostics
- adds regression coverage for summary-only cycle events backed by full reports

Verification:
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_autonomy_stagnation_dashboard.py ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -q -> 31 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 86 passed