### PR TITLE
fix: block healthy dashboard state on active ambition blocker

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1233,6 +1233,7 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     repeated_tasks: list[str] = []
     feedback_modes: list[str] = []
     materialized_artifacts: list[str] = []
+    blocked_escalation: dict | None = None
     for row in recent[:20]:
         detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
         feedback_decision = detail.get('feedback_decision') if isinstance(detail.get('feedback_decision'), dict) else {}
@@ -1266,6 +1267,14 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     current_experiment = experiment_visibility.get('current_experiment') if isinstance(experiment_visibility, dict) else {}
     current_budget_used = current_experiment.get('budget_used') if isinstance(current_experiment, dict) and isinstance(current_experiment.get('budget_used'), dict) else {}
     current_outcome = current_experiment.get('outcome') if isinstance(current_experiment, dict) else None
+    if isinstance(current_experiment, dict):
+        current_feedback_decision = current_experiment.get('feedback_decision') if isinstance(current_experiment.get('feedback_decision'), dict) else None
+        current_raw = current_experiment.get('raw') if isinstance(current_experiment.get('raw'), dict) else {}
+        raw_feedback_decision = current_raw.get('feedback_decision') if isinstance(current_raw.get('feedback_decision'), dict) else None
+        for candidate in (current_feedback_decision, raw_feedback_decision):
+            if isinstance(candidate, dict) and candidate.get('mode') == 'ambition_escalation_blocked':
+                blocked_escalation = candidate
+                break
     if inspected == 0 and isinstance(current_budget_used, dict):
         inspected = 1
         total_requests = int(current_budget_used.get('requests') or 0)
@@ -1285,6 +1294,8 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     )
     bridge_summary = subagent_visibility if isinstance(subagent_visibility, dict) else {}
     reasons: list[str] = []
+    if blocked_escalation is not None:
+        reasons.append('ambition_escalation_blocked')
     if not rotating_synthesis_reward_window:
         if low_budget_discard_count >= 5:
             reasons.append('low_budget_discard_streak')
@@ -1296,7 +1307,21 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
             reasons.append('tool_budget_underused')
     state = 'underutilized' if reasons else 'substantive'
     escalation = None
-    if state == 'underutilized':
+    if blocked_escalation is not None:
+        blocked_payload = blocked_escalation.get('ambition_escalation') if isinstance(blocked_escalation.get('ambition_escalation'), dict) else {}
+        escalation = {
+            'schema_version': 'ambition-escalation-v1',
+            'state': 'blocked',
+            'safe_bounded_lanes': blocked_payload.get('safe_bounded_lanes') or [
+                'materialize-synthesized-improvement',
+                'subagent-verify-materialized-improvement',
+                'synthesize-next-improvement-candidate',
+            ],
+            'policy': blocked_payload.get('policy') or 'select_safe_bounded_lane_or_emit_precise_blocker',
+            'blocker': blocked_payload.get('blocker') or 'ambition_escalation_blocked',
+            'source': 'feedback_decision',
+        }
+    elif state == 'underutilized':
         escalation = {
             'schema_version': 'ambition-escalation-v1',
             'state': 'required',
@@ -1323,7 +1348,7 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
         'same_task_streak': same_task_streak,
         'rotating_synthesis_reward_window': rotating_synthesis_reward_window,
         'subagent_visibility_available': bool(bridge_summary),
-        'recommended_next_action': 'escalate_to_higher_ambition_lane_or_emit_precise_blocker' if state == 'underutilized' else None,
+        'recommended_next_action': 'resolve_ambition_escalation_blocker' if blocked_escalation is not None else ('escalate_to_higher_ambition_lane_or_emit_precise_blocker' if state == 'underutilized' else None),
         'escalation': escalation,
     }
 
@@ -1374,6 +1399,10 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     if runtime_parity_is_blocking and not runtime_can_be_historical:
         reasons.append('runtime_parity_blocked')
     ambition_utilization = ambition_utilization if isinstance(ambition_utilization, dict) else {}
