### PR TITLE
fix: persist subagent consumption in credits ledger

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2411,6 +2411,8 @@ def _write_credits_ledger(
         "reason": reward_signal.get("source") if isinstance(reward_signal, dict) else None,
         "reward_gate": reward_gate,
     }
+    if isinstance(experiment, dict) and isinstance(experiment.get("subagent_consumption"), dict):
+        payload["subagent_consumption"] = experiment.get("subagent_consumption")
     (credits_dir / "latest.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     with (credits_dir / "history.jsonl").open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, ensure_ascii=False) + "\n")

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -339,6 +339,7 @@ def test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget(
     assert consumed_path in report["artifact_paths"]
     assert consumed_path in report_index["goal"]["follow_through"]["artifact_paths"]
     assert outbox["subagent_consumption"] == consumption
+    assert credits["subagent_consumption"] == consumption
 
 
 def test_cycle_writes_discard_revert_record_when_metric_regresses(tmp_path):


### PR DESCRIPTION
Follow-up to #293/#288. Live verification proved canonical report/experiment/outbox/report.index had subagent_consumption, while credits/latest only had budget_used.subagents. This makes the credits ledger carry the same consumption proof.\n\nSummary:\n- persist experiment.subagent_consumption into credits/latest and history\n- extend runtime regression to require credits subagent_consumption parity\n\nVerification:\n- python3 -m pytest tests/test_runtime_coordinator.py::test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget -q\n- python3 -m pytest tests -q\n- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q