### PR TITLE
fix: report stale no-live executor heartbeats

### DIFF
--- a/ops/dashboard/scripts/build_status_feed.py
+++ b/ops/dashboard/scripts/build_status_feed.py
@@ -21,18 +21,54 @@ def now_utc() -> str:
     return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
 
 
-def _project_summary(project: dict[str, Any]) -> dict[str, Any]:
+def _project_summary(project: dict[str, Any], *, fallback_status: str | None = None) -> dict[str, Any]:
+    status = project.get('status')
+    if status == 'in_progress' and fallback_status in {'waiting_for_dispatch', 'stale_blocked'}:
+        status = fallback_status
     return {
         'id': project.get('id'),
-        'status': project.get('status'),
+        'status': status,
         'current_stage': project.get('current_stage'),
         'goal': project.get('goal'),
     }
 
 
-def _live_task_summary(live_task: dict[str, Any] | None) -> dict[str, Any] | str:
+def _incident_summary(active_execution: dict[str, Any]) -> dict[str, Any]:
+    incident = active_execution.get('stale_execution_incident_task') if isinstance(active_execution.get('stale_execution_incident_task'), dict) else {}
+    summary = active_execution.get('summary') if isinstance(active_execution.get('summary'), dict) else {}
+    return {
+        'source': incident.get('source'),
+        'report_source': incident.get('report_source'),
+        'incident_path': incident.get('stale_execution_incident_path'),
+        'next_action_path': incident.get('stale_execution_next_action_path'),
+        'next_action': incident.get('stale_execution_next_action_summary') or incident.get('stale_execution_recommended_next_action') or 'redispatch_stale_execution',
+        'stale_execution_incidents': summary.get('stale_execution_incidents', 0),
+    }
+
+
+def _live_task_summary(active_execution: dict[str, Any]) -> dict[str, Any] | str:
+    live_task = active_execution.get('live_task') if isinstance(active_execution, dict) else None
     if live_task is None:
-        return 'no_live_executor'
+        summary = active_execution.get('summary') if isinstance(active_execution, dict) and isinstance(active_execution.get('summary'), dict) else {}
+        stale_execution_detected = bool(active_execution.get('stale_execution_detected')) if isinstance(active_execution, dict) else False
+        needs_redispatch = int(summary.get('needs_redispatch') or 0) > 0
+        if stale_execution_detected or needs_redispatch:
+            return {
+                'execution_state': 'needs_redispatch' if needs_redispatch else 'no_live_executor',
+                'status': 'stale_blocked' if stale_execution_detected else 'no_live_executor',
+                'queue_status': 'stale_blocked' if stale_execution_detected else 'no_live_executor',
+                'stale_execution_detected': stale_execution_detected,
+                'needs_redispatch': summary.get('needs_redispatch', 0),
+                **_incident_summary(active_execution),
+            }
+        return {
+            'execution_state': 'waiting_for_dispatch',
+            'status': 'waiting_for_dispatch',
+            'queue_status': 'no_live_executor',
+            'stale_execution_detected': False,
+            'needs_redispatch': summary.get('needs_redispatch', 0),
+            'next_action': 'dispatch_or_enqueue_bounded_task',
+        }
     return {
         'task_key': live_task.get('task_key'),
         'queue_status': live_task.get('queue_status'),
@@ -53,15 +89,19 @@ def build_status_feed_entry(updated_at: str | None = None) -> dict[str, Any]:
     if not isinstance(project_items, list):
         project_items = []
 
+    fallback_project_status = None
+    if not active_execution.get('has_actually_executing_task'):
+        fallback_project_status = 'stale_blocked' if active_execution.get('stale_execution_detected') else 'waiting_for_dispatch'
+
     feed_entry = {
         'timestamp': snapshot_at,
         'active_projects_summary': [
-            _project_summary(project)
+            _project_summary(project, fallback_status=fallback_project_status)
             for project in project_items
             if isinstance(project, dict)
         ],
         'live_execution_exists': bool(active_execution.get('has_actually_executing_task')),
-        'current_live_task_or_state': _live_task_summary(active_execution.get('live_task')),
+        'current_live_task_or_state': _live_task_summary(active_execution),
         'status_snapshot_updated_at': active_execution.get('updated_at'),
         'status_snapshot_summary': active_execution.get('summary'),
     }

--- a/ops/dashboard/tests/test_status_feed_writer.py
+++ b/ops/dashboard/tests/test_status_feed_writer.py
@@ -68,6 +68,29 @@ def _queue_without_live_task() -> dict[str, object]:
     }
 
 
+def _queue_without_live_task_but_with_stale_incident() -> dict[str, object]:
+    return {
+        'tasks': [
+            {
+                'created_at': '2026-04-16T07:30:50.705406Z',
+                'status': 'stale_blocked',
+                'source': 'hermes-autonomy-controller',
+                'diagnosis': 'stagnating_on_quality_blocker',
+                'severity': 'critical',
+                'active_goal': 'goal-44e50921129bf475',
+                'report_source': '/var/lib/eeepc-agent/self-evolving-agent/state/reports/evolution-20260416T121151Z.json',
+                'failure_class': 'no_concrete_change',
+                'remediation_class': 'planner_hardening',
+                'execution_state': 'needs_redispatch',
+                'stale_execution_detected': True,
+                'stale_execution_detected_at': REFERENCE_NOW,
+                'stale_execution_incident_path': '/tmp/stale_execution_incident.json',
+                'stale_execution_next_action_path': '/tmp/stale_execution_next_action.json',
+            }
+        ]
+    }
+
+
 def test_append_status_feed_writes_current_live_state(tmp_path: Path, monkeypatch) -> None:
     active_projects_path = tmp_path / 'active_projects.json'
     queue_path = tmp_path / 'execution_queue.json'
