### PR TITLE
fix: emit ambition escalation and bound reward confirmations

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -251,8 +251,20 @@ def _history_budget_used(history_entry: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _ambition_streak_key(task_id: str | None) -> str | None:
+    if not task_id:
+        return None
+    normalized = str(task_id)
+    if normalized in {"record-reward", SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID}:
+        return "synthesized-reward-loop"
+    return normalized
+
+
 def _ambition_underutilization_reasons(history_entries: list[dict[str, Any]], current_task_id: str | None) -> list[str]:
     if not current_task_id:
+        return []
+    current_streak_key = _ambition_streak_key(current_task_id)
+    if not current_streak_key:
         return []
     inspected = 0
     repeated_task_ids: list[str] = []
@@ -262,16 +274,17 @@ def _ambition_underutilization_reasons(history_entries: list[dict[str, Any]], cu
         if (entry.get("result_status") or entry.get("status")) != "PASS":
             break
         task_id = entry.get("current_task_id") or entry.get("currentTaskId")
-        if not task_id:
+        task_streak_key = _ambition_streak_key(str(task_id) if task_id else None)
+        if not task_streak_key:
             break
-        repeated_task_ids.append(str(task_id))
+        repeated_task_ids.append(task_streak_key)
         budget_used = _history_budget_used(entry)
         total_tool_calls += int(budget_used.get("tool_calls") or 0)
         total_subagents += int(budget_used.get("subagents") or 0)
         inspected += 1
     if inspected < AMBITION_UNDERUTILIZATION_STREAK_LIMIT:
         return []
-    if len(set(repeated_task_ids)) != 1 or repeated_task_ids[0] != str(current_task_id):
+    if len(set(repeated_task_ids)) != 1 or repeated_task_ids[0] != current_streak_key:
         return []
     reasons = ["same_task_streak"]
     if total_subagents == 0:
@@ -480,7 +493,7 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
             reason = "healthy-progress lane is underusing tools/subagents; materialize the synthesized candidate instead of repeating low-ambition review"
             selection_source = "feedback_ambition_escalation_materialize"
         else:
-            for preferred_id in ["subagent-verify-materialized-improvement", SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID, MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID]:
+            for preferred_id in [MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID, "subagent-verify-materialized-improvement", SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID]:
                 for task in task_records:
                     task_id = task.get("task_id") or task.get("taskId")
                     if task_id in {None, current_task_id} or task_id != preferred_id:
@@ -2147,6 +2160,15 @@ def _build_task_plan_snapshot(
     if current_task_id in materialization_task_ids and result_status == "PASS" and materialized_improvement_artifact_path:
         is_synthesized_materialization = current_task_id == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
         completed_materialization_task_id = current_task_id
+        repeated_synthesized_materialization_completion = (
+            is_synthesized_materialization
+            and isinstance(recorded_feedback_decision_for_repair, dict)
+            and recorded_feedback_decision_for_repair.get("mode") == "complete_active_lane"
+            and recorded_feedback_decision_for_repair.get("current_task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+            and recorded_feedback_decision_for_repair.get("selected_task_id") == "record-reward"
+            and recorded_feedback_decision_for_repair.get("selection_source") == "feedback_complete_active_lane"
+            and str(recorded_feedback_decision_for_repair.get("artifact_path") or "") == str(materialized_improvement_artifact_path)
+        )
         for task in tasks:
             if task.get("task_id") == completed_materialization_task_id:
                 task["status"] = "done"
@@ -2160,7 +2182,27 @@ def _build_task_plan_snapshot(
                 task["status"] = "pending"
         combined_candidates = [candidate for candidate in combined_candidates if candidate.get("task_id") not in {"inspect-pass-streak", "materialize-pass-streak-improvement", MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID}]
         next_candidate = None if is_synthesized_materialization else next((candidate for candidate in combined_candidates if candidate.get("task_id") == "subagent-verify-materialized-improvement"), None)
-        if next_candidate is not None and not isinstance(latest_failure_learning, dict):
+        if repeated_synthesized_materialization_completion:
+            for task in tasks:
+                if task.get("task_id") == "record-reward":
+                    task["status"] = "active"
+                elif task.get("status") == "active":
+                    task["status"] = "pending"
+            current_task_id = "record-reward"
+            feedback_decision = {
+                "mode": "record_reward_after_synthesized_materialization",
+                "reason": "synthesized materialization completion for this artifact is already confirmed; advance to post-materialization reward accounting",
+                "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
+                "current_task_id": "record-reward",
+                "current_task_class": _task_action_class("record-reward"),
+                "selected_task_id": "record-reward",
+                "selected_task_class": _task_action_class("record-reward"),
+                "selection_source": "feedback_synthesized_materialization_complete_reward",
+                "selected_task_title": "Record cycle reward",
+                "selected_task_label": "Record cycle reward [task_id=record-reward]",
+                "artifact_path": materialized_improvement_artifact_path,
+            }
+        elif next_candidate is not None and not isinstance(latest_failure_learning, dict):
             for task in tasks:
                 if task.get("task_id") == next_candidate.get("task_id"):
                     task["status"] = "active"

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -437,6 +437,56 @@ def test_completed_materialization_does_not_reselect_terminal_failure_learning_t
     assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
 
 
+def test_repeated_synthesized_materialization_completion_goes_to_reward_accounting(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    artifact = state_root / 'improvements' / 'materialized-cycle-repeat.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({'task_id': 'materialize-synthesized-improvement'}), encoding='utf-8')
+    (goals / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'record-reward',
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'current_task_id': 'materialize-synthesized-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_complete_active_lane',
+            'artifact_path': str(artifact),
+        },
+        'tasks': [
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'},
+            {'task_id': 'synthesize-next-improvement-candidate', 'title': 'Synthesize', 'status': 'done'},
+            {'task_id': 'materialize-synthesized-improvement', 'title': 'Materialize synthesized', 'status': 'active'},
+        ],
+        'materialized_improvement_artifact_path': str(artifact),
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-repeat-materialization-completion',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {}, 'outcome': 'discard'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals,
+        materialized_improvement_artifact_path=str(artifact),
+    )
+
+    decision = plan.get('feedback_decision') or {}
+    assert plan['current_task_id'] == 'record-reward'
+    assert decision.get('mode') == 'record_reward_after_synthesized_materialization'
+    assert decision.get('selection_source') == 'feedback_synthesized_materialization_complete_reward'
+    assert decision.get('selected_task_id') == 'record-reward'
+    assert decision.get('mode') != 'complete_active_lane'
+
+
 def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current_task_is_record_reward(tmp_path: Path, monkeypatch) -> None:
     workspace = tmp_path / 'workspace'
     state_root = workspace / 'state'

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -904,6 +904,109 @@ def test_underutilized_synthesized_candidate_escalates_to_materialization(tmp_pa
     assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
 
 
+def test_underutilized_alternating_reward_synthesis_loop_escalates(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    task_ids = [
+        "record-reward",
+        "synthesize-next-improvement-candidate",
+        "record-reward",
+        "synthesize-next-improvement-candidate",
+        "record-reward",
+    ]
+    for index, task_id in enumerate(task_ids):
+        (history / f"cycle-loop-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-loop-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": task_id,
+                    "artifact_paths": [task_id],
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                    "experiment": {"outcome": "discard"},
+                    "recorded_at_utc": f"2026-04-15T12:0{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals.parent / "experiments").mkdir()
+    (goals.parent / "experiments" / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0}}),
+        encoding="utf-8",
+    )
+    task_plan = {
+        "current_task_id": "synthesize-next-improvement-candidate",
+        "reward_signal": {"value": 1.2},
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "done"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "active"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "pending"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision is not None
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["ambition_escalation"]["state"] == "selected"
+    assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
+
+
+def test_underutilized_alternating_reward_current_loop_escalates_to_materialization(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    task_ids = [
+        "synthesize-next-improvement-candidate",
+        "record-reward",
+        "synthesize-next-improvement-candidate",
+        "record-reward",
+        "synthesize-next-improvement-candidate",
+    ]
+    for index, task_id in enumerate(task_ids):
+        (history / f"cycle-current-reward-loop-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-current-reward-loop-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": task_id,
+                    "artifact_paths": [task_id],
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                    "experiment": {"outcome": "discard"},
+                    "recorded_at_utc": f"2026-04-15T12:1{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals.parent / "experiments").mkdir()
+    (goals.parent / "experiments" / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0}}),
+        encoding="utf-8",
+    )
+    task_plan = {
+        "current_task_id": "record-reward",
+        "reward_signal": {"value": 1.2},
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "pending"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "pending"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision is not None
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["ambition_escalation"]["state"] == "selected"
+
+
 def test_underutilized_ambition_emits_precise_blocker_when_no_safe_lane_exists(tmp_path):
     goals = tmp_path / "goals"
     history = goals / "history"


### PR DESCRIPTION
## Summary
- Fixes #338 by treating alternating `record-reward` / `synthesize-next-improvement-candidate` low-budget PASS cycles as one underutilized synthesized-reward loop so canonical reports emit `ambition_escalation` instead of silently continuing.
- Prioritizes `materialize-synthesized-improvement` as the bounded higher-ambition lane when escalation is required from `record-reward`.
- Fixes #339 by making repeated synthesized materialization completion idempotent for the same artifact path: after one `complete_active_lane` confirmation, the next cycle advances to `record_reward_after_synthesized_materialization` instead of reconfirming the same artifact.

## Test Plan
- `python3 -m pytest tests/test_runtime_coordinator.py::test_underutilized_alternating_reward_synthesis_loop_escalates tests/test_runtime_coordinator.py::test_underutilized_alternating_reward_current_loop_escalates_to_materialization tests/test_autonomy_stagnation_followthrough.py::test_repeated_synthesized_materialization_completion_goes_to_reward_accounting -q`
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

Fixes #338
Fixes #339
