### PR TITLE
Fix freshness-aware autonomy diagnostics

### DIFF
--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -196,10 +196,18 @@ def _material_progress_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
         and subagent_blocked_count >= subagent_terminal_count
         and subagent_terminal_count > 0
     )
+    latest_subagent_age = latest_subagent_result.get('age_seconds') if isinstance(latest_subagent_result, dict) else None
+    try:
+        latest_subagent_age_int = int(latest_subagent_age) if latest_subagent_age is not None else None
+    except (TypeError, ValueError):
+        latest_subagent_age_int = None
+    fresh_subagent_window_seconds = 6 * 60 * 60
+    latest_subagent_fresh = latest_subagent_age_int is not None and latest_subagent_age_int <= fresh_subagent_window_seconds
     consumed_subagent_result = bool(
         (subagent_terminal_count or _present(latest_subagent_result))
         and latest_subagent_status not in {'blocked', 'failed', 'error'}
         and not subagent_only_blocked
+        and latest_subagent_fresh
     )
     promotion_evidence_artifact = bool(
         _present(runtime.get('promotion_artifact_path'))
@@ -244,6 +252,9 @@ def _material_progress_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
                 'completed_result_count': subagent_rollup.get('completed_result_count') or subagent_rollup.get('count_completed'),
                 'latest_result_path': (subagent_rollup.get('latest_result') or {}).get('path') if isinstance(subagent_rollup.get('latest_result'), dict) else None,
                 'active_task_id': subagent_rollup.get('active_task_id'),
+                'latest_result_age_seconds': latest_subagent_age_int,
+                'freshness_state': 'fresh' if latest_subagent_fresh else 'stale',
+                'freshness_window_seconds': fresh_subagent_window_seconds,
             },
         },
         {
@@ -270,6 +281,8 @@ def _material_progress_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
             non_qualifying_proofs.append('historic_or_unlinked_selfevo_pr')
         if promotion_evidence_artifact:
             non_qualifying_proofs.append('historic_or_unaccepted_promotion_artifact')
+        if subagent_terminal_count and not latest_subagent_fresh:
+            non_qualifying_proofs.append('stale_subagent_result')
         state = 'blocked'
         healthy_allowed = False
         blocking_reason = 'missing_current_material_progress'

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -906,6 +906,17 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
     else:
         state = 'stale' if stale_count else ('available' if requests or results else 'empty')
         reason = 'stale_requests_present' if stale_count else ('available_subagent_activity' if requests or results else 'no_subagent_activity')
+    def _result_age_seconds(item: dict) -> int | None:
+        try:
+            return int(item.get('age_seconds')) if item.get('age_seconds') is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    stale_result_count = sum(
+        1 for item in results
+        if _result_age_seconds(item) is None or _result_age_seconds(item) >= 6 * 60 * 60
+    )
+    fresh_result_count = max(0, result_count - stale_result_count)
     return {
         'schema_version': 'subagent-visibility-v1',
         'requests': requests,
@@ -917,6 +928,11 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             'queued_request_count': queued_count,
             'result_count': result_count,
             'blocked_result_count': blocked_count,
+            'stale_result_count': stale_result_count,
+            'fresh_result_count': fresh_result_count,
+            'latest_result_age_seconds': (results[0].get('age_seconds') if results else ((rollup or {}).get('latest_result') or {}).get('age_seconds') if isinstance((rollup or {}).get('latest_result'), dict) else None),
+            'freshness_state': 'fresh' if fresh_result_count else ('stale' if stale_result_count else state),
+            'freshness_window_seconds': 6 * 60 * 60,
             'state': state,
             'reason': reason,
         },
@@ -1334,10 +1350,10 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
             reasons.append('low_budget_discard_streak')
         if same_task_streak:
             reasons.append('same_task_streak')
-        if inspected >= 5 and total_subagents == 0:
-            reasons.append('subagents_unused')
-        if inspected >= 5 and total_tool_calls <= inspected * 2:
-            reasons.append('tool_budget_underused')
+    if inspected >= 5 and total_subagents == 0 and (bridge_summary or not rotating_synthesis_reward_window):
+        reasons.append('subagents_unused')
+    if inspected >= 5 and total_tool_calls <= inspected * 2 and (bridge_summary or not rotating_synthesis_reward_window):
+        reasons.append('tool_budget_underused')
     state = 'underutilized' if reasons else 'substantive'
     escalation = None
     if blocked_escalation is not None:
@@ -1386,7 +1402,7 @@ def _ambition_utilization_verdict(*, analytics: dict, experiment_visibility: dic
     }
 
 
-def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None, hypothesis_dynamics: dict | None = None, promotion_replay_readiness: dict | None = None, strong_reflection_freshness: dict | None = None) -> dict:
+def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_visibility: dict, credits_visibility: dict, cfg: DashboardConfig, material_progress: dict | None = None, runtime_parity: dict | None = None, ambition_utilization: dict | None = None, hypothesis_dynamics: dict | None = None, promotion_replay_readiness: dict | None = None, strong_reflection_freshness: dict | None = None, subagent_visibility: dict | None = None) -> dict:
     reasons: list[str] = []
     state_root = cfg.nanobot_repo_root / 'workspace' / 'state'
     recent = analytics.get('recent_status_sequence') or []
