### PR TITLE
fix: trust pass streak switch source task

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -976,7 +976,6 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         and isinstance(live_feedback, dict)
         and live_feedback.get('mode') == 'retire_goal_artifact_pair'
         and live_feedback.get('retire_goal_artifact_pair') is True
-        and live_feedback.get('current_task_id') == 'record-reward'
         and live_feedback.get('selection_source') == 'feedback_pass_streak_switch'
         and _has_value(live_hadi_handoff_selected_task)
         and str(live_hadi_handoff_selected_task) in {str(live_task), str(local_task)}

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -966,8 +966,8 @@ def test_runtime_parity_trusts_pass_streak_switch_to_reward_even_when_selected_t
         'task_selection_source': 'feedback_pass_streak_switch',
         'feedback_decision': {
             'mode': 'retire_goal_artifact_pair',
-            'current_task_id': 'record-reward',
-            'selected_task_id': 'inspect-pass-streak',
+            'current_task_id': 'analyze-last-failed-candidate',
+            'selected_task_id': 'record-reward',
             'selection_source': 'feedback_pass_streak_switch',
             'retire_goal_artifact_pair': True,
         },


### PR DESCRIPTION
## Summary
- Broadens the pass-streak switch authority check to match the live payload where `current_task_id` is the retired source lane and `selected_task_id` is `record-reward`.
- Keeps the switch constrained to `mode=retire_goal_artifact_pair`, `retire_goal_artifact_pair=true`, and `selection_source=feedback_pass_streak_switch`.
- Updates the regression to mirror the observed live shape.

## Live evidence before fix
- `/api/system.runtime_parity.state = degraded`
- `reasons = ["current_task_drift"]`
- local/current canonical task: `inspect-pass-streak`
- live current task: `record-reward`
- live feedback decision:
  - `mode = retire_goal_artifact_pair`
  - `current_task_id = analyze-last-failed-candidate`
  - `selected_task_id = record-reward`
  - `selection_source = feedback_pass_streak_switch`

## Test Plan
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_runtime_parity_trusts_pass_streak_switch_to_reward_even_when_selected_task_is_local_task -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #321
