### PR TITLE
fix: use eeepc block reachability for runtime parity

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -3057,6 +3057,7 @@ def create_app(cfg: DashboardConfig):
             or _has_value(_plan_snapshot_from_row(row).get('task_selection_source'))
         ]
         eeepc_plan_snapshot = _latest_plan_snapshot(eeepc_plan_rows) if eeepc_plan_rows else None
+        eeepc_parity_snapshot = eeepc_plan_snapshot or (_plan_snapshot_from_row(eeepc_latest) if eeepc_latest else None)
         plan_rows = repo_plan_rows or eeepc_plan_rows
         plan_history = [
             snapshot
@@ -3068,7 +3069,7 @@ def create_app(cfg: DashboardConfig):
         credits_visibility = _discover_credits_visibility(cfg)
         hypotheses_visibility = _discover_hypotheses_visibility(cfg)
         subagent_visibility = _discover_subagent_requests(cfg)
-        runtime_parity = _dashboard_runtime_parity(repo_plan_snapshot or plan_latest, eeepc_plan_snapshot, cfg)
+        runtime_parity = _dashboard_runtime_parity(repo_plan_snapshot or plan_latest, eeepc_parity_snapshot, cfg)
         runtime_authority_resolution = runtime_parity.get('authority_resolution') if isinstance(runtime_parity, dict) else None
         authoritative_plan_latest = eeepc_plan_snapshot if runtime_authority_resolution in {'fresh_live_terminal_selfevo_retire', 'fresh_live_active_lane', 'fresh_live_synthesized_materialization', 'fresh_live_post_materialization_reward', 'fresh_live_synthesis_candidate', 'fresh_live_failure_learning_handoff'} and eeepc_plan_snapshot else plan_latest
         hypotheses_visibility = _reconcile_hypotheses_visibility_with_runtime(hypotheses_visibility, runtime_parity, authoritative_plan_latest or plan_latest)

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -1130,6 +1130,82 @@ def test_runtime_parity_explains_unreachable_live_authority_when_feedback_is_mis
     assert parity['next_action'] == 'restore_live_authority_reachability_then_recollect'
 
 
+def test_api_system_runtime_parity_uses_latest_eeepc_block_row_for_authority_reachability(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    for rel in ['hypotheses/backlog.json', 'credits/latest.json', 'control_plane/current_summary.json', 'self_evolution/current_state.json']:
+        path = state_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{}', encoding='utf-8')
+    repo_plan = {
+        'current_task_id': 'record-reward',
+        'current_task': 'Record cycle reward',
+        'feedback_decision': {
+            'mode': 'complete_active_lane',
+            'current_task_id': 'materialize-synthesized-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_complete_active_lane',
+        },
+    }
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({'task_plan': repo_plan}), encoding='utf-8')
+    insert_collection(db, {
+        'collected_at': '2026-04-29T12:00:00Z',
+        'source': 'repo',
+        'status': 'PASS',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': '/workspace/state/reports/evolution-current.json',
+        'outbox_source': '/workspace/state/outbox/report.index.json',
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({'current_plan': repo_plan, 'outbox': {'status': 'PASS'}}),
+    })
+    insert_collection(db, {
+        'collected_at': '2026-04-29T12:01:00Z',
+        'source': 'eeepc',
+        'status': 'BLOCK',
+        'active_goal': 'goal-bootstrap',
+        'approval_gate': None,
+        'gate_state': None,
+        'report_source': None,
+        'outbox_source': None,
+        'artifact_paths_json': '[]',
+        'promotion_summary': None,
+        'promotion_candidate_path': None,
+        'promotion_decision_record': None,
+        'promotion_accepted_record': None,
+        'raw_json': json.dumps({
+            'outbox': {},
+            'goals': {},
+            'reachability': {
+                'reachable': False,
+                'ssh_host': 'eeepc',
+                'target': 'eeepc',
+                'error': 'ssh: connect to host 192.168.1.44 port 22: Connection timed out',
+                'recommended_next_action': 'Treat as a control-plane incident; verify eeepc power/network access, then retry collection.',
+            },
+        }),
+    })
+    cfg = DashboardConfig(project_root=project_root, nanobot_repo_root=repo_root, db_path=db, eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+    app = create_app(cfg)
+
+    system = _call_json(app, '/api/system')
+
+    parity = system['runtime_parity']
+    assert 'live_authority_unreachable' in parity['reasons']
+    assert 'live_feedback_decision_missing' in parity['reasons']
+    assert parity['live_authority']['reachable'] is False
+    assert 'Connection timed out' in parity['live_authority']['error']
+    assert parity['next_action'] == 'restore_live_authority_reachability_then_recollect'
+
+
 def test_closed_terminal_selfevo_evidence_is_historical_not_live_blocker(tmp_path: Path) -> None:
     repo_root = tmp_path / 'nanobot'
     state_root = repo_root / 'workspace' / 'state' / 'self_evolution'


### PR DESCRIPTION
Follow-up for #363 after live proof.

## Summary
- Previous #363 PR exposed `live_authority_unreachable` when runtime parity receives reachability data.
- Live proof showed `/api/system.runtime_parity.live_authority` was still null because eeepc `BLOCK` rows with reachability-only payloads were filtered out of `eeepc_plan_rows` before parity calculation.
- This patch passes the latest eeepc collection row as a parity-only fallback snapshot when no eeepc task-plan row exists.
- It does not change authoritative plan selection: `/api/plan` still uses `eeepc_plan_snapshot` only for fresh live task-plan authority.

## Verification
- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -k 'unreachable_live_authority or latest_eeepc_block_row' -q` -> 2 passed
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py tests/test_autonomy_stagnation_dashboard.py tests/test_app.py -q)` -> 79 passed
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 121 passed
- `python3 -m pytest tests/test_runtime_coordinator.py tests/test_app_main.py tests/test_run_local_cycle_refresh.py -q` -> 52 passed
- `python3 -m pytest -q` -> 662 passed, 5 skipped

## Review
- Follow-up review subagent PASS: parity-only fallback uses latest eeepc BLOCK reachability row without overriding authoritative plan selection.
