### PR TITLE
fix: prefer non-core pass rotation candidates

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -487,17 +487,24 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                     reason = "active inspect-pass-streak review produced a concrete bounded follow-up candidate"
                     break
         if selected_task is None:
-            preferred_ids = ["inspect-pass-streak"]
+            preferred_ids = [SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID]
             for preferred_id in preferred_ids:
                 for task in task_records:
                     task_id = task.get("task_id") or task.get("taskId")
-                    if task_id == current_task_id:
-                        continue
                     if task_id == preferred_id and _task_is_selectable(task):
                         selected_task = task
                         selection_source = "feedback_pass_streak_switch"
                         break
                 if selected_task is not None:
+                    break
+        if selected_task is None:
+            for task in task_records:
+                task_id = task.get("task_id") or task.get("taskId")
+                if task_id in CORE_TASK_IDS or task_id in {None, current_task_id}:
+                    continue
+                if _task_is_selectable(task):
+                    selected_task = task
+                    selection_source = "feedback_pass_streak_switch"
                     break
         if selected_task is None:
             for task in task_records:

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1488,6 +1488,54 @@ def test_feedback_decision_does_not_continue_or_promote_completed_inspect_follow
     assert decision["selection_source"] == "feedback_pass_streak_switch"
 
 
+def test_feedback_decision_prefers_synthesized_next_improvement_candidate_over_record_reward_under_strong_pass_rotation(tmp_path: Path) -> None:
+    goals_dir = tmp_path / "state" / "goals"
+    history_dir = goals_dir / "history"
+    experiments_dir = tmp_path / "state" / "experiments"
+    history_dir.mkdir(parents=True)
+    experiments_dir.mkdir(parents=True)
+
+    for idx in range(3):
+        cycle_path = history_dir / f"cycle-{idx}.json"
+        cycle_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "result_status": "PASS",
+                    "goal_id": "goal-bootstrap",
+                    "current_task_id": "record-reward",
+                    "artifact_paths": ["state/improvements/materialized-pass-streak.json"],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    (experiments_dir / "latest.json").write_text(
+        json.dumps({"outcome": "keep", "current_task_id": "synthesize-next-improvement-candidate", "reward_signal": {"value": 1.2}}),
+        encoding="utf-8",
+    )
+
+    task_plan = {
+        "current_task_id": "synthesize-next-improvement-candidate",
+        "reward_signal": {"value": 1.2},
+        "tasks": [
+            {"task_id": "inspect-pass-streak", "title": "Inspect repeated PASS streak", "status": "done"},
+            {"task_id": "materialize-pass-streak-improvement", "title": "Materialize improvement", "status": "done"},
+            {"task_id": "subagent-verify-materialized-improvement", "title": "Verify materialized improvement", "status": "terminal_merged"},
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize one new bounded improvement candidate from retired lanes", "status": "pending", "kind": "review"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals_dir)
+
+    assert decision is not None
+    assert decision["mode"] == "retire_goal_artifact_pair"
+    assert decision["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert decision["selected_task_class"] == "review"
+    assert decision["selection_source"] == "feedback_pass_streak_switch"
+
+
 def test_feedback_decision_synthesizes_next_improvement_candidate_when_retirement_has_no_selectable_lanes(tmp_path: Path) -> None:
     goals_dir = tmp_path / "state" / "goals"
     history_dir = goals_dir / "history"


### PR DESCRIPTION
Fixes #279.

Summary:
- changes strong PASS rotation fallback to prefer selectable non-core/generated lanes before core bookkeeping tasks
- prevents record-reward from winning feedback_pass_streak_switch while synthesize-next-improvement-candidate is pending/selectable
- adds regression covering record-reward vs synthesize-next-improvement-candidate ordering

Verification:
- python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py -q -> 49 passed
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q -> 91 passed