### PR TITLE
fix: advance reward after materialization confirmation

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2165,6 +2165,18 @@ def _build_task_plan_snapshot(
         artifact_task_record = next((task for task in tasks if task.get("task_id") == materialized_artifact_task_id), None)
         if _task_is_selectable(artifact_task_record):
             current_task_id = materialized_artifact_task_id
+    confirmed_synthesized_materialization_completion = (
+        current_task_id == "record-reward"
+        and materialized_artifact_task_id == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+        and isinstance(recorded_feedback_decision_for_repair, dict)
+        and recorded_feedback_decision_for_repair.get("mode") == "complete_active_lane"
+        and recorded_feedback_decision_for_repair.get("current_task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+        and recorded_feedback_decision_for_repair.get("selected_task_id") == "record-reward"
+        and recorded_feedback_decision_for_repair.get("selection_source") == "feedback_complete_active_lane"
+        and str(recorded_feedback_decision_for_repair.get("artifact_path") or "") == str(materialized_improvement_artifact_path)
+    )
+    if confirmed_synthesized_materialization_completion:
+        current_task_id = MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
     if current_task_id in materialization_task_ids and result_status == "PASS" and materialized_improvement_artifact_path:
         is_synthesized_materialization = current_task_id == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
         completed_materialization_task_id = current_task_id

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -487,6 +487,56 @@ def test_repeated_synthesized_materialization_completion_goes_to_reward_accounti
     assert decision.get('mode') != 'complete_active_lane'
 
 
+def test_record_reward_after_completed_synthesized_materialization_confirmation_advances_to_reward_accounting(tmp_path: Path) -> None:
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    artifact = state_root / 'improvements' / 'materialized-cycle-confirmed.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({'task_id': 'materialize-synthesized-improvement'}), encoding='utf-8')
+    (goals / 'current.json').write_text(json.dumps({
+        'schema_version': 'task-plan-v1',
+        'current_task_id': 'record-reward',
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'current_task_id': 'materialize-synthesized-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_complete_active_lane',
+            'artifact_path': str(artifact),
+        },
+        'tasks': [
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'active'},
+            {'task_id': 'synthesize-next-improvement-candidate', 'title': 'Synthesize', 'status': 'done'},
+            {'task_id': 'materialize-synthesized-improvement', 'title': 'Materialize synthesized', 'status': 'done'},
+        ],
+        'materialized_improvement_artifact_path': str(artifact),
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-record-reward-after-confirmed-materialization',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.2}, 'budget': {}, 'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0}, 'outcome': 'discard'},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.2,
+        feedback_decision=None,
+        goals_dir=goals,
+        materialized_improvement_artifact_path=str(artifact),
+    )
+
+    decision = plan.get('feedback_decision') or {}
+    assert plan['current_task_id'] == 'record-reward'
+    assert decision.get('mode') == 'record_reward_after_synthesized_materialization'
+    assert decision.get('selection_source') == 'feedback_synthesized_materialization_complete_reward'
+    assert decision.get('selected_task_id') == 'record-reward'
+    assert decision.get('mode') != 'ambition_escalation_blocked'
+
+
 def test_terminal_selfevo_issue_outranks_stale_complete_lane_repair_when_current_task_is_record_reward(tmp_path: Path, monkeypatch) -> None:
     workspace = tmp_path / 'workspace'
     state_root = workspace / 'state'


### PR DESCRIPTION
## Summary
- Fixes #343 by recognizing the live shape where `record-reward` is active after a persisted `complete_active_lane` confirmation for the same synthesized materialization artifact.
- Advances directly to `record_reward_after_synthesized_materialization` instead of letting ambition escalation classify the reward lane as blocked.
- Preserves #339's duplicate confirmation bound for repeated synthesized materialization completions.

## Test Plan
- `python3 -m pytest tests/test_autonomy_stagnation_followthrough.py::test_record_reward_after_completed_synthesized_materialization_confirmation_advances_to_reward_accounting tests/test_autonomy_stagnation_followthrough.py::test_repeated_synthesized_materialization_completion_goes_to_reward_accounting -q`
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

Fixes #343
