### PR TITLE
fix: prioritize reward accounting before ambition

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -458,6 +458,34 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
         and latest_experiment.get("revert_status") == "queued"
         and latest_experiment_task_id == current_task_id
     )
+    materialized_artifact_path = task_plan.get("materialized_improvement_artifact_path")
+    materialized_artifact_payload = _safe_read_json(Path(str(materialized_artifact_path))) if materialized_artifact_path else None
+    materialize_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID), None)
+    if (
+        current_task_id == "record-reward"
+        and isinstance(materialized_artifact_payload, dict)
+        and materialized_artifact_payload.get("task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+        and _task_status(materialize_task) in COMPLETED_TASK_STATUSES
+    ):
+        selected_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == "record-reward"), None) or {"task_id": "record-reward", "title": "Record cycle reward"}
+        return {
+            "mode": "record_reward_after_synthesized_materialization",
+            "reason": "synthesized materialization artifact is already completed; prioritize post-materialization reward accounting before ambition escalation",
+            "reward_value": reward_value,
+            "current_task_id": "record-reward",
+            "current_task_class": _task_action_class("record-reward"),
+            "repeat_block_count": repeat_block_count,
+            "repeat_block_failure_class": repeat_block_failure_class,
+            "goal_artifact_signature": list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+            "strong_pass_count": strong_pass_count,
+            "retire_goal_artifact_pair": False,
+            "selected_task_id": "record-reward",
+            "selected_task_class": _task_action_class("record-reward"),
+            "selection_source": "feedback_synthesized_materialization_complete_reward",
+            "selected_task_title": selected_task.get("title") or "Record cycle reward",
+            "selected_task_label": _render_task_selection(selected_task),
+            "artifact_path": str(materialized_artifact_path),
+        }
 
     if latest_experiment_revert_queued:
         mode = "execute_queued_revert"

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -956,6 +956,60 @@ def test_underutilized_alternating_reward_synthesis_loop_escalates(tmp_path):
     assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
 
 
+def test_record_reward_with_done_synthesized_materialization_prioritizes_reward_accounting_before_ambition(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    artifact = tmp_path / "improvements" / "materialized-cycle-live.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({"task_id": "materialize-synthesized-improvement"}), encoding="utf-8")
+    for index in range(5):
+        (history / f"cycle-live-blocked-record-reward-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-live-blocked-record-reward-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": "record-reward",
+                    "materialized_improvement_artifact_path": str(artifact),
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                    "experiment": {"outcome": "discard"},
+                    "recorded_at_utc": f"2026-04-15T12:3{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals.parent / "experiments").mkdir()
+    (goals.parent / "experiments" / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0}}),
+        encoding="utf-8",
+    )
+    task_plan = {
+        "current_task_id": "record-reward",
+        "reward_signal": {"value": 1.2},
+        "materialized_improvement_artifact_path": str(artifact),
+        "feedback_decision": {
+            "mode": "ambition_escalation_blocked",
+            "selected_task_id": "record-reward",
+            "selection_source": "feedback_ambition_escalation_blocked",
+        },
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "done"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "done"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision is not None
+    assert decision["mode"] == "record_reward_after_synthesized_materialization"
+    assert decision["selected_task_id"] == "record-reward"
+    assert decision["selection_source"] == "feedback_synthesized_materialization_complete_reward"
+    assert decision["artifact_path"] == str(artifact)
+
+
 def test_underutilized_synthesis_refreshes_completed_materialization_lane(tmp_path):
     goals = tmp_path / "goals"
     history = goals / "history"


### PR DESCRIPTION
## Summary
- Fixes #345 by making `_derive_feedback_decision` prioritize post-materialization reward accounting before ambition escalation when `record-reward` is active and a completed synthesized materialization artifact is already persisted.
- Prevents the live `record-reward ambition_escalation_blocked` loop observed after #344.
- Adds a regression using the exact live state shape: active reward lane, done synthesized materialization task, persisted materialization artifact, and low-budget history that would otherwise trigger ambition underutilization.

## Test Plan
- `python3 -m pytest tests/test_runtime_coordinator.py::test_record_reward_with_done_synthesized_materialization_prioritizes_reward_accounting_before_ambition tests/test_autonomy_stagnation_followthrough.py::test_record_reward_after_completed_synthesized_materialization_confirmation_advances_to_reward_accounting -q`
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

Fixes #345
