### PR TITLE
Block healthy progress on unresolved subagent request

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -1450,16 +1450,29 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
                 pass
     subagent_visibility = subagent_visibility if isinstance(subagent_visibility, dict) else {}
     subagent_summary = subagent_visibility.get('summary') if isinstance(subagent_visibility.get('summary'), dict) else {}
+    fresh_subagent_result_count = int(subagent_summary.get('fresh_result_count') or 0) if subagent_summary else 0
+    subagent_result_count = int(subagent_summary.get('result_count') or 0) if subagent_summary else 0
+    stale_subagent_result_count = int(subagent_summary.get('stale_result_count') or 0) if subagent_summary else 0
+    queued_subagent_request_count = int(subagent_summary.get('queued_request_count') or 0) if subagent_summary else 0
+    blocked_subagent_result_count = int(subagent_summary.get('blocked_result_count') or 0) if subagent_summary else 0
     no_fresh_subagent_result = bool(
         subagent_summary
-        and int(subagent_summary.get('fresh_result_count') or 0) == 0
-        and (int(subagent_summary.get('result_count') or 0) > 0 or int(subagent_summary.get('stale_result_count') or 0) > 0)
+        and fresh_subagent_result_count == 0
+        and (subagent_result_count > 0 or stale_subagent_result_count > 0)
+    )
+    unresolved_subagent_request = bool(
+        subagent_summary
+        and queued_subagent_request_count > 0
+        and fresh_subagent_result_count == 0
+        and blocked_subagent_result_count == 0
     )
     discard_only_recent_window = bool(len(recent_discard_rows) >= 5 and all(recent_discard_rows) and recent_budget_rows and recent_subagent_sum == 0)
     if material_allows_healthy and discard_only_recent_window:
         reasons.append('recent_window_discard_only')
     if material_allows_healthy and no_fresh_subagent_result:
         reasons.append('subagent_evidence_stale')
