### PR TITLE
docs: remove invalid active model routes

### DIFF
--- a/docs/MODEL_ROUTING_FALLBACK_V1.md
+++ b/docs/MODEL_ROUTING_FALLBACK_V1.md
@@ -1,10 +1,19 @@
 # Model Routing Fallback V1
 
-Last updated: 2026-03-30 UTC
+Last updated: 2026-04-29 UTC
 
 ## Purpose
 
 Define the smallest task-type routing layer after live host model probes.
+
+## Current Live Telegram Constraint
+
+The live Telegram gateway must use models that are verified against the current
+OpenAI-compatible `/chat/completions` endpoint, not just models that appear in
+`/v1/models`. On 2026-04-29 the live Telegram key rejected
+`qwen3-coder-flash` and `coder-model` at chat-completion time. Do not put those
+names back into active routing without a fresh successful `/chat/completions`
+probe for the same key.
 
 ## Scope
 
@@ -23,25 +32,20 @@ It keeps a single provider instance and switches only the `model` parameter per 
 Fallback order:
 
 1. `gpt-5.4-mini`
-2. `gpt-oss-120b-medium`
-3. `coder-model`
-4. `gemini-3-flash`
-5. `gpt-5.4`
+2. `gemini-3-flash`
+3. `gpt-5.4`
 
 ### Code
 
 Fallback order:
 
-1. `qwen3-coder-plus`
-2. `gpt-5.3-codex`
-3. `qwen3-coder-flash`
+1. `gpt-5.3-codex`
 
 ### Vision
 
 Fallback order:
 
-1. `vision-model`
-2. `gemini-3.1-flash-image`
+1. `gemini-3.1-flash-image`
 
 ## Detection Rules
 
@@ -57,6 +61,7 @@ Fallback triggers only on model-availability style failures, such as:
 - model not found
 - unsupported model
 - access denied
+- invalid model name
 
 It does not fallback on every error, to avoid hiding prompt/runtime bugs.
 
@@ -65,8 +70,8 @@ It does not fallback on every error, to avoid hiding prompt/runtime bugs.
 V1 also supports a small per-task executor override after the first tool-calling
 response:
 
-- `general` executor -> `gpt-oss-120b-medium`
-- `code` executor -> `qwen3-coder-flash`
+- `general` executor -> `gpt-5.4-mini`
+- `code` executor -> `gpt-5.3-codex`
 - `vision` executor -> `gemini-3.1-flash-image`
 
 This keeps one provider instance and only switches the `model` parameter.
@@ -86,4 +91,4 @@ This keeps one provider instance and only switches the `model` parameter.
 ## Host Rollout Status
 
 - `modelRouting` is enabled in the live host runtime config.
-- Host simulator still returns valid answers after the rollout.
+- Live Telegram gateway default/code executor was repaired to `gpt-5.3-codex` after the `qwen3-coder-flash` chat-completion rejection.

--- a/tests/test_model_routing_docs.py
+++ b/tests/test_model_routing_docs.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+ROUTING_DOC = Path(__file__).resolve().parents[1] / "docs" / "MODEL_ROUTING_FALLBACK_V1.md"
+
+
+def _section(text: str, heading: str, next_heading: str) -> str:
+    start = text.index(heading)
+    end = text.index(next_heading, start)
+    return text[start:end]
+
+
+def test_active_model_routing_doc_excludes_live_invalid_models() -> None:
+    text = ROUTING_DOC.read_text(encoding="utf-8")
+
+    routing_rules = _section(text, "## Routing Rules", "## Detection Rules")
+    executor_split = _section(text, "## Minimal Planner/Executor Split", "## Deferred On Purpose")
+    active_routing_text = routing_rules + executor_split
+
+    assert "qwen3-coder-flash" not in active_routing_text
+    assert "coder-model" not in active_routing_text
+    assert "gpt-oss-120b-medium" not in active_routing_text
+
+
+def test_active_model_routing_doc_uses_verified_codex_for_code_executor() -> None:
+    text = ROUTING_DOC.read_text(encoding="utf-8")
+
+    assert "1. `gpt-5.3-codex`" in text
+    assert "- `code` executor -> `gpt-5.3-codex`" in text
+    assert "invalid model name" in text


### PR DESCRIPTION
## Summary
- Updates active model-routing fallback documentation to match the current live Telegram verified route set.
- Removes stale invalid model names from active routing recommendations:
  - `qwen3-coder-flash`
  - `coder-model`
  - `gpt-oss-120b-medium`
- Makes code/default executor routing explicitly use `gpt-5.3-codex`.
- Adds regression tests so stale invalid model names cannot re-enter active routing docs while allowing historical/contextual references outside active routing sections.

Fixes #388

## Verification
- RED: initial doc regression failed because stale names were still present in active routing documentation.
- delegated first review: FAIL because the first test was too broad and rejected contextual historical mentions.
- scoped test to active routing sections only.
- delegated re-review: PASS.
- `python3 -m pytest tests/test_model_routing_docs.py -q` -> 2 passed
- `python3 -m pytest tests -q` -> 677 passed, 5 skipped

## Notes
- Live config repair for #387 was performed separately on eeepc and verified without printing secrets.
