### PR TITLE
fix: surface autonomy blocker verdicts

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -65,6 +65,51 @@ def _overview_promotion_decision_trail(repo_latest: dict | None, control_plane: 
     return None
 
 
+def _missing_record(value) -> bool:
+    if not _has_value(value):
+        return True
+    if isinstance(value, str) and value.strip().lower() in {'missing', 'none', 'null', 'not_present', 'absent'}:
+        return True
+    return False
+
+
+def _promotion_replay_readiness_from_promotions(promotions: list[dict] | None) -> dict | None:
+    if not promotions:
+        return None
+    for row in promotions:
+        detail = row.get('detail') if isinstance(row.get('detail'), dict) else _json_loads_dict(row.get('detail_json'))
+        if not isinstance(detail, dict):
+            detail = {}
+        governance = detail.get('governance_packet') if isinstance(detail.get('governance_packet'), dict) else {}
+        decision_record = detail.get('decision_record')
+        accepted_record = detail.get('accepted_record')
+        review_status = governance.get('review_status') or detail.get('review_status') or row.get('status')
+        decision = governance.get('decision') or detail.get('decision') or row.get('status')
+        replay_state = row.get('replay_readiness') or detail.get('replay_readiness')
+        pending_or_missing = (
+            review_status == 'pending_policy_review'
+            or decision == 'pending_policy_review'
+            or _missing_record(decision_record)
+            or _missing_record(accepted_record)
+        )
+        if replay_state == 'blocked' or pending_or_missing:
+            return {
+                'schema_version': 'promotion-replay-readiness-v1',
+                'state': 'blocked' if pending_or_missing else str(replay_state or 'unknown'),
+                'reason': 'pending_policy_review_or_missing_records' if pending_or_missing else 'promotion_replay_not_ready',
+                'promotion_id': row.get('identity_key') or row.get('title'),
+                'status': row.get('status'),
+                'review_status': review_status,
+                'decision': decision,
+                'decision_record': decision_record,
+                'accepted_record': accepted_record,
+                'candidate_path': detail.get('candidate_path'),
+                'artifact_path': detail.get('artifact_path'),
+                'collected_at': row.get('collected_at'),
+            }
+    return {'schema_version': 'promotion-replay-readiness-v1', 'state': 'ready', 'reason': 'no_blocked_promotions'}
+
+
 def _env(cfg: DashboardConfig) -> Environment:
     templates = cfg.project_root / 'src' / 'nanobot_ops_dashboard' / 'templates'
     return Environment(
@@ -1173,7 +1218,7 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     }
 
 
-def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None, hypothesis_dynamics: dict | None = None, promotion_replay_readiness: dict | None = None) -> dict:
+def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None, hypothesis_dynamics: dict | None = None, promotion_replay_readiness: dict | None = None, strong_reflection_freshness: dict | None = None) -> dict:
     reasons: list[str] = []
     state_root = cfg.nanobot_repo_root / 'workspace' / 'state'
     recent = analytics.get('recent_status_sequence') or []
@@ -1226,11 +1271,14 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     promotion_pending = (
         promotion_replay_readiness.get('review_status') == 'pending_policy_review'
         or promotion_replay_readiness.get('decision') == 'pending_policy_review'
-        or not _has_value(promotion_replay_readiness.get('decision_record'))
-        or not _has_value(promotion_replay_readiness.get('accepted_record'))
+        or _missing_record(promotion_replay_readiness.get('decision_record'))
+        or _missing_record(promotion_replay_readiness.get('accepted_record'))
     )
     if promotion_replay_readiness.get('state') == 'blocked' and promotion_pending:
         reasons.append('promotion_lifecycle_blocked')
+    strong_reflection_freshness = strong_reflection_freshness if isinstance(strong_reflection_freshness, dict) else {}
+    if strong_reflection_freshness.get('state') in {'missing', 'stale', 'degraded'}:
+        reasons.append('strong_reflection_not_fresh')
     historical_reasons: list[str] = []
     if material_allows_healthy:
         stale_after_material_progress = {'same_task_streak', 'discarded_experiment', 'suppressed_reward', 'terminal_noop'}
