### PR TITLE
feat: collect redacted Telegram live proof

### DIFF
--- a/docs/LIVE_TELEGRAM_PROBE_PROTOCOL.md
+++ b/docs/LIVE_TELEGRAM_PROBE_PROTOCOL.md
@@ -86,5 +86,12 @@ markdown evidence with:
 python3 scripts/validate_telegram_live_proof.py /path/to/filled-telegram-live-proof.md
 ```
 
+After validation, collect a redacted read-only summary with:
+
+```bash
+python3 scripts/collect_telegram_live_proof.py /path/to/filled-telegram-live-proof.md
+```
+
 The validator is intentionally conservative: it passes only for a filled real
-allowlisted Telegram transcript and rejects simulated/local evidence.
+allowlisted Telegram transcript and rejects simulated/local evidence. The
+collector is also read-only and emits redacted JSON only.

--- a/docs/userstory/TELEGRAM_LIVE_PROBE_EVIDENCE_TEMPLATE.md
+++ b/docs/userstory/TELEGRAM_LIVE_PROBE_EVIDENCE_TEMPLATE.md
@@ -6,6 +6,9 @@ Use this artifact when running the final allowed-account Telegram probe for:
 - `#7` real Telegram model-selection proof
 - `#3` remaining live Telegram proof gap
 
+After filling the template, validate it with the conservative validator and then
+collect a redacted JSON summary with the read-only collector.
+
 ## Probe metadata
 
 - Probe date (UTC):

