### PR TITLE
fix: ignore closed terminal selfevo blockers

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2092,13 +2092,38 @@ def _reconcile_hypotheses_visibility_with_runtime(hypotheses_visibility: dict, r
     return reconciled
 
 
+def _terminal_issue_evidence_is_live(issue: dict | None) -> bool:
+    if not isinstance(issue, dict) or not issue:
+        return False
+    issue_state = str(issue.get('github_issue_state') or issue.get('state') or '').strip().upper()
+    status = str(issue.get('terminal_status') or issue.get('status') or '').strip().lower()
+    retry_allowed = issue.get('retry_allowed')
+    terminal_status = status.startswith('terminal_') or status in {'merged', 'closed', 'terminal-merged', 'terminal-closed'}
+    if issue_state == 'CLOSED' and retry_allowed is False:
+        return False
+    if terminal_status and retry_allowed is False:
+        return False
+    return True
+
+
+def _terminal_pr_evidence_is_live(pr: dict | None) -> bool:
+    if not isinstance(pr, dict) or not pr:
+        return False
+    state = str(pr.get('state') or '').strip().upper()
+    if pr.get('merged') is True or state == 'MERGED':
+        return False
+    if state in {'CLOSED'} and pr.get('merged') is not False:
+        return False
+    return True
+
+
 def _selected_hypothesis_terminal_evidence(cfg: DashboardConfig) -> tuple[dict | None, dict | None]:
     state_root = cfg.nanobot_repo_root / 'workspace' / 'state' / 'self_evolution'
     current_state = _json_file(state_root / 'current_state.json')
     latest_noop = _json_file(state_root / 'runtime' / 'latest_noop.json')
     issue = current_state.get('selfevo_issue') if isinstance(current_state.get('selfevo_issue'), dict) else latest_noop.get('selfevo_issue') if isinstance(latest_noop.get('selfevo_issue'), dict) else None
     pr = current_state.get('last_pr') if isinstance(current_state.get('last_pr'), dict) else latest_noop.get('pr') if isinstance(latest_noop.get('pr'), dict) else None
-    return issue, pr
+    return issue if _terminal_issue_evidence_is_live(issue) else None, pr if _terminal_pr_evidence_is_live(pr) else None
 
 
 def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibility: dict, credits_visibility: dict, cfg: DashboardConfig) -> dict:

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from wsgiref.util import setup_testing_defaults
 
-from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity
+from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence
 from nanobot_ops_dashboard.config import DashboardConfig
 from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
 
@@ -979,6 +979,57 @@ def test_runtime_parity_trusts_pass_streak_switch_to_reward_even_when_selected_t
     assert parity['authority_resolution'] == 'fresh_live_pass_streak_switch'
     assert parity['canonical_current_task_id'] == 'record-reward'
     assert 'current_task_drift' not in parity['reasons']
+
+
+def test_closed_terminal_selfevo_evidence_is_historical_not_live_blocker(tmp_path: Path) -> None:
+    repo_root = tmp_path / 'nanobot'
+    state_root = repo_root / 'workspace' / 'state' / 'self_evolution'
+    state_root.mkdir(parents=True, exist_ok=True)
+    (state_root / 'current_state.json').write_text(json.dumps({
+        'selfevo_issue': {
+            'number': 82,
+            'status': 'terminal_merged',
+            'terminal_status': 'terminal_merged',
+            'github_issue_state': 'CLOSED',
+            'retry_allowed': False,
+        },
+        'last_pr': {
+            'number': 89,
+            'merged': True,
+            'state': 'MERGED',
+        },
+    }), encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    issue, pr = _selected_hypothesis_terminal_evidence(cfg)
+
+    assert issue is None
+    assert pr is None
+
+
+def test_open_terminal_selfevo_evidence_remains_live_blocker(tmp_path: Path) -> None:
+    repo_root = tmp_path / 'nanobot'
+    state_root = repo_root / 'workspace' / 'state' / 'self_evolution'
+    state_root.mkdir(parents=True, exist_ok=True)
+    (state_root / 'current_state.json').write_text(json.dumps({
+        'selfevo_issue': {
+            'number': 83,
+            'status': 'blocked',
+            'github_issue_state': 'OPEN',
+            'retry_allowed': True,
+        },
+        'last_pr': {
+            'number': 90,
+            'merged': False,
+            'state': 'OPEN',
+        },
+    }), encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    issue, pr = _selected_hypothesis_terminal_evidence(cfg)
+
+    assert issue and issue['number'] == 83
+    assert pr and pr['number'] == 90
 
 
 def test_api_system_exposes_selfevo_current_state_freshness_against_product_head(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Treats closed/merged terminal self-evolution issue/PR records as historical evidence rather than live hypothesis blockers.
- Keeps open/in-flight terminal selfevo evidence as a live blocker.
- Adds regressions for both closed terminal evidence and open terminal evidence.

## Live evidence before fix
- `/api/system.autonomy_verdict.state = stagnant`
- `/api/system.autonomy_verdict.reasons = ["hypothesis_dynamics_stagnant"]`
- `/api/hypotheses.selected_hypothesis_diagnostics.reasons` included `terminal_selfevo_issue_present`
- The terminal selfevo issue evidence pointed at an already closed/merged issue: `terminal_merged`, `github_issue_state=CLOSED`, `retry_allowed=false`.

## Test Plan
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_closed_terminal_selfevo_evidence_is_historical_not_live_blocker ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_open_terminal_selfevo_evidence_remains_live_blocker -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #325
Refs #316
Refs #322
