### PR TITLE
fix: compact recursive selfevo evidence

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -291,7 +291,13 @@ def _compact_selfevo_lifecycle_evidence(value):
         if key in {'last_issue_lifecycle', 'terminal_selfevo_issue'} and isinstance(item, dict):
             lifecycle = _compact_selfevo_lifecycle_evidence(item)
             if isinstance(lifecycle, dict):
-                compact[key] = {k: lifecycle.get(k) for k in ('status', 'issue_number', 'issue_title', 'issue_url', 'pr_number', 'pr_url', 'selfevo_branch', 'github_issue_state', 'retry_allowed', 'selfevo_issue') if _has_value(lifecycle.get(k))}
+                compact_lifecycle = {k: lifecycle.get(k) for k in ('status', 'issue_number', 'issue_title', 'issue_url', 'pr_number', 'pr_url', 'selfevo_branch', 'github_issue_state', 'retry_allowed', 'selfevo_issue') if _has_value(lifecycle.get(k))}
+                pr = item.get('pr') if isinstance(item.get('pr'), dict) else {}
+                if _has_value(pr.get('number')) and not _has_value(compact_lifecycle.get('pr_number')):
+                    compact_lifecycle['pr_number'] = pr.get('number')
+                if _has_value(pr.get('url')) and not _has_value(compact_lifecycle.get('pr_url')):
+                    compact_lifecycle['pr_url'] = pr.get('url')
+                compact[key] = compact_lifecycle
             continue
         if key in {'raw_json', 'stdout', 'stderr', 'stdout_tail', 'stderr_tail'}:
             if isinstance(item, str) and len(item) > 500:

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from wsgiref.util import setup_testing_defaults
 
-from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence
+from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence, _material_progress_summary
 from nanobot_ops_dashboard.config import DashboardConfig
 from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
 
@@ -73,6 +73,64 @@ def _seed_hypotheses_backlog(repo_root: Path, *, entry_count: int, selected_id: 
         'selected_hypothesis_title': selected_title,
     }), encoding='utf-8')
     return backlog
+
+
+def test_material_progress_compacts_recursive_selfevo_lifecycle_evidence() -> None:
+    recursive_issue = {
+        'number': 82,
+        'title': 'Recursive lifecycle evidence',
+        'url': 'https://github.com/ozand/eeebot-self-evolving/issues/82',
+        'state': 'CLOSED',
+    }
+    current = recursive_issue
+    for depth in range(12):
+        nested = {
+            'number': 82,
+            'title': f'Recursive lifecycle evidence depth {depth}',
+            'url': 'https://github.com/ozand/eeebot-self-evolving/issues/82',
+            'state': 'CLOSED',
+            'selfevo_issue': current,
+            'last_issue_lifecycle': {'selfevo_issue': current, 'status': 'terminal_merged'},
+            'huge_blob': 'x' * 1000,
+        }
+        current = nested
+    payload = {
+        'schema_version': 'material-progress-v1',
+        'state': 'proven',
+        'healthy_autonomy_allowed': True,
+        'proofs': [
+            {
+                'kind': 'github_selfevo_pr',
+                'evidence': {
+                    'selfevo_issue': current,
+                    'last_issue_lifecycle': {
+                        'status': 'terminal_merged',
+                        'selfevo_branch': 'fix/issue-82',
+                        'selfevo_issue': current,
+                        'pr': {'number': 92, 'url': 'https://github.com/ozand/eeebot-self-evolving/pull/92'},
+                    },
+                },
+            }
+        ],
+    }
+
+    compact = _material_progress_summary(payload)
+    encoded = json.dumps(compact)
+
+    assert compact['available'] is True
+    issue = compact['proofs'][0]['evidence']['selfevo_issue']
+    assert issue == {
+        'number': 82,
+        'title': 'Recursive lifecycle evidence depth 11',
+        'url': 'https://github.com/ozand/eeebot-self-evolving/issues/82',
+        'state': 'CLOSED',
+    }
+    lifecycle = compact['proofs'][0]['evidence']['last_issue_lifecycle']
+    assert lifecycle['status'] == 'terminal_merged'
+    assert lifecycle['pr_number'] == 92
+    assert 'selfevo_issue' in lifecycle
+    assert 'selfevo_issue' not in lifecycle['selfevo_issue']
+    assert len(encoded) < 2500
 
 
 def test_dashboard_truth_prefers_current_summary_and_flags_stale_legacy_active_execution(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fixes #332 by compacting recursive self-evolution lifecycle evidence before it is exposed through material-progress/dashboard payloads.
- Normalizes nested `selfevo_issue` evidence into a bounded issue/PR reference shape and truncates large raw string blobs.
- Adds a regression for deeply nested `selfevo_issue.selfevo_issue...` payloads and verifies the encoded material-progress payload remains bounded.

## Test Plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_material_progress_compacts_recursive_selfevo_lifecycle_evidence -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

Fixes #332