--- a/scripts/collect_telegram_live_proof.py
+++ b/scripts/collect_telegram_live_proof.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Collect a redacted, read-only Telegram live-proof summary.
+
+The collector never talks to Telegram, never reads secrets, and never mutates
+state. It takes a filled proof markdown file, validates it with the conservative
+validator, and emits a compact redacted JSON summary suitable for review.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.validate_telegram_live_proof import (
+    STEP_HEADINGS,
+    _field_value,
+    _section_after_heading,
+    evaluate_telegram_live_proof_markdown,
+)
+
+SCHEMA_VERSION = "telegram-live-proof-collector-v1"
+
+REDACTED_VALUE = "[redacted]"
+TOKEN_RE = re.compile(r"(?i)(bot)?token\s*[=:]\s*[^\s;,]+")
+CHAT_ID_RE = re.compile(r"(?i)chat[_ -]?id\s*[=:]\s*[-]?\d+")
+LONG_NUMBER_RE = re.compile(r"\b\d{8,}\b")
+
+
+def _redact_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    redacted = TOKEN_RE.sub("token=[redacted-token]", value)
+    redacted = CHAT_ID_RE.sub("chat_id=[redacted]", redacted)
+    redacted = LONG_NUMBER_RE.sub("[redacted-number]", redacted)
+    return redacted
+
+
+def _step_summary(text: str, step_id: str, heading: str) -> dict[str, Any]:
+    section = _section_after_heading(text, heading)
+    return {
+        "step_id": step_id,
+        "command": _redact_text(_field_value(section, "Outbound command text")),
+        "reply_excerpt": _redact_text(_field_value(section, "Reply text")),
+        "classification": _field_value(section, "Classification"),
+    }
+
+
+def _redacted_metadata(text: str) -> dict[str, Any]:
+    return {
+        "probe_date_utc": _field_value(text, "Probe date (UTC)"),
+        "operator_account": REDACTED_VALUE if _field_value(text, "Operator/account used") else None,
+        "chat_thread_identifier": REDACTED_VALUE if _field_value(text, "Chat/thread identifier") else None,
+        "telegram_bot_identity": _field_value(text, "Telegram bot identity observed"),
+        "host_runtime_source": _field_value(text, "Host/runtime source being validated"),
+    }
+
+
+def collect_telegram_live_proof_markdown(text: str, *, collected_at_utc: str | None = None) -> dict[str, Any]:
+    """Collect a redacted proof summary from filled evidence markdown."""
+    validation = evaluate_telegram_live_proof_markdown(text)
+    valid = validation["state"] == "valid"
+    reasons = set(validation.get("reasons", []))
+    simulated_or_local = "simulated_or_local_evidence" in reasons
+    pending_real_transcript = (not valid) and (not simulated_or_local) and "missing_real_allowlisted_transcript_source" in reasons
+    steps = []
+    if valid:
+        steps = [_step_summary(text, step_id, heading) for step_id, heading in STEP_HEADINGS.items()]
+    transcript_status = "complete" if valid else ("pending_real_transcript" if pending_real_transcript else "invalid")
+    state = "collected" if valid else transcript_status
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "state": state,
+        "transcript_status": transcript_status,
+        "collected_at_utc": collected_at_utc or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "validation": validation,
+        "command_checklist": validation.get("required_commands_present", {}),
+        "redacted_metadata": _redacted_metadata(text),
+        "steps": steps,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1 or args[0] in {"-h", "--help"}:
+        print(f"Usage: {Path(sys.argv[0]).name} <filled-telegram-live-proof.md>", file=sys.stderr)
+        return 64
+    text = Path(args[0]).read_text(encoding="utf-8")
+    result = collect_telegram_live_proof_markdown(text)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["state"] == "collected" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_telegram_live_proof_collector.py
+++ b/tests/test_telegram_live_proof_collector.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.collect_telegram_live_proof import collect_telegram_live_proof_markdown
+
+
+VALID_EVIDENCE = """# Telegram Live Probe Evidence
+
+## Probe metadata
+
+- Probe date (UTC): 2026-04-29T18:40:00Z
+- Operator/account used: allowlisted real Telegram account
+- Chat/thread identifier: redacted-real-chat
+- Telegram bot identity observed: @nanobot_live_bot
+- Host/runtime source being validated: eeepc live gateway
+- Transcript source: real allowlisted Telegram chat transcript
+
+## Required command sequence
+
+1. `PING 2026-04-29T18:40:00Z`
+2. `/cap_status`
+3. `/workspace experiment tiny-runtime-check`
+4. `/sub_run --profile research_only --budget micro ping-telegram-live-2026-04-29T18:40:00Z`
+
+## Evidence capture checklist
+
+### Step 1: PING
+- Sent at: 2026-04-29T18:40:00Z
+- Outbound command text: PING 2026-04-29T18:40:00Z
+- Reply received at: 2026-04-29T18:40:01Z
+- Reply text: PONG 2026-04-29T18:40:00Z from live Telegram path
+- Same Telegram chat/thread? yes
+- Matches expected runtime truth? yes
+- Classification: success
+
+### Step 2: /cap_status
+- Sent at: 2026-04-29T18:40:05Z
+- Outbound command text: /cap_status
+- Reply received at: 2026-04-29T18:40:06Z
+- Reply text: autonomy: enabled=True; dry_run_default=False; model: gpt-5.3-codex; workspace actions enabled
+- Contains runtime/model truth? yes
+- Matches direct host truth? yes
+- Same Telegram chat/thread? yes
+- Classification: success
+
+### Step 3: /workspace experiment tiny-runtime-check
+- Sent at: 2026-04-29T18:40:10Z
+- Outbound command text: /workspace experiment tiny-runtime-check
+- Reply received at: 2026-04-29T18:40:12Z
+- Reply text: action_id: workspace.experiment.tiny_runtime_check; written: True; executed: True; verified: True
+- Same Telegram chat/thread? yes
+- Matches expected runtime truth? yes
+- Classification: success
+
+### Step 4: /sub_run --profile research_only --budget micro ...
+- Sent at: 2026-04-29T18:40:15Z
+- Outbound command text: /sub_run --profile research_only --budget micro ping-telegram-live-2026-04-29T18:40:00Z
+- Reply received at: 2026-04-29T18:40:17Z
+- Reply text: bounded subagent accepted; task_id=sub-redacted; policy gate ok
+- Same Telegram chat/thread? yes
+- Matches expected runtime truth? yes
+- Classification: success
+
+## Final outcome summary
+
+- PING status: success
+- /cap_status status: success
+- /workspace status: success
+- /sub_run status: success
+- Final classification: live proof complete
+
+## Closure rule
+
+The remaining Telegram issues can be closed only when this template is filled with a real transcript from an allowlisted account and the captured replies match the expected runtime truth.
+"""
+
+
+def test_collector_redacts_sensitive_metadata_and_keeps_step_summary() -> None:
+    result = collect_telegram_live_proof_markdown(VALID_EVIDENCE)
+
+    assert result["schema_version"] == "telegram-live-proof-collector-v1"
+    assert result["state"] == "collected"
+    assert result["validation"]["state"] == "valid"
+    assert result["redacted_metadata"] == {
+        "probe_date_utc": "2026-04-29T18:40:00Z",
+        "operator_account": "[redacted]",
+        "chat_thread_identifier": "[redacted]",
+        "telegram_bot_identity": "@nanobot_live_bot",
+        "host_runtime_source": "eeepc live gateway",
+    }
+    assert result["steps"][0] == {
+        "step_id": "step_1_ping",
+        "command": "PING 2026-04-29T18:40:00Z",
+        "reply_excerpt": "PONG 2026-04-29T18:40:00Z from live Telegram path",
+        "classification": "success",
+    }
+    assert result["steps"][2]["reply_excerpt"].endswith("verified: True")
+
+
+def test_collector_keeps_validation_failures_and_avoids_fake_collection() -> None:
+    evidence = VALID_EVIDENCE.replace("- Transcript source: real allowlisted Telegram chat transcript", "- Transcript source: simulated local CLI artifact, not Telegram")
+
+    result = collect_telegram_live_proof_markdown(evidence, collected_at_utc="2026-04-29T19:00:00Z")
+
+    assert result["state"] == "invalid"
+    assert result["transcript_status"] == "invalid"
+    assert result["validation"]["state"] == "invalid"
+    assert "simulated_or_local_evidence" in result["validation"]["reasons"]
+    assert result["steps"] == []
+
+
+def test_collector_classifies_blank_template_as_pending_real_transcript() -> None:
+    template = Path("docs/userstory/TELEGRAM_LIVE_PROBE_EVIDENCE_TEMPLATE.md").read_text(encoding="utf-8")
+
+    result = collect_telegram_live_proof_markdown(template, collected_at_utc="2026-04-29T19:00:00Z")
+
+    assert result["state"] == "pending_real_transcript"
+    assert result["transcript_status"] == "pending_real_transcript"
+    assert result["collected_at_utc"] == "2026-04-29T19:00:00Z"
+    assert result["command_checklist"] == {
+        "ping": True,
+        "cap_status": True,
+        "workspace_tiny_runtime_check": True,
+        "sub_run_micro": True,
+    }
+    assert result["steps"] == []
+
+
+def test_collector_redacts_secret_like_reply_and_metadata() -> None:
+    evidence = VALID_EVIDENCE.replace(
+        "PONG 2026-04-29T18:40:00Z from live Telegram path",
+        "PONG token=123456:ABCDEF chat_id=987654321 from live Telegram path",
+    )
+
+    result = collect_telegram_live_proof_markdown(evidence, collected_at_utc="2026-04-29T19:00:00Z")
+
+    dumped = json.dumps(result)
+    assert "123456:ABCDEF" not in dumped
+    assert "987654321" not in dumped
+    assert "[redacted-token]" in dumped
+    assert "chat_id=[redacted]" in dumped
+
+
+def test_cli_writes_collected_json_for_valid_evidence(tmp_path: Path) -> None:
+    evidence_path = tmp_path / "proof.md"
+    evidence_path.write_text(VALID_EVIDENCE, encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "scripts/collect_telegram_live_proof.py", str(evidence_path)],
+        cwd=Path(__file__).resolve().parents[1],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    result = json.loads(proc.stdout)
+    assert result["state"] == "collected"
+    assert result["validation"]["state"] == "valid"


### PR DESCRIPTION
## Summary
- Adds a read-only Telegram live-proof collector that turns filled markdown evidence into redacted JSON.
- Reuses the conservative #367 validator and preserves validation status/reasons.
- Classifies blank/missing transcript evidence as `pending_real_transcript`, not complete.
- Redacts operator/chat metadata and secret-like token/chat-id values from collected step excerpts.
- Documents the validator -> collector workflow.

Fixes #368

## Verification
- RED: collector tests first failed on missing module; additional RED cases failed until `pending_real_transcript` and redaction were implemented.
- `python3 -m py_compile scripts/collect_telegram_live_proof.py`
- `python3 -m pytest tests/test_telegram_live_proof_collector.py -q` -> 5 passed
- delegated safety review: PASS
- `python3 -m pytest tests/test_telegram_live_proof_validator.py tests/test_telegram_live_proof_collector.py tests/test_security_network.py -q` -> 29 passed
- `python3 -m pytest tests -q` -> 675 passed, 5 skipped

## Safety
- Reads only the provided markdown proof file.
- No network calls.
- No Telegram sends.
- No token/config reads.
- No secrets printed.