@@ -102,6 +125,38 @@ def test_append_status_feed_writes_current_live_state(tmp_path: Path, monkeypatc
     assert refreshed['live_task']['task_key'].startswith('stagnating_on_quality_blocker|goal-44e50921129bf475')
 
 
+def test_append_status_feed_records_stale_no_live_executor_state(tmp_path: Path, monkeypatch) -> None:
+    active_projects_path = tmp_path / 'active_projects.json'
+    queue_path = tmp_path / 'execution_queue.json'
+    active_execution_path = tmp_path / 'active_execution.json'
+    feed_path = tmp_path / 'status_feed.jsonl'
+
+    active_projects_path.write_text(json.dumps(_active_projects(), indent=2), encoding='utf-8')
+    queue_path.write_text(json.dumps(_queue_without_live_task_but_with_stale_incident(), indent=2), encoding='utf-8')
+
+    monkeypatch.setattr(snapshot, 'ACTIVE_PROJECTS', active_projects_path)
+    monkeypatch.setattr(snapshot, 'QUEUE', queue_path)
+    monkeypatch.setattr(snapshot, 'ACTIVE_EXECUTION', active_execution_path)
+    monkeypatch.setattr(feed, 'FEED_PATH', feed_path)
+
+    feed.append_status_feed(updated_at=REFERENCE_NOW)
+
+    entry = json.loads(feed_path.read_text(encoding='utf-8').splitlines()[-1])
+    assert entry['live_execution_exists'] is False
+    assert isinstance(entry['current_live_task_or_state'], dict)
+    assert entry['current_live_task_or_state']['execution_state'] == 'needs_redispatch'
+    assert entry['current_live_task_or_state']['status'] == 'stale_blocked'
+    assert entry['current_live_task_or_state']['stale_execution_detected'] is True
+    assert entry['current_live_task_or_state']['incident_path'] == '/tmp/stale_execution_incident.json'
+    assert entry['current_live_task_or_state']['next_action_path'] == '/tmp/stale_execution_next_action.json'
+    assert entry['current_live_task_or_state']['source'] == 'hermes-autonomy-controller'
+    assert entry['current_live_task_or_state']['report_source'] == '/var/lib/eeepc-agent/self-evolving-agent/state/reports/evolution-20260416T121151Z.json'
+    assert entry['current_live_task_or_state']['next_action'] == 'redispatch_stale_execution'
+    assert entry['active_projects_summary'][0]['status'] == 'stale_blocked'
+    assert entry['status_snapshot_summary']['needs_redispatch'] == 1
+    assert entry['status_snapshot_summary']['stale_execution_detected'] is True
+
+
 def test_append_status_feed_records_no_live_executor_state(tmp_path: Path, monkeypatch) -> None:
     active_projects_path = tmp_path / 'active_projects.json'
     queue_path = tmp_path / 'execution_queue.json'
@@ -120,4 +175,8 @@ def test_append_status_feed_records_no_live_executor_state(tmp_path: Path, monke
 
     entry = json.loads(feed_path.read_text(encoding='utf-8').splitlines()[-1])
     assert entry['live_execution_exists'] is False
-    assert entry['current_live_task_or_state'] == 'no_live_executor'
+    assert isinstance(entry['current_live_task_or_state'], dict)
+    assert entry['current_live_task_or_state']['execution_state'] == 'waiting_for_dispatch'
+    assert entry['current_live_task_or_state']['status'] == 'waiting_for_dispatch'
+    assert entry['current_live_task_or_state']['next_action'] == 'dispatch_or_enqueue_bounded_task'
+    assert entry['active_projects_summary'][0]['status'] == 'waiting_for_dispatch'


### PR DESCRIPTION
## Summary
- Makes status-feed heartbeat output non-silent for stale/no-live executor incidents.
- Replaces the bare `no_live_executor` string with structured `waiting_for_dispatch` state for ordinary no-live cases.
- Emits incident source/path/report source/next action for stale redispatch incidents.
- Downgrades project status away from `in_progress` when there is no live executor.

Fixes #370

## Verification
- RED: updated #370 regression initially failed on missing incident_path and generic `no_live_executor` string.
- delegated review before fix: FAIL, missing incident path/source/next action and project status normalization.
- delegated re-review after fix: PASS.
- `cd ops/dashboard && python3 -m pytest tests/test_status_feed_writer.py tests/test_stale_execution_watchdog.py tests/test_stale_execution_incident_controller.py -q` -> 7 passed
- `cd ops/dashboard && python3 -m pytest tests -q` -> 126 passed
- `python3 -m pytest tests -q` -> 675 passed, 5 skipped

## Notes
- No Telegram/network/secrets involved.
- This is status-feed/reporting behavior only; it does not dispatch executors by itself.
