### PR TITLE
fix: keep local cycle state root writable

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,8 +20,9 @@ async def _execute_turn(tasks: str) -> str:
 
 
 def _prime_runtime_defaults() -> None:
-    os.environ.setdefault("NANOBOT_RUNTIME_STATE_SOURCE", DEFAULT_RUNTIME_STATE_SOURCE)
-    os.environ.setdefault("NANOBOT_RUNTIME_STATE_ROOT", str(DEFAULT_RUNTIME_STATE_ROOT))
+    source = os.environ.setdefault("NANOBOT_RUNTIME_STATE_SOURCE", DEFAULT_RUNTIME_STATE_SOURCE)
+    if source == "host_control_plane":
+        os.environ.setdefault("NANOBOT_RUNTIME_STATE_ROOT", str(DEFAULT_RUNTIME_STATE_ROOT))
 
 
 def _write_strong_reflection_artifact(*, state_root: Path, workspace: Path, summary: str) -> Path:

--- a/tests/test_app_main.py
+++ b/tests/test_app_main.py
@@ -29,3 +29,24 @@ def test_main_persists_strong_reflection_on_normal_cycle(tmp_path, monkeypatch, 
     assert payload['mode'] == 'strong-reflection'
     assert payload['summary'].endswith('normal')
     assert 'Strong reflection artifact persisted:' not in capsys.readouterr().out
+
+
+def test_main_uses_workspace_state_for_local_cycle_when_root_is_unset(tmp_path, monkeypatch):
+    import app.main as main_mod
+
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir()
+    monkeypatch.setenv('NANOBOT_WORKSPACE', str(workspace))
+    monkeypatch.setenv('NANOBOT_RUNTIME_STATE_SOURCE', 'workspace_state')
+    monkeypatch.delenv('NANOBOT_RUNTIME_STATE_ROOT', raising=False)
+
+    async def fake_cycle(**_kwargs):
+        return 'Self-evolving cycle PASS — evidence=workspace-local'
+
+    monkeypatch.setattr(main_mod, 'run_self_evolving_cycle', fake_cycle)
+    monkeypatch.setattr(main_mod.sys, 'argv', ['app/main.py'])
+
+    assert main_mod.main() == 0
+
+    payload = json.loads((workspace / 'state' / 'strong_reflection' / 'latest.json').read_text(encoding='utf-8'))
+    assert payload['summary'].endswith('workspace-local')


### PR DESCRIPTION
Fixes #353

## Summary
- keep the local workspace cycle on a writable workspace state root when `NANOBOT_RUNTIME_STATE_SOURCE=workspace_state`
- retain `/var/lib/eeepc-agent/self-evolving-agent/state` default only for `host_control_plane`
- add regression proving normal local-cycle strong reflection writes to `workspace/state/strong_reflection/latest.json`

## Last-hour audit evidence
`eeebot-local-cycle.service` failed twice in the last hour with `PermissionError: [Errno 13] Permission denied: '/var/lib/eeepc-agent'` while writing strong reflection.

## Verification
- `python3 -m pytest tests/test_app_main.py tests/test_service_entrypoint.py tests/test_run_local_cycle_refresh.py -q` -> 6 passed
- direct local workspace run with `PYTHONPATH=. NANOBOT_RUNTIME_STATE_SOURCE=workspace_state` exits 0 and writes `workspace/state/strong_reflection/latest.json`
