### PR TITLE
fix: ignore sparse goal rows in ambition verdict

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1246,6 +1246,8 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
         budget_used = detail.get('budget_used') if isinstance(detail.get('budget_used'), dict) else experiment.get('budget_used') if isinstance(experiment.get('budget_used'), dict) else {}
         if not isinstance(budget_used, dict):
             budget_used = {}
+        if not detail.get('current_task_id') and not feedback_decision and not budget_used and not experiment:
+            continue
         outcome = experiment.get('outcome') or detail.get('outcome')
         task_id = detail.get('current_task_id') or row.get('title')
         if task_id:

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -2041,6 +2041,31 @@ def test_ambition_utilization_treats_rotating_synthesis_reward_window_as_substan
     assert verdict['escalation'] is None
 
 
+def test_ambition_utilization_ignores_sparse_goal_only_cycle_rows() -> None:
+    from nanobot_ops_dashboard.app import _ambition_utilization_verdict
+
+    analytics = {
+        'recent_status_sequence': [
+            {
+                'status': 'PASS',
+                'title': 'goal-bootstrap',
+                'detail': {
+                    'report_source': f'/var/lib/eeepc-agent/self-evolving-agent/state/reports/evolution-{index}.json',
+                    'artifact_paths': [f'/var/lib/eeepc-agent/self-evolving-agent/state/reports/evolution-{index}.json'],
+                },
+            }
+            for index in range(20)
+        ]
+    }
+
+    verdict = _ambition_utilization_verdict(analytics=analytics, experiment_visibility={}, subagent_visibility={})
+
+    assert verdict['state'] == 'substantive'
+    assert verdict['recent_window'] == 1
+    assert verdict['reasons'] == []
+    assert verdict['escalation'] is None
+
+
 def test_strong_reflection_freshness_exposes_latest_artifact(tmp_path: Path) -> None:
     from datetime import datetime, timezone
     from nanobot_ops_dashboard.app import _strong_reflection_freshness


### PR DESCRIPTION
## Summary
- Follow-up for #349: dashboard cycle rows can contain only goal-level titles and sparse report references, not task/mode/budget details.
- Prevents `_ambition_utilization_verdict` from treating sparse `goal-bootstrap` rows as repeated task evidence.
- Keeps the rotating synthesis/reward-window exemption and preserves true low-budget discard streak detection.

## Test Plan
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_ambition_utilization_ignores_sparse_goal_only_cycle_rows ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_ambition_utilization_treats_rotating_synthesis_reward_window_as_substantive ops/dashboard/tests/test_dashboard_truth_audit_gaps.py::test_ambition_utilization_flags_low_budget_discard_streak -q`
- `PYTHONPATH=ops/dashboard:ops/dashboard/src python3 -m pytest ops/dashboard/tests -q`
- `python3 -m pytest tests -q`

Refs #349