@@ -1243,7 +1291,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
         if runtime_parity_is_blocking and runtime_can_be_historical:
             historical_reasons.append('runtime_parity_blocked')
         reasons = blocking_reasons
-    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant', 'promotion_lifecycle_blocked'}) else 'healthy')
+    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant', 'promotion_lifecycle_blocked', 'strong_reflection_not_fresh'}) else 'healthy')
     return {
         'schema_version': 'autonomy-verdict-v1',
         'state': status,
@@ -2870,6 +2918,11 @@ def create_app(cfg: DashboardConfig):
             'eeepc_outbox_preview': '{}',
         }
         control_plane = _control_plane_summary(repo_latest, eeepc_latest, experiment_visibility['current_experiment'], current_blocker, cfg)
+        promotion_replay_readiness = _promotion_replay_readiness_from_promotions(promotions)
+        if isinstance(control_plane, dict):
+            control_plane = dict(control_plane)
+            if promotion_replay_readiness is not None:
+                control_plane['promotion_replay_readiness'] = promotion_replay_readiness
         overview_subagent_cycle_id = None
         if subagent_latest_event and isinstance(subagent_latest_event.get('detail'), dict):
             detail = subagent_latest_event['detail']
@@ -2991,7 +3044,8 @@ def create_app(cfg: DashboardConfig):
             runtime_parity=runtime_parity,
             ambition_utilization=ambition_utilization,
             hypothesis_dynamics=hypothesis_dynamics,
-            promotion_replay_readiness=control_plane.get('promotion_replay_readiness') if isinstance(control_plane, dict) else None,
+            promotion_replay_readiness=promotion_replay_readiness,
+            strong_reflection_freshness=strong_reflection_freshness,
         )
         analytics['runtime_parity'] = runtime_parity
         analytics['hypothesis_dynamics'] = hypothesis_dynamics

--- a/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
+++ b/ops/dashboard/tests/test_autonomy_stagnation_dashboard.py
@@ -811,9 +811,11 @@ def test_autonomy_verdict_treats_stale_blockers_as_historical_after_material_pro
     (state_root / 'experiments').mkdir(parents=True)
     (state_root / 'credits').mkdir(parents=True)
     (state_root / 'hypotheses').mkdir(parents=True)
