### PR TITLE
fix: resolve terminal selfevo from runtime state

### DIFF
--- a/nanobot/runtime/autoevolve.py
+++ b/nanobot/runtime/autoevolve.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from nanobot.runtime.state import resolve_runtime_state_root
+
 
 def _utc_stamp(now: datetime | None = None) -> str:
     current = now.astimezone(timezone.utc) if now else datetime.now(timezone.utc)
@@ -85,12 +87,26 @@ def _record_matches_source_task(record: dict[str, Any], source_task_id: str | No
 
 
 def resolve_terminal_selfevo_issue(*, workspace: Path, source_task_id: str | None) -> dict[str, Any] | None:
-    root = _self_evolution_root(workspace.resolve())
-    candidates = [
-        _load_json(root / 'runtime' / 'latest_issue_lifecycle.json'),
-        _load_json(root / 'runtime' / 'latest_noop.json'),
-    ]
-    for record in candidates:
+    workspace = workspace.resolve()
+    candidate_paths: list[Path] = []
+    try:
+        runtime_root = resolve_runtime_state_root(workspace)
+        candidate_paths.extend([
+            runtime_root / 'self_evolution' / 'runtime' / 'latest_issue_lifecycle.json',
+            runtime_root / 'self_evolution' / 'runtime' / 'latest_noop.json',
+        ])
+    except Exception:
+        pass
+    candidate_paths.extend([
+        workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_issue_lifecycle.json',
+        workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_noop.json',
+    ])
+    seen: set[Path] = set()
+    for path in candidate_paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        record = _load_json(path)
         if not isinstance(record, dict):
             continue
         if not _record_matches_source_task(record, source_task_id):

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -356,3 +356,79 @@ def test_failure_learning_uses_resolved_runtime_state_root(tmp_path: Path, monke
     assert result is not None
     assert result['candidate_id'] == 'host-control-plane-candidate'
     assert result['_source_path'] == str(failure_dir / 'latest.json')
+
+
+def test_terminal_selfevo_issue_uses_resolved_runtime_state_root(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir()
+    runtime_state = tmp_path / 'host-state'
+    runtime_dir = runtime_state / 'self_evolution' / 'runtime'
+    runtime_dir.mkdir(parents=True)
+    lifecycle_path = runtime_dir / 'latest_issue_lifecycle.json'
+    lifecycle_path.write_text(json.dumps({
+        'schema_version': 'autoevolve-issue-lifecycle-v1',
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'selfevo_branch': 'fix/issue-261-analyze-last-failed-candidate',
+        'selfevo_issue': {'number': 261, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+    }), encoding='utf-8')
+    monkeypatch.setenv('NANOBOT_RUNTIME_STATE_ROOT', str(runtime_state))
+
+    result = autoevolve.resolve_terminal_selfevo_issue(workspace=workspace, source_task_id='analyze-last-failed-candidate')
+
+    assert result is not None
+    assert result['number'] == 261
+    assert result['created'] is False
+    assert result['reused_terminal_lane'] is True
+    assert result['terminal_status'] == 'terminal_merged'
+
+
+def test_coordinator_retires_analyze_last_failed_candidate_when_terminal_issue_exists_only_in_runtime_state_root(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    (goals / 'current.json').write_text(json.dumps({
+        'current_task_id': 'analyze-last-failed-candidate',
+        'tasks': [
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'active'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+        ],
+    }), encoding='utf-8')
+    runtime_state = tmp_path / 'host-state'
+    runtime_dir = runtime_state / 'self_evolution' / 'runtime'
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / 'latest_issue_lifecycle.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-issue-lifecycle-v1',
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'issue_number': 261,
+        'selfevo_branch': 'fix/issue-261-analyze-last-failed-candidate',
+        'selfevo_issue': {'number': 261, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+        'source_task_id': 'analyze-last-failed-candidate',
+    }), encoding='utf-8')
+    monkeypatch.setenv('NANOBOT_RUNTIME_STATE_ROOT', str(runtime_state))
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-retire-terminal-selfevo-runtime-root',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.0}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard', 'revert_status': 'skipped_no_material_change'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.0,
+        feedback_decision=None,
+        goals_dir=goals,
+    )
+
+    assert plan['current_task_id'] == 'record-reward'
+    assert plan['feedback_decision']['mode'] == 'retire_terminal_selfevo_lane'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_terminal_selfevo_retire'
+    assert plan['feedback_decision']['selected_task_id'] == 'record-reward'
+    assert plan['feedback_decision']['terminal_selfevo_issue']['selfevo_issue']['number'] == 261
+    assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])


### PR DESCRIPTION
Fixes #261.

Summary:
- checks canonical runtime state root for terminal self-evolution lifecycle/noop artifacts
- preserves workspace/state fallback
- adds regression for analyze-last-failed-candidate retirement when lifecycle exists only under runtime state root

Verification:
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py -q -> 14 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 87 passed