### PR TITLE
Expose source skew in runtime parity state

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1189,9 +1189,13 @@ def _dashboard_runtime_parity(repo_plan: dict | None, eeepc_plan: dict | None, c
         reasons.append('live_hadi_artifacts_missing')
     legacy = live_is_legacy_reward or (not live_feedback and 'record-reward' in str(live_task or '') and bool(missing))
     source_skew = _snapshot_source_skew(repo_plan, eeepc_plan)
+    source_skew_state = source_skew.get('state') if isinstance(source_skew, dict) else None
+    parity_state = 'legacy_reward_loop' if legacy else ('healthy' if not reasons else 'degraded')
+    if parity_state == 'healthy' and authority_resolution and source_skew_state == 'skewed':
+        parity_state = 'authority_resolved_with_source_skew'
     return {
         'schema_version': 'runtime-parity-v1',
-        'state': 'legacy_reward_loop' if legacy else ('healthy' if not reasons else 'degraded'),
+        'state': parity_state,
         'reasons': reasons,
         'missing_live_artifacts': missing,
         'local_current_task_id': local_task,

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -581,7 +581,7 @@ def test_dashboard_runtime_parity_trusts_fresh_live_failure_learning_handoff_and
 
     system = _call_json(app, '/api/system')
     parity = system['runtime_parity']
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert parity['local_current_task_id'] == 'record-reward'
     assert parity['live_current_task_id'] == 'analyze-last-failed-candidate'
     assert parity['canonical_current_task_id'] == 'analyze-last-failed-candidate'
@@ -1051,9 +1051,11 @@ def test_api_system_and_plan_adopt_fresh_live_active_lane_when_local_task_is_sta
     system = _call_json(app, '/api/system')
     plan = _call_json(app, '/api/plan')
 
-    assert system['runtime_parity']['state'] == 'healthy'
+    assert system['runtime_parity']['state'] == 'authority_resolved_with_source_skew'
     assert system['runtime_parity']['authority_resolution'] == 'fresh_live_active_lane'
     assert system['runtime_parity']['canonical_current_task_id'] == 'synthesize-next-improvement-candidate'
+    assert system['runtime_parity']['source_skew']['state'] == 'skewed'
+    assert 'current_task_drift' in system['runtime_parity']['source_skew']['reasons']
     assert plan['current_plan_source'] == 'eeepc'
     assert plan['current_task_id'] == 'synthesize-next-improvement-candidate'
     assert plan['task_plan']['current_task_id'] == 'synthesize-next-improvement-candidate'
@@ -1086,7 +1088,7 @@ def test_runtime_parity_trusts_pass_streak_switch_to_reward_even_when_selected_t
 
     parity = _dashboard_runtime_parity(repo_plan, eeepc_plan, cfg)
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert parity['authority_resolution'] == 'fresh_live_pass_streak_switch'
     assert parity['canonical_current_task_id'] == 'record-reward'
     assert 'current_task_drift' not in parity['reasons']
@@ -1790,7 +1792,7 @@ def test_runtime_parity_adopts_fresh_live_synthesized_materialization_when_local
         cfg,
     )
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'materialize-synthesized-improvement'
     assert parity['authority_resolution'] == 'fresh_live_synthesized_materialization'
@@ -1827,7 +1829,7 @@ def test_runtime_parity_adopts_fresh_live_post_materialization_reward_when_local
         cfg,
     )
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'record-reward'
     assert parity['authority_resolution'] == 'fresh_live_post_materialization_reward'
@@ -1863,7 +1865,7 @@ def test_runtime_parity_adopts_fresh_live_synthesized_candidate_after_reward_rot
         cfg,
     )
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'synthesize-next-improvement-candidate'
     assert parity['authority_resolution'] == 'fresh_live_synthesis_candidate'
@@ -1998,7 +2000,7 @@ def test_runtime_parity_adopts_fresh_live_hadi_handoff_when_local_task_is_stale(
         cfg,
     )
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'subagent-verify-materialized-improvement'
     assert parity['authority_resolution'] == 'fresh_live_hadi_handoff'
@@ -2040,7 +2042,7 @@ def test_runtime_parity_adopts_fresh_live_pass_streak_switch_when_local_task_is_
         cfg,
     )
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'inspect-pass-streak'
     assert parity['authority_resolution'] == 'fresh_live_pass_streak_switch'
@@ -2086,7 +2088,7 @@ def test_runtime_parity_adopts_live_terminal_selfevo_retirement_when_local_task_
         cfg,
     )
 
-    assert parity['state'] == 'healthy'
+    assert parity['state'] == 'authority_resolved_with_source_skew'
     assert 'current_task_drift' not in parity['reasons']
     assert parity['canonical_current_task_id'] == 'record-reward'
     assert parity['authority_resolution'] == 'fresh_live_terminal_selfevo_retire'
@@ -2360,7 +2362,7 @@ def test_runtime_parity_accepts_local_failure_learning_repair_over_stale_live_co
 
     result = _dashboard_runtime_parity(repo_plan, live_plan, cfg)
 
-    assert result['state'] == 'healthy'
+    assert result['state'] == 'authority_resolved_with_source_skew'
     assert result['reasons'] == []
     assert result['canonical_current_task_id'] == 'analyze-last-failed-candidate'
     assert result['authority_resolution'] == 'local_failure_learning_repair_over_stale_live_complete_lane'
@@ -2402,7 +2404,7 @@ def test_runtime_parity_adopts_fresh_live_active_lane_when_local_task_is_stale(t
 
     result = _dashboard_runtime_parity(repo_plan, live_plan, cfg)
 
-    assert result['state'] == 'healthy'
+    assert result['state'] == 'authority_resolved_with_source_skew'
     assert result['reasons'] == []
     assert result['canonical_current_task_id'] == 'synthesize-next-improvement-candidate'
     assert result['authority_resolution'] == 'fresh_live_active_lane'


### PR DESCRIPTION
## Summary

Fixes reopened #403.

Post-#408 dashboard proof showed a truth contradiction:

- canonical plan fields correctly used fresh live eeepc authority;
- but `/api/system.runtime_parity.state` still reported `healthy` while `source_skew.state=skewed` with `current_task_drift`/`cycle_drift`.

This PR preserves canonical authority selection while making the parity state truthful:

- when a fresh live authority resolution is selected and `source_skew.state == skewed`, runtime parity now reports `authority_resolved_with_source_skew` instead of plain `healthy`;
- API consumers can distinguish “we chose the right canonical authority” from “all sources are aligned”.

## Verification

- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py::test_api_system_and_plan_adopt_fresh_live_active_lane_when_local_task_is_stale -q` -> passed
- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -q` -> 55 passed
- `python3 -m py_compile src/nanobot_ops_dashboard/app.py`
- `python3 -m pytest tests -q` from `ops/dashboard` -> 137 passed
- `python3 -m pytest tests -q` from repo root -> 683 passed, 5 skipped
- `git diff --check` -> passed

## Rollout proof plan

After merge:

- restart dashboard services;
- run `/collect`;
- verify `/api/system.runtime_parity.state != healthy` whenever `source_skew.state=skewed`;
- verify `/api/system` and `/api/plan` still expose fresh live canonical task.
