### PR TITLE
fix: persist collected strong reflection payload

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/collector.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/collector.py
@@ -1010,6 +1010,7 @@ def _normalize_eeepc_state(cfg: DashboardConfig) -> dict[str, Any]:
         goals = payloads.get('goals') if isinstance(payloads.get('goals'), dict) else None
         current_plan = payloads.get('current_plan') if isinstance(payloads.get('current_plan'), dict) else None
         active_plan = payloads.get('active_plan') if isinstance(payloads.get('active_plan'), dict) else None
+        strong_reflection = payloads.get('strong_reflection') if isinstance(payloads.get('strong_reflection'), dict) else None
         history_payloads = [payload for payload in bundle.get('history_payloads') or [] if isinstance(payload, dict)]
         source_errors = bundle.get('source_errors') if isinstance(bundle.get('source_errors'), dict) else {}
         report_fallback_path = bundle.get('report_fallback_path') if isinstance(bundle.get('report_fallback_path'), str) else None
@@ -1028,6 +1029,7 @@ def _normalize_eeepc_state(cfg: DashboardConfig) -> dict[str, Any]:
         goals, goals_error = _load_ssh_json(cfg, f"{state_root}/goals/registry.json")
         current_plan, current_plan_error = _load_ssh_json(cfg, f"{state_root}/goals/current.json")
         active_plan, active_plan_error = _load_ssh_json(cfg, f"{state_root}/goals/active.json")
+        strong_reflection, strong_reflection_error = _load_ssh_json(cfg, f"{state_root}/strong_reflection/latest.json")
         history_paths = _run_ssh_lines(cfg, f"sh -lc 'ls -1t {state_root}/goals/history/cycle-*.json 2>/dev/null | head -n 10'")
         history_payloads: list[dict[str, Any]] = []
         history_errors: list[dict[str, Any]] = []
@@ -1057,6 +1059,8 @@ def _normalize_eeepc_state(cfg: DashboardConfig) -> dict[str, Any]:
             source_errors['current_plan'] = current_plan_error
         if active_plan_error:
             source_errors['active_plan'] = active_plan_error
+        if strong_reflection_error:
+            source_errors['strong_reflection'] = strong_reflection_error
         if history_errors:
             source_errors['history'] = history_errors
         eeepc_subagent_records = _load_ssh_subagent_telemetry(cfg, state_root)
@@ -1111,7 +1115,7 @@ def _normalize_eeepc_state(cfg: DashboardConfig) -> dict[str, Any]:
     normalized['task_list'] = current_snapshot.get('task_list') if current_snapshot else normalized.get('task_list') or []
     normalized['reward_signal'] = current_snapshot.get('reward_signal') if current_snapshot else normalized.get('reward_signal')
     normalized['plan_history'] = current_snapshot.get('plan_history') if current_snapshot else normalized.get('plan_history') or []
-    normalized['raw'] = {'outbox': outbox, 'goals': goals, 'reachability': reachability, 'current_plan': current_plan, 'active_plan': active_plan, 'plan_history': history_payloads}
+    normalized['raw'] = {'outbox': outbox, 'goals': goals, 'reachability': reachability, 'current_plan': current_plan, 'active_plan': active_plan, 'strong_reflection': strong_reflection, 'plan_history': history_payloads}
     if eeepc_subagent_records:
         normalized['raw']['subagents'] = eeepc_subagent_records
     if source_errors:

--- a/ops/dashboard/tests/test_collector.py
+++ b/ops/dashboard/tests/test_collector.py
@@ -174,6 +174,8 @@ def test_normalize_eeepc_state_falls_back_to_goals_when_report_index_is_permissi
             }, None
         if remote_path.endswith('/goals/active.json'):
             return None, None
+        if remote_path.endswith('/strong_reflection/latest.json'):
+            return None, None
         if remote_path.endswith('/goals/history/cycle-1.json'):
             return {'current_task': 'draft plan', 'reward_signal': 'seed'}, None
         raise AssertionError(remote_path)
@@ -245,7 +247,7 @@ def test_normalize_eeepc_state_falls_back_to_latest_readable_report_when_authori
                 'error_type': 'CalledProcessError',
                 'returncode': 1,
             }
-        if remote_path.endswith('/goals/current.json') or remote_path.endswith('/goals/active.json'):
+        if remote_path.endswith('/goals/current.json') or remote_path.endswith('/goals/active.json') or remote_path.endswith('/strong_reflection/latest.json'):
             return None, None
         if remote_path == latest_report:
             return {
@@ -319,6 +321,12 @@ def test_normalize_eeepc_state_batches_remote_authority_reads(tmp_path: Path, mo
                     'reward_signal': {'status': 'dense', 'score': 1.0},
                 },
                 'active_plan': None,
+                'strong_reflection': {
+                    'schema_version': 'strong-reflection-run-v1',
+                    'recorded_at_utc': '2999-04-28T16:37:45+00:00',
+                    'summary': 'Self-evolving cycle PASS — evidence=collector-live',
+                    'mode': 'strong-reflection',
+                },
             },
             'history_payloads': [{'current_task': 'Record cycle reward'}],
             'report_fallback_path': None,
@@ -342,6 +350,7 @@ def test_normalize_eeepc_state_batches_remote_authority_reads(tmp_path: Path, mo
     assert result['collection_status'] == 'ok'
     assert result['current_task'] == 'Synthesize next improvement'
     assert result['raw']['current_plan']['current_task_id'] == 'synthesize-next-improvement-candidate'
+    assert result['raw']['strong_reflection']['summary'].endswith('collector-live')
     assert result['raw']['subagents'][0]['subagent_id'] == 'bridge-1'
     assert any(event['event_type'] == 'subagent' for event in result['events'])
 


### PR DESCRIPTION
## Summary
- Persists the batched eeepc strong_reflection/latest.json payload into collection raw_json.
- Keeps the existing /api/system collected-eeepc fallback effective after /collect instead of reporting strong_reflection_latest_missing from local-only state.
- Adds collector regression coverage for preserving strong_reflection from the batched authority bundle.

## Live evidence before fix
- Canonical eeepc file existed: /var/lib/eeepc-agent/self-evolving-agent/state/strong_reflection/latest.json
- Latest collected eeepc raw_json keys omitted strong_reflection.
- /api/system.strong_reflection_freshness.state remained missing.

## Test Plan
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #310