### PR TITLE
fix: guard eeepc selfevo service paths

### DIFF
--- a/scripts/verify_eeepc_self_evolving_service_guard.py
+++ b/scripts/verify_eeepc_self_evolving_service_guard.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Guard eeepc self-evolving systemd service against stale release pins.
+
+Usage:
+    systemctl cat eeepc-self-evolving-agent.service | \
+        scripts/verify_eeepc_self_evolving_service_guard.py
+
+The guard is intentionally text-based so it can run during deploy/verify without
+requiring dbus or root privileges. It fails when the effective unit pins a stale
+release path instead of following the `/current` symlink.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+CURRENT_ROOT = '/opt/eeepc-agent/runtimes/self-evolving-agent/current'
+RELEASE_ROOT_RE = re.compile(r'/opt/eeepc-agent/runtimes/self-evolving-agent/releases/[^\s:"\']+')
+
+
+def _last_assignment(text: str, key: str) -> str | None:
+    value: str | None = None
+    prefix = f'{key}='
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if line.startswith(prefix):
+            value = line[len(prefix):].strip()
+    return value
+
+
+def _environment_values(text: str, name: str) -> list[str]:
+    values: list[str] = []
+    needle = f'{name}='
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith('Environment='):
+            continue
+        payload = line[len('Environment='):]
+        for token in payload.split():
+            if token.startswith(needle):
+                values.append(token[len(needle):].strip().strip('"'))
+    return values
+
+
+def evaluate_service_text(text: str) -> dict[str, Any]:
+    reasons: list[str] = []
+    working_directory = _last_assignment(text, 'WorkingDirectory')
+    exec_start = _last_assignment(text, 'ExecStart')
+    policy_values = _environment_values(text, 'POLICY_FILE')
+    policy_file = policy_values[-1] if policy_values else None
+
+    if working_directory != CURRENT_ROOT:
+        reasons.append('working_directory_not_current')
+    if working_directory and RELEASE_ROOT_RE.search(working_directory):
+        reasons.append('working_directory_pinned_to_release')
+
+    if policy_file and RELEASE_ROOT_RE.search(policy_file):
+        reasons.append('policy_file_pinned_to_release')
+    if exec_start and RELEASE_ROOT_RE.search(exec_start):
+        reasons.append('exec_start_pinned_to_release')
+    if exec_start and CURRENT_ROOT not in exec_start:
+        reasons.append('exec_start_not_current')
+
+    # Preserve stable order while removing duplicates.
+    ordered_reasons = list(dict.fromkeys(reasons))
+    return {
+        'schema_version': 'eeepc-self-evolving-service-guard-v1',
+        'state': 'healthy' if not ordered_reasons else 'blocked',
+        'reasons': ordered_reasons,
+        'working_directory': working_directory,
+        'policy_file': policy_file,
+        'exec_start': exec_start,
+    }
+
+
+def main() -> int:
+    result = evaluate_service_text(sys.stdin.read())
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result['state'] == 'healthy' else 2
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_eeepc_service_guard.py
+++ b/tests/test_eeepc_service_guard.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'scripts' / 'verify_eeepc_self_evolving_service_guard.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('verify_eeepc_self_evolving_service_guard', MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_service_guard_rejects_stale_release_paths() -> None:
+    guard = _load_module()
+    text = '''
+[Service]
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260324-staged
+Environment=POLICY_FILE=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260324-staged/config/policy.yaml
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main
+'''
+
+    result = guard.evaluate_service_text(text)
+
+    assert result['state'] == 'blocked'
+    assert 'working_directory_not_current' in result['reasons']
+    assert 'policy_file_pinned_to_release' in result['reasons']
+
+
+def test_service_guard_accepts_current_symlink_and_empty_policy_file() -> None:
+    guard = _load_module()
+    text = '''
+[Service]
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=POLICY_FILE=
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main
+'''
+
+    result = guard.evaluate_service_text(text)
+
+    assert result['state'] == 'healthy'
+    assert result['reasons'] == []


### PR DESCRIPTION
## Summary
- Adds a deploy/verification guard that rejects stale eeepc self-evolving systemd unit paths pinned to old releases.
- The guard accepts the live-good shape where `WorkingDirectory` and `ExecStart` follow `/opt/eeepc-agent/runtimes/self-evolving-agent/current` and `POLICY_FILE` is unset/empty.
- Adds regression tests for the exact stale `20260324-staged` failure shape and the current-symlink success shape.

## Live evidence that motivated this
The live service previously mixed old and new runtime paths:

- `WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260324-staged`
- `POLICY_FILE=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260324-staged/config/policy.yaml`
- `ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main`

This produced `FileNotFoundError` and blocked autonomous-cycle verification until the live drop-in was manually remediated.

## Test Plan
- python3 -m pytest tests/test_eeepc_service_guard.py -q
- python3 -m pytest tests/test_autonomy_stagnation_followthrough.py -q
- PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q
- python3 -m pytest tests -q

Fixes #318
