### PR TITLE
fix: rotate after reward accounting is consumed

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -461,6 +461,48 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
     materialized_artifact_path = task_plan.get("materialized_improvement_artifact_path")
     materialized_artifact_payload = _safe_read_json(Path(str(materialized_artifact_path))) if materialized_artifact_path else None
     materialize_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID), None)
+    post_materialization_reward_already_confirmed = (
+        current_task_id == "record-reward"
+        and isinstance(recorded_feedback_decision, dict)
+        and recorded_feedback_decision.get("mode") == "record_reward_after_synthesized_materialization"
+        and recorded_feedback_decision.get("selected_task_id") == "record-reward"
+        and (
+            not materialized_artifact_path
+            or not recorded_feedback_decision.get("artifact_path")
+            or str(recorded_feedback_decision.get("artifact_path")) == str(materialized_artifact_path)
+        )
+    )
+    if (
+        current_task_id == "record-reward"
+        and isinstance(materialized_artifact_payload, dict)
+        and materialized_artifact_payload.get("task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+        and _task_status(materialize_task) in COMPLETED_TASK_STATUSES
+        and post_materialization_reward_already_confirmed
+    ):
+        selected_task = _synthesized_next_improvement_candidate(
+            current_task_id=current_task_id,
+            strong_pass_count=strong_pass_count,
+            goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+            status="active",
+        )
+        return {
+            "mode": "synthesize_next_candidate",
+            "reason": "post-materialization reward accounting is already confirmed; rotate to a fresh bounded improvement candidate instead of repeating reward bookkeeping",
+            "reward_value": reward_value,
+            "current_task_id": current_task_id,
+            "current_task_class": current_task_class,
+            "repeat_block_count": repeat_block_count,
+            "repeat_block_failure_class": repeat_block_failure_class,
+            "goal_artifact_signature": list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+            "strong_pass_count": strong_pass_count,
+            "retire_goal_artifact_pair": False,
+            "ambition_escalation": None,
+            "selected_task_id": selected_task.get("task_id") or selected_task.get("taskId"),
+            "selected_task_class": _task_action_class(selected_task.get("task_id") or selected_task.get("taskId")),
+            "selection_source": "feedback_no_selectable_retired_lane_synthesis",
+            "selected_task_title": selected_task.get("title") or selected_task.get("summary") or selected_task.get("task_id"),
+            "selected_task_label": _render_task_selection(selected_task),
+        }
     if (
         current_task_id == "record-reward"
         and isinstance(materialized_artifact_payload, dict)

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1010,6 +1010,66 @@ def test_record_reward_with_done_synthesized_materialization_prioritizes_reward_
     assert decision["artifact_path"] == str(artifact)
 
 
+def test_consumed_post_materialization_reward_accounting_rotates_to_fresh_synthesis(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    artifact = tmp_path / "improvements" / "materialized-cycle-consumed.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({"task_id": "materialize-synthesized-improvement"}), encoding="utf-8")
+    for index in range(5):
+        (history / f"cycle-repeated-reward-accounting-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-repeated-reward-accounting-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": "record-reward",
+                    "materialized_improvement_artifact_path": str(artifact),
+                    "feedback_decision": {
+                        "mode": "record_reward_after_synthesized_materialization",
+                        "selection_source": "feedback_synthesized_materialization_complete_reward",
+                        "selected_task_id": "record-reward",
+                        "artifact_path": str(artifact),
+                    },
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                    "experiment": {"outcome": "discard"},
+                    "recorded_at_utc": f"2026-04-15T12:4{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals.parent / "experiments").mkdir()
+    (goals.parent / "experiments" / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0}}),
+        encoding="utf-8",
+    )
+    task_plan = {
+        "current_task_id": "record-reward",
+        "reward_signal": {"value": 1.2},
+        "materialized_improvement_artifact_path": str(artifact),
+        "feedback_decision": {
+            "mode": "record_reward_after_synthesized_materialization",
+            "selected_task_id": "record-reward",
+            "selection_source": "feedback_synthesized_materialization_complete_reward",
+            "artifact_path": str(artifact),
+        },
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "done"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "done"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision is not None
+    assert decision["mode"] == "synthesize_next_candidate"
+    assert decision["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert decision["selection_source"] == "feedback_no_selectable_retired_lane_synthesis"
+
+
 def test_underutilized_synthesis_refreshes_completed_materialization_lane(tmp_path):
     goals = tmp_path / "goals"
     history = goals / "history"


### PR DESCRIPTION
## Summary
- Fixes #347 by making consumed post-materialization reward accounting rotate to a fresh synthesized improvement candidate instead of re-emitting the same reward-accounting decision forever.
- Adds a regression for the observed live shape: active `record-reward`, completed synthesized materialization artifact, and previously persisted `record_reward_after_synthesized_materialization` for the same artifact.
- Preserves #345 first-time reward-accounting behavior: the first pass still prioritizes `record_reward_after_synthesized_materialization` before ambition escalation.

## Test Plan
- `python3 -m pytest tests/test_runtime_coordinator.py::test_consumed_post_materialization_reward_accounting_rotates_to_fresh_synthesis tests/test_runtime_coordinator.py::test_record_reward_with_done_synthesized_materialization_prioritizes_reward_accounting_before_ambition -q`
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_autonomy_stagnation_followthrough.py -q`
- `python3 -m pytest tests -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`

Fixes #347
