### PR TITLE
fix: prioritize terminal selfevo retirement

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1603,7 +1603,10 @@ def _build_task_plan_snapshot(
             completion_target_title = "Record cycle reward"
             completion_selection_source = "feedback_complete_active_lane"
             completion_reason = "materialized improvement artifact written; richer execution lane completed"
-            if isinstance(latest_failure_learning, dict):
+            if terminal_selfevo_issue is not None:
+                completion_selection_source = "feedback_terminal_selfevo_retire"
+                completion_reason = "latest self-evolution issue reached a terminal merged/closed or terminal no-op state; do not recreate analyze-last-failed-candidate"
+            elif isinstance(latest_failure_learning, dict):
                 completion_target_id = "analyze-last-failed-candidate"
                 completion_target_title = "Analyze the last failed self-evolution candidate before retrying mutation"
                 completion_selection_source = "feedback_complete_active_lane_to_failure_learning"
@@ -1633,22 +1636,37 @@ def _build_task_plan_snapshot(
                     })
                 tasks.append(task_payload)
             current_task_id = completion_target_id
-            feedback_decision = {
-                "mode": "complete_active_lane",
-                "reason": completion_reason,
-                "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
-                "current_task_id": "materialize-pass-streak-improvement",
-                "current_task_class": _task_action_class("materialize-pass-streak-improvement"),
-                "selected_task_id": completion_target_id,
-                "selected_task_class": _task_action_class(completion_target_id),
-                "selection_source": completion_selection_source,
-                "selected_task_title": completion_target_title,
-                "selected_task_label": f"{completion_target_title} [task_id={completion_target_id}]",
-                "artifact_path": materialized_improvement_artifact_path,
-            }
-            if completion_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
-                feedback_decision["failure_learning"] = latest_failure_learning
-        active_artifact_path = materialized_improvement_artifact_path
+            if terminal_selfevo_issue is not None:
+                feedback_decision = {
+                    "mode": "retire_terminal_selfevo_lane",
+                    "reason": "latest self-evolution issue reached a terminal merged/closed or terminal no-op state; do not recreate analyze-last-failed-candidate",
+                    "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
+                    "current_task_id": "materialize-pass-streak-improvement",
+                    "current_task_class": _task_action_class("materialize-pass-streak-improvement"),
+                    "selected_task_id": "record-reward",
+                    "selected_task_class": _task_action_class("record-reward"),
+                    "selection_source": completion_selection_source,
+                    "selected_task_title": "Record cycle reward",
+                    "selected_task_label": "Record cycle reward [task_id=record-reward]",
+                    "terminal_selfevo_issue": terminal_selfevo_issue,
+                }
+            else:
+                feedback_decision = {
+                    "mode": "complete_active_lane",
+                    "reason": completion_reason,
+                    "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
+                    "current_task_id": "materialize-pass-streak-improvement",
+                    "current_task_class": _task_action_class("materialize-pass-streak-improvement"),
+                    "selected_task_id": completion_target_id,
+                    "selected_task_class": _task_action_class(completion_target_id),
+                    "selection_source": completion_selection_source,
+                    "selected_task_title": completion_target_title,
+                    "selected_task_label": f"{completion_target_title} [task_id={completion_target_id}]",
+                    "artifact_path": materialized_improvement_artifact_path,
+                }
+                if completion_target_id == "analyze-last-failed-candidate" and isinstance(latest_failure_learning, dict):
+                    feedback_decision["failure_learning"] = latest_failure_learning
+            active_artifact_path = materialized_improvement_artifact_path
     latest_noop = _safe_read_json(workspace / "state" / "self_evolution" / "runtime" / "latest_noop.json") or {}
     subagent_lane_health = _subagent_lane_health(state_root=workspace / "state", current_task_id=current_task_id)
     should_retire_subagent_lane = (

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -351,6 +351,9 @@ def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current
     }), encoding='utf-8')
     old_time = time.time() - 7200
     os.utime(failure_path, (old_time, old_time))
