### PR TITLE
fix: complete synthesized materialization artifact lane

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1908,6 +1908,13 @@ def _build_task_plan_snapshot(
                 "selected_task_label": _render_task_selection(materialize_synthesized),
             }
     materialization_task_ids = {"materialize-pass-streak-improvement", MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID}
+    materialized_artifact_task_id = None
+    if materialized_improvement_artifact_path:
+        materialized_artifact_payload = _safe_read_json(Path(materialized_improvement_artifact_path))
+        if isinstance(materialized_artifact_payload, dict) and materialized_artifact_payload.get("task_id") in materialization_task_ids:
+            materialized_artifact_task_id = materialized_artifact_payload.get("task_id")
+    if materialized_artifact_task_id in materialization_task_ids:
+        current_task_id = materialized_artifact_task_id
     if current_task_id in materialization_task_ids and result_status == "PASS" and materialized_improvement_artifact_path:
         is_synthesized_materialization = current_task_id == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
         completed_materialization_task_id = current_task_id
@@ -1987,8 +1994,8 @@ def _build_task_plan_snapshot(
                     "mode": "retire_terminal_selfevo_lane",
                     "reason": "latest self-evolution issue reached a terminal merged/closed or terminal no-op state; do not recreate analyze-last-failed-candidate",
                     "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
-                    "current_task_id": "materialize-pass-streak-improvement",
-                    "current_task_class": _task_action_class("materialize-pass-streak-improvement"),
+                    "current_task_id": completed_materialization_task_id,
+                    "current_task_class": _task_action_class(completed_materialization_task_id),
                     "selected_task_id": "record-reward",
                     "selected_task_class": _task_action_class("record-reward"),
                     "selection_source": completion_selection_source,
@@ -2001,8 +2008,8 @@ def _build_task_plan_snapshot(
                     "mode": "complete_active_lane",
                     "reason": completion_reason,
                     "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
-                    "current_task_id": "materialize-pass-streak-improvement",
-                    "current_task_class": _task_action_class("materialize-pass-streak-improvement"),
+                    "current_task_id": completed_materialization_task_id,
+                    "current_task_class": _task_action_class(completed_materialization_task_id),
                     "selected_task_id": completion_target_id,
                     "selected_task_class": _task_action_class(completion_target_id),
                     "selection_source": completion_selection_source,
@@ -2895,6 +2902,16 @@ async def run_self_evolving_cycle(
             encoding="utf-8",
         )
 
+    artifact_current_task_id = experiment.get("current_task_id")
+    if isinstance(recorded_task_plan, dict):
+        recorded_current_task_id = recorded_task_plan.get("current_task_id") or recorded_task_plan.get("currentTaskId")
+        recorded_feedback = recorded_task_plan.get("feedback_decision") if isinstance(recorded_task_plan.get("feedback_decision"), dict) else {}
+        if (
+            recorded_current_task_id == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+            or recorded_feedback.get("selected_task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+        ):
+            artifact_current_task_id = MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+
     current_plan = _build_task_plan_snapshot(
         workspace=workspace,
         cycle_id=cycle_id,
@@ -2912,7 +2929,7 @@ async def run_self_evolving_cycle(
             state_root=state_root,
             cycle_id=cycle_id,
             goal_id=active_goal,
-            current_task_id=experiment.get("current_task_id"),
+            current_task_id=artifact_current_task_id,
             summary=summary,
             reward_signal=reward_signal,
             feedback_decision=feedback_decision,

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -710,6 +710,89 @@ def test_cycle_materializes_synthesized_execution_lane_artifact_and_completes(tm
     assert all(task.get("task_id") != "materialize-synthesized-improvement" or task.get("status") != "active" for task in current["tasks"])
 
 
+def test_cycle_writes_synthesized_materialization_artifact_when_pass_rotation_preselects_parent(tmp_path):
+    approvals_dir = tmp_path / "state" / "approvals"
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)
+    (approvals_dir / "apply.ok").write_text(json.dumps({"expires_at_utc": expires_at.isoformat(), "ttl_minutes": 60}), encoding="utf-8")
+
+    goals_dir = tmp_path / "state" / "goals"
+    history_dir = goals_dir / "history"
+    history_dir.mkdir(parents=True)
+    for index in range(3):
+        (history_dir / f"cycle-prior-materialize-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-prior-materialize-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": "materialize-synthesized-improvement",
+                    "recorded_at_utc": f"2026-04-15T12:0{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals_dir / "current.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "task-plan-v1",
+                "current_task_id": "materialize-synthesized-improvement",
+                "tasks": [
+                    {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
+                    {
+                        "task_id": "synthesize-next-improvement-candidate",
+                        "title": "Synthesize one new bounded improvement candidate from retired lanes",
+                        "status": "pending",
+                        "kind": "review",
+                    },
+                    {
+                        "task_id": "materialize-synthesized-improvement",
+                        "title": "Materialize one bounded improvement from the synthesized candidate",
+                        "status": "active",
+                        "kind": "execution",
+                    },
+                ],
+                "generated_candidates": [
+                    {
+                        "task_id": "synthesize-next-improvement-candidate",
+                        "title": "Synthesize one new bounded improvement candidate from retired lanes",
+                        "status": "pending",
+                        "kind": "review",
+                    },
+                    {
+                        "task_id": "materialize-synthesized-improvement",
+                        "title": "Materialize one bounded improvement from the synthesized candidate",
+                        "status": "active",
+                        "kind": "execution",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = asyncio.run(
+        run_self_evolving_cycle(
+            workspace=tmp_path,
+            tasks="materialize synthesized improvement",
+            execute_turn=AsyncMock(return_value="agent completed synthesized materialization"),
+            now=expires_at - timedelta(minutes=30),
+        )
+    )
+
+    assert "PASS" in summary
+    current = _read_json(tmp_path / "state" / "goals" / "current.json")
+    artifact_path = current.get("materialized_improvement_artifact_path")
+    assert artifact_path
+    assert Path(artifact_path).exists()
+    artifact = _read_json(artifact_path)
+    assert artifact["task_id"] == "materialize-synthesized-improvement"
+    assert current["current_task_id"] == "record-reward"
+    assert current["feedback_decision"]["mode"] == "complete_active_lane"
+    assert current["feedback_decision"]["current_task_id"] == "materialize-synthesized-improvement"
+
+
 def test_cycle_rotates_goal_after_repeated_same_goal_artifact_passes(tmp_path):
     approvals_dir = tmp_path / "state" / "approvals"
     approvals_dir.mkdir(parents=True)


### PR DESCRIPTION
Fixes #284.\n\nSummary:\n- writes materialized artifacts for synthesized materialization even when pass-rotation preselects its parent review lane\n- completes the synthesized materialization lane using the artifact payload task id\n- preserves accurate feedback_decision.current_task_id for the completed materialization lane\n\nVerification:\n- python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_writes_synthesized_materialization_artifact_when_pass_rotation_preselects_parent tests/test_runtime_coordinator.py::test_cycle_materializes_synthesized_execution_lane_artifact_and_completes -q\n- python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py tests/test_live_followthrough_drift.py tests/test_active_lane_continue.py tests/test_review_to_candidate.py tests/test_self_improvement_followthrough.py -q\n- python3 -m pytest tests -q\n- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q