### PR TITLE
fix: ignore generated control artifacts

### DIFF
--- a/ops/dashboard/.gitignore
+++ b/ops/dashboard/.gitignore
@@ -7,3 +7,9 @@ data/*.sqlite3-wal
 control/status_feed.jsonl
 control/eeepc_reachability.json
 control/no_live_executor_incident.json
+# Runtime-generated dashboard control evidence. Existing checked-in baseline
+# artifacts remain tracked by Git; intentional new baselines require git add -f.
+control/stale_execution_incidents/*.json
+control/stale_execution_next_actions/*.json
+control/stale_execution_redispatches/*.json
+control/execution_assignments/*.json

--- a/ops/dashboard/tests/test_canonical_import.py
+++ b/ops/dashboard/tests/test_canonical_import.py
@@ -61,6 +61,43 @@ def test_stale_execution_controllers_default_to_canonical_dashboard_root():
     assert redispatch_controller.LATEST_ASSIGNMENT_PATH == expected_control_root / "execution_assignment.json"
 
 
+def test_generated_dashboard_control_artifacts_are_ignored():
+    check_paths = [
+        'ops/dashboard/control/stale_execution_incidents/20990101T000000Z-runtime-generated.json',
+        'ops/dashboard/control/stale_execution_next_actions/20990101T000000Z-runtime-generated.json',
+        'ops/dashboard/control/stale_execution_redispatches/20990101T000000Z-runtime-generated.json',
+        'ops/dashboard/control/execution_assignments/20990101T000000Z-runtime-generated.json',
+    ]
+    result = subprocess.run(
+        ['git', 'check-ignore', *check_paths],
+        cwd=CANONICAL_REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    ignored = set(result.stdout.splitlines())
+    assert ignored == set(check_paths)
+
+
+def test_checked_in_dashboard_control_baselines_remain_tracked():
+    baseline_paths = [
+        'ops/dashboard/control/stale_execution_incidents/20260416T114049015519Z-stagnating_on_quality_blocker-goal-44e50921129bf475-var-lib-eeepc-agent-self-evolving-agent-state-reports-evolution-20260416T121151Z.json-no_concrete_change-planner_hardening.json',
+        'ops/dashboard/control/stale_execution_next_actions/20260416T114049015519Z-stagnating_on_quality_blocker-goal-44e50921129bf475-var-lib-eeepc-agent-self-evolving-agent-state-reports-evolution-20260416T121151Z.json-no_concrete_change-planner_hardening.json',
+        'ops/dashboard/control/stale_execution_redispatches/20260417T022553513622Z-stagnating_on_quality_blocker-goal-44e50921129bf475-var-lib-eeepc-agent-self-evolving-agent-state-reports-evolution-20260416T121151Z.json-no_concrete_change-planner_hardening.json',
+        'ops/dashboard/control/execution_assignments/20260417T024647743230Z-stagnating_on_quality_blocker-goal-44e50921129bf475-var-lib-eeepc-agent-self-evolving-agent-state-reports-evolution-20260416T121151Z.json-no_concrete_change-planner_hardening.json',
+    ]
+    result = subprocess.run(
+        ['git', 'ls-files', *baseline_paths],
+        cwd=CANONICAL_REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    tracked = set(result.stdout.splitlines())
+    assert tracked == set(baseline_paths)
+
+
+
 def test_imported_dashboard_readme_marks_sibling_repo_as_noncanonical():
     readme = (DASHBOARD_ROOT / "README.md").read_text()
 


### PR DESCRIPTION
## Summary
- Ignores runtime-generated dashboard control evidence JSON under stale execution and assignment artifact directories.
- Existing checked-in baseline fixtures remain tracked by Git.
- Documents that intentional new baselines require `git add -f`.
- Adds regression coverage for both generated ignored paths and existing tracked baselines.

Fixes #385

## Verification
- RED: generated-control-artifact ignore test failed before `.gitignore` update.
- delegated review initially failed on overbroad-ignore risk.
- added comments and tracked-baseline regression; delegated re-review: PASS.
- `cd ops/dashboard && python3 -m pytest tests/test_canonical_import.py -q` -> 8 passed
- `cd ops/dashboard && python3 -m pytest tests -q` -> 133 passed
- `python3 -m pytest tests -q` -> 675 passed, 5 skipped
- `git status --short --ignored ops/dashboard/control` shows the current generated #378 artifacts as ignored (`!!`) rather than untracked source changes.

## Notes
- No existing baseline fixture files were removed.
- This keeps future live stale-execution controller runs from leaving generated artifacts as untracked product-source changes.
