### PR TITLE
fix: compact approvals api payload

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -2715,6 +2715,31 @@ def _compact_observation_group(item: dict) -> dict:
     }
 
 
+def _approval_snapshot(row) -> dict | None:
+    compact = _compact_collection_row(row)
+    if compact is None:
+        return None
+    plan_snapshot = _plan_snapshot_from_row(row)
+    compact['approval_gate'] = row.get('approval_gate') if isinstance(row, dict) else None
+    compact['plan_snapshot'] = {
+        'collected_at': plan_snapshot.get('collected_at'),
+        'source': plan_snapshot.get('source'),
+        'status': plan_snapshot.get('status'),
+        'current_task_id': plan_snapshot.get('current_task_id'),
+        'current_task': plan_snapshot.get('current_task'),
+        'task_count': plan_snapshot.get('task_count'),
+        'reward_signal': plan_snapshot.get('reward_signal'),
+        'reward_signal_text': plan_snapshot.get('reward_signal_text'),
+        'feedback_decision': _compact_selfevo_lifecycle_evidence(plan_snapshot.get('feedback_decision')) if isinstance(plan_snapshot.get('feedback_decision'), dict) else plan_snapshot.get('feedback_decision'),
+        'selected_tasks_text': plan_snapshot.get('selected_tasks_text'),
+        'selected_task_title': plan_snapshot.get('selected_task_title'),
+        'task_selection_source': plan_snapshot.get('task_selection_source'),
+        'plan_history_count': plan_snapshot.get('plan_history_count'),
+        'plan_payload_source': plan_snapshot.get('plan_payload_source'),
+    }
+    return compact
+
+
 
 def _deployment_snapshot(row, plan_snapshot):
     compact = _compact_collection_row(row)
@@ -3524,8 +3549,7 @@ def create_app(cfg: DashboardConfig):
         if path == '/api/approvals':
             payload = {
                 'items': [
-                    {**dict(r), 'plan_snapshot': _plan_snapshot_from_row(r)}
-                    for r in (eeepc_rows + repo_rows)
+                    snapshot for snapshot in (_approval_snapshot(r) for r in (eeepc_rows + repo_rows)) if snapshot is not None
                 ],
             }
             body = json.dumps(payload, ensure_ascii=False, indent=2).encode('utf-8')

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from wsgiref.util import setup_testing_defaults
 
-from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence, _material_progress_summary
+from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence, _material_progress_summary, _approval_snapshot
 from nanobot_ops_dashboard.config import DashboardConfig
 from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
 
@@ -131,6 +131,55 @@ def test_material_progress_compacts_recursive_selfevo_lifecycle_evidence() -> No
     assert 'selfevo_issue' in lifecycle
     assert 'selfevo_issue' not in lifecycle['selfevo_issue']
     assert len(encoded) < 2500
+
+
+def test_approvals_snapshot_omits_raw_recursive_payloads() -> None:
+    raw_payload = {
+        'current_plan': {
+            'feedback_decision': {
+                'mode': 'retire_terminal_selfevo_lane',
+                'terminal_selfevo_issue': {
+                    'status': 'terminal_merged',
+                    'selfevo_issue': {
+                        'number': 82,
+                        'title': 'Recursive issue',
+                        'selfevo_issue': {'number': 82, 'title': 'Nested recursive issue'},
+                    },
+                },
+            },
+            'selected_tasks': 'Record cycle reward [task_id=record-reward]',
+        },
+        'material_progress': {
+            'proofs': [{'evidence': {'selfevo_issue': {'number': 82, 'selfevo_issue': {'number': 82}}}}]
+        },
+        'huge': 'x' * 200000,
+    }
+    row = {
+        'id': 1,
+        'collected_at': '2026-04-28T20:00:00Z',
+        'source': 'eeepc',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'current_task': 'Record cycle reward',
+        'gate_state': 'fresh',
+        'report_source': '/state/reports/evolution.json',
+        'outbox_source': '/state/outbox.json',
+        'raw_json': json.dumps(raw_payload),
+        'plan_history_json': json.dumps([raw_payload] * 5),
+        'task_list_json': json.dumps([{'task_id': 'record-reward'}]),
+        'approval_gate': json.dumps({'state': 'fresh'}),
+    }
+
+    snapshot = _approval_snapshot(row)
+    encoded = json.dumps(snapshot)
+
+    assert 'raw_json' not in snapshot
+    assert 'plan_history_json' not in snapshot
+    assert 'task_list_json' not in snapshot
+    assert 'plan_history' not in snapshot['plan_snapshot']
+    assert 'terminal_selfevo_issue' in encoded
+    assert 'selfevo_issue": {"selfevo_issue' not in encoded
+    assert len(encoded) < 5000
 
 
 def test_dashboard_truth_prefers_current_summary_and_flags_stale_legacy_active_execution(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Completes #332 by compacting `/api/approvals` rows instead of returning raw collection JSON and full plan history snapshots.
- Keeps the actionable approval/task/feedback fields while omitting `raw_json`, `plan_history_json`, `task_list_json`, and full `plan_history` from the API response.
- Reuses the selfevo lifecycle normalizer for nested terminal/selfevo feedback evidence.

## Test Plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_material_progress_compacts_recursive_selfevo_lifecycle_evidence ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_approvals_snapshot_omits_raw_recursive_payloads -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

Fixes #332
