### PR TITLE
fix: consume subagent bridge telemetry in runtime accounting

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -3224,6 +3224,8 @@ async def run_self_evolving_cycle(
         "summary": summary,
         "execution_response": execution_response,
         "execution_error": execution_error,
+        "artifact_paths": artifact_paths,
+        "subagent_consumption": subagent_consumption,
         "materialized_improvement_artifact_path": current_plan.get("materialized_improvement_artifact_path"),
     }
     report_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
@@ -3239,6 +3241,7 @@ async def run_self_evolving_cycle(
         "feedback_decision": resolved_feedback_decision,
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
+        "subagent_consumption": subagent_consumption,
         "experiment": experiment,
         "goal": {
             "goal_id": active_goal,
@@ -3298,6 +3301,7 @@ async def run_self_evolving_cycle(
         "improvement_score": current_plan.get("reward_signal", {}).get("value") if isinstance(current_plan.get("reward_signal"), dict) else reward_signal["value"],
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
+        "subagent_consumption": subagent_consumption,
         "experiment": experiment,
         "feedback_decision": resolved_feedback_decision,
         "goal": {


### PR DESCRIPTION
Fixes #293.\nCompletes the runtime-side canonical-accounting part of #288.\n\nSummary:\n- consume correlated bridge subagent results from canonical state and .nanobot/subagents before writing reports/experiments/outbox/credits\n- update budget_used.subagents consistently across report, experiment, outbox, report index, and credits ledger\n- expose subagent_consumption and include consumed bridge result paths in artifact paths\n- add regression test for cycle_id/report_path/current_task_id correlation\n\nVerification:\n- python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget tests/test_runtime_coordinator.py::test_subagent_rollup_materializes_terminal_telemetry_for_matching_request tests/test_runtime_coordinator.py::test_cycle_writes_pass_report_when_gate_is_fresh -q\n- python3 -m pytest tests -q\n- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q