### PR TITLE
fix: avoid replaying terminal selfevo retirement

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1828,15 +1828,9 @@ def _build_task_plan_snapshot(
             or recorded_terminal_selfevo_task_was_already_retired
         )
         and recorded_feedback_decision_for_repair.get('mode') == 'retire_terminal_selfevo_lane'
-        and recorded_feedback_decision_for_repair.get('current_task_id') == 'analyze-last-failed-candidate'
         and recorded_feedback_decision_for_repair.get('selected_task_id') == 'record-reward'
         and recorded_feedback_decision_for_repair.get('selection_source') == 'feedback_terminal_selfevo_retire'
         and terminal_selfevo_issue is not None
-        and isinstance(recorded_feedback_decision_for_repair.get('terminal_selfevo_issue'), dict)
-        and (
-            recorded_feedback_decision_for_repair['terminal_selfevo_issue'].get('terminal_status') == terminal_selfevo_issue.get('terminal_status')
-            or recorded_feedback_decision_for_repair['terminal_selfevo_issue'].get('selfevo_issue', {}).get('number') == terminal_selfevo_issue.get('selfevo_issue', {}).get('number')
-        )
     )
     if recorded_terminal_selfevo_retirement:
         terminal_selfevo_retired = True

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -606,6 +606,79 @@ def test_terminal_selfevo_active_lane_with_continue_decision_is_retired(tmp_path
     assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
 
 
+def test_terminal_selfevo_retirement_is_not_replayed_after_selected_reward_lane(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    runtime_state = tmp_path / 'host-state'
+    runtime_dir = runtime_state / 'self_evolution' / 'runtime'
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / 'latest_issue_lifecycle.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-issue-lifecycle-v1',
+        'status': 'terminal_merged',
+        'github_issue_state': 'CLOSED',
+        'issue_number': 61,
+        'selfevo_issue': {'number': 61, 'title': 'Analyze the last failed self-evolution candidate before retrying mutation'},
+        'retry_allowed': False,
+        'source_task_id': 'analyze-last-failed-candidate',
+    }), encoding='utf-8')
+    monkeypatch.setenv('NANOBOT_RUNTIME_STATE_ROOT', str(runtime_state))
+    artifact_path = state_root / 'improvements' / 'materialized-cycle-live.json'
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(json.dumps({'task_id': 'materialize-synthesized-improvement'}), encoding='utf-8')
+    history = goals / 'history'
+    history.mkdir()
+    for index in range(3):
+        (history / f'cycle-record-{index}.json').write_text(json.dumps({
+            'schema_version': 'task-history-v1',
+            'cycle_id': f'cycle-record-{index}',
+            'goal_id': 'goal-bootstrap',
+            'result_status': 'PASS',
+            'current_task_id': 'record-reward',
+            'artifact_paths': [str(artifact_path)],
+            'recorded_at_utc': f'2026-04-15T12:0{index}:00Z',
+        }), encoding='utf-8')
+    (goals / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'record-reward',
+        'materialized_improvement_artifact_path': str(artifact_path),
+        'tasks': [
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'},
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'done', 'terminal_reason': 'terminal_merged'},
+            {'task_id': 'synthesize-next-improvement-candidate', 'title': 'Synthesize', 'status': 'done'},
+            {'task_id': 'materialize-synthesized-improvement', 'title': 'Materialize synthesized', 'status': 'done'},
+        ],
+        'feedback_decision': {
+            'mode': 'retire_terminal_selfevo_lane',
+            'current_task_id': 'analyze-last-failed-candidate',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_terminal_selfevo_retire',
+            'terminal_selfevo_issue': {'terminal_status': 'terminal_merged'},
+        },
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-terminal-reward-selected',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals,
+    )
+
+    decision = plan.get('feedback_decision') or {}
+    assert plan['current_task_id'] == 'record-reward'
+    assert decision.get('mode') != 'retire_terminal_selfevo_lane'
+    assert decision.get('selection_source') != 'feedback_terminal_selfevo_retire'
+
+
 def test_failure_learning_uses_resolved_runtime_state_root(tmp_path: Path, monkeypatch) -> None:
     from nanobot.runtime.coordinator import _latest_failure_learning
 


### PR DESCRIPTION
## Summary
- Completes #331 after live verification showed terminal retirement could still repeat once the previous decision had already selected `record-reward`.
- Relaxes consumed-retirement detection to trust any previous `retire_terminal_selfevo_lane` decision that selected `record-reward` while terminal selfevo evidence is still present.
- Adds a regression for the exact selected-reward replay shape.

## Test Plan
- `python3 -m pytest tests/test_autonomy_stagnation_followthrough.py::test_terminal_selfevo_retirement_is_not_replayed_after_selected_reward_lane tests/test_autonomy_stagnation_followthrough.py::test_terminal_selfevo_retirement_is_idempotent_when_source_task_is_already_terminal -q`
- `python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_runtime_coordinator.py -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

Fixes #331
