### PR TITLE
fix: escalate repeated reward pass-streak loops

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -255,7 +255,7 @@ def _ambition_streak_key(task_id: str | None) -> str | None:
     if not task_id:
         return None
     normalized = str(task_id)
-    if normalized in {"record-reward", SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID}:
+    if normalized in {"record-reward", "inspect-pass-streak", SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID}:
         return "synthesized-reward-loop"
     return normalized
 

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -904,6 +904,71 @@ def test_underutilized_synthesized_candidate_escalates_to_materialization(tmp_pa
     assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
 
 
+def test_underutilized_alternating_reward_inspect_pass_streak_loop_escalates(tmp_path):
+    goals = tmp_path / "goals"
+    history = goals / "history"
+    history.mkdir(parents=True)
+    artifact = tmp_path / "improvements" / "materialized-cycle-repeat.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({"task_id": "materialize-synthesized-improvement"}), encoding="utf-8")
+    task_ids = [
+        "record-reward",
+        "inspect-pass-streak",
+        "record-reward",
+        "inspect-pass-streak",
+        "record-reward",
+    ]
+    for index, task_id in enumerate(task_ids):
+        (history / f"cycle-reward-inspect-loop-{index}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "cycle_id": f"cycle-reward-inspect-loop-{index}",
+                    "goal_id": "goal-bootstrap",
+                    "result_status": "PASS",
+                    "current_task_id": task_id,
+                    "artifact_paths": [str(artifact)],
+                    "materialized_improvement_artifact_path": str(artifact),
+                    "feedback_decision": {
+                        "mode": "retire_goal_artifact_pair",
+                        "selected_task_id": task_id,
+                        "selection_source": "feedback_pass_streak_switch",
+                    },
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                    "experiment": {"outcome": "discard", "revert_status": "skipped_no_material_change"},
+                    "recorded_at_utc": f"2026-04-15T12:1{index}:00Z",
+                }
+            ),
+            encoding="utf-8",
+        )
+    (goals.parent / "experiments").mkdir()
+    (goals.parent / "experiments" / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "revert_status": "skipped_no_material_change", "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0}}),
+        encoding="utf-8",
+    )
+    task_plan = {
+        "current_task_id": "inspect-pass-streak",
+        "reward_signal": {"value": 1.2},
+        "materialized_improvement_artifact_path": str(artifact),
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
+            {"task_id": "inspect-pass-streak", "title": "Inspect repeated PASS streak", "status": "active"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Materialize synthesized", "status": "pending"},
+            {"task_id": "synthesize-next-improvement-candidate", "title": "Synthesize", "status": "pending"},
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals)
+
+    assert decision is not None
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selection_source"] == "feedback_ambition_escalation_bounded_lane"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["retire_goal_artifact_pair"] is False
+    assert decision["selection_source"] != "feedback_pass_streak_switch"
+    assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
+
+
 def test_underutilized_alternating_reward_synthesis_loop_escalates(tmp_path):
     goals = tmp_path / "goals"
     history = goals / "history"


### PR DESCRIPTION
Fixes #354

## Summary
- Treat `inspect-pass-streak` as part of the same underutilized synthesized/reward loop as `record-reward` and `synthesize-next-improvement-candidate`.
- Add a regression for the exact last-hour failure shape: alternating `record-reward`/`inspect-pass-streak`, `retire_goal_artifact_pair`, `feedback_pass_streak_switch`, discard/no material change, same artifact, no subagents.
- The repeated loop now escalates to `materialize-synthesized-improvement` instead of reselecting the reward/pass-streak pair.

## Verification
- `python3 -m py_compile nanobot/runtime/coordinator.py tests/test_runtime_coordinator.py`
- `python3 -m pytest tests/test_runtime_coordinator.py -k 'reward_inspect_pass_streak_loop or underutilized_alternating_reward_synthesis_loop_escalates or underutilized_synthesized_candidate_escalates_to_materialization' -q` -> 3 passed
- `python3 -m pytest tests/test_runtime_coordinator.py -q` -> 47 passed
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_app_main.py tests/test_run_local_cycle_refresh.py -q` -> 52 passed
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -q)` -> 45 passed
- `python3 -m pytest -q` -> 662 passed, 5 skipped

## Delegation/review
- Two inspection subagents mapped selector insertion points and live artifact proof paths.
- One review subagent approved the minimal fix and overmatch risk.
