### PR TITLE
fix: ignore linked closed terminal selfevo pr

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2112,7 +2112,7 @@ def _terminal_pr_evidence_is_live(pr: dict | None) -> bool:
     state = str(pr.get('state') or '').strip().upper()
     if pr.get('merged') is True or state == 'MERGED':
         return False
-    if state in {'CLOSED'} and pr.get('merged') is not False:
+    if state == 'CLOSED':
         return False
     return True
 
@@ -2123,7 +2123,12 @@ def _selected_hypothesis_terminal_evidence(cfg: DashboardConfig) -> tuple[dict |
     latest_noop = _json_file(state_root / 'runtime' / 'latest_noop.json')
     issue = current_state.get('selfevo_issue') if isinstance(current_state.get('selfevo_issue'), dict) else latest_noop.get('selfevo_issue') if isinstance(latest_noop.get('selfevo_issue'), dict) else None
     pr = current_state.get('last_pr') if isinstance(current_state.get('last_pr'), dict) else latest_noop.get('pr') if isinstance(latest_noop.get('pr'), dict) else None
-    return issue if _terminal_issue_evidence_is_live(issue) else None, pr if _terminal_pr_evidence_is_live(pr) else None
+    issue_live = _terminal_issue_evidence_is_live(issue)
+    pr_live = _terminal_pr_evidence_is_live(pr)
+    pr_state = str(pr.get('state') or '').strip().upper() if isinstance(pr, dict) else ''
+    if not issue_live and pr_live and isinstance(issue, dict) and not pr_state and pr.get('merged') is not False:
+        pr_live = False
+    return issue if issue_live else None, pr if pr_live else None
 
 
 def _selected_hypothesis_diagnostics(*, cycles: list[dict], hypotheses_visibility: dict, credits_visibility: dict, cfg: DashboardConfig) -> dict:

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -995,8 +995,8 @@ def test_closed_terminal_selfevo_evidence_is_historical_not_live_blocker(tmp_pat
         },
         'last_pr': {
             'number': 89,
-            'merged': True,
-            'state': 'MERGED',
+            'created': True,
+            'dry_run': False,
         },
     }), encoding='utf-8')
     cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')


### PR DESCRIPTION
## Summary
- Filters ambiguous linked PR records out of live terminal evidence when the associated selfevo issue is already closed/terminal and retry is not allowed.
- Preserves existing open/in-flight terminal PR behavior for real blockers.
- Updates regression to match the live shape where `last_pr` has no explicit `state` but the linked issue is `terminal_merged`, `github_issue_state=CLOSED`, `retry_allowed=false`.

## Test Plan
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_closed_terminal_selfevo_evidence_is_historical_not_live_blocker ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_open_terminal_selfevo_evidence_remains_live_blocker -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #325
Refs #316
Refs #322
