### PR TITLE
fix: honor terminal selfevo retired guard

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1379,7 +1379,19 @@ def _build_task_plan_snapshot(
     )
     if recorded_terminal_selfevo_retirement:
         terminal_selfevo_retired = True
-    if terminal_selfevo_issue is not None and current_task_id == "analyze-last-failed-candidate":
+        for task in tasks:
+            if task.get("task_id") == "analyze-last-failed-candidate":
+                task["status"] = "done"
+                task["terminal_reason"] = terminal_selfevo_issue.get("terminal_status") or "terminal_selfevo_issue"
+            elif task.get("task_id") == "record-reward":
+                task["status"] = "active"
+            elif task.get("status") == "active":
+                task["status"] = "pending"
+        if not any(task.get("task_id") == "record-reward" for task in tasks):
+            tasks.append({"task_id": "record-reward", "title": "Record cycle reward", "status": "active"})
+        current_task_id = "record-reward"
+        feedback_decision = None
+    if terminal_selfevo_issue is not None and not terminal_selfevo_retired and current_task_id == "analyze-last-failed-candidate":
         for task in tasks:
             if task.get("task_id") == "analyze-last-failed-candidate":
                 task["status"] = "done"


### PR DESCRIPTION
Fixes #269.

Summary:
- when terminal self-evo retirement is already recorded, force analyze-last-failed-candidate done and record-reward active
- suppress the immediate terminal-retirement branch for already-retired terminal self-evo issues
- clears stale incoming feedback_decision so the same terminal retirement is not re-emitted

Verification:
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py::test_terminal_selfevo_retirement_is_idempotent_after_record_reward_cycle tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py tests/test_runtime_coordinator.py -q -> 43 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 89 passed