+    ambition_reasons = ambition_utilization.get('reasons') if isinstance(ambition_utilization.get('reasons'), list) else []
+    ambition_escalation = ambition_utilization.get('escalation') if isinstance(ambition_utilization.get('escalation'), dict) else {}
+    if 'ambition_escalation_blocked' in ambition_reasons or ambition_escalation.get('state') == 'blocked':
+        reasons.append('ambition_underutilized')
     hypothesis_dynamics = hypothesis_dynamics if isinstance(hypothesis_dynamics, dict) else {}
     if hypothesis_dynamics.get('state') == 'stagnant':
         reasons.append('hypothesis_dynamics_stagnant')

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -1998,6 +1998,123 @@ def test_ambition_utilization_flags_low_budget_discard_streak() -> None:
     assert 'materialize-synthesized-improvement' in verdict['escalation']['safe_bounded_lanes']
 
 
+def test_ambition_utilization_treats_blocked_escalation_as_underutilized() -> None:
+    from nanobot_ops_dashboard.app import _ambition_utilization_verdict
+
+    blocked_feedback = {
+        'mode': 'ambition_escalation_blocked',
+        'selection_source': 'feedback_ambition_escalation_blocked',
+        'ambition_escalation': {
+            'state': 'blocked',
+            'reasons': ['same_task_streak', 'subagents_unused', 'tool_budget_underused'],
+            'blocker': 'no_safe_bounded_escalation_lane_selectable',
+        },
+    }
+    verdict = _ambition_utilization_verdict(
+        analytics={'recent_status_sequence': []},
+        experiment_visibility={
+            'current_experiment': {
+                'outcome': 'discard',
+                'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+                'raw': {'feedback_decision': blocked_feedback},
+            }
+        },
+        subagent_visibility={},
+    )
+
+    assert verdict['state'] == 'underutilized'
+    assert 'ambition_escalation_blocked' in verdict['reasons']
+    assert verdict['escalation']['state'] == 'blocked'
+    assert verdict['escalation']['blocker'] == 'no_safe_bounded_escalation_lane_selectable'
+    assert verdict['recommended_next_action'] == 'resolve_ambition_escalation_blocker'
+
+
+def test_autonomy_verdict_blocks_healthy_progress_when_ambition_is_blocked(tmp_path: Path) -> None:
+    from nanobot_ops_dashboard.app import _autonomy_verdict
+
+    cfg = DashboardConfig(
+        project_root=tmp_path / 'dashboard',
+        nanobot_repo_root=tmp_path / 'repo',
+        db_path=tmp_path / 'dashboard.sqlite3',
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'id_ed25519',
+        eeepc_state_root='/var/lib/eeepc-agent/self-evolving-agent/state',
+    )
+    verdict = _autonomy_verdict(
+        analytics={'recent_status_sequence': []},
+        plan_latest={'current_task_id': 'record-reward'},
+        experiment_visibility={'current_experiment': {}},
+        credits_visibility={'current': {}},
+        cfg=cfg,
+        material_progress={'state': 'proven', 'healthy_autonomy_allowed': True},
+        runtime_parity={'state': 'healthy', 'reasons': [], 'local_current_task_id': 'record-reward', 'live_current_task_id': 'record-reward', 'canonical_current_task_id': 'record-reward'},
+        ambition_utilization={
+            'state': 'underutilized',
+            'reasons': ['ambition_escalation_blocked'],
+            'escalation': {'state': 'blocked', 'blocker': 'no_safe_bounded_escalation_lane_selectable'},
+        },
+        hypothesis_dynamics={'state': 'healthy'},
+        promotion_replay_readiness={'state': 'not_ready', 'decision_record': {'present': True}, 'accepted_record': {'present': True}},
+        strong_reflection_freshness={'state': 'fresh'},
+    )
+
+    assert verdict['state'] == 'stagnant'
+    assert 'ambition_underutilized' in verdict['reasons']
+
+
+def test_historical_blocked_escalation_does_not_poison_current_ambition_truth() -> None:
+    from nanobot_ops_dashboard.app import _ambition_utilization_verdict
+
+    verdict = _ambition_utilization_verdict(
+        analytics={
+            'recent_status_sequence': [
+                {
+                    'detail': {
+                        'feedback_decision': {
+                            'mode': 'ambition_escalation_blocked',
+                            'ambition_escalation': {'state': 'blocked', 'blocker': 'old_blocker'},
+                        }
+                    }
+                }
+            ]
+        },
+        experiment_visibility={'current_experiment': {'outcome': 'accept', 'raw': {'feedback_decision': {'mode': 'complete_active_lane'}}}},
+        subagent_visibility={},
+    )
+
+    assert verdict['state'] == 'substantive'
+    assert 'ambition_escalation_blocked' not in verdict['reasons']
+
+
+def test_current_blocked_escalation_overrides_rotating_synthesis_window() -> None:
+    from nanobot_ops_dashboard.app import _ambition_utilization_verdict
+
+    rotating_rows = [
+        {'detail': {'current_task_id': 'synthesize-next-improvement-candidate', 'feedback_decision': {'mode': 'synthesize_next_candidate'}, 'materialized_improvement_artifact_path': '/tmp/a.json', 'experiment': {'outcome': 'accept'}, 'budget_used': {'requests': 4, 'tool_calls': 8, 'subagents': 1, 'elapsed_seconds': 30}}},
+        {'detail': {'current_task_id': 'materialize-synthesized-improvement', 'feedback_decision': {'mode': 'complete_active_lane'}, 'materialized_improvement_artifact_path': '/tmp/b.json', 'experiment': {'outcome': 'accept'}, 'budget_used': {'requests': 4, 'tool_calls': 8, 'subagents': 1, 'elapsed_seconds': 30}}},
+        {'detail': {'current_task_id': 'record-reward', 'feedback_decision': {'mode': 'record_reward_after_synthesized_materialization'}, 'materialized_improvement_artifact_path': '/tmp/c.json', 'experiment': {'outcome': 'accept'}, 'budget_used': {'requests': 4, 'tool_calls': 8, 'subagents': 1, 'elapsed_seconds': 30}}},
+    ]
+    verdict = _ambition_utilization_verdict(
+        analytics={'recent_status_sequence': rotating_rows},
+        experiment_visibility={
+            'current_experiment': {
+                'outcome': 'discard',
+                'raw': {
+                    'feedback_decision': {
+                        'mode': 'ambition_escalation_blocked',
+                        'ambition_escalation': {'state': 'blocked', 'blocker': 'no_safe_bounded_escalation_lane_selectable'},
+                    }
+                },
+            }
+        },
+        subagent_visibility={},
+    )
+
+    assert verdict['rotating_synthesis_reward_window'] is True
+    assert verdict['state'] == 'underutilized'
+    assert verdict['escalation']['state'] == 'blocked'
+
+
 def test_ambition_utilization_treats_rotating_synthesis_reward_window_as_substantive() -> None:
     from nanobot_ops_dashboard.app import _ambition_utilization_verdict
 


### PR DESCRIPTION
Fixes #355

## Summary
- Dashboard ambition utilization now treats the canonical/current `ambition_escalation_blocked` feedback decision as active underutilization instead of reporting `substantive` from historical windows.
- Autonomy verdict now blocks `healthy_progress` when the current ambition escalation is blocked.
- Historical blocked rows no longer poison current truth, and a current blocked escalation overrides an otherwise substantive rotating synthesis/reward history.

## Verification
- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -k 'blocked_escalation or ambition_is_blocked or historical_blocked or current_blocked' -q` -> 4 passed
- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py tests/test_autonomy_stagnation_dashboard.py tests/test_app.py -q` -> 77 passed
- `python3 -m pytest tests -q` in `ops/dashboard` -> 119 passed
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_app_main.py tests/test_run_local_cycle_refresh.py -q` -> 52 passed
- `python3 -m pytest -q` -> 662 passed, 5 skipped

## Delegation/review
- Inspection subagent identified the narrow dashboard truth fix.
- Review subagent required tightening historical/current scope.
- Re-review subagent PASS after blocked escalation was sourced only from current experiment/raw decision and tests were added.
