### PR TITLE
Fix HADI materialization subagent handoff

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2420,7 +2420,7 @@ def _build_task_plan_snapshot(
                     task["status"] = "pending"
             current_task_id = next_candidate.get("task_id")
             feedback_decision = {
-                "mode": "handoff_to_subagent_verification" if next_candidate.get("task_id") == "subagent-verify-materialized-improvement" else "handoff_to_next_candidate",
+                "mode": "handoff_to_subagent_verification" if is_synthesized_materialization and next_candidate.get("task_id") == "subagent-verify-materialized-improvement" else "handoff_to_next_candidate",
                 "reason": "materialized lane completed and handed off to the next bounded candidate",
                 "reward_value": reward_signal.get("value") if isinstance(reward_signal, dict) else None,
                 "current_task_id": completed_materialization_task_id,
@@ -3445,7 +3445,7 @@ async def run_self_evolving_cycle(
         experiment["budget_used"]["tool_calls"] = max(int(experiment["budget_used"].get("tool_calls") or 0), 2)
         if current_plan.get("current_task_id") == "subagent-verify-materialized-improvement":
             experiment["budget_used"]["subagents"] = max(int(experiment["budget_used"].get("subagents") or 0), 1)
-        if (current_plan.get("feedback_decision") or {}).get("mode") in {"complete_active_lane", "handoff_to_next_candidate"}:
+        if (current_plan.get("feedback_decision") or {}).get("mode") in {"complete_active_lane", "handoff_to_next_candidate", "handoff_to_subagent_verification"}:
             experiment["review_status"] = "ready_for_policy_review"
             experiment["decision"] = "ready_for_policy_review"
             experiment["readiness_checks"] = [

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -431,8 +431,9 @@ def test_completed_materialization_does_not_reselect_terminal_failure_learning_t
     )
 
     decision = plan.get('feedback_decision') or {}
-    assert plan['current_task_id'] == 'record-reward'
-    assert decision.get('selected_task_id') == 'record-reward'
+    assert plan['current_task_id'] == 'subagent-verify-materialized-improvement'
+    assert decision.get('selected_task_id') == 'subagent-verify-materialized-improvement'
+    assert decision.get('mode') == 'handoff_to_subagent_verification'
     assert decision.get('selection_source') != 'feedback_complete_active_lane_to_failure_learning'
     assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
 


### PR DESCRIPTION
## Summary

Fixes #402

Post-PR #404 live proof showed the ambition/materialization fix worked but resource utilization was still not proven: the eeepc cycle wrote an accepted synthesized materialization artifact while `budget_used.subagents=0` and no durable subagent request/result/blocker existed.

This corrective PR tightens the HADI synthesized-materialization handoff:

- preserves legacy pass-streak materialization public contract (`handoff_to_next_candidate`) so existing governance/readiness behavior remains stable;
- uses explicit `handoff_to_subagent_verification` only for HADI synthesized materialization handoff;
- treats `handoff_to_subagent_verification` as a materialized readiness/reviewable completion mode so reports/promotions keep readiness evidence;
- updates the terminal/failure-learning regression to assert that completed synthesized materialization goes to subagent verification instead of reward accounting/failure-learning diversion.

## HADI

Hypothesis: #402 remained open because HADI materialization produced a durable artifact, but the reward/readiness chain did not require fresh subagent verification evidence.

Action: make the synthesized materialization handoff explicit and reviewable without changing legacy pass-streak semantics.

Data: live rollout after PR #404 showed `materialize-synthesized-improvement` accepted, but `budget_used.subagents=0`, `subagent_consumption.state=none`.

Insight: the main constraint is dependency ordering after materialization: subagent verification must be the next gate for HADI materialization before reward accounting can be considered complete.

## Verification

- `python3 -m py_compile nanobot/runtime/coordinator.py`
- `python3 -m pytest tests/test_runtime_coordinator.py -q` → 50 passed
- targeted regression group → 31 passed
- `(cd ops/dashboard && python3 -m pytest tests -q)` → 137 passed
- `python3 -m pytest tests -q` → 683 passed, 5 skipped
- `git diff --check` → passed

## Live proof plan after merge

- roll out merged main to both eeepc runtime roots:
  - `/home/opencode/.nanobot-eeepc/runtime/pinned/current`
  - `/opt/eeepc-agent/runtimes/self-evolving-agent/current`
- run `eeepc-self-evolving-agent.service` cycle;
- inspect `/var/lib/eeepc-agent/self-evolving-agent/state/goals/current.json`, latest report, and `state/subagents/requests`;
- require fresh `subagent-request-v1` or explicit blocker before closing #402 again.
