### PR TITLE
fix: make terminal selfevo retirement idempotent

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1280,6 +1280,9 @@ def _build_task_plan_snapshot(
     materialized_improvement_artifact_path: str | None = None,
 ) -> dict[str, Any]:
     blocked_next_step = next_hint if result_status == "BLOCK" else ""
+    recorded_current_task_id = None
+    recorded_materialized_improvement_artifact_path = None
+    recorded_feedback_artifact_path = None
     if result_status == "BLOCK":
         file_action = {
             "kind": "file_write",
@@ -1360,6 +1363,22 @@ def _build_task_plan_snapshot(
         and recorded_feedback_decision_for_repair.get('selected_task_id') == 'record-reward'
         and recorded_feedback_decision_for_repair.get('selection_source') == 'feedback_complete_active_lane'
     )
+    recorded_terminal_selfevo_retirement = (
+        isinstance(recorded_feedback_decision_for_repair, dict)
+        and recorded_current_task_id == 'record-reward'
+        and recorded_feedback_decision_for_repair.get('mode') == 'retire_terminal_selfevo_lane'
+        and recorded_feedback_decision_for_repair.get('current_task_id') == 'analyze-last-failed-candidate'
+        and recorded_feedback_decision_for_repair.get('selected_task_id') == 'record-reward'
+        and recorded_feedback_decision_for_repair.get('selection_source') == 'feedback_terminal_selfevo_retire'
+        and terminal_selfevo_issue is not None
+        and isinstance(recorded_feedback_decision_for_repair.get('terminal_selfevo_issue'), dict)
+        and (
+            recorded_feedback_decision_for_repair['terminal_selfevo_issue'].get('terminal_status') == terminal_selfevo_issue.get('terminal_status')
+            or recorded_feedback_decision_for_repair['terminal_selfevo_issue'].get('selfevo_issue', {}).get('number') == terminal_selfevo_issue.get('selfevo_issue', {}).get('number')
+        )
+    )
+    if recorded_terminal_selfevo_retirement:
+        terminal_selfevo_retired = True
     if terminal_selfevo_issue is not None and current_task_id == "analyze-last-failed-candidate":
         for task in tasks:
             if task.get("task_id") == "analyze-last-failed-candidate":

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -402,6 +402,85 @@ def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current
     assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
 
 
+def test_terminal_selfevo_retirement_is_idempotent_after_record_reward_cycle(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+
+    failure_dir = state_root / 'self_evolution' / 'failure_learning'
+    failure_dir.mkdir(parents=True)
+    (failure_dir / 'latest.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-idempotent-loop',
+        'failed_commit': 'feedface',
+        'health_reasons': ['stale_report'],
+        'learning_summary': 'Fresh failure learning should not re-retire an already retired terminal lane.',
+    }), encoding='utf-8')
+
+    runtime_state = tmp_path / 'host-state'
+    runtime_dir = runtime_state / 'self_evolution' / 'runtime'
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / 'latest_issue_lifecycle.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-issue-lifecycle-v1',
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'issue_number': 61,
+        'selfevo_branch': 'fix/issue-61-analyze-last-failed-candidate',
+        'selfevo_issue': {'number': 61, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+        'source_task_id': 'analyze-last-failed-candidate',
+    }), encoding='utf-8')
+    monkeypatch.setenv('NANOBOT_RUNTIME_STATE_ROOT', str(runtime_state))
+
+    (goals / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'record-reward',
+        'tasks': [
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'},
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'pending', 'kind': 'review'},
+        ],
+        'feedback_decision': {
+            'mode': 'retire_terminal_selfevo_lane',
+            'reason': 'latest self-evolution issue reached a terminal merged/closed or terminal no-op state; do not recreate analyze-last-failed-candidate',
+            'reward_value': 1.0,
+            'current_task_id': 'analyze-last-failed-candidate',
+            'current_task_class': 'other',
+            'selected_task_id': 'record-reward',
+            'selected_task_class': 'reflection',
+            'selection_source': 'feedback_terminal_selfevo_retire',
+            'selected_task_title': 'Record cycle reward',
+            'selected_task_label': 'Record cycle reward [task_id=record-reward]',
+            'terminal_selfevo_issue': {
+                'terminal_status': 'terminal_merged',
+                'selfevo_issue': {'number': 61, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+            },
+        },
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-terminal-retirement-idempotent',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.0}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.0,
+        feedback_decision=None,
+        goals_dir=goals,
+    )
+
+    decision = plan.get('feedback_decision') or {}
+
+    assert plan['current_task_id'] == 'record-reward'
+    assert plan.get('next_cycle_task_id') != 'analyze-last-failed-candidate'
+    assert decision.get('mode') != 'retire_terminal_selfevo_lane'
+    assert decision.get('selected_task_id') != 'analyze-last-failed-candidate'
+
+
 def test_failure_learning_uses_resolved_runtime_state_root(tmp_path: Path, monkeypatch) -> None:
     from nanobot.runtime.coordinator import _latest_failure_learning
 


### PR DESCRIPTION
Fixes #267.

Summary:
- treats already-recorded terminal self-evo retirement as idempotent
- prevents repeated retire_terminal_selfevo_lane emissions for the same terminal issue
- prevents fallback to analyze-last-failed-candidate when the terminal lane was already retired
- adds regression covering fresh failure-learning evidence plus an already-retired terminal self-evo issue

Verification:
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py tests/test_runtime_coordinator.py -q -> 43 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 89 passed