@@ -1412,6 +1428,34 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     material_allows_healthy = bool(material_progress.get('healthy_autonomy_allowed'))
     if material_progress and not material_allows_healthy:
         reasons.append('material_progress_missing')
+    recent_discard_rows = []
+    recent_budget_rows = []
+    recent_subagent_sum = 0
+    for row in recent[:20]:
+        detail = row.get('detail') if isinstance(row.get('detail'), dict) else {}
+        experiment = detail.get('experiment') if isinstance(detail.get('experiment'), dict) else {}
+        outcome = experiment.get('outcome') or detail.get('outcome')
+        budget_used = detail.get('budget_used') if isinstance(detail.get('budget_used'), dict) else experiment.get('budget_used') if isinstance(experiment.get('budget_used'), dict) else {}
+        if outcome:
+            recent_discard_rows.append(outcome == 'discard')
+        if isinstance(budget_used, dict) and budget_used:
+            recent_budget_rows.append(budget_used)
+            try:
+                recent_subagent_sum += int(budget_used.get('subagents') or 0)
+            except (TypeError, ValueError):
+                pass
+    subagent_visibility = subagent_visibility if isinstance(subagent_visibility, dict) else {}
+    subagent_summary = subagent_visibility.get('summary') if isinstance(subagent_visibility.get('summary'), dict) else {}
+    no_fresh_subagent_result = bool(
+        subagent_summary
+        and int(subagent_summary.get('fresh_result_count') or 0) == 0
+        and (int(subagent_summary.get('result_count') or 0) > 0 or int(subagent_summary.get('stale_result_count') or 0) > 0)
+    )
+    discard_only_recent_window = bool(len(recent_discard_rows) >= 5 and all(recent_discard_rows) and recent_budget_rows and recent_subagent_sum == 0)
+    if material_allows_healthy and discard_only_recent_window:
+        reasons.append('recent_window_discard_only')
+    if material_allows_healthy and no_fresh_subagent_result:
+        reasons.append('subagent_evidence_stale')
     runtime_parity = runtime_parity if isinstance(runtime_parity, dict) else {}
     runtime_reasons = runtime_parity.get('reasons') if isinstance(runtime_parity.get('reasons'), list) else []
     runtime_tasks_aligned = (
@@ -1434,7 +1478,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     ambition_utilization = ambition_utilization if isinstance(ambition_utilization, dict) else {}
     ambition_reasons = ambition_utilization.get('reasons') if isinstance(ambition_utilization.get('reasons'), list) else []
     ambition_escalation = ambition_utilization.get('escalation') if isinstance(ambition_utilization.get('escalation'), dict) else {}
-    if 'ambition_escalation_blocked' in ambition_reasons or ambition_escalation.get('state') == 'blocked':
+    if 'ambition_escalation_blocked' in ambition_reasons or ambition_escalation.get('state') == 'blocked' or ambition_utilization.get('state') == 'underutilized':
         reasons.append('ambition_underutilized')
     hypothesis_dynamics = hypothesis_dynamics if isinstance(hypothesis_dynamics, dict) else {}
     if hypothesis_dynamics.get('state') == 'stagnant':
@@ -1454,16 +1498,24 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     historical_reasons: list[str] = []
     if material_allows_healthy:
         stale_after_material_progress = {'same_task_streak', 'discarded_experiment', 'suppressed_reward', 'terminal_noop'}
+        freshness_blockers = {'recent_window_discard_only', 'subagent_evidence_stale'}
         blocking_reasons = []
         for reason in reasons:
             if reason in stale_after_material_progress:
+                historical_reasons.append(reason)
+            elif (
+                reason == 'ambition_underutilized'
+                and not any(blocker in reasons for blocker in freshness_blockers)
+                and 'ambition_escalation_blocked' not in ambition_reasons
+                and ambition_escalation.get('state') != 'blocked'
+            ):
                 historical_reasons.append(reason)
             else:
                 blocking_reasons.append(reason)
         if runtime_parity_is_blocking and runtime_can_be_historical:
             historical_reasons.append('runtime_parity_blocked')
         reasons = blocking_reasons
-    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant', 'promotion_lifecycle_blocked', 'strong_reflection_not_fresh'}) else 'healthy')
+    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant', 'promotion_lifecycle_blocked', 'strong_reflection_not_fresh', 'recent_window_discard_only', 'subagent_evidence_stale'}) else 'healthy')
     return {
         'schema_version': 'autonomy-verdict-v1',
         'state': status,
@@ -1795,7 +1847,15 @@ def _experiment_snapshot_from_payload(payload, source_path: Path) -> dict | None
         if isinstance(parsed_subagent_consumption, dict):
             subagent_consumption = parsed_subagent_consumption
     if not isinstance(subagent_consumption, dict):
-        subagent_consumption = None
+        subagent_count = None
+        if isinstance(budget_used_payload, dict):
+            subagent_count = budget_used_payload.get('subagents')
+        subagent_consumption = {
+            'schema_version': 'subagent-consumption-v1',
+            'state': 'consumed' if isinstance(subagent_count, (int, float)) and subagent_count > 0 else 'unused',
+            'used': int(subagent_count or 0) if isinstance(subagent_count, (int, float)) else 0,
+            'source': 'budget_used' if isinstance(budget_used_payload, dict) else 'missing_explicit_subagent_consumption',
+        }
     if not isinstance(budget_payload, dict):
         budget_payload = {
             key: value for key, value in {
@@ -1813,6 +1873,11 @@ def _experiment_snapshot_from_payload(payload, source_path: Path) -> dict | None
     execution_status = _first_present(experiment_payload, ('result_status', 'resultStatus', 'status', 'state')) or status
     phase = _first_present(experiment_payload, ('phase', 'stage'))
     outcome = _first_present(experiment_payload, ('outcome',))
+    if not _has_value(phase):
+        if _has_value(outcome):
+            phase = 'completed'
+        elif str(status).upper() in {'PASS', 'FAIL', 'BLOCK', 'ERROR'}:
+            phase = 'completed'
     metric_name = _first_present(experiment_payload, ('metric_name', 'metricName'))
     metric_baseline = _first_present(experiment_payload, ('metric_baseline', 'metricBaseline'))
     metric_current = _first_present(experiment_payload, ('metric_current', 'metricCurrent'))
@@ -3431,7 +3496,57 @@ def create_app(cfg: DashboardConfig):
             hypothesis_dynamics=hypothesis_dynamics,
             promotion_replay_readiness=promotion_replay_readiness,
             strong_reflection_freshness=strong_reflection_freshness,
+            subagent_visibility=subagent_visibility,
         )
+        existing_blocker_summary = control_plane.get('blocker_summary') if isinstance(control_plane, dict) else None
+        producer_has_blocker_summary = bool(
+            isinstance(control_plane, dict)
+            and isinstance(control_plane.get('producer_summary'), dict)
+            and control_plane['producer_summary'].get('blocker_summary')
+        )
+        synthesized_clear_summary = bool(
+            isinstance(existing_blocker_summary, dict)
+            and existing_blocker_summary.get('state') == 'clear'
+            and existing_blocker_summary.get('reason') == 'none'
+        )
+        control_blocker = control_plane.get('current_blocker') if isinstance(control_plane, dict) else None
+        should_hydrate_blocker = bool(
+            autonomy_verdict.get('reasons')
+            and not producer_has_blocker_summary
+            and (
+                (isinstance(current_blocker, dict) and current_blocker.get('kind') == 'unknown')
+                or control_blocker is None
+                or (isinstance(control_blocker, dict) and control_blocker.get('kind') == 'unknown')
+            )
+        )
+        if should_hydrate_blocker:
+            current_blocker = dict(current_blocker) if isinstance(current_blocker, dict) else {}
+            current_blocker['kind'] = 'diagnostic_gap'
+            current_blocker['source'] = 'autonomy_verdict'
+            reason_priority = [
+                'material_progress_missing',
+                'recent_window_discard_only',
+                'subagent_evidence_stale',
+                'ambition_underutilized',
+            ]
+            selected_reason = next((reason for reason in reason_priority if reason in autonomy_verdict['reasons']), autonomy_verdict['reasons'][0])
+            current_blocker['failure_class'] = current_blocker.get('failure_class') or selected_reason
+            current_blocker['blocked_next_step'] = (
+                ambition_utilization.get('recommended_next_action')
+                or 'inspect recent discard-only cycles, refresh subagent proof, and escalate to a bounded materialization lane'
+            )
+            if isinstance(control_plane, dict):
+                control_plane = dict(control_plane)
+                control_plane['current_blocker'] = current_blocker
+                control_plane['blocker_summary'] = {
+                    'schema_version': 'blocker-summary-v1',
+                    'state': 'stagnant',
+                    'reason': current_blocker['failure_class'],
+                    'recommended_next_action': current_blocker['blocked_next_step'],
+                    'source': 'autonomy_verdict',
+                    'current_task_id': (plan_latest or {}).get('current_task_id'),
+                    'current_task_title': (plan_latest or {}).get('current_task'),
+                }
         analytics['runtime_parity'] = runtime_parity
         analytics['hypothesis_dynamics'] = hypothesis_dynamics
         analytics['autonomy_verdict'] = autonomy_verdict

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from wsgiref.util import setup_testing_defaults
 
-from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence, _material_progress_summary, _approval_snapshot
+from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence, _material_progress_summary, _approval_snapshot, _autonomy_verdict, _ambition_utilization_verdict, _experiment_snapshot_from_payload
 from nanobot_ops_dashboard.config import DashboardConfig
 from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
 
@@ -2755,3 +2755,143 @@ def test_hypotheses_visibility_reconciles_stale_selection_to_runtime_canonical_t
     assert reconciled['runtime_reconciled_selected_hypothesis'] is True
     assert reconciled['stale_selected_hypothesis_id'] == 'inspect-pass-streak'
     assert 'selected_hypothesis_reconciled_to_runtime' in reconciled['mismatch_reasons']
+
+
+def test_autonomy_verdict_blocks_historical_progress_when_recent_window_is_discard_only_and_subagents_stale(tmp_path: Path) -> None:
+    analytics = {
+        'recent_status_sequence': [
+            {
+                'status': 'PASS',
+                'title': 'record-reward' if idx % 2 else 'synthesize-next-improvement-candidate',
+                'detail': {
+                    'current_task_id': 'record-reward' if idx % 2 else 'synthesize-next-improvement-candidate',
+                    'experiment': {'outcome': 'discard', 'revert_status': 'skipped_no_material_change'},
+                    'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+                },
+            }
+            for idx in range(8)
+        ],
+        'current_streak': {'status': 'PASS', 'length': 8},
+    }
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=tmp_path / 'nanobot', db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    verdict = _autonomy_verdict(
+        analytics=analytics,
+        plan_latest={'current_task_id': 'record-reward'},
+        experiment_visibility={'current_experiment': {'outcome': 'discard'}},
+        credits_visibility={'current': {}},
+        cfg=cfg,
+        material_progress={'schema_version': 'material-progress-v1', 'state': 'proven', 'healthy_autonomy_allowed': True},
+        subagent_visibility={'summary': {'result_count': 1, 'stale_result_count': 1, 'fresh_result_count': 0}},
+    )
+
+    assert verdict['state'] == 'stagnant'
+    assert 'recent_window_discard_only' in verdict['reasons']
+    assert 'subagent_evidence_stale' in verdict['reasons']
+
+
+def test_ambition_utilization_escalates_rotating_synthesis_reward_window_when_subagents_and_tools_underused() -> None:
+    analytics = {
+        'recent_status_sequence': [
+            {
+                'status': 'PASS',
+                'title': task_id,
+                'detail': {
+                    'current_task_id': task_id,
+                    'materialized_improvement_artifact_path': f'workspace/state/improvements/artifact-{idx}.json',
+                    'feedback_decision': {'mode': mode},
+                    'experiment': {'outcome': 'discard'},
+                    'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0, 'elapsed_seconds': 0},
+                },
+            }
+            for idx, (task_id, mode) in enumerate([
+                ('record-reward', 'record_reward_after_synthesized_materialization'),
+                ('synthesize-next-improvement-candidate', 'synthesize_next_candidate'),
+                ('record-reward', 'complete_active_lane'),
+                ('synthesize-next-improvement-candidate', 'synthesize_next_candidate'),
+                ('record-reward', 'record_reward_after_synthesized_materialization'),
+                ('synthesize-next-improvement-candidate', 'complete_active_lane'),
+            ])
+        ]
+    }
+
+    verdict = _ambition_utilization_verdict(
+        analytics=analytics,
+        experiment_visibility={'current_experiment': {'outcome': 'discard'}},
+        subagent_visibility={'summary': {'fresh_result_count': 0}},
+    )
+
+    assert verdict['state'] == 'underutilized'
+    assert 'subagents_unused' in verdict['reasons']
+    assert 'tool_budget_underused' in verdict['reasons']
+    assert verdict['recommended_next_action'] == 'escalate_to_higher_ambition_lane_or_emit_precise_blocker'
+
+
+def test_experiment_snapshot_hydrates_phase_and_subagent_consumption_from_budget(tmp_path: Path) -> None:
+    path = tmp_path / 'latest.json'
+    path.write_text('{}', encoding='utf-8')
+
+    snapshot = _experiment_snapshot_from_payload(
+        {'experiment_id': 'exp-1', 'status': 'PASS', 'outcome': 'discard', 'budget_used': {'requests': 1, 'tool_calls': 2, 'subagents': 0}},
+        path,
+    )
+
+    assert snapshot['phase'] == 'completed'
+    assert snapshot['subagent_consumption']['state'] == 'unused'
+    assert snapshot['subagent_consumption']['used'] == 0
+    assert snapshot['subagent_consumption']['source'] == 'budget_used'
+
+
+
+def test_api_system_hydrates_unknown_blocker_from_autonomy_verdict(tmp_path: Path) -> None:
+    project_root = tmp_path / 'dashboard'
+    repo_root = tmp_path / 'nanobot'
+    db = tmp_path / 'dashboard.sqlite3'
+    init_db(db)
+    state_root = repo_root / 'workspace' / 'state'
+    (state_root / 'control_plane').mkdir(parents=True, exist_ok=True)
+    (state_root / 'experiments').mkdir(parents=True, exist_ok=True)
+    (state_root / 'credits').mkdir(parents=True, exist_ok=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True, exist_ok=True)
+    (state_root / 'strong_reflection').mkdir(parents=True, exist_ok=True)
+    (state_root / 'hypotheses').mkdir(parents=True, exist_ok=True)
+    (state_root / 'hypotheses' / 'backlog.json').write_text(json.dumps([]), encoding='utf-8')
+    (state_root / 'strong_reflection' / 'latest.json').write_text(json.dumps({
+        'recorded_at_utc': '2999-04-24T12:59:00+00:00',
+        'status': 'PASS',
+        'summary': 'fresh test reflection',
+    }), encoding='utf-8')
+    (state_root / 'control_plane' / 'current_summary.json').write_text(json.dumps({
+        'task_plan': {'current_task_id': 'record-reward', 'current_task': 'Record cycle reward'},
+        'current_blocker': {'kind': 'unknown'},
+        'material_progress': {
+            'schema_version': 'material-progress-v1',
+            'state': 'blocked',
+            'available': True,
+            'healthy_autonomy_allowed': False,
+            'proof_count': 0,
+            'proofs': [],
+            'qualifying_proofs': [],
+            'blocking_reason': 'missing_current_material_progress',
+        },
+    }), encoding='utf-8')
+    (state_root / 'experiments' / 'latest.json').write_text(json.dumps({'outcome': 'discard', 'revert_status': 'skipped_no_material_change'}), encoding='utf-8')
+    (state_root / 'credits' / 'latest.json').write_text(json.dumps({'delta': 0.0, 'reward_gate': {'status': 'suppressed'}}), encoding='utf-8')
+    cfg = DashboardConfig(
+        project_root=project_root,
+        nanobot_repo_root=repo_root,
+        db_path=db,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root='/state',
+    )
+
+    control = _call_json(create_app(cfg), '/api/system')['control_plane']
+
+    assert control['current_blocker']['kind'] == 'diagnostic_gap'
+    assert control['current_blocker']['source'] == 'autonomy_verdict'
+    assert control['current_blocker']['failure_class'] == 'material_progress_missing'
+    assert control['current_blocker']['blocked_next_step']
+    assert control['blocker_summary']['state'] == 'stagnant'
+    assert control['blocker_summary']['reason'] == 'material_progress_missing'
+    assert control['blocker_summary']['source'] == 'autonomy_verdict'

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -2571,3 +2571,52 @@ def test_task_plan_snapshot_adds_synthesized_next_improvement_candidate_when_all
     assert plan["generated_candidates"]
     assert any(candidate["task_id"] == "synthesize-next-improvement-candidate" and candidate["status"] == "active" for candidate in plan["generated_candidates"])
     assert any(task["task_id"] == "synthesize-next-improvement-candidate" and task["status"] == "active" for task in plan["tasks"])
+
+
+def test_material_progress_retires_stale_subagent_result_for_current_discarded_cycle():
+    snapshot = _material_progress_snapshot({
+        'experiment': {'outcome': 'discard', 'revert_status': 'skipped_no_material_change'},
+        'subagent_rollup': {
+            'state': 'completed',
+            'count_completed': 1,
+            'completed_result_count': 1,
+            'latest_result': {
+                'path': 'workspace/state/subagents/results/stale.json',
+                'status': 'completed',
+                'age_seconds': 7 * 60 * 60,
+            },
+        },
+    })
+
+    assert snapshot['state'] == 'blocked'
+    assert snapshot['healthy_autonomy_allowed'] is False
+    assert 'consumed_subagent_result' not in snapshot['qualifying_proofs']
+    assert 'stale_subagent_result' in snapshot['non_qualifying_proofs']
+    consumed = next(proof for proof in snapshot['proofs'] if proof['kind'] == 'consumed_subagent_result')
+    assert consumed['present'] is False
+    assert consumed['evidence']['freshness_state'] == 'stale'
+
+
+
+def test_material_progress_treats_unknown_subagent_result_age_as_stale():
+    snapshot = _material_progress_snapshot({
+        'experiment': {'outcome': 'discard', 'revert_status': 'skipped_no_material_change'},
+        'subagent_rollup': {
+            'state': 'completed',
+            'count_completed': 1,
+            'completed_result_count': 1,
+            'latest_result': {
+                'path': 'workspace/state/subagents/results/no-age.json',
+                'status': 'completed',
+            },
+        },
+    })
+
+    assert snapshot['state'] == 'blocked'
+    assert snapshot['healthy_autonomy_allowed'] is False
+    assert 'consumed_subagent_result' not in snapshot['qualifying_proofs']
+    assert 'stale_subagent_result' in snapshot['non_qualifying_proofs']
+    consumed = next(proof for proof in snapshot['proofs'] if proof['kind'] == 'consumed_subagent_result')
+    assert consumed['present'] is False
+    assert consumed['evidence']['latest_result_age_seconds'] is None
+    assert consumed['evidence']['freshness_state'] == 'stale'


### PR DESCRIPTION
Fixes #396
Fixes #397
Fixes #398
Fixes #399

## Summary
- make material-progress accounting retire stale or unknown-age subagent results instead of treating historical bridge evidence as current proof
- make dashboard autonomy verdict freshness-aware for recent discard-only/no-subagent windows
- surface low tool/subagent utilization as actionable autonomy reasons when current evidence is fresh enough to classify
- add subagent result freshness counts/age/state to `/api/subagents` visibility
- hydrate missing experiment phase/subagent-consumption diagnostics and synthesize dashboard blocker summaries from autonomy verdict reasons when the control plane only exposes an unknown blocker

## Verification
- `python3 -m py_compile nanobot/runtime/state.py ops/dashboard/src/nanobot_ops_dashboard/app.py`
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 137 passed
- `python3 -m pytest tests -q` -> 682 passed, 5 skipped
- `git diff --check`

## Live proof plan after merge
- restart local dashboard services
- roll out pinned eeepc runtime because `nanobot/runtime/state.py` changed
- run dashboard `/collect`
- verify `/api/system`, `/api/experiments`, `/api/subagents`, and autonomy/material-progress freshness fields
