### PR TITLE
fix: retire active terminal selfevo lanes

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -142,7 +142,7 @@ def _task_is_terminal_selfevo_retired(task: dict[str, Any] | None, terminal_self
 
     task_status = _task_status(task)
     terminal_reason = str(task.get("terminal_reason") or "").strip().lower()
-    return task_status == terminal_status or terminal_reason == terminal_status
+    return task_status in COMPLETED_TASK_STATUSES and (task_status == terminal_status or terminal_reason == terminal_status)
 
 
 def _render_task_selection(task: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- Fixes the remaining #316/#322 runtime path where an active `analyze-last-failed-candidate` task with `terminal_reason=terminal_merged` was incorrectly treated as already retired.
- Requires the task status itself to be completed before `_task_is_terminal_selfevo_retired()` suppresses the retirement guard.
- This allows `_build_task_plan_snapshot()` to retire an active terminal selfevo lane and switch to `record-reward` instead of repeating `continue_active_lane`.

## Root cause
`_task_is_terminal_selfevo_retired()` returned true when only `terminal_reason` matched the terminal issue status. Live had:

- `task_id = analyze-last-failed-candidate`
- `status = active`
- `terminal_reason = terminal_merged`
- latest issue lifecycle `status = terminal_merged`, `github_issue_state = CLOSED`, `retry_allowed = false`

Because the helper returned true, the actual retirement branch was skipped and the runtime kept selecting `feedback_continue_active_lane`.

## Test Plan
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py::test_terminal_selfevo_active_lane_with_continue_decision_is_retired -q
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #322
Refs #316
