### PR TITLE
fix: collect eeepc strong reflection snapshot

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/collector.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/collector.py
@@ -251,7 +251,7 @@ for key, rel in {{
     'current_plan': 'goals/current.json',
     'active_plan': 'goals/active.json',
     'strong_reflection': 'strong_reflection/latest.json',
-}.items():
+}}.items():
     payload, error = read_json(rel)
     payloads[key] = payload
     if error:


### PR DESCRIPTION
## Summary
- Fixes the batched eeepc collector remote-script dict escaping after adding strong_reflection/latest.json to the bundle.
- Ensures /collect can persist canonical eeepc strong-reflection truth so /api/system.strong_reflection_freshness can stop reporting missing when the live host has the artifact.

## Test Plan
- python3 -m py_compile ops/dashboard/src/nanobot_ops_dashboard/collector.py ops/dashboard/src/nanobot_ops_dashboard/app.py
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_collector.py -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #310