### PR TITLE
fix: expose unreachable live authority in runtime parity

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1006,6 +1006,20 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         'self_evolution_current_state': (state_root / 'self_evolution' / 'current_state.json').exists(),
     }
     reasons = []
+    eeepc_raw = _json_loads_dict(eeepc_plan.get('raw_json')) if _has_value(eeepc_plan.get('raw_json')) else {}
+    live_reachability = eeepc_plan.get('reachability') if isinstance(eeepc_plan.get('reachability'), dict) else None
+    if live_reachability is None and isinstance(eeepc_raw.get('reachability'), dict):
+        live_reachability = eeepc_raw.get('reachability')
+    live_authority = None
+    if isinstance(live_reachability, dict):
+        live_authority = {
+            'reachable': bool(live_reachability.get('reachable')),
+            'host': live_reachability.get('host') or cfg.eeepc_ssh_host,
+            'port': live_reachability.get('port') or 22,
+            'error': live_reachability.get('error') or live_reachability.get('stderr') or live_reachability.get('reason'),
+        }
+        if live_reachability.get('reachable') is False:
+            reasons.append('live_authority_unreachable')
     local_feedback = repo_plan.get('feedback_decision') if isinstance(repo_plan.get('feedback_decision'), dict) else None
     live_feedback = eeepc_plan.get('feedback_decision') if isinstance(eeepc_plan.get('feedback_decision'), dict) else None
     if local_feedback and not live_feedback:
@@ -1152,6 +1166,8 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         'live_current_task_id': live_task,
         'canonical_current_task_id': canonical_task,
         'live_task_selection_source': eeepc_plan.get('task_selection_source'),
+        'live_authority': live_authority,
+        'next_action': 'restore_live_authority_reachability_then_recollect' if live_authority and live_authority.get('reachable') is False else None,
         'authority_resolution': authority_resolution,
     }
 

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -1088,6 +1088,48 @@ def test_runtime_parity_trusts_pass_streak_switch_to_reward_even_when_selected_t
     assert 'current_task_drift' not in parity['reasons']
 
 
+def test_runtime_parity_explains_unreachable_live_authority_when_feedback_is_missing(tmp_path: Path) -> None:
+    repo_root = tmp_path / 'nanobot'
+    state_root = repo_root / 'workspace' / 'state'
+    for rel in ['hypotheses/backlog.json', 'credits/latest.json', 'control_plane/current_summary.json', 'self_evolution/current_state.json']:
+        path = state_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{}', encoding='utf-8')
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=repo_root, db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='192.168.1.44', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/var/lib/eeepc-agent/self-evolving-agent/state')
+    repo_plan = {
+        'current_task_id': 'record-reward',
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'current_task_id': 'materialize-synthesized-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_complete_active_lane',
+        },
+    }
+    eeepc_plan = {
+        'status': 'BLOCK',
+        'raw_json': json.dumps({
+            'outbox': {},
+            'goals': {},
+            'reachability': {
+                'reachable': False,
+                'host': '192.168.1.44',
+                'port': 22,
+                'error': 'ssh timed out',
+            },
+        }),
+    }
+
+    parity = _dashboard_runtime_parity(repo_plan, eeepc_plan, cfg)
+
+    assert parity['state'] == 'degraded'
+    assert 'live_authority_unreachable' in parity['reasons']
+    assert 'live_feedback_decision_missing' in parity['reasons']
+    assert parity['live_authority']['reachable'] is False
+    assert parity['live_authority']['host'] == '192.168.1.44'
+    assert parity['live_authority']['port'] == 22
+    assert parity['next_action'] == 'restore_live_authority_reachability_then_recollect'
+
+
 def test_closed_terminal_selfevo_evidence_is_historical_not_live_blocker(tmp_path: Path) -> None:
     repo_root = tmp_path / 'nanobot'
     state_root = repo_root / 'workspace' / 'state' / 'self_evolution'


### PR DESCRIPTION
Fixes #363

## Summary
- Makes runtime parity explain the real live-authority failure behind `live_feedback_decision_missing`.
- Parses eeepc reachability from the collected live payload and adds `live_authority_unreachable` when the live authority host is unreachable.
- Preserves `live_feedback_decision_missing` instead of masking it, while adding explicit `live_authority` metadata and `next_action=restore_live_authority_reachability_then_recollect`.

## Root cause
After #360, the runtime generated and executed the bounded fallback lane, but the dashboard still reported generic `runtime_parity_blocked`. Subagent diagnosis found live eeepc collection rows were `BLOCK` with empty outbox/goals because SSH to `192.168.1.44:22` timed out. The dashboard was technically correct to report missing live feedback, but it hid the actionable authority reachability cause.

## Verification
- RED test: `test_runtime_parity_explains_unreachable_live_authority_when_feedback_is_missing` initially failed because only `live_feedback_decision_missing` was present.
- GREEN: the test now sees both `live_authority_unreachable` and `live_feedback_decision_missing`, plus live authority metadata and next action.
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py tests/test_autonomy_stagnation_dashboard.py tests/test_app.py -q)` -> 78 passed
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 120 passed
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_app_main.py tests/test_run_local_cycle_refresh.py -q` -> 52 passed
- `python3 -m pytest -q` -> 662 passed, 5 skipped

## Delegation/review
- Diagnosis subagent confirmed this is a real live authority reachability blocker, not stale dashboard truth.
- Diff-review subagent PASS: change preserves `live_feedback_decision_missing` and only adds explicit unreachable authority evidence.
