### PR TITLE
fix: retire terminal self-evolution lanes before stale failure learning

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1809,7 +1809,7 @@ def _build_task_plan_snapshot(
                 "terminal_selfevo_issue": terminal_selfevo_issue,
             }
             terminal_selfevo_retired = True
-        elif (recorded_reward_retirement and failure_learning_is_fresh) or recorded_complete_lane_to_reward:
+        elif terminal_selfevo_issue is None and ((recorded_reward_retirement and failure_learning_is_fresh) or recorded_complete_lane_to_reward):
             repair_source = 'fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'stale_complete_lane_record_reward_repair'
             repair_selection_source = 'feedback_fresh_failure_learning_after_reward_retirement' if recorded_reward_retirement else 'feedback_complete_active_lane_to_failure_learning'
             repair_reason = (

--- a/tests/test_live_followthrough_drift.py
+++ b/tests/test_live_followthrough_drift.py
@@ -13,7 +13,7 @@ def _read_json(path: Path):
     return json.loads(path.read_text(encoding='utf-8'))
 
 
-def test_retired_record_reward_does_not_mask_fresh_failure_learning_even_with_terminal_selfevo(tmp_path: Path):
+def test_terminal_selfevo_retirement_blocks_fresh_failure_learning_from_reselecting_analyze_lane(tmp_path: Path):
     approvals_dir = tmp_path / 'state' / 'approvals'
     approvals_dir.mkdir(parents=True)
     expires_at = datetime(2026, 4, 27, 1, 0, tzinfo=timezone.utc)
@@ -59,13 +59,13 @@ def test_retired_record_reward_does_not_mask_fresh_failure_learning_even_with_te
     asyncio.run(run_self_evolving_cycle(workspace=tmp_path, tasks='check open tasks', execute_turn=execute, now=now))
 
     current = _read_json(tmp_path / 'state' / 'goals' / 'current.json')
-    assert current['current_task_id'] == 'analyze-last-failed-candidate'
-    assert current['feedback_decision']['mode'] == 'fresh_failure_learning_after_reward_retirement'
-    assert current['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'
+    assert current['current_task_id'] == 'record-reward'
+    assert current['feedback_decision']['mode'] == 'retire_terminal_selfevo_lane'
+    assert current['feedback_decision']['selected_task_id'] == 'record-reward'
 
     report = _read_json(sorted((tmp_path / 'state' / 'reports').glob('evolution-*.json'))[-1])
-    assert report['current_task_id'] == 'analyze-last-failed-candidate'
-    assert report['feedback_decision']['selection_source'] == 'feedback_fresh_failure_learning_after_reward_retirement'
+    assert report['current_task_id'] == 'record-reward'
+    assert report['feedback_decision']['selection_source'] == 'feedback_terminal_selfevo_retire'
 
 
 def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current_task_is_record_reward(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- Prevents terminal self-evolution lifecycle evidence from being masked by a fresh failure-learning handoff.
- When a terminal merged/closed self-evolution issue is present, runtime keeps the terminal-retirement handoff authoritative before reselecting analyze-last-failed-candidate.
- Updates regression coverage so a terminal selfevo issue blocks reselecting the stale analyze lane.

## Context
This is the remaining runtime-side follow-up for the dashboard-visible blocker in #316. The dashboard now truthfully reports hypothesis_dynamics_stagnant; this change narrows one concrete re-selection path that allowed terminal lanes to reappear.

## Test Plan
- python3 -m pytest tests/test_live_followthrough_drift.py::test_terminal_selfevo_retirement_blocks_fresh_failure_learning_from_reselecting_analyze_lane tests/test_live_followthrough_drift.py -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Refs #316