+    if material_allows_healthy and unresolved_subagent_request:
+        reasons.append('subagent_request_unresolved')
     runtime_parity = runtime_parity if isinstance(runtime_parity, dict) else {}
     runtime_reasons = runtime_parity.get('reasons') if isinstance(runtime_parity.get('reasons'), list) else []
     runtime_tasks_aligned = (
@@ -1502,7 +1515,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     historical_reasons: list[str] = []
     if material_allows_healthy:
         stale_after_material_progress = {'same_task_streak', 'discarded_experiment', 'suppressed_reward', 'terminal_noop'}
-        freshness_blockers = {'recent_window_discard_only', 'subagent_evidence_stale'}
+        freshness_blockers = {'recent_window_discard_only', 'subagent_evidence_stale', 'subagent_request_unresolved'}
         blocking_reasons = []
         for reason in reasons:
             if reason in stale_after_material_progress:
@@ -1519,7 +1532,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
         if runtime_parity_is_blocking and runtime_can_be_historical:
             historical_reasons.append('runtime_parity_blocked')
         reasons = blocking_reasons
-    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant', 'promotion_lifecycle_blocked', 'strong_reflection_not_fresh', 'recent_window_discard_only', 'subagent_evidence_stale'}) else 'healthy')
+    status = 'healthy_progress' if material_allows_healthy and not reasons else ('stagnant' if any(reason in reasons for reason in {'same_task_streak', 'discarded_experiment', 'terminal_noop', 'material_progress_missing', 'runtime_parity_blocked', 'ambition_underutilized', 'hypothesis_dynamics_stagnant', 'promotion_lifecycle_blocked', 'strong_reflection_not_fresh', 'recent_window_discard_only', 'subagent_evidence_stale', 'subagent_request_unresolved'}) else 'healthy')
     return {
         'schema_version': 'autonomy-verdict-v1',
         'state': status,
@@ -3532,6 +3545,7 @@ def create_app(cfg: DashboardConfig):
                 'material_progress_missing',
                 'recent_window_discard_only',
                 'subagent_evidence_stale',
+                'subagent_request_unresolved',
                 'ambition_underutilized',
             ]
             selected_reason = next((reason for reason in reason_priority if reason in autonomy_verdict['reasons']), autonomy_verdict['reasons'][0])

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -2796,6 +2796,23 @@ def test_autonomy_verdict_blocks_historical_progress_when_recent_window_is_disca
     assert 'subagent_evidence_stale' in verdict['reasons']
 
 
+def test_autonomy_verdict_blocks_healthy_progress_when_subagent_request_is_queued_without_result(tmp_path: Path) -> None:
+    cfg = DashboardConfig(project_root=tmp_path / 'dashboard', nanobot_repo_root=tmp_path / 'nanobot', db_path=tmp_path / 'dashboard.sqlite3', eeepc_ssh_host='eeepc', eeepc_ssh_key=tmp_path / 'missing-key', eeepc_state_root='/state')
+
+    verdict = _autonomy_verdict(
+        analytics={'recent_status_sequence': [], 'current_streak': {'status': 'PASS', 'length': 3}},
+        plan_latest={'current_task_id': 'subagent-verify-materialized-improvement'},
+        experiment_visibility={'current_experiment': {'outcome': 'accept'}},
+        credits_visibility={'current': {}},
+        cfg=cfg,
+        material_progress={'schema_version': 'material-progress-v1', 'state': 'proven', 'healthy_autonomy_allowed': True},
+        subagent_visibility={'summary': {'queued_request_count': 1, 'result_count': 0, 'blocked_result_count': 0, 'stale_result_count': 0, 'fresh_result_count': 0}},
+    )
+
+    assert verdict['state'] == 'stagnant'
+    assert 'subagent_request_unresolved' in verdict['reasons']
+
+
 def test_ambition_utilization_escalates_rotating_synthesis_reward_window_when_subagents_and_tools_underused() -> None:
     analytics = {
         'recent_status_sequence': [


### PR DESCRIPTION
## Summary

Fixes #406.

After #402, live runtime correctly creates a fresh durable `subagent-request-v1` and records dispatch budget. The remaining reward/readiness problem was that dashboard autonomy verdict could still overclaim `healthy_progress` when the subagent proof was only queued and no fresh result or explicit blocker had been consumed.

This PR binds dashboard readiness/reward truth to delegated verification state:

- queued subagent request without fresh result/blocker now adds `subagent_request_unresolved`;
- `subagent_request_unresolved` blocks `healthy_progress` and yields `stagnant` until verification is consumed;
- blocker prioritization surfaces unresolved subagent requests alongside stale subagent evidence;
- existing stale-result behavior remains `subagent_evidence_stale`.

The runtime budget semantics from #402 remain intact: creating a durable request can count as dispatched subagent budget, but readiness/progress is no longer complete until the result/blocker evidence advances.

## HADI

Hypothesis: the main post-#402 bottleneck is not request creation, but reward/readiness overclaiming while the request remains unresolved.

Action: add an explicit queued-only blocker to autonomy verdict and dashboard blocker priority.

Data: live proof after #402 showed `request_status=queued` and `budget_used.subagents=1`, while result consumption remained absent/stale.

Insight: dispatch budget and verification completion must be represented as separate states.

## Verification

- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py::test_autonomy_verdict_blocks_healthy_progress_when_subagent_request_is_queued_without_result -q` -> passed
- `python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -q` -> 56 passed
- `python3 -m py_compile src/nanobot_ops_dashboard/app.py`
- dashboard suite -> 138 passed
- root suite -> 683 passed, 5 skipped
- `git diff --check` -> passed

## Rollout proof plan

After merge:

- restart dashboard services;
- run `/collect`;
- verify `/api/system.autonomy_verdict.state` is not `healthy_progress` when `/api/subagents.summary.queued_request_count > 0` and no fresh result/blocker exists;
- comment/close #406 with live API proof.
