### PR TITLE
fix: annotate stale live task in status feed

### DIFF
--- a/ops/dashboard/scripts/build_status_feed.py
+++ b/ops/dashboard/scripts/build_status_feed.py
@@ -76,6 +76,10 @@ def _live_task_summary(active_execution: dict[str, Any]) -> dict[str, Any] | str
         'active_goal': live_task.get('active_goal'),
         'diagnosis': live_task.get('diagnosis'),
         'stale_execution_detected': bool(live_task.get('stale_execution_detected')),
+        'stale_execution_age_seconds': live_task.get('stale_execution_age_seconds'),
+        'stale_execution_age': live_task.get('stale_execution_age'),
+        'stale_execution_recommended_next_action': live_task.get('stale_execution_recommended_next_action'),
+        'stale_execution_threshold_minutes': live_task.get('stale_execution_threshold_minutes'),
     }
 
 

--- a/ops/dashboard/scripts/build_status_snapshot.py
+++ b/ops/dashboard/scripts/build_status_snapshot.py
@@ -153,6 +153,34 @@ def normalize_historical_stale_metadata(snapshot: dict[str, Any], threshold_minu
     return snapshot
 
 
+def annotate_stale_live_task(
+    live_task: dict[str, Any] | None,
+    active_tasks: list[dict[str, Any]],
+    stale_watch: dict[str, Any],
+    threshold_minutes: int,
+    policy_summary: str,
+) -> dict[str, Any] | None:
+    if live_task is None or not stale_watch.get('stale_detected'):
+        return live_task
+
+    stale_task_index = stale_watch.get('task_index')
+    if isinstance(stale_task_index, int) and 0 <= stale_task_index < len(active_tasks):
+        stale_task = active_tasks[stale_task_index]
+    elif live_task.get('task_key') == stale_watch.get('task_key'):
+        stale_task = live_task
+    else:
+        return live_task
+
+    annotated = dict(stale_task)
+    annotated['stale_execution_detected'] = True
+    annotated['stale_execution_threshold_minutes'] = threshold_minutes
+    annotated['stale_execution_policy_summary'] = policy_summary
+    annotated['stale_execution_age_seconds'] = stale_watch.get('age_seconds')
+    annotated['stale_execution_age'] = stale_watch.get('age')
+    annotated['stale_execution_recommended_next_action'] = stale_watch.get('recommended_next_action')
+    return annotated
+
+
 def build_active_execution(queue: dict[str, Any], updated_at: str) -> dict[str, Any]:
     tasks = queue.get('tasks') if isinstance(queue, dict) else []
     if not isinstance(tasks, list):
@@ -202,6 +230,7 @@ def build_active_execution(queue: dict[str, Any], updated_at: str) -> dict[str, 
         'stale_execution_incidents': len(stale_incident_tasks),
     }
 
+    live_task = annotate_stale_live_task(live_task, active_tasks, stale_watch, current_threshold_minutes, current_policy_summary)
     normalized_active_tasks = [normalize_historical_stale_metadata(task, current_threshold_minutes, current_policy_summary) for task in active_tasks]
     normalized_terminal_tasks = [normalize_historical_stale_metadata(task, current_threshold_minutes, current_policy_summary) for task in terminal_tasks]
     normalized_live_task = normalize_historical_stale_metadata(live_task, current_threshold_minutes, current_policy_summary) if live_task is not None else None

--- a/ops/dashboard/tests/test_status_feed_writer.py
+++ b/ops/dashboard/tests/test_status_feed_writer.py
@@ -68,6 +68,71 @@ def _queue_without_live_task() -> dict[str, object]:
     }
 
 
