### PR TITLE
fix: prevent terminal failure-learning resurrection

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -146,6 +146,16 @@ def _task_is_terminal_selfevo_retired(task: dict[str, Any] | None, terminal_self
     return task_status in COMPLETED_TASK_STATUSES and (task_status == terminal_status or terminal_reason == terminal_status)
 
 
+def _task_has_recorded_terminal_selfevo_retirement(task: dict[str, Any] | None) -> bool:
+    if not isinstance(task, dict):
+        return False
+    if task.get("task_id") != "analyze-last-failed-candidate":
+        return False
+    task_status = _task_status(task)
+    terminal_reason = str(task.get("terminal_reason") or "").strip().lower()
+    return task_status in COMPLETED_TASK_STATUSES and terminal_reason.startswith("terminal_")
+
+
 def _render_task_selection(task: dict[str, Any]) -> str:
     task_id = task.get("task_id") or task.get("taskId")
     task_title = task.get("title") or task.get("summary") or task_id or "task"
@@ -1802,9 +1812,14 @@ def _build_task_plan_snapshot(
     terminal_selfevo_issue = resolve_terminal_selfevo_issue(workspace=workspace, source_task_id='analyze-last-failed-candidate')
     terminal_selfevo_retired = False
     recorded_terminal_selfevo_task = next((task for task in tasks if task.get('task_id') == 'analyze-last-failed-candidate'), None)
-    recorded_terminal_selfevo_task_was_already_retired = _task_is_terminal_selfevo_retired(
-        recorded_terminal_selfevo_task_before_activation or recorded_terminal_selfevo_task,
-        terminal_selfevo_issue,
+    recorded_terminal_selfevo_task_was_already_retired = (
+        _task_is_terminal_selfevo_retired(
+            recorded_terminal_selfevo_task_before_activation or recorded_terminal_selfevo_task,
+            terminal_selfevo_issue,
+        )
+        or _task_has_recorded_terminal_selfevo_retirement(
+            recorded_terminal_selfevo_task_before_activation or recorded_terminal_selfevo_task
+        )
     )
     if recorded_terminal_selfevo_task_was_already_retired:
         terminal_selfevo_retired = True

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -335,6 +335,58 @@ def test_stale_complete_lane_record_reward_revives_failure_learning(tmp_path: Pa
     assert plan['feedback_decision']['selected_task_id'] == 'analyze-last-failed-candidate'
 
 
+def test_terminal_failure_learning_does_not_resurrect_already_retired_source_task(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    failure_dir = state_root / 'self_evolution' / 'failure_learning'
+    failure_dir.mkdir(parents=True)
+    (failure_dir / 'latest.json').write_text(json.dumps({
+        'schema_version': 'autoevolve-failure-learning-v1',
+        'candidate_id': 'candidate-terminal-resurrection',
+        'failed_commit': 'decafbad',
+        'health_reasons': ['stale_report'],
+        'learning_summary': 'Already-terminal failure-learning source must not be reactivated.',
+    }), encoding='utf-8')
+    (goals / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'record-reward',
+        'tasks': [
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'},
+            {'task_id': 'analyze-last-failed-candidate', 'title': 'Analyze the last failed self-evolution candidate before retrying mutation', 'status': 'done', 'kind': 'review', 'terminal_reason': 'terminal_merged'},
+        ],
+        'feedback_decision': {
+            'mode': 'retire_terminal_selfevo_lane',
+            'current_task_id': 'analyze-last-failed-candidate',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_terminal_selfevo_retire',
+        },
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-terminal-failure-learning-idempotent',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals,
+    )
+
+    decision = plan.get('feedback_decision') or {}
+    assert plan['current_task_id'] == 'record-reward'
+    assert decision.get('mode') != 'fresh_failure_learning_repair'
+    assert decision.get('mode') != 'stale_complete_lane_record_reward_repair'
+    assert decision.get('selected_task_id') != 'analyze-last-failed-candidate'
+    assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
+
+
 def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current_task_is_record_reward(tmp_path: Path, monkeypatch) -> None:
     workspace = tmp_path / 'workspace'
     state_root = workspace / 'state'


### PR DESCRIPTION
## Summary
- Completes #331 by preventing fresh failure-learning repair from resurrecting `analyze-last-failed-candidate` after that source task is already completed with a terminal selfevo reason.
- Adds `_task_has_recorded_terminal_selfevo_retirement(...)` so persisted canonical task state remains authoritative even when runtime issue resolution is unavailable or stale.
- Adds a regression for the live recurrence shape: `record-reward` active, fresh failure-learning present, and `analyze-last-failed-candidate` already `done`/`terminal_merged`.

## Test Plan
- `python3 -m pytest tests/test_autonomy_stagnation_followthrough.py::test_terminal_failure_learning_does_not_resurrect_already_retired_source_task tests/test_autonomy_stagnation_followthrough.py::test_stale_complete_lane_record_reward_revives_failure_learning tests/test_autonomy_stagnation_followthrough.py::test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current_task_is_record_reward -q`
- `python3 -m pytest tests/test_autonomy_stagnation_followthrough.py tests/test_runtime_coordinator.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

Fixes #331