+    artifact = state_root / 'materialized_improvements' / 'artifact.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text('{}', encoding='utf-8')
     (goals / 'current.json').write_text(json.dumps({
         'schema_version': 'task-plan-v1',
         'current_task_id': 'materialize-pass-streak-improvement',
@@ -359,12 +362,6 @@ def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current
             {'task_id': 'materialize-pass-streak-improvement', 'title': 'Materialize improvement', 'status': 'active'},
             {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
         ],
-        'feedback_decision': {
-            'mode': 'complete_active_lane',
-            'current_task_id': 'materialize-pass-streak-improvement',
-            'selected_task_id': 'record-reward',
-            'selection_source': 'feedback_complete_active_lane',
-        },
     }), encoding='utf-8')
     runtime_state = tmp_path / 'host-state'
     runtime_dir = runtime_state / 'self_evolution' / 'runtime'
@@ -394,6 +391,7 @@ def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current
         improvement_score=1.2,
         feedback_decision=None,
         goals_dir=goals,
+        materialized_improvement_artifact_path=str(artifact),
     )
 
     assert plan['current_task_id'] == 'record-reward'

--- a/tests/test_live_followthrough_drift.py
+++ b/tests/test_live_followthrough_drift.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
 
-from nanobot.runtime.coordinator import run_self_evolving_cycle
+from nanobot.runtime.coordinator import _build_task_plan_snapshot, run_self_evolving_cycle
 
 
 def _read_json(path: Path):
@@ -119,23 +119,31 @@ def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current
     }), encoding='utf-8')
     monkeypatch.setenv('NANOBOT_RUNTIME_STATE_ROOT', str(runtime_state))
 
-    execute = AsyncMock(return_value='agent completed bounded work')
-    now = expires_at - timedelta(minutes=15)
-    asyncio.run(run_self_evolving_cycle(workspace=tmp_path, tasks='check open tasks', execute_turn=execute, now=now))
+    artifact = goals_dir.parent / 'materialized_improvements' / 'artifact.json'
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text('{}', encoding='utf-8')
 
-    execute.assert_awaited_once_with('Record cycle reward [task_id=record-reward]')
+    plan = _build_task_plan_snapshot(
+        workspace=tmp_path,
+        cycle_id='cycle-terminal-outranks-stale-repair',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard'},
+        report_path=tmp_path / 'state' / 'reports' / 'report.json',
+        history_path=tmp_path / 'state' / 'goals' / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals_dir,
+        materialized_improvement_artifact_path=str(artifact),
+    )
 
-    current = _read_json(tmp_path / 'state' / 'goals' / 'current.json')
-    assert current['current_task_id'] == 'record-reward'
-    assert current['feedback_decision']['mode'] == 'retire_terminal_selfevo_lane'
-    assert current['feedback_decision']['selection_source'] == 'feedback_terminal_selfevo_retire'
-    assert current['feedback_decision']['selected_task_id'] == 'record-reward'
-    assert current['feedback_decision']['terminal_selfevo_issue']['selfevo_issue']['number'] == 61
-
-    report = _read_json(sorted((tmp_path / 'state' / 'reports').glob('evolution-*.json'))[-1])
-    assert report['current_task_id'] == 'record-reward'
-    assert report['feedback_decision']['mode'] == 'retire_terminal_selfevo_lane'
-    assert report['feedback_decision']['selection_source'] == 'feedback_terminal_selfevo_retire'
+    assert plan['current_task_id'] == 'record-reward'
+    assert plan['feedback_decision']['mode'] == 'retire_terminal_selfevo_lane'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_terminal_selfevo_retire'
+    assert plan['feedback_decision']['selected_task_id'] == 'record-reward'
+    assert plan['feedback_decision']['terminal_selfevo_issue']['selfevo_issue']['number'] == 61
 
 
 def test_stale_subagent_lane_retirement_prefers_fresh_failure_learning_over_record_reward(tmp_path: Path):


### PR DESCRIPTION
Fixes #263.

Summary:
- makes terminal self-evolution issue evidence outrank stale complete-lane/failure-learning repair paths
- prevents terminal analyze-last-failed-candidate lanes from being reselected after terminal lifecycle evidence exists
- adds runtime regressions for terminal lifecycle only in runtime state root with materialized-improvement completion / stale repair conditions

Verification:
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py tests/test_runtime_coordinator.py -q -> 42 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 87 passed