### PR TITLE
Fix HADI escalation for stagnant self-evolution

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -228,11 +228,18 @@ def _synthesized_materialize_improvement_candidate(
         "title": "Materialize one bounded improvement from the synthesized candidate",
         "status": status,
         "kind": "execution",
-        "acceptance": "write a concrete bounded improvement proposal or artifact and route it into self-evolution",
+        "acceptance": "write a concrete bounded HADI improvement proposal or artifact (hypothesis, action, data, insight) and route it into self-evolution",
         "selection_source": "feedback_synthesis_materialization",
         "parent_task_id": current_task_id,
         "strong_pass_count": strong_pass_count,
         "goal_artifact_signature": goal_artifact_signature,
+        "hadi_required": True,
+        "hadi_cycle": {
+            "hypothesis": "A concrete bounded materialization will break the reward/candidate discard loop.",
+            "action": "Create one reviewable artifact or follow-up task with explicit acceptance checks.",
+            "data": "Use recent task history, experiment outcome, and budget/subagent utilization evidence.",
+            "insight": "Decide whether the artifact should be accepted, escalated to subagent review, or blocked with a concrete reason.",
+        },
     }
 
 
@@ -260,6 +267,24 @@ def _ambition_streak_key(task_id: str | None) -> str | None:
     return normalized
 
 
+def _history_experiment_outcome(history_entry: dict[str, Any]) -> str | None:
+    if not isinstance(history_entry, dict):
+        return None
+    experiment = history_entry.get("experiment")
+    if isinstance(experiment, dict) and experiment.get("outcome"):
+        return str(experiment.get("outcome"))
+    detail = history_entry.get("detail")
+    if isinstance(detail, dict):
+        detail_experiment = detail.get("experiment")
+        if isinstance(detail_experiment, dict) and detail_experiment.get("outcome"):
+            return str(detail_experiment.get("outcome"))
+        if detail.get("outcome"):
+            return str(detail.get("outcome"))
+    if history_entry.get("outcome"):
+        return str(history_entry.get("outcome"))
+    return None
+
+
 def _ambition_underutilization_reasons(history_entries: list[dict[str, Any]], current_task_id: str | None) -> list[str]:
     if not current_task_id:
         return []
@@ -268,8 +293,11 @@ def _ambition_underutilization_reasons(history_entries: list[dict[str, Any]], cu
         return []
     inspected = 0
     repeated_task_ids: list[str] = []
+    raw_task_ids: list[str] = []
+    outcomes: list[str | None] = []
     total_tool_calls = 0
     total_subagents = 0
+    total_elapsed_seconds = 0
     for entry in history_entries[:AMBITION_UNDERUTILIZATION_STREAK_LIMIT]:
         if (entry.get("result_status") or entry.get("status")) != "PASS":
             break
@@ -278,19 +306,28 @@ def _ambition_underutilization_reasons(history_entries: list[dict[str, Any]], cu
         if not task_streak_key:
             break
         repeated_task_ids.append(task_streak_key)
+        raw_task_ids.append(str(task_id) if task_id else "unknown")
+        outcomes.append(_history_experiment_outcome(entry))
         budget_used = _history_budget_used(entry)
         total_tool_calls += int(budget_used.get("tool_calls") or 0)
         total_subagents += int(budget_used.get("subagents") or 0)
+        total_elapsed_seconds += int(budget_used.get("elapsed_seconds") or 0)
         inspected += 1
     if inspected < AMBITION_UNDERUTILIZATION_STREAK_LIMIT:
         return []
     if len(set(repeated_task_ids)) != 1 or repeated_task_ids[0] != current_streak_key:
         return []
     reasons = ["same_task_streak"]
+    if len(set(raw_task_ids)) <= 2:
+        reasons.append("low_task_diversity")
+    if outcomes and all(outcome == "discard" for outcome in outcomes):
+        reasons.append("recent_window_discard_only")
     if total_subagents == 0:
         reasons.append("subagents_unused")
     if total_tool_calls <= inspected * 2:
         reasons.append("tool_budget_underused")
+    if total_elapsed_seconds <= inspected:
+        reasons.append("time_budget_underused")
     if reasons == ["same_task_streak"]:
         return []
     return reasons
@@ -472,6 +509,52 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path)
             or str(recorded_feedback_decision.get("artifact_path")) == str(materialized_artifact_path)
         )
     )
+    if (
+        current_task_id == "record-reward"
+        and isinstance(materialized_artifact_payload, dict)
+        and materialized_artifact_payload.get("task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
+        and _task_status(materialize_task) in COMPLETED_TASK_STATUSES
+        and post_materialization_reward_already_confirmed
+        and {"recent_window_discard_only", "subagents_unused"}.issubset(set(ambition_underutilization_reasons))
+    ):
+        selected_task = _synthesized_materialize_improvement_candidate(
+            current_task_id=current_task_id,
+            strong_pass_count=strong_pass_count,
+            goal_artifact_signature=list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+            status="active",
+        )
+        return {
+            "mode": "escalate_underutilized_ambition",
+            "reason": "HADI escalation: recent reward/candidate cycles are discard-only and resource/subagent budgets are underused; materialize a stronger bounded experiment instead of repeating reward/synthesis bookkeeping",
+            "reward_value": reward_value,
+            "current_task_id": current_task_id,
+            "current_task_class": current_task_class,
+            "repeat_block_count": repeat_block_count,
+            "repeat_block_failure_class": repeat_block_failure_class,
+            "goal_artifact_signature": list(str(value) for value in strong_pass_signature) if strong_pass_signature else None,
+            "strong_pass_count": strong_pass_count,
+            "retire_goal_artifact_pair": False,
+            "ambition_escalation": {
+                "state": "selected",
+                "blocker": None,
+                "schema_version": "hadi-ambition-escalation-v1",
+                "strategy": "hadi_materialize_after_discard_only_underuse",
+                "reasons": ambition_underutilization_reasons,
+                "hypothesis": "A HADI materialization lane will break the discard-only reward/candidate loop.",
+                "action": "Select a concrete materialization task with explicit hypothesis/action/data/insight evidence.",
+                "data": {
+                    "recent_window_size": AMBITION_UNDERUTILIZATION_STREAK_LIMIT,
+                    "current_task_id": current_task_id,
+                    "materialized_artifact_path": str(materialized_artifact_path),
+                },
+                "insight": "Reward bookkeeping is already confirmed; further progress requires a fresh materialized experiment or explicit blocker.",
+            },
+            "selected_task_id": selected_task.get("task_id") or selected_task.get("taskId"),
+            "selected_task_class": _task_action_class(selected_task.get("task_id") or selected_task.get("taskId")),
+            "selection_source": "feedback_hadi_discard_loop_materialize",
+            "selected_task_title": selected_task.get("title") or selected_task.get("summary") or selected_task.get("task_id"),
+            "selected_task_label": _render_task_selection(selected_task),
+        }
     if (
         current_task_id == "record-reward"
         and isinstance(materialized_artifact_payload, dict)
@@ -1686,6 +1769,17 @@ def _write_materialized_improvement_artifact(
         "summary": summary,
         "reward_signal": reward_signal,
         "feedback_decision": feedback_decision,
+        "hadi_cycle": {
+            "hypothesis": "A concrete bounded materialization will create stronger self-improvement evidence than another reward/candidate bookkeeping cycle.",
+            "action": "Materialize one reviewable improvement artifact and route it to a follow-up verification lane.",
+            "data": {
+                "task_id": current_task_id,
+                "reward_signal": reward_signal,
+                "feedback_mode": feedback_decision.get("mode") if isinstance(feedback_decision, dict) else None,
+                "ambition_escalation_reasons": ((feedback_decision.get("ambition_escalation") or {}).get("reasons") if isinstance(feedback_decision, dict) and isinstance(feedback_decision.get("ambition_escalation"), dict) else None),
+            },
+            "insight": "The artifact must either qualify as material progress or trigger explicit subagent verification/blocker handling.",
+        },
         "concrete_improvement_statement": concrete_statement,
         "rationale": rationale,
         "acceptance_checks": [

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -3484,9 +3484,10 @@ def create_app(cfg: DashboardConfig):
             cfg=cfg,
         )
         hypotheses_visibility = {**hypotheses_visibility, 'selected_hypothesis_diagnostics': hypothesis_dynamics}
+        visible_plan_latest = authoritative_plan_latest or plan_latest
         autonomy_verdict = _autonomy_verdict(
             analytics=analytics,
-            plan_latest=plan_latest,
+            plan_latest=visible_plan_latest,
             experiment_visibility=experiment_visibility,
             credits_visibility=credits_visibility,
             cfg=cfg,
@@ -3544,14 +3545,46 @@ def create_app(cfg: DashboardConfig):
                     'reason': current_blocker['failure_class'],
                     'recommended_next_action': current_blocker['blocked_next_step'],
                     'source': 'autonomy_verdict',
-                    'current_task_id': (plan_latest or {}).get('current_task_id'),
-                    'current_task_title': (plan_latest or {}).get('current_task'),
+                    'current_task_id': (visible_plan_latest or {}).get('current_task_id'),
+                    'current_task_title': (visible_plan_latest or {}).get('current_task'),
                 }
         analytics['runtime_parity'] = runtime_parity
         analytics['hypothesis_dynamics'] = hypothesis_dynamics
         analytics['autonomy_verdict'] = autonomy_verdict
         if isinstance(control_plane, dict):
             control_plane = dict(control_plane)
+            if isinstance(visible_plan_latest, dict) and runtime_authority_resolution in {'fresh_live_terminal_selfevo_retire', 'fresh_live_active_lane', 'fresh_live_synthesized_materialization', 'fresh_live_post_materialization_reward', 'fresh_live_synthesis_candidate', 'fresh_live_failure_learning_handoff'}:
+                canonical_task_id = visible_plan_latest.get('current_task_id')
+                canonical_task_title = visible_plan_latest.get('current_task') or canonical_task_id
+                if canonical_task_id:
+                    control_plane['current_task_id'] = canonical_task_id
+                    control_plane['current_task'] = canonical_task_title
+                    control_plane['current_task_title'] = canonical_task_title
+                    producer_summary = control_plane.get('producer_summary')
+                    if isinstance(producer_summary, dict):
+                        producer_summary = dict(producer_summary)
+                        producer_task_plan = producer_summary.get('task_plan')
+                        if isinstance(producer_task_plan, dict):
+                            producer_task_plan = dict(producer_task_plan)
+                            producer_task_plan['current_task_id'] = canonical_task_id
+                            producer_task_plan['current_task'] = canonical_task_title
+                            producer_summary['task_plan'] = producer_task_plan
+                        control_plane['producer_summary'] = producer_summary
+                    blocker_summary = control_plane.get('blocker_summary')
+                    if isinstance(blocker_summary, dict):
+                        blocker_summary = dict(blocker_summary)
+                        blocker_summary['current_task_id'] = canonical_task_id
+                        blocker_summary['current_task_title'] = canonical_task_title
+                        blocker_summary['authority_source'] = 'canonical_live_plan'
+                        control_plane['blocker_summary'] = blocker_summary
+                    current_blocker_payload = control_plane.get('current_blocker')
+                    if isinstance(current_blocker_payload, dict) and current_blocker_payload.get('kind') in {None, 'unknown', 'diagnostic_gap'}:
+                        current_blocker_payload = dict(current_blocker_payload)
+                        current_blocker_payload['current_task_id'] = canonical_task_id
+                        current_blocker_payload['current_task'] = canonical_task_id
+                        current_blocker_payload['current_task_title'] = canonical_task_title
+                        current_blocker_payload['authority_source'] = 'canonical_live_plan'
+                        control_plane['current_blocker'] = current_blocker_payload
             control_plane['material_progress'] = _material_progress_summary(control_plane.get('material_progress'))
             control_plane['runtime_parity'] = runtime_parity
             control_plane['ambition_utilization'] = ambition_utilization

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -587,6 +587,10 @@ def test_dashboard_runtime_parity_trusts_fresh_live_failure_learning_handoff_and
     assert parity['canonical_current_task_id'] == 'analyze-last-failed-candidate'
     assert parity['authority_resolution'] == 'fresh_live_failure_learning_handoff'
     assert 'current_task_drift' not in parity['reasons']
+    assert system['autonomy_verdict']['current_task_id'] == 'analyze-last-failed-candidate'
+    assert system['control_plane']['current_task_id'] == 'analyze-last-failed-candidate'
+    assert system['control_plane']['current_task'] == 'Analyze the last failed self-evolution candidate before retrying mutation'
+    assert system['control_plane']['current_task_title'] == 'Analyze the last failed self-evolution candidate before retrying mutation'
 
     plan = _call_json(app, '/api/plan')
     assert plan['current_task_id'] == 'analyze-last-failed-candidate'

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -901,7 +901,10 @@ def test_underutilized_synthesized_candidate_escalates_to_materialization(tmp_pa
     assert decision["selection_source"] == "feedback_ambition_escalation_materialize"
     assert decision["selected_task_id"] == "materialize-synthesized-improvement"
     assert decision["ambition_escalation"]["state"] == "selected"
-    assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
+    reasons = decision["ambition_escalation"]["reasons"]
+    assert "same_task_streak" in reasons
+    assert "subagents_unused" in reasons
+    assert "tool_budget_underused" in reasons
 
 
 def test_underutilized_alternating_reward_inspect_pass_streak_loop_escalates(tmp_path):
@@ -966,7 +969,10 @@ def test_underutilized_alternating_reward_inspect_pass_streak_loop_escalates(tmp
     assert decision["selected_task_id"] == "materialize-synthesized-improvement"
     assert decision["retire_goal_artifact_pair"] is False
     assert decision["selection_source"] != "feedback_pass_streak_switch"
-    assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
+    reasons = decision["ambition_escalation"]["reasons"]
+    assert "same_task_streak" in reasons
+    assert "subagents_unused" in reasons
+    assert "tool_budget_underused" in reasons
 
 
 def test_underutilized_alternating_reward_synthesis_loop_escalates(tmp_path):
@@ -1018,7 +1024,10 @@ def test_underutilized_alternating_reward_synthesis_loop_escalates(tmp_path):
     assert decision["mode"] == "escalate_underutilized_ambition"
     assert decision["selected_task_id"] == "materialize-synthesized-improvement"
     assert decision["ambition_escalation"]["state"] == "selected"
-    assert decision["ambition_escalation"]["reasons"] == ["same_task_streak", "subagents_unused", "tool_budget_underused"]
+    reasons = decision["ambition_escalation"]["reasons"]
+    assert "same_task_streak" in reasons
+    assert "subagents_unused" in reasons
+    assert "tool_budget_underused" in reasons
 
 
 def test_record_reward_with_done_synthesized_materialization_prioritizes_reward_accounting_before_ambition(tmp_path):
@@ -1130,9 +1139,12 @@ def test_consumed_post_materialization_reward_accounting_rotates_to_fresh_synthe
     decision = _derive_feedback_decision(task_plan, goals)
 
     assert decision is not None
-    assert decision["mode"] == "synthesize_next_candidate"
-    assert decision["selected_task_id"] == "synthesize-next-improvement-candidate"
-    assert decision["selection_source"] == "feedback_no_selectable_retired_lane_synthesis"
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["selection_source"] == "feedback_hadi_discard_loop_materialize"
+    reasons = decision["ambition_escalation"]["reasons"]
+    assert "recent_window_discard_only" in reasons
+    assert "subagents_unused" in reasons
 
 
 def test_underutilized_synthesis_refreshes_completed_materialization_lane(tmp_path):
@@ -2620,3 +2632,87 @@ def test_material_progress_treats_unknown_subagent_result_age_as_stale():
     assert consumed['present'] is False
     assert consumed['evidence']['latest_result_age_seconds'] is None
     assert consumed['evidence']['freshness_state'] == 'stale'
+
+def test_feedback_decision_escalates_discard_only_reward_candidate_loop_to_hadi_materialization(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+    goals_dir = state_root / "goals"
+    history_dir = goals_dir / "history"
+    experiments_dir = state_root / "experiments"
+    improvements_dir = state_root / "improvements"
+    history_dir.mkdir(parents=True)
+    experiments_dir.mkdir(parents=True)
+    improvements_dir.mkdir(parents=True)
+    materialized_path = improvements_dir / "materialized-old.json"
+    materialized_path.write_text(
+        json.dumps({"schema_version": "materialized-improvement-v1", "task_id": "materialize-synthesized-improvement"}),
+        encoding="utf-8",
+    )
+
+    task_ids = [
+        "record-reward",
+        "synthesize-next-improvement-candidate",
+        "record-reward",
+        "synthesize-next-improvement-candidate",
+        "record-reward",
+    ]
+    for idx, task_id in enumerate(task_ids):
+        (history_dir / f"cycle-{idx}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "task-history-v1",
+                    "result_status": "PASS",
+                    "goal_id": "goal-bootstrap",
+                    "current_task_id": task_id,
+                    "experiment": {"outcome": "discard", "revert_status": "skipped_no_material_change"},
+                    "budget_used": {"requests": 1, "tool_calls": 2, "subagents": 0, "elapsed_seconds": 0},
+                }
+            ),
+            encoding="utf-8",
+        )
+    (experiments_dir / "latest.json").write_text(
+        json.dumps({"outcome": "discard", "current_task_id": "record-reward", "revert_status": "skipped_no_material_change"}),
+        encoding="utf-8",
+    )
+
+    task_plan = {
+        "current_task_id": "record-reward",
+        "reward_signal": {"value": 1.2},
+        "materialized_improvement_artifact_path": str(materialized_path),
+        "feedback_decision": {
+            "mode": "record_reward_after_synthesized_materialization",
+            "current_task_id": "record-reward",
+            "selected_task_id": "record-reward",
+            "artifact_path": str(materialized_path),
+        },
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "active"},
+            {
+                "task_id": "synthesize-next-improvement-candidate",
+                "title": "Synthesize one new bounded improvement candidate from retired lanes",
+                "status": "pending",
+                "kind": "review",
+            },
+            {
+                "task_id": "materialize-synthesized-improvement",
+                "title": "Materialize one bounded improvement from the synthesized candidate",
+                "status": "done",
+                "kind": "execution",
+            },
+        ],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals_dir)
+
+    assert decision is not None
+    assert decision["mode"] == "escalate_underutilized_ambition"
+    assert decision["selection_source"] == "feedback_hadi_discard_loop_materialize"
+    assert decision["selected_task_id"] == "materialize-synthesized-improvement"
+    assert decision["selected_task_class"] == "execution"
+    reasons = decision["ambition_escalation"]["reasons"]
+    assert "recent_window_discard_only" in reasons
+    assert "low_task_diversity" in reasons
+    assert "subagents_unused" in reasons
+    assert "tool_budget_underused" in reasons
+    assert "time_budget_underused" in reasons
+    assert decision["ambition_escalation"]["schema_version"] == "hadi-ambition-escalation-v1"
+    assert "HADI" in decision["reason"]


### PR DESCRIPTION
## Summary

Fixes #401
Fixes #402
Fixes #403

This PR applies the HADI-first intervention selected from the 12h self-evolution audit:

- Hypothesis: repeated discard-only reward/candidate loops need a stronger materialization lane instead of more bookkeeping.
- Action: escalate underused discard-only reward/candidate windows into a HADI materialization task.
- Data: recent history outcome, task diversity, subagent/tool/time budget usage are now included in ambition escalation reasons.
- Insight: reward accounting already confirmed is not enough; the next lane must produce a material artifact or explicit blocker.

Runtime changes:
- enrich underutilization detection with low task diversity, discard-only windows, and time-budget underuse.
- add a HADI escalation branch for confirmed post-materialization reward loops that would otherwise rotate back to synthesis.
- mark synthesized materialization candidates as HADI-required.
- write HADI fields into materialized improvement artifacts.

Dashboard changes:
- `/api/system.autonomy_verdict` now uses the same authoritative live plan selected for `/api/plan` when live authority is fresh.
- `/api/system.control_plane` overlays `current_task_id`, `current_task`, `current_task_title`, blocker summary, and producer task plan with canonical live authority when applicable.

## Verification

- `python3 -m py_compile nanobot/runtime/coordinator.py ops/dashboard/src/nanobot_ops_dashboard/app.py`
- `python3 -m pytest tests/test_runtime_coordinator.py -q` → 50 passed
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py tests/test_autonomy_stagnation_dashboard.py -q)` → 68 passed
- `(cd ops/dashboard && python3 -m pytest tests -q)` → 137 passed
- `python3 -m pytest tests -q` → 683 passed, 5 skipped
- `git diff --check` → passed

## Live proof plan after merge

- rollout pinned eeepc runtime from merged main.
- restart local dashboard services and remote `nanobot-gateway-eeepc.service`.
- trigger `/collect`.
- verify `/api/system` and `/api/plan` canonical task coherence.
- run/inspect live self-evolving cycle artifacts for HADI escalation fields or explicit blocker evidence.
