### PR TITLE
fix: dedupe consumed subagent bridge telemetry

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1086,6 +1086,7 @@ def _subagent_consumption_snapshot(
     report_path_str = str(report_path)
     rows: list[tuple[float, str, dict[str, Any]]] = []
     seen: set[Path] = set()
+    logical_seen: set[tuple[str, str, str]] = set()
     for root in candidate_dirs:
         if not root.exists():
             continue
@@ -1113,9 +1114,18 @@ def _subagent_consumption_snapshot(
                 mtime = path.stat().st_mtime
             except Exception:
                 mtime = 0.0
+            subagent_id = str(payload.get("subagent_id") or payload.get("id") or path.stem)
+            logical_key = (
+                subagent_id,
+                str(payload.get("cycle_id") or ""),
+                str(payload.get("report_path") or payload.get("report_source") or ""),
+            )
+            if logical_key in logical_seen:
+                continue
+            logical_seen.add(logical_key)
             rows.append((mtime, str(path), {
                 "path": str(path),
-                "subagent_id": payload.get("subagent_id") or payload.get("id") or path.stem,
+                "subagent_id": subagent_id,
                 "status": payload.get("status") or payload.get("result_status"),
                 "summary": payload.get("summary") or payload.get("result"),
                 "goal_id": payload.get("goal_id"),

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -305,6 +305,9 @@ def test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget(
         "current_task_id": "record-reward",
         "task_feedback_decision": {"mode": "record_reward_after_synthesized_materialization"},
     }), encoding="utf-8")
+    state_bridge_dir = tmp_path / "state" / "subagents"
+    state_bridge_dir.mkdir(parents=True)
+    (state_bridge_dir / "same-logical-result.json").write_text(bridge_result_path.read_text(encoding="utf-8"), encoding="utf-8")
 
     summary = asyncio.run(
         run_self_evolving_cycle(
@@ -327,12 +330,14 @@ def test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget(
         assert payload["budget_used"]["subagents"] == 1
     consumption = report["subagent_consumption"]
     assert consumption["consumed_count"] == 1
-    assert consumption["result_paths"] == [str(bridge_result_path)]
+    assert len(consumption["result_paths"]) == 1
+    consumed_path = consumption["result_paths"][0]
+    assert consumed_path in {str(bridge_result_path), str(state_bridge_dir / "same-logical-result.json")}
     assert consumption["results"][0]["subagent_id"] == "bridge-1"
     assert consumption["results"][0]["match_reasons"] == ["cycle_id", "report_path", "current_task_id"]
     assert report["experiment"]["subagent_consumption"] == consumption
-    assert str(bridge_result_path) in report["artifact_paths"]
-    assert str(bridge_result_path) in report_index["goal"]["follow_through"]["artifact_paths"]
+    assert consumed_path in report["artifact_paths"]
+    assert consumed_path in report_index["goal"]["follow_through"]["artifact_paths"]
     assert outbox["subagent_consumption"] == consumption
 
 


### PR DESCRIPTION
Follow-up to #293/#288 after live verification showed the same bridge result can be visible from both canonical state and .nanobot/subagents.\n\nSummary:\n- dedupe canonical subagent consumption by logical subagent_id/cycle_id/report_path\n- keep budget_used.subagents as unique consumed bridge work, not duplicate paths\n- extend regression with duplicate logical bridge result\n\nVerification:\n- python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget -q\n- python3 -m pytest tests -q\n- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q