### PR TITLE
fix: use canonical stale control root

### DIFF
--- a/ops/dashboard/scripts/consume_queued_redispatch_assignments.py
+++ b/ops/dashboard/scripts/consume_queued_redispatch_assignments.py
@@ -17,7 +17,7 @@ if str(SCRIPT_ROOT) not in sys.path:
 
 import scripts.build_status_snapshot as status_snapshot
 
-ROOT = Path('/home/ozand/herkoot/Projects/nanobot-ops-dashboard')
+ROOT = Path(__file__).resolve().parents[1]
 ACTIVE_EXECUTION_PATH = ROOT / 'control' / 'active_execution.json'
 QUEUE_PATH = ROOT / 'control' / 'execution_queue.json'
 ASSIGNMENT_DIR = ROOT / 'control' / 'execution_assignments'

--- a/ops/dashboard/scripts/consume_stale_execution_incidents.py
+++ b/ops/dashboard/scripts/consume_stale_execution_incidents.py
@@ -18,7 +18,7 @@ if str(SCRIPT_ROOT) not in sys.path:
 from scripts.build_status_snapshot import build_active_execution
 from scripts.stale_execution_watchdog import DEFAULT_THRESHOLD_MINUTES, detect_stale_execution
 
-ROOT = Path('/home/ozand/herkoot/Projects/nanobot-ops-dashboard')
+ROOT = Path(__file__).resolve().parents[1]
 ACTIVE_EXECUTION_PATH = ROOT / 'control' / 'active_execution.json'
 QUEUE_PATH = ROOT / 'control' / 'execution_queue.json'
 INCIDENT_DIR = ROOT / 'control' / 'stale_execution_incidents'

--- a/ops/dashboard/scripts/consume_stale_execution_next_actions.py
+++ b/ops/dashboard/scripts/consume_stale_execution_next_actions.py
@@ -17,7 +17,7 @@ if str(SCRIPT_ROOT) not in sys.path:
 
 from scripts.build_status_snapshot import build_active_execution
 
-ROOT = Path('/home/ozand/herkoot/Projects/nanobot-ops-dashboard')
+ROOT = Path(__file__).resolve().parents[1]
 ACTIVE_EXECUTION_PATH = ROOT / 'control' / 'active_execution.json'
 QUEUE_PATH = ROOT / 'control' / 'execution_queue.json'
 NEXT_ACTION_DIR = ROOT / 'control' / 'stale_execution_next_actions'

--- a/ops/dashboard/scripts/stale_execution_watchdog.py
+++ b/ops/dashboard/scripts/stale_execution_watchdog.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-ROOT = Path('/home/ozand/herkoot/Projects/nanobot-ops-dashboard')
+ROOT = Path(__file__).resolve().parents[1]
 ACTIVE_EXECUTION_PATH = ROOT / 'control' / 'active_execution.json'
 QUEUE_PATH = ROOT / 'control' / 'execution_queue.json'
 DEFAULT_THRESHOLD_MINUTES = 30

--- a/ops/dashboard/tests/test_canonical_import.py
+++ b/ops/dashboard/tests/test_canonical_import.py
@@ -4,6 +4,10 @@ import subprocess
 from pathlib import Path
 
 from nanobot_ops_dashboard.config import DEFAULT_PROJECT_ROOT, load_config
+from scripts import consume_queued_redispatch_assignments as redispatch_controller
+from scripts import consume_stale_execution_incidents as stale_incident_controller
+from scripts import consume_stale_execution_next_actions as stale_next_action_controller
+from scripts import stale_execution_watchdog as stale_watchdog
 
 
 CANONICAL_REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -33,6 +37,28 @@ def test_systemd_units_point_at_canonical_import_path():
         text = unit.read_text()
         assert f"WorkingDirectory={expected_root}" in text
         assert f"ExecStart={expected_root}/scripts/" in text
+
+
+def test_stale_execution_controllers_default_to_canonical_dashboard_root():
+    expected_control_root = DASHBOARD_ROOT / "control"
+
+    for module in (stale_watchdog, stale_incident_controller, stale_next_action_controller, redispatch_controller):
+        assert module.ROOT == DASHBOARD_ROOT
+
+    assert stale_watchdog.ACTIVE_EXECUTION_PATH == expected_control_root / "active_execution.json"
+    assert stale_watchdog.QUEUE_PATH == expected_control_root / "execution_queue.json"
+    assert stale_incident_controller.ACTIVE_EXECUTION_PATH == expected_control_root / "active_execution.json"
+    assert stale_incident_controller.QUEUE_PATH == expected_control_root / "execution_queue.json"
+    assert stale_incident_controller.INCIDENT_DIR == expected_control_root / "stale_execution_incidents"
+    assert stale_incident_controller.NEXT_ACTION_DIR == expected_control_root / "stale_execution_next_actions"
+    assert stale_next_action_controller.ACTIVE_EXECUTION_PATH == expected_control_root / "active_execution.json"
+    assert stale_next_action_controller.QUEUE_PATH == expected_control_root / "execution_queue.json"
+    assert stale_next_action_controller.NEXT_ACTION_DIR == expected_control_root / "stale_execution_next_actions"
+    assert stale_next_action_controller.REDISPATCH_DIR == expected_control_root / "stale_execution_redispatches"
+    assert redispatch_controller.ACTIVE_EXECUTION_PATH == expected_control_root / "active_execution.json"
+    assert redispatch_controller.QUEUE_PATH == expected_control_root / "execution_queue.json"
+    assert redispatch_controller.ASSIGNMENT_DIR == expected_control_root / "execution_assignments"
+    assert redispatch_controller.LATEST_ASSIGNMENT_PATH == expected_control_root / "execution_assignment.json"
 
 
 def test_imported_dashboard_readme_marks_sibling_repo_as_noncanonical():


### PR DESCRIPTION
## Summary
- Removes hardcoded sibling `nanobot-ops-dashboard` control roots from stale-execution controllers.
- Defaults stale-control scripts to the current checkout's `ops/dashboard/control` root.
- Preserves explicit path overrides.
- Adds a canonical-root regression test.

Fixes #381

## Verification
- delegated implementation/review: PASS.
- `cd ops/dashboard && python3 -m pytest tests/test_canonical_import.py tests/test_stale_execution_incident_controller.py tests/test_stale_execution_next_action_controller.py tests/test_execution_assignment_controller.py -q` -> 12 passed
- `cd ops/dashboard && python3 -m pytest tests -q` -> 129 passed
- `python3 -m pytest tests -q` -> 675 passed, 5 skipped

## Notes
- This unblocks #378 by ensuring canonical scripts mutate canonical control state, not the sibling dashboard repo.
- Remaining hardcoded sibling roots in unrelated dashboard helper/consumer scripts should be audited separately if they are still part of live control flow.
