### PR TITLE
fix: generate fallback lane for blocked ambition escalation

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -586,11 +586,15 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
                 reason = "healthy-progress lane is underusing tools/subagents; select the next safe bounded higher-ambition lane"
                 selection_source = "feedback_ambition_escalation_bounded_lane"
             else:
-                active_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == current_task_id), None)
-                selected_task = active_task or {"task_id": current_task_id, "title": current_task_id, "status": "active"}
-                mode = "ambition_escalation_blocked"
-                reason = "healthy-progress lane is underutilized but no safe bounded escalation lane is selectable"
-                selection_source = "feedback_ambition_escalation_blocked"
+                selected_task = _synthesized_materialize_improvement_candidate(
+                    current_task_id=current_task_id,
+                    strong_pass_count=strong_pass_count,
+                    goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+                    status="active",
+                )
+                mode = "escalate_underutilized_ambition"
+                reason = "healthy-progress lane is underutilized and all recorded safe lanes are completed; generate a fresh bounded materialization lane instead of staying blocked"
+                selection_source = "feedback_ambition_escalation_generated_lane"
     elif current_task_id == "inspect-pass-streak":
         followup_task = next((task for task in task_records if (task.get("task_id") or task.get("taskId")) == "materialize-pass-streak-improvement"), None)
         if followup_task is not None and _task_is_selectable(followup_task):

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1231,7 +1231,7 @@ def test_underutilized_alternating_reward_current_loop_escalates_to_materializat
     assert decision["ambition_escalation"]["state"] == "selected"
 
 
-def test_underutilized_ambition_emits_precise_blocker_when_no_safe_lane_exists(tmp_path):
+def test_underutilized_ambition_synthesizes_bounded_lane_when_no_safe_lane_exists(tmp_path):
     goals = tmp_path / "goals"
     history = goals / "history"
     history.mkdir(parents=True)
@@ -1267,11 +1267,13 @@ def test_underutilized_ambition_emits_precise_blocker_when_no_safe_lane_exists(t
     decision = _derive_feedback_decision(task_plan, goals)
 
     assert decision is not None
-    assert decision["mode"] == "ambition_escalation_blocked"
-    assert decision["selection_source"] == "feedback_ambition_escalation_blocked"
-    assert decision["selected_task_id"] == "inspect-pass-streak"
-    assert decision["ambition_escalation"]["state"] == "blocked"
-    assert decision["ambition_escalation"]["blocker"] == "no_safe_bounded_escalation_lane_selectable"
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selection_source"] == "feedback_ambition_escalation_generated_lane"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["selected_task_class"] == "execution"
+    assert decision["selected_task_id"] != "inspect-pass-streak"
+    assert decision["ambition_escalation"]["state"] == "selected"
+    assert decision["ambition_escalation"]["blocker"] is None
 
 
 def test_completed_synthesized_materialization_artifact_is_not_replayed_as_terminal_retirement(tmp_path):


### PR DESCRIPTION
Fixes #360

## Summary
- Replaces the live `ambition_escalation_blocked` dead-end when all recorded safe lanes are completed/missing.
- In the underutilized-ambition branch, the runtime now generates an active bounded execution lane (`materialize-synthesized-improvement`) instead of staying on the current review/reward task.
- Converts the previous blocker regression into the desired behavior: no `no_safe_bounded_escalation_lane_selectable` blocker when a safe synthesized materialization lane can be generated.

## Verification
- RED first: `test_underutilized_ambition_synthesizes_bounded_lane_when_no_safe_lane_exists` failed with old `ambition_escalation_blocked` behavior.
- GREEN: the same test passes after generated fallback lane implementation.
- `python3 -m pytest tests/test_runtime_coordinator.py -q` -> 47 passed
- `python3 -m py_compile nanobot/runtime/coordinator.py tests/test_runtime_coordinator.py && python3 -m pytest tests/test_runtime_coordinator.py tests/test_app_main.py tests/test_run_local_cycle_refresh.py -q` -> 52 passed
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py tests/test_autonomy_stagnation_dashboard.py -q)` -> 62 passed
- `python3 -m pytest -q` -> 662 passed, 5 skipped

## Delegation/review
- Subagent code inspection mapped `_derive_feedback_decision()` as the blocked branch and recommended generated bounded fallback.
- Subagent live-artifact audit confirmed live `current.json`/`experiments/latest.json`/reports were blocked on `no_safe_bounded_escalation_lane_selectable`.
- Review subagent PASS: generated execution lane is minimal and does not reintroduce reward/pass-streak loop.
