### PR TITLE
fix: resolve Telegram cap status runtime state

### DIFF
--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -23,7 +23,7 @@ from eeebot.config.paths import get_media_dir
 from eeebot.config.schema import Base
 from eeebot.security.network import validate_url_target
 from eeebot.utils.helpers import split_message
-from nanobot.runtime.state import format_runtime_state, load_runtime_state
+from nanobot.runtime.state import format_runtime_state, load_runtime_state_for_workspace
 from nanobot.config.loader import load_config
 
 TELEGRAM_MAX_MESSAGE_LEN = 4000  # Telegram message character limit
@@ -533,7 +533,7 @@ class TelegramChannel(BaseChannel):
             return
         cfg = load_config()
         workspace = Path(cfg.agents.defaults.workspace).expanduser()
-        runtime = load_runtime_state(workspace)
+        runtime = load_runtime_state_for_workspace(workspace)
         lines = format_runtime_state(runtime)
         model = getattr(cfg.agents.defaults, "model", "unknown")
         text = "\n".join([

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -861,11 +861,16 @@ async def test_on_cap_status_replies_with_runtime_status(monkeypatch, tmp_path) 
         "load_config",
         lambda: SimpleNamespace(agents=SimpleNamespace(defaults=SimpleNamespace(workspace=str(tmp_path), model="gpt-5.3-codex"))),
     )
-    monkeypatch.setitem(TelegramChannel._on_cap_status.__globals__, "load_runtime_state", lambda workspace: {"workspace": str(workspace)})
+    captured_workspace = []
+    monkeypatch.setitem(
+        TelegramChannel._on_cap_status.__globals__,
+        "load_runtime_state_for_workspace",
+        lambda workspace: captured_workspace.append(workspace) or {"workspace": str(workspace), "runtime_status": "PASS"},
+    )
     monkeypatch.setitem(
         TelegramChannel._on_cap_status.__globals__,
         "format_runtime_state",
-        lambda runtime: ["Runtime:", "  Runtime status: unknown"],
+        lambda runtime: ["Runtime:", f"  Runtime status: {runtime['runtime_status']}"],
     )
 
     await channel._on_cap_status(update, None)
@@ -876,3 +881,5 @@ async def test_on_cap_status_replies_with_runtime_status(monkeypatch, tmp_path) 
     assert "model: gpt-5.3-codex" in reply_text
     assert f"workspace: {tmp_path}" in reply_text
     assert "Runtime:" in reply_text
+    assert "Runtime status: PASS" in reply_text
+    assert captured_workspace == [tmp_path]


### PR DESCRIPTION
## Summary
- Makes Telegram `/cap_status` use the canonical workspace-aware runtime state resolver.
- Replaces the workspace-only `load_runtime_state(workspace)` call with `load_runtime_state_for_workspace(workspace)`.
- This aligns Telegram with the CLI status path and lets eeepc live workspaces resolve to the host control-plane state root instead of the empty workspace-state root.
- Updates regression coverage to assert `/cap_status` calls the workspace-aware loader and returns non-unknown runtime status markers.

Fixes #394

## Root cause
The live Telegram gateway workspace is `/home/opencode/.nanobot-eeepc/workspace`. The previous `/cap_status` handler used `load_runtime_state(workspace)`, which always reads `workspace/state`. On eeepc that path did not contain the live authoritative control-plane state, so `/cap_status` rendered mostly `unknown`.

The existing resolver already knows that `.nanobot-eeepc/workspace` should use the host control-plane root (`/var/lib/eeepc-agent/self-evolving-agent/state`) unless explicitly overridden.

## Verification
- delegated read-only audit: identified `/var/lib/eeepc-agent/self-evolving-agent/state` as the authoritative live root and `load_runtime_state_for_workspace()` as the existing correct resolver.
- delegated implementation review: PASS.
- `python3 -m py_compile nanobot/channels/telegram.py` -> pass
- `python3 -m pytest tests/test_runtime_slash_commands.py tests/test_telegram_live_proof_validator.py -q` -> 11 passed
- `python3 -m pytest tests -q` -> 680 passed, 5 skipped

## Rollout plan
After merge:
- roll eeepc pinned runtime forward.
- restart `nanobot-gateway-eeepc.service`.
- run remote `/cap_status` smoke via pinned runtime and verify non-unknown runtime fields.
