### PR TITLE
fix: refresh synthesized materialization escalation

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -482,13 +482,21 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
             selection_source = "feedback_discard_revert_generated"
     elif ambition_underutilization_reasons:
         materialize_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID), None)
-        if current_task_id == SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID and (materialize_task is None or _task_is_selectable(materialize_task)):
-            selected_task = materialize_task or _synthesized_materialize_improvement_candidate(
-                current_task_id=current_task_id,
-                strong_pass_count=strong_pass_count,
-                goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
-                status="active",
-            )
+        if current_task_id == SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID:
+            if materialize_task is None or _task_is_selectable(materialize_task):
+                selected_task = materialize_task or _synthesized_materialize_improvement_candidate(
+                    current_task_id=current_task_id,
+                    strong_pass_count=strong_pass_count,
+                    goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+                    status="active",
+                )
+            else:
+                selected_task = _synthesized_materialize_improvement_candidate(
+                    current_task_id=current_task_id,
+                    strong_pass_count=strong_pass_count,
+                    goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+                    status="active",
+                )
             mode = "escalate_underutilized_ambition"
             reason = "healthy-progress lane is underusing tools/subagents; materialize the synthesized candidate instead of repeating low-ambition review"
             selection_source = "feedback_ambition_escalation_materialize"

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -956,6 +956,51 @@ def test_underutilized_alternating_reward_synthesis_loop_escalates(tmp_path):
     assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
 
 
+def test_underutilized_synthesis_refreshes_completed_materialization_lane(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    for index in range(5):
+        (history / f"cycle-completed-materialization-loop-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-completed-materialization-loop-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": "synthesize-next-improvement-candidate",
+                    "artifact_paths": ["synthesize-next-improvement-candidate"],
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                    "experiment": {"outcome": "discard"},
+                    "recorded_at_utc": f"2026-04-15T12:2{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals.parent / "experiments").mkdir()
+    (goals.parent / "experiments" / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0}}),
+        encoding="utf-8",
+    )
+    task_plan = {
+        "current_task_id": "synthesize-next-improvement-candidate",
+        "reward_signal": {"value": 1.2},
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "active"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "done"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision is not None
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["ambition_escalation"]["state"] == "selected"
+    assert decision["selection_source"] == "feedback_ambition_escalation_materialize"
+
+
 def test_underutilized_alternating_reward_current_loop_escalates_to_materialization(tmp_path):
     goals = tmp_path / "goals"
     history = goals / "history"


### PR DESCRIPTION
## Summary
- Fixes #341 by allowing the underutilized active synthesis lane to refresh/reactivate `materialize-synthesized-improvement` when the prior materialization task is already completed.
- Preserves #338's precise blocker behavior for other no-safe-lane cases, while making the observed live `synthesize-next-improvement-candidate` + completed materialization state convergent.
- Adds a regression for the exact live shape that previously emitted repeated `ambition_escalation_blocked` cycles.

## Test Plan
- `python3 -m pytest tests/test_runtime_coordinator.py::test_underutilized_synthesis_refreshes_completed_materialization_lane tests/test_runtime_coordinator.py::test_underutilized_alternating_reward_synthesis_loop_escalates tests/test_runtime_coordinator.py::test_underutilized_alternating_reward_current_loop_escalates_to_materialization -q`
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

Fixes #341
