### PR TITLE
fix: avoid ambition false positive on rotating cycles

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1231,8 +1231,17 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     total_subagents = 0
     total_elapsed = 0
     repeated_tasks: list[str] = []
+    feedback_modes: list[str] = []
+    materialized_artifacts: list[str] = []
     for row in recent[:20]:
         detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        feedback_decision = detail.get('feedback_decision') if isinstance(detail.get('feedback_decision'), dict) else {}
+        feedback_mode = feedback_decision.get('mode')
+        if feedback_mode:
+            feedback_modes.append(str(feedback_mode))
+        artifact_path = detail.get('materialized_improvement_artifact_path') or feedback_decision.get('artifact_path')
+        if artifact_path:
+            materialized_artifacts.append(str(artifact_path))
         experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
         budget_used = detail.get('budget_used') if isinstance(detail.get('budget_used'), dict) else experiment.get('budget_used') if isinstance(experiment.get('budget_used'), dict) else {}
         if not isinstance(budget_used, dict):
@@ -1264,16 +1273,25 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
         if current_outcome == 'discard' and total_requests <= 1 and total_tool_calls <= 2 and total_subagents == 0 and total_elapsed <= 1:
             low_budget_discard_count = 1
     same_task_streak = len(repeated_tasks) >= 5 and len(set(repeated_tasks[:5])) == 1
+    recent_mode_set = set(feedback_modes[:8])
+    rotating_synthesis_reward_window = (
+        len(feedback_modes) >= 3
+        and 'synthesize_next_candidate' in recent_mode_set
+        and 'complete_active_lane' in recent_mode_set
+        and 'record_reward_after_synthesized_materialization' in recent_mode_set
+        and len(set(materialized_artifacts[:8])) >= 2
+    )
     bridge_summary = subagent_visibility if isinstance(subagent_visibility, dict) else {}
     reasons: list[str] = []
-    if low_budget_discard_count >= 5:
-        reasons.append('low_budget_discard_streak')
-    if same_task_streak:
-        reasons.append('same_task_streak')
-    if inspected >= 5 and total_subagents == 0:
-        reasons.append('subagents_unused')
-    if inspected >= 5 and total_tool_calls <= inspected * 2:
-        reasons.append('tool_budget_underused')
+    if not rotating_synthesis_reward_window:
+        if low_budget_discard_count >= 5:
+            reasons.append('low_budget_discard_streak')
+        if same_task_streak:
+            reasons.append('same_task_streak')
+        if inspected >= 5 and total_subagents == 0:
+            reasons.append('subagents_unused')
+        if inspected >= 5 and total_tool_calls <= inspected * 2:
+            reasons.append('tool_budget_underused')
     state = 'underutilized' if reasons else 'substantive'
     escalation = None
     if state == 'underutilized':
@@ -1301,6 +1319,7 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
             'elapsed_seconds': total_elapsed,
         },
         'same_task_streak': same_task_streak,
+        'rotating_synthesis_reward_window': rotating_synthesis_reward_window,
         'subagent_visibility_available': bool(bridge_summary),
         'recommended_next_action': 'escalate_to_higher_ambition_lane_or_emit_precise_blocker' if state == 'underutilized' else None,
         'escalation': escalation,

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -1998,6 +1998,49 @@ def test_ambition_utilization_flags_low_budget_discard_streak() -> None:
     assert 'materialize-synthesized-improvement' in verdict['escalation']['safe_bounded_lanes']
 
 
+def test_ambition_utilization_treats_rotating_synthesis_reward_window_as_substantive() -> None:
+    from nanobot_ops_dashboard.app import _ambition_utilization_verdict
+
+    def row(task_id: str, mode: str, artifact: str) -> dict:
+        return {
+            'status': 'PASS',
+            'title': task_id,
+            'detail': {
+                'current_task_id': task_id,
+                'materialized_improvement_artifact_path': artifact,
+                'feedback_decision': {
+                    'mode': mode,
+                    'selected_task_id': task_id,
+                    'selection_source': 'feedback_no_selectable_retired_lane_synthesis'
+                    if mode == 'synthesize_next_candidate'
+                    else 'feedback_synthesized_materialization_complete_reward'
+                    if mode == 'record_reward_after_synthesized_materialization'
+                    else 'feedback_complete_active_lane',
+                },
+                'experiment': {'outcome': 'discard'},
+                'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+            },
+        }
+
+    analytics = {
+        'recent_status_sequence': [
+            row('record-reward', 'record_reward_after_synthesized_materialization', 'materialized-cycle-c.json'),
+            row('record-reward', 'complete_active_lane', 'materialized-cycle-c.json'),
+            row('synthesize-next-improvement-candidate', 'synthesize_next_candidate', 'materialized-cycle-b.json'),
+            row('record-reward', 'record_reward_after_synthesized_materialization', 'materialized-cycle-b.json'),
+            row('record-reward', 'complete_active_lane', 'materialized-cycle-b.json'),
+            row('synthesize-next-improvement-candidate', 'synthesize_next_candidate', 'materialized-cycle-a.json'),
+        ]
+    }
+
+    verdict = _ambition_utilization_verdict(analytics=analytics, experiment_visibility={}, subagent_visibility={})
+
+    assert verdict['state'] == 'substantive'
+    assert verdict['reasons'] == []
+    assert verdict['recommended_next_action'] is None
+    assert verdict['escalation'] is None
+
+
 def test_strong_reflection_freshness_exposes_latest_artifact(tmp_path: Path) -> None:
     from datetime import datetime, timezone
     from nanobot_ops_dashboard.app import _strong_reflection_freshness


### PR DESCRIPTION
## Summary
- Fixes #349 by recognizing a recent live rotating synthesis/materialization/reward window as substantive dashboard activity.
- Prevents `/api/system` from continuing to show `ambition_utilization.state=underutilized` and `escalation.required` when canonical cycles are already rotating through `synthesize_next_candidate`, `complete_active_lane`, and `record_reward_after_synthesized_materialization` with fresh materialized artifacts.
- Preserves the prior low-budget discard streak regression so true shallow repeated loops still require escalation.

## Test Plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_ambition_utilization_treats_rotating_synthesis_reward_window_as_substantive ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_ambition_utilization_flags_low_budget_discard_streak -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

Fixes #349
