### PR TITLE
fix: trust pass streak switch parity

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -979,7 +979,7 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         and live_feedback.get('current_task_id') == 'record-reward'
         and live_feedback.get('selection_source') == 'feedback_pass_streak_switch'
         and _has_value(live_hadi_handoff_selected_task)
-        and str(live_hadi_handoff_selected_task) == str(live_task)
+        and str(live_hadi_handoff_selected_task) in {str(live_task), str(local_task)}
     )
     live_terminal_selfevo_retire = (
         all(artifacts.values())


### PR DESCRIPTION
## Summary
- Trusts the fresh live `feedback_pass_streak_switch` handoff even when the live current task is `record-reward` and the selected retired task is the local `inspect-pass-streak` lane.
- Prevents dashboard runtime parity from flagging `current_task_drift` for the live pass-streak switch observed after deploy.
- Adds a regression covering the exact local/live task shape.

## Live evidence before fix
- `/api/system.runtime_parity.state = degraded`
- `reasons = ["current_task_drift"]`
- `local_current_task_id = inspect-pass-streak`
- `live_current_task_id = record-reward`
- `live_task_selection_source = feedback_pass_streak_switch`
- `authority_resolution = null`

## Test Plan
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_runtime_parity_trusts_pass_streak_switch_to_reward_even_when_selected_task_is_local_task -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #321
