### PR TITLE
fix: rotate after post-materialization reward confirmation

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -664,7 +664,13 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                 and not _task_is_selectable(task)
                 for task in task_records
             )
-            if synthesized_parent_completed and synthesized_materialization_completed:
+            post_materialization_reward_already_confirmed = (
+                current_task_id == "record-reward"
+                and isinstance(recorded_feedback_decision, dict)
+                and recorded_feedback_decision.get("mode") == "record_reward_after_synthesized_materialization"
+                and recorded_feedback_decision.get("selected_task_id") == "record-reward"
+            )
+            if synthesized_parent_completed and synthesized_materialization_completed and not post_materialization_reward_already_confirmed:
                 selected_task = next(
                     (task for task in task_records if (task.get("task_id") or task.get("taskId")) == "record-reward"),
                     {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
@@ -674,7 +680,10 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                 selection_source = "feedback_synthesized_materialization_complete_reward"
             else:
                 mode = "synthesize_next_candidate"
-                reason = "goal/artifact PASS retirement pressure reached with no selectable bounded lane; synthesize a new bounded improvement candidate"
+                if post_materialization_reward_already_confirmed:
+                    reason = "post-materialization reward accounting is already confirmed; rotate to a fresh bounded improvement candidate instead of repeating reward bookkeeping"
+                else:
+                    reason = "goal/artifact PASS retirement pressure reached with no selectable bounded lane; synthesize a new bounded improvement candidate"
                 selected_task = _synthesized_next_improvement_candidate(
                     current_task_id=current_task_id,
                     strong_pass_count=strong_pass_count,

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -817,6 +817,49 @@ def test_completed_synthesized_candidate_pair_returns_to_reward_instead_of_repla
     assert decision["selected_task_id"] != "synthesize-next-improvement-candidate"
 
 
+def test_confirmed_post_materialization_reward_rotates_to_new_synthesis_instead_of_repeating_reward(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    for index in range(3):
+        (history / f"cycle-record-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-record-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": "record-reward",
+                    "artifact_paths": ["/tmp/materialized-cycle-synth.json"],
+                    "recorded_at_utc": f"2026-04-15T12:0{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    task_plan = {
+        "current_task_id": "record-reward",
+        "reward_signal": {"value": 1.2},
+        "feedback_decision": {
+            "mode": "record_reward_after_synthesized_materialization",
+            "current_task_id": "record-reward",
+            "selected_task_id": "record-reward",
+            "selection_source": "feedback_synthesized_materialization_complete_reward",
+        },
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "done"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "done"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision["mode"] == "synthesize_next_candidate"
+    assert decision["selection_source"] == "feedback_no_selectable_retired_lane_synthesis"
+    assert decision["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert decision["selected_task_id"] != "record-reward"
+
+
 def test_completed_synthesized_materialization_artifact_is_not_replayed_as_terminal_retirement(tmp_path):
     workspace = tmp_path / "workspace"
     state_root = workspace / "state"


### PR DESCRIPTION
Fixes #302. Continues #288 by removing the remaining truthful runtime stagnation after canonical subagent/dashboard fixes.\n\nSummary:\n- preserve first post-materialization reward confirmation after synthesized parent/child completion\n- detect when that reward confirmation is already recorded for record-reward\n- rotate to a fresh synthesized bounded improvement candidate instead of repeating reward bookkeeping indefinitely\n- add regression proving confirmed post-materialization reward does not reselect record-reward\n\nVerification:\n- python3 -m pytest tests/test_runtime_coordinator.py::test_completed_synthesized_candidate_pair_returns_to_reward_instead_of_replaying_parent tests/test_runtime_coordinator.py::test_confirmed_post_materialization_reward_rotates_to_new_synthesis_instead_of_repeating_reward tests/test_runtime_coordinator.py::test_completed_synthesized_materialization_artifact_is_not_replayed_as_terminal_retirement -q\n- python3 -m pytest tests/test_runtime_coordinator.py -q\n- python3 -m pytest tests -q\n- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q