### PR TITLE
fix: synthesize candidate after retired lanes

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -40,6 +40,7 @@ CORE_TASK_IDS = {
     "run-bounded-turn",
     "record-reward",
 }
+SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID = "synthesize-next-improvement-candidate"
 
 COMPLETED_TASK_STATUSES = {
     "blocked",
@@ -65,6 +66,7 @@ TASK_ACTION_CLASS_BY_ID = {
     "inspect-pass-streak": "review",
     "materialize-pass-streak-improvement": "execution",
     "subagent-verify-materialized-improvement": "review",
+    SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID: "review",
 }
 
 
@@ -163,6 +165,26 @@ def _pick_task_for_classes(
         if task_id != current_task_id:
             return task
     return None
+
+
+def _synthesized_next_improvement_candidate(
+    *,
+    current_task_id: str | None,
+    strong_pass_count: int,
+    goal_artifact_signature: list[str] | None,
+    status: str = "pending",
+) -> dict[str, Any]:
+    return {
+        "task_id": SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID,
+        "title": "Synthesize one new bounded improvement candidate from retired lanes",
+        "status": status,
+        "kind": "review",
+        "acceptance": "produce one new bounded improvement candidate that is not a retired terminal/completed lane",
+        "selection_source": "feedback_no_selectable_retired_lane_synthesis",
+        "parent_task_id": current_task_id,
+        "strong_pass_count": strong_pass_count,
+        "goal_artifact_signature": goal_artifact_signature,
+    }
 
 
 def _history_failure_class(history_entry: dict[str, Any]) -> str | None:
@@ -471,6 +493,16 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                     selected_task = task
                     selection_source = "feedback_pass_streak_switch"
                     break
+        if selected_task is None:
+            mode = "synthesize_next_candidate"
+            reason = "goal/artifact PASS retirement pressure reached with no selectable bounded lane; synthesize a new bounded improvement candidate"
+            selected_task = _synthesized_next_improvement_candidate(
+                current_task_id=current_task_id,
+                strong_pass_count=strong_pass_count,
+                goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+                status="active",
+            )
+            selection_source = "feedback_no_selectable_retired_lane_synthesis"
 
     decision = {
         "mode": mode,
@@ -1583,6 +1615,19 @@ def _build_task_plan_snapshot(
         failure_learning=latest_failure_learning,
         retire_analyze_last_failed_candidate=terminal_selfevo_issue is not None,
     )
+    if (
+        isinstance(feedback_decision, dict)
+        and feedback_decision.get("selected_task_id") == SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID
+        and not any(candidate.get("task_id") == SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID for candidate in generated_candidates)
+    ):
+        generated_candidates.append(
+            _synthesized_next_improvement_candidate(
+                current_task_id=current_task_id,
+                strong_pass_count=int(feedback_decision.get("strong_pass_count") or 0),
+                goal_artifact_signature=feedback_decision.get("goal_artifact_signature") if isinstance(feedback_decision.get("goal_artifact_signature"), list) else None,
+                status="active",
+            )
+        )
     carried_candidates = [dict(item) for item in recorded_generated_candidates if isinstance(item, dict)] if 'recorded_generated_candidates' in locals() else []
     inferred_candidates = _inferred_generated_candidates_from_tasks(tasks)
     combined_candidates: list[dict[str, Any]] = []

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from nanobot.runtime.state import _material_progress_snapshot, _subagent_rollup_snapshot, format_runtime_state, load_runtime_state, load_runtime_state_from_root, resolve_runtime_state_location
-from nanobot.runtime.coordinator import _derive_feedback_decision, run_self_evolving_cycle
+from nanobot.runtime.coordinator import _build_task_plan_snapshot, _derive_feedback_decision, run_self_evolving_cycle
 
 
 def _read_json(path):
@@ -528,7 +528,7 @@ def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):
         )
     )
 
-    execute.assert_awaited_once_with("Record cycle reward [task_id=record-reward]")
+    execute.assert_awaited_once_with("Synthesize one new bounded improvement candidate from retired lanes [task_id=synthesize-next-improvement-candidate]")
     assert "PASS" in summary
 
     runtime = load_runtime_state(tmp_path)
@@ -537,13 +537,13 @@ def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):
     assert runtime["goal_rotation_streak"] == 3
     assert runtime["goal_rotation_trigger_goal"] == target_goal
     assert runtime["goal_rotation_trigger_artifact_paths"] == ["prompts/diagnostics.md"]
-    assert runtime["task_feedback_decision"]["mode"] == "retire_goal_artifact_pair"
-    assert runtime["task_feedback_decision"]["retire_goal_artifact_pair"] is True
+    assert runtime["task_feedback_decision"]["mode"] == "synthesize_next_candidate"
+    assert runtime["task_feedback_decision"]["retire_goal_artifact_pair"] is False
 
     report = _read_json(runtime["report_path"])
     assert report["goal_id"] == "goal-bootstrap"
     assert report["result_status"] == "PASS"
-    assert report["feedback_decision"]["mode"] == "retire_goal_artifact_pair"
+    assert report["feedback_decision"]["mode"] == "synthesize_next_candidate"
 
     active = _read_json(goals_dir / "active.json")
     assert active["active_goal"] == "goal-bootstrap"
@@ -552,11 +552,11 @@ def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):
     assert active["rotation_streak"] == 3
 
     current = _read_json(goals_dir / "current.json")
-    assert current["feedback_decision"]["mode"] == "retire_goal_artifact_pair"
+    assert current["feedback_decision"]["mode"] == "synthesize_next_candidate"
     history = _read_json(history_dir / f"cycle-{runtime['cycle_id']}.json")
-    assert history["feedback_decision"]["mode"] == "retire_goal_artifact_pair"
+    assert history["feedback_decision"]["mode"] == "synthesize_next_candidate"
     experiment = _read_json(runtime["experiment_path"])
-    assert experiment["feedback_decision"]["mode"] == "retire_goal_artifact_pair"
+    assert experiment["feedback_decision"]["mode"] == "synthesize_next_candidate"
 
 
 def test_cycle_writes_runtime_surfaces_into_host_control_plane_root_when_lane_active(tmp_path, monkeypatch):
@@ -1403,3 +1403,137 @@ def test_feedback_decision_does_not_continue_or_promote_completed_inspect_follow
     assert decision["selected_task_id"] == "record-reward"
     assert decision["selected_task_id"] not in {"inspect-pass-streak", "materialize-pass-streak-improvement"}
     assert decision["selection_source"] == "feedback_pass_streak_switch"
+
+
+def test_feedback_decision_synthesizes_next_improvement_candidate_when_retirement_has_no_selectable_lanes(tmp_path: Path) -> None:
+    goals_dir = tmp_path / "state" / "goals"
+    history_dir = goals_dir / "history"
+    experiments_dir = tmp_path / "state" / "experiments"
+    history_dir.mkdir(parents=True)
+    experiments_dir.mkdir(parents=True)
+
+    for idx in range(3):
+        cycle_path = history_dir / f"cycle-{idx}.json"
+        cycle_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "result_status": "PASS",
+                    "goal_id": "goal-bootstrap",
+                    "current_task_id": "record-reward",
+                    "artifact_paths": ["state/improvements/materialized-pass-streak.json"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    (experiments_dir / "latest.json").write_text(
+        json.dumps({"outcome": "keep", "current_task_id": "record-reward", "reward_signal": {"value": 1.2}}),
+        encoding="utf-8",
+    )
+
+    task_plan = {
+        "current_task_id": "record-reward",
+        "reward_signal": {"value": 1.2},
+        "tasks": [
+            {"task_id": "inspect-pass-streak", "title": "Inspect repeated PASS streak", "status": "done"},
+            {"task_id": "materialize-pass-streak-improvement", "title": "Materialize improvement", "status": "done"},
+            {"task_id": "subagent-verify-materialized-improvement", "title": "Verify materialized improvement", "status": "terminal_merged"},
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {"task_id": "analyze-last-failed-candidate", "title": "Analyze the last failed candidate", "status": "terminal_merged", "kind": "review"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals_dir)
+
+    assert decision is not None
+    assert decision["mode"] == "synthesize_next_candidate"
+    assert decision["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert decision["selected_task_class"] == "review"
+    assert decision["selection_source"] == "feedback_no_selectable_retired_lane_synthesis"
+    assert decision["selected_task_title"] == "Synthesize one new bounded improvement candidate from retired lanes"
+
+
+def test_task_plan_snapshot_adds_synthesized_next_improvement_candidate_when_all_known_lanes_are_terminal(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    state_root = workspace / "state"
+    goals_dir = state_root / "goals"
+    history_dir = goals_dir / "history"
+    experiments_dir = state_root / "experiments"
+    history_dir.mkdir(parents=True)
+    experiments_dir.mkdir(parents=True)
+
+    for idx in range(3):
+        (history_dir / f"cycle-{idx}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "result_status": "PASS",
+                    "goal_id": "goal-bootstrap",
+                    "current_task_id": "record-reward",
+                    "artifact_paths": ["state/improvements/materialized-pass-streak.json"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    (experiments_dir / "latest.json").write_text(
+        json.dumps({"outcome": "keep", "current_task_id": "record-reward", "reward_signal": {"value": 1.2}}),
+        encoding="utf-8",
+    )
+    (goals_dir / "current.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "task-plan-v1",
+                "current_task_id": "record-reward",
+                "tasks": [
+                    {"task_id": "inspect-pass-streak", "title": "Inspect repeated PASS streak", "status": "done"},
+                    {"task_id": "materialize-pass-streak-improvement", "title": "Materialize improvement", "status": "done"},
+                    {"task_id": "subagent-verify-materialized-improvement", "title": "Verify materialized improvement", "status": "terminal_merged"},
+                    {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+                    {"task_id": "analyze-last-failed-candidate", "title": "Analyze the last failed candidate", "status": "terminal_merged", "kind": "review"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    feedback_decision = _derive_feedback_decision(
+        {
+            "current_task_id": "record-reward",
+            "reward_signal": {"value": 1.2},
+            "tasks": [
+                {"task_id": "inspect-pass-streak", "title": "Inspect repeated PASS streak", "status": "done"},
+                {"task_id": "materialize-pass-streak-improvement", "title": "Materialize improvement", "status": "done"},
+                {"task_id": "subagent-verify-materialized-improvement", "title": "Verify materialized improvement", "status": "terminal_merged"},
+                {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+                {"task_id": "analyze-last-failed-candidate", "title": "Analyze the last failed candidate", "status": "terminal_merged", "kind": "review"},
+            ],
+        },
+        goals_dir,
+    )
+    assert feedback_decision is not None
+    assert feedback_decision["selected_task_id"] == "synthesize-next-improvement-candidate"
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id="cycle-synth-fallback",
+        goal_id="goal-bootstrap",
+        result_status="PASS",
+        approval_gate_state="fresh",
+        next_hint="continue",
+        experiment={"reward_signal": {"value": 1.2}, "budget": {}, "budget_used": {}, "outcome": "keep"},
+        report_path=tmp_path / "report.json",
+        history_path=tmp_path / "history.json",
+        improvement_score=1.2,
+        feedback_decision=feedback_decision,
+        goals_dir=goals_dir,
+    )
+
+    assert plan["current_task_id"] == "synthesize-next-improvement-candidate"
+    assert plan["feedback_decision"]["mode"] == "synthesize_next_candidate"
+    assert plan["feedback_decision"]["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert plan["feedback_decision"]["selection_source"] == "feedback_no_selectable_retired_lane_synthesis"
+    assert plan["generated_candidates"]
+    assert any(candidate["task_id"] == "synthesize-next-improvement-candidate" and candidate["status"] == "active" for candidate in plan["generated_candidates"])
+    assert any(task["task_id"] == "synthesize-next-improvement-candidate" and task["status"] == "active" for task in plan["tasks"])


### PR DESCRIPTION
Fixes #273.

Summary:
- adds a bounded synthesis fallback when retirement pressure exists but all known non-core lanes are done/terminal
- emits synthesize_next_candidate with selection_source=feedback_no_selectable_retired_lane_synthesis
- adds the synthesized candidate into current task, generated_candidates, and tasks instead of leaving selected_task_id null
- prevents retired inspect/materialize/subagent/analyze lanes from being chosen as the fallback

Verification:
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py tests/test_runtime_coordinator.py -q -> 47 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 89 passed