### PR TITLE
fix: detect repeated hypothesis stagnation

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2001,12 +2001,18 @@ def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibilit
     if not isinstance(reward_gate, dict):
         reward_gate = {}
     terminal_issue, terminal_pr = _selected_hypothesis_terminal_evidence(cfg)
+    run_count = len(window_cycles)
+    selected_hypothesis_repetition = run_count >= 5
     state = 'stagnant' if (
-        run_count := len(window_cycles)
-    ) and run_streak >= 5 and outcome_counts['discard'] == run_count and reward_gate.get('status') == 'suppressed' and (terminal_issue or terminal_pr) else 'healthy'
+        run_count
+        and selected_hypothesis_repetition
+        and outcome_counts['discard'] == run_count
+        and reward_gate.get('status') == 'suppressed'
+        and (terminal_issue or terminal_pr)
+    ) else 'healthy'
     reasons: list[str] = []
     if run_count:
-        if run_streak >= 5:
+        if selected_hypothesis_repetition:
             reasons.append('selected_hypothesis_repetition')
         if outcome_counts['discard'] == run_count:
             reasons.append('discard_only_selected_hypothesis')

--- a/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
+++ b/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
@@ -432,6 +432,137 @@ def test_dashboard_api_surfaces_selected_hypothesis_diagnostics_and_hypothesis_d
     assert system['autonomy_verdict']['state'] == 'stagnant'
 
 
+def test_dashboard_api_marks_selected_hypothesis_stagnant_when_non_selected_cycle_interrupts_streak(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'experiments').mkdir(parents=True)
+    (state_root / 'credits').mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    (state_root / 'control_plane').mkdir(parents=True)
+    _seed_hypothesis_backlog(
+        repo_root,
+        selected_id='analyze-last-failed-candidate',
+        selected_title='Analyze the last failed self-evolution candidate before retrying mutation',
+        selected_score=100,
+    )
+    _write_control_plane_summary(
+        project_root,
+        task_plan={
+            'current_task_id': 'analyze-last-failed-candidate',
+            'current_task': 'Analyze the last failed self-evolution candidate before retrying mutation',
+        },
+    )
+    for idx in range(5):
+        _seed_selected_hypothesis_cycle(db, idx, 'analyze-last-failed-candidate')
+    interrupt_stamp = '2026-04-24T14:00:00Z'
+    insert_collection(db, {
+        'collected_at': interrupt_stamp,
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': '/workspace/state/reports/evolution-interrupt.json',
+        'outbox_source': '/workspace/state/outbox/latest.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({
+            'current_plan': {
+                'current_task_id': 'newer-unrelated-cycle',
+                'current_task': 'Close out an unrelated maintenance pass',
+                'feedback_decision': {
+                    'mode': 'handoff_to_next_candidate',
+                    'selected_task_id': 'newer-unrelated-cycle',
+                },
+                'task_selection_source': 'feedback_review_to_execution',
+                'selected_tasks': 'Close out an unrelated maintenance pass [task_id=newer-unrelated-cycle]',
+            },
+            'outbox': {'status': 'PASS'},
+        }),
+    })
+    upsert_event(db, {
+        'collected_at': interrupt_stamp,
+        'source': 'repo',
+        'event_type': 'cycle',
+        'identity_key': 'cycle-interrupting-non-selected',
+        'title': 'newer-unrelated-cycle',
+        'status': 'PASS',
+        'detail_json': json.dumps({'current_task_id': 'newer-unrelated-cycle'}),
+    })
+    (state_root / 'experiments' / 'latest.json').write_text(json.dumps({
+        'outcome': 'discard',
+        'revert_required': True,
+        'revert_status': 'skipped_no_material_change',
+    }), encoding='utf-8')
+    (state_root / 'credits' / 'latest.json').write_text(json.dumps({
+        'delta': 0.0,
+        'reward_gate': {
+            'status': 'suppressed',
+            'reason': 'discarded_experiment_unresolved_revert',
+        },
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'runtime' / 'latest_noop.json').write_text(json.dumps({
+        'status': 'terminal_noop',
+        'selfevo_issue': {
+            'number': 61,
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/61',
+            'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+        },
+        'pr': {
+            'number': 62,
+            'url': 'https://github.com/ozand/eeebot-self-evolving/pull/62',
+            'title': 'Terminal self-evolution lane closure',
+        },
+    }), encoding='utf-8')
+    (state_root / 'self_evolution' / 'current_state.json').write_text(json.dumps({
+        'selfevo_issue': {
+            'number': 61,
+            'title': 'Analyze the last failed self-evolution candidate before retrying mutation',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/61',
+        },
+        'last_pr': {
+            'number': 62,
+            'title': 'Terminal self-evolution lane closure',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/pull/62',
+        },
+    }), encoding='utf-8')
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+    app = create_app(cfg)
+
+    hypotheses = _call_json(app, '/api/hypotheses')
+    system = _call_json(app, '/api/system')
+
+    diagnostics = hypotheses['selected_hypothesis_diagnostics']
+    assert diagnostics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
+    assert diagnostics['run_count'] == 5
+    assert diagnostics['run_streak'] == 0
+    assert diagnostics['state'] == 'stagnant'
+    assert 'selected_hypothesis_repetition' in diagnostics['reasons']
+    assert 'discard_only_selected_hypothesis' in diagnostics['reasons']
+    assert diagnostics['last_24h']['discard_count'] == 5
+    assert diagnostics['last_24h']['reward_gate']['status'] == 'suppressed'
+    assert diagnostics['terminal_selfevo_issue']['number'] == 61
+    assert diagnostics['terminal_selfevo_pr']['number'] == 62
+
+    hypothesis_dynamics = system['hypothesis_dynamics']
+    assert hypothesis_dynamics['state'] == 'stagnant'
+    assert hypothesis_dynamics['selected_hypothesis_id'] == 'analyze-last-failed-candidate'
+    assert hypothesis_dynamics['run_count'] == 5
+    assert hypothesis_dynamics['run_streak'] == 0
+    assert hypothesis_dynamics['last_24h']['discard_count'] == 5
+    assert hypothesis_dynamics['last_24h']['reward_gate']['reason'] == 'discarded_experiment_unresolved_revert'
+    assert hypothesis_dynamics['terminal_selfevo_issue']['number'] == 61
+    assert hypothesis_dynamics['terminal_selfevo_pr']['number'] == 62
+    assert 'hypothesis_dynamics_stagnant' in system['autonomy_verdict']['reasons']
+    assert system['autonomy_verdict']['state'] == 'stagnant'
+
+
 def test_dashboard_api_hydrates_summary_only_cycle_detail_from_report_source(tmp_path: Path) -> None:
     project_root = tmp_path / 'dashboard'
     repo_root = tmp_path / 'nanobot'


### PR DESCRIPTION
Fixes #259.

Summary:
- treats repeated selected hypothesis runs in the 24h window as stagnation evidence, not only contiguous latest streak
- preserves discard-only + suppressed reward + terminal self-evo evidence requirements
- adds regression for selected discarded runs interrupted by a newer non-selected cycle

Verification:
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 87 passed