### PR TITLE
Fix fresh subagent handoff before stale-lane retirement

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2502,10 +2502,10 @@ def _build_task_plan_snapshot(
                     feedback_decision["failure_learning"] = latest_failure_learning
             active_artifact_path = materialized_improvement_artifact_path
     latest_noop = _safe_read_json(workspace / "state" / "self_evolution" / "runtime" / "latest_noop.json") or {}
-    subagent_lane_health = _subagent_lane_health(state_root=workspace / "state", current_task_id=current_task_id)
+    subagent_lane_health = _subagent_lane_health(state_root=goals_dir.parent, current_task_id=current_task_id)
     should_retire_subagent_lane = (
         current_task_id == "subagent-verify-materialized-improvement"
-        and not (isinstance(feedback_decision, dict) and feedback_decision.get("mode") == "execute_queued_revert")
+        and not (isinstance(feedback_decision, dict) and feedback_decision.get("mode") in {"execute_queued_revert", "handoff_to_subagent_verification"})
         and (
             latest_noop.get("status") == "terminal_noop"
             or subagent_lane_health.get("state") == "stale"


### PR DESCRIPTION
## Summary

Follow-up for #402 after live rollout of PR #407.

Live eeepc proof showed the HADI materialization handoff attempted to route through `subagent-verify-materialized-improvement`, but the runtime immediately retired that lane with `retire_stale_subagent_lane` before `_write_subagent_request_artifact()` could create a fresh durable request.

Root cause:
- subagent lane retirement was evaluated in `_build_task_plan_snapshot` using the pre-plan experiment `discard` outcome;
- the same-cycle `handoff_to_subagent_verification` feedback was not exempted from retirement;
- subagent lane health read `workspace/state` instead of the resolved runtime state root represented by `goals_dir.parent`, which is wrong for host-control-plane eeepc state.

Fix:
- use `goals_dir.parent` for subagent lane health;
- do not retire a subagent lane in the same cycle that explicitly selected it via `handoff_to_subagent_verification`.

## Verification

- `python3 -m py_compile nanobot/runtime/coordinator.py`
- `python3 -m pytest tests/test_runtime_coordinator.py -q` → 50 passed
- targeted regression group → 31 passed
- `(cd ops/dashboard && python3 -m pytest tests -q)` → 137 passed
- `python3 -m pytest tests -q` → 683 passed, 5 skipped
- `git diff --check` → passed

## Live proof requirement after merge

Run eeepc self-evolving service and require canonical host-control-plane proof that:
- current/last cycle uses `subagent-verify-materialized-improvement`, or writes a concrete blocker;
- a fresh `subagent-request-v1` is present under `/var/lib/eeepc-agent/self-evolving-agent/state/subagents/requests`;
- `budget_used.subagents >= 1` for the request-writing cycle.