+def _queue_with_fresh_and_stale_live_tasks() -> dict[str, object]:
+    return {
+        'tasks': [
+            {
+                'created_at': '2026-04-17T06:25:51.835039Z',
+                'status': 'in_progress',
+                'source': 'hermes-autonomy-controller',
+                'diagnosis': 'recent_execution',
+                'severity': 'medium',
+                'active_goal': 'goal-fresh-task',
+                'report_source': '/tmp/fresh-report.json',
+                'failure_class': 'none',
+                'remediation_class': 'monitoring',
+                'dedupe_key': 'fresh-task',
+                'delegated_executor_started_at': '2026-04-17T06:25:51.835039Z',
+                'delegated_executor_requested_at': '2026-04-17T06:25:51.835039Z',
+            },
+            {
+                'created_at': '2026-04-16T07:30:50.705406Z',
+                'status': 'in_progress',
+                'source': 'hermes-autonomy-controller',
+                'diagnosis': 'stagnating_on_quality_blocker',
+                'severity': 'critical',
+                'active_goal': 'goal-44e50921129bf475',
+                'report_source': '/var/lib/eeepc-agent/self-evolving-agent/state/reports/evolution-20260416T121151Z.json',
+                'failure_class': 'no_concrete_change',
+                'remediation_class': 'planner_hardening',
+                'dedupe_key': 'stagnating_on_quality_blocker|goal-44e50921129bf475|/var/lib/eeepc-agent/self-evolving-agent/state/reports/evolution-20260416T121151Z.json|no_concrete_change|planner_hardening',
+                'delegated_executor_started_at': '2026-04-16T11:40:49.015519Z',
+                'delegated_executor_requested_at': '2026-04-16T11:40:49.015519Z',
+            },
+        ]
+    }
+
+
+def test_append_status_feed_prefers_stale_live_task_when_multiple_in_progress_tasks_exist(tmp_path: Path, monkeypatch) -> None:
+    active_projects_path = tmp_path / 'active_projects.json'
+    queue_path = tmp_path / 'execution_queue.json'
+    active_execution_path = tmp_path / 'active_execution.json'
+    feed_path = tmp_path / 'status_feed.jsonl'
+
+    active_projects_path.write_text(json.dumps(_active_projects(), indent=2), encoding='utf-8')
+    queue_path.write_text(json.dumps(_queue_with_fresh_and_stale_live_tasks(), indent=2), encoding='utf-8')
+
+    monkeypatch.setattr(snapshot, 'ACTIVE_PROJECTS', active_projects_path)
+    monkeypatch.setattr(snapshot, 'QUEUE', queue_path)
+    monkeypatch.setattr(snapshot, 'ACTIVE_EXECUTION', active_execution_path)
+    monkeypatch.setattr(feed, 'FEED_PATH', feed_path)
+
+    feed.append_status_feed(updated_at=REFERENCE_NOW)
+
+    entry = json.loads(feed_path.read_text(encoding='utf-8').splitlines()[-1])
+    assert entry['status_snapshot_summary']['stale_execution_detected'] is True
+    assert entry['status_snapshot_summary']['stale_execution_incidents'] == 0
+    assert entry['current_live_task_or_state']['stale_execution_detected'] is True
+    assert entry['current_live_task_or_state']['stale_execution_recommended_next_action'].startswith('Treat this as a stale-execution incident')
+    assert entry['current_live_task_or_state']['stale_execution_age_seconds'] > 0
+    assert entry['current_live_task_or_state']['active_goal'] == 'goal-44e50921129bf475'
+
+    refreshed = json.loads(active_execution_path.read_text(encoding='utf-8'))
+    assert refreshed['live_task']['stale_execution_detected'] is True
+    assert refreshed['live_task']['active_goal'] == 'goal-44e50921129bf475'
+    assert refreshed['summary']['stale_execution_detected'] is True
+
+
 def _queue_without_live_task_but_with_stale_incident() -> dict[str, object]:
     return {
         'tasks': [


### PR DESCRIPTION
## Summary
- Annotates the surfaced active execution live task when the stale watchdog detects that task is stale.
- Handles multiple `in_progress` tasks by surfacing/annotating the stale candidate instead of hiding it behind a fresh first live task.
- Propagates stale watchdog metadata into status-feed `current_live_task_or_state`:
  - stale age seconds/text
  - threshold minutes
  - recommended next action
- Keeps `stale_execution_incidents=0` valid before the incident consumer runs.

Fixes #376

## Verification
- delegated review before final feed propagation: FAIL, recommended action/age missing from feed.
- delegated final review: PASS.
- `cd ops/dashboard && python3 -m pytest tests/test_status_feed_writer.py tests/test_stale_execution_watchdog.py tests/test_stale_execution_incident_controller.py -q` -> 8 passed
- `cd ops/dashboard && python3 -m pytest tests -q` -> 127 passed
- `python3 -m pytest tests -q` -> 675 passed, 5 skipped

## Notes
- No dispatch side effects; changes are limited to active-execution snapshot/status-feed shaping.
- Control runtime JSON was generated during tests/live checks but not committed.