+    (state_root / 'strong_reflection').mkdir(parents=True)
     (state_root / 'control_plane').mkdir(parents=True)
     (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
     (state_root / 'hypotheses' / 'backlog.json').write_text(json.dumps([]), encoding='utf-8')
+    (state_root / 'strong_reflection' / 'latest.json').write_text(json.dumps({'recorded_at_utc': '2999-04-24T12:59:00+00:00', 'status': 'PASS', 'summary': 'fresh test reflection'}), encoding='utf-8')
     (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({'task_plan': {'current_task_id': 'record-reward'}}), encoding='utf-8')
     (state_root / 'self_evolution' / 'current_state.json').write_text(json.dumps({'state': 'running'}), encoding='utf-8')
     for i in range(10):
@@ -930,9 +932,11 @@ def test_autonomy_verdict_downgrades_classified_legacy_reward_loop_after_canonic
     (state_root / 'experiments').mkdir(parents=True)
     (state_root / 'credits').mkdir(parents=True)
     (state_root / 'hypotheses').mkdir(parents=True)
+    (state_root / 'strong_reflection').mkdir(parents=True)
     (state_root / 'control_plane').mkdir(parents=True)
     (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
     (state_root / 'hypotheses' / 'backlog.json').write_text(json.dumps([]), encoding='utf-8')
+    (state_root / 'strong_reflection' / 'latest.json').write_text(json.dumps({'recorded_at_utc': '2999-04-24T12:59:00+00:00', 'status': 'PASS', 'summary': 'fresh test reflection'}), encoding='utf-8')
     (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({'task_plan': {'current_task_id': 'analyze-last-failed-candidate'}}), encoding='utf-8')
     (state_root / 'self_evolution' / 'current_state.json').write_text(json.dumps({'state': 'running'}), encoding='utf-8')
     for i in range(10):

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -2059,6 +2059,59 @@ def test_autonomy_verdict_flags_blocked_pending_promotion_lifecycle(tmp_path: Pa
     assert verdict['promotion_replay_readiness']['state'] == 'blocked'
 
 
+def test_autonomy_verdict_flags_missing_strong_reflection(tmp_path: Path) -> None:
+    from nanobot_ops_dashboard.app import _autonomy_verdict
+
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=tmp_path / 'repo', db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing', eeepc_state_root='/state')
+    verdict = _autonomy_verdict(
+        analytics={'recent_status_sequence': [], 'current_streak': {'status': 'PASS', 'length': 3}},
+        plan_latest={'current_task_id': 'synthesize-next-improvement-candidate'},
+        experiment_visibility={'current_experiment': {'outcome': 'keep'}},
+        credits_visibility={'current': {'delta': 1.0}},
+        cfg=cfg,
+        material_progress={'state': 'proven', 'healthy_autonomy_allowed': True},
+        runtime_parity={'state': 'healthy', 'reasons': []},
+        hypothesis_dynamics={'state': 'healthy'},
+        strong_reflection_freshness={'state': 'missing', 'reason': 'strong_reflection_latest_missing'},
+    )
+
+    assert verdict['state'] == 'stagnant'
+    assert 'strong_reflection_not_fresh' in verdict['reasons']
+
+
+def test_api_system_promotes_stuck_promotion_lifecycle_to_autonomy_verdict(tmp_path: Path) -> None:
+    from nanobot_ops_dashboard.storage import upsert_event
+
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    insert_collection(db, {'collected_at': '2999-04-27T21:00:00Z', 'source': 'repo', 'status': 'PASS', 'active_goal': 'goal-bootstrap', 'current_task': 'Record cycle reward', 'raw_json': '{}'})
+    upsert_event(db, {
+        'collected_at': '2999-04-27T21:00:00Z',
+        'source': 'repo',
+        'event_type': 'promotion',
+        'identity_key': 'promotion-stuck',
+        'title': 'promotion-stuck | pending_policy_review | pending_policy_review',
+        'status': 'pending_policy_review',
+        'detail_json': json.dumps({
+            'candidate_path': '/state/promotions/promotion-stuck.json',
+            'decision_record': 'missing',
+            'accepted_record': 'missing',
+            'governance_packet': {'review_status': 'pending_policy_review', 'decision': 'pending_policy_review'},
+        }),
+    })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    system = _call_json(create_app(cfg), '/api/system')
+
+    readiness = system['control_plane']['promotion_replay_readiness']
+    assert readiness['state'] == 'blocked'
+    assert readiness['decision_record'] == 'missing'
+    assert readiness['accepted_record'] == 'missing'
+    assert 'promotion_lifecycle_blocked' in system['autonomy_verdict']['reasons']
+
+
 def test_remote_file_preview_kill_switch_avoids_request_time_ssh(tmp_path: Path, monkeypatch) -> None:
     import nanobot_ops_dashboard.app as dashboard_app
     from nanobot_ops_dashboard.app import _remote_file_preview


### PR DESCRIPTION
## Summary
- Surfaces missing/stale/degraded strong reflection as a first-class autonomy verdict blocker instead of allowing proven material progress to hide it.
- Derives promotion replay readiness from promotion events and flags pending_policy_review/missing decision or accepted records as promotion_lifecycle_blocked.
- Keeps previous dashboard truth fixes intact: live failure-learning handoff authority and blocked-dominant subagent rollups.

## Dashboard audit evidence addressed
- /api/system previously showed strong_reflection_freshness.state=missing while autonomy_verdict only reported hypothesis_dynamics_stagnant.
- /api/promotions showed stuck promotion rows: pending_policy_review with decision_record=missing and accepted_record=missing, but /api/system did not include promotion_lifecycle_blocked.
- /api/subagents live already now reports blocked_result_count=174 and state=degraded/reason=blocked_results_dominant.

## Test Plan
- python3 -m py_compile ops/dashboard/src/nanobot_ops_dashboard/app.py
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py -k 'missing_strong_reflection or stuck_promotion_lifecycle or blocked_pending_promotion or collected_eeepc_strong_reflection' -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #310
Fixes #311