### PR TITLE
Preflight eeepc venv symlink loops

### DIFF
--- a/docs/plans/2026-04-16-eeepc-live-repair-approval-subagents.md
+++ b/docs/plans/2026-04-16-eeepc-live-repair-approval-subagents.md
@@ -60,6 +60,7 @@ Ready for privileged rollout requires all of these:
 - `sudo` or equivalent privileged execution is available for `/var/lib/eeepc-agent/self-evolving-agent/state`
 - the opencode Nanobot venv can be executed through the intended service account or through `sudo env PYTHONPATH=... /home/opencode/.venvs/nanobot/bin/nanobot ...`
 - `outbox/report.index.json`, `goals/registry.json`, and the newest report can be read from the same authority root
+- the `/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python` path resolves to an executable interpreter without a `.venv -> current/.venv` symlink loop
 - side-by-side `nanobot status --runtime-state-source host_control_plane --runtime-state-root /var/lib/eeepc-agent/self-evolving-agent/state` reports concrete status, goal, approval, report, and outbox fields, not `unknown`
 
 If any of those are false, the slice remains a readiness/proof-preservation slice only. Do not claim HADI/follow-through host-emitter parity from readable reports alone; create or keep a privileged follow-up issue with exact blockers.

--- a/scripts/eeepc_privileged_rollout_preflight.py
+++ b/scripts/eeepc_privileged_rollout_preflight.py
@@ -13,6 +13,7 @@ from typing import Any, Sequence
 DEFAULT_STATE_ROOT = "/var/lib/eeepc-agent/self-evolving-agent/state"
 DEFAULT_NANOBOT = "/home/opencode/.venvs/nanobot/bin/nanobot"
 DEFAULT_OPENCODE_HOME = "/home/opencode"
+DEFAULT_SELF_EVOLVING_BASE = "/opt/eeepc-agent/runtimes/self-evolving-agent"
 
 
 def run_command(args: Sequence[str], timeout: int = 20) -> subprocess.CompletedProcess[str]:
@@ -52,6 +53,68 @@ def _with_via(result: dict[str, Any], via: str) -> dict[str, Any]:
     return enriched
 
 
+def _parse_key_value_lines(text: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in str(text or "").splitlines():
+        if "=" not in raw_line:
+            continue
+        key, value = raw_line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def _self_evolving_venv_guard_command(self_evolving_base: str) -> str:
+    base = _quote(self_evolving_base)
+    script = (
+        "echo EEEBOT_VENV_GUARD=1; "
+        f"BASE={base}; "
+        'CUR=$(readlink -f "$BASE/current" 2>/dev/null || true); '
+        'echo "current=$CUR"; '
+        'if [ -n "$CUR" ]; then '
+        '  LINK=$(readlink "$CUR/.venv" 2>/dev/null || true); '
+        '  PY=$(readlink -f "$CUR/.venv/bin/python" 2>/dev/null || true); '
+        '  echo "venv_link=$LINK"; '
+        '  echo "python=$PY"; '
+        '  test -x "$CUR/.venv/bin/python"; '
+        'else '
+        '  echo "venv_link="; echo "python="; exit 1; '
+        'fi'
+    )
+    return f"sh -lc {_quote(script)}"
+
+
+def _evaluate_venv_guard(raw: dict[str, Any], *, self_evolving_base: str) -> dict[str, Any]:
+    values = _parse_key_value_lines(str(raw.get("stdout") or ""))
+    current = values.get("current", "")
+    venv_link = values.get("venv_link", "")
+    python = values.get("python", "")
+    reasons: list[str] = []
+    current_venv = f"{self_evolving_base.rstrip('/')}/current/.venv"
+    if not raw.get("ok"):
+        reasons.append("venv_python_missing")
+    if venv_link == current_venv or venv_link.endswith("/current/.venv"):
+        reasons.append("venv_symlink_loop_risk")
+    if current and venv_link and venv_link.startswith(f"{current.rstrip('/')}/"):
+        reasons.append("venv_symlink_loop_risk")
+    if not python:
+        reasons.append("venv_python_missing")
+    result = dict(raw)
+    result.update({
+        "ok": not reasons,
+        "current": current or None,
+        "venv_link": venv_link or None,
+        "python": python or None,
+        "reasons": sorted(set(reasons)),
+    })
+    return result
+
+
+def _self_evolving_venv_guard(host: str, *, self_evolving_base: str, sudo_available: bool, key: str | None = None) -> dict[str, Any]:
+    command = _self_evolving_venv_guard_command(self_evolving_base)
+    raw = _ssh(host, _sudo(command) if sudo_available else command, key=key)
+    return _evaluate_venv_guard(_with_via(raw, "sudo" if sudo_available else "direct"), self_evolving_base=self_evolving_base)
+
+
 def _effective_check(host: str, direct_command: str, sudo_command: str, *, sudo_available: bool, key: str | None = None) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]:
     direct = _ssh(host, direct_command, key=key)
     if direct["ok"]:
@@ -81,7 +144,7 @@ def _read_latest_report(host: str, state_root: str, *, key: str | None = None, s
         return report_path, None, {"ok": False, "message": str(exc), "stage": "parse_latest_report", "path": report_path}
 
 
-def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str | None = None, nanobot_path: str = DEFAULT_NANOBOT, opencode_home: str = DEFAULT_OPENCODE_HOME) -> dict[str, Any]:
+def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str | None = None, nanobot_path: str = DEFAULT_NANOBOT, opencode_home: str = DEFAULT_OPENCODE_HOME, self_evolving_base: str = DEFAULT_SELF_EVOLVING_BASE) -> dict[str, Any]:
     collected_at = datetime.now(timezone.utc).isoformat()
     ssh_probe = _ssh(host, "hostname; whoami; id", key=key)
     blockers: list[str] = []
@@ -110,6 +173,7 @@ def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str
     )
     outbox, direct_outbox, sudo_outbox = _effective_check(host, outbox_command, outbox_command, sudo_available=sudo_available, key=key)
     goals, direct_goals, sudo_goals = _effective_check(host, goals_command, goals_command, sudo_available=sudo_available, key=key)
+    self_evolving_release_venv = _self_evolving_venv_guard(host, self_evolving_base=self_evolving_base, sudo_available=sudo_available, key=key)
     checks.update({
         "sudo_noninteractive": sudo,
         "opencode_nanobot_executable": opencode_home_check,
@@ -121,6 +185,7 @@ def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str
         "read_goal_registry": goals,
         "direct_read_goal_registry": direct_goals,
         "sudo_read_goal_registry": sudo_goals,
+        "self_evolving_release_venv": self_evolving_release_venv,
     })
     if not sudo_available:
         blockers.append("sudo_noninteractive")
@@ -130,6 +195,8 @@ def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str
         blockers.append("read_authority_outbox")
     if not goals["ok"]:
         blockers.append("read_goal_registry")
+    if not self_evolving_release_venv["ok"]:
+        blockers.extend(self_evolving_release_venv.get("reasons") or ["self_evolving_release_venv"])
 
     report_path, report_payload, report_error = _read_latest_report(host, state_root, key=key, sudo_available=sudo_available)
     latest_report = None
@@ -169,9 +236,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--ssh-key", default=str(Path.home() / ".ssh" / "id_ed25519_eeepc"))
     parser.add_argument("--nanobot-path", default=DEFAULT_NANOBOT)
     parser.add_argument("--opencode-home", default=DEFAULT_OPENCODE_HOME)
+    parser.add_argument("--self-evolving-base", default=DEFAULT_SELF_EVOLVING_BASE)
     parser.add_argument("--json", action="store_true", help="Accepted for explicitness; output is always JSON.")
     args = parser.parse_args(argv)
-    payload = build_preflight(host=args.host, state_root=args.state_root, key=args.ssh_key, nanobot_path=args.nanobot_path, opencode_home=args.opencode_home)
+    payload = build_preflight(host=args.host, state_root=args.state_root, key=args.ssh_key, nanobot_path=args.nanobot_path, opencode_home=args.opencode_home, self_evolving_base=args.self_evolving_base)
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0
 

--- a/tests/test_eeepc_privileged_rollout_preflight.py
+++ b/tests/test_eeepc_privileged_rollout_preflight.py
@@ -10,6 +10,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / 'scripts' / 'eeepc_privileged_rollout_preflight.py'
 
 
+def _good_venv_guard_stdout():
+    return '\n'.join([
+        'EEEBOT_VENV_GUARD=1',
+        'current=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260430-new',
+        'venv_link=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260430-old/.venv',
+        'python=/usr/bin/python3.11',
+    ])
+
+
 def _load_module():
     spec = importlib.util.spec_from_file_location('eeepc_privileged_rollout_preflight', SCRIPT)
     module = importlib.util.module_from_spec(spec)
@@ -42,6 +51,8 @@ def test_preflight_reports_blocked_privileged_access_with_latest_readable_report
             return subprocess.CompletedProcess(args, 1, '', '')
         if 'goals/registry.json' in command:
             return subprocess.CompletedProcess(args, 1, '', '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
         if '/reports/evolution-*.json' in command:
             return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
         if command == f'cat {latest_report}' or command == f'sudo -n cat {latest_report}':
@@ -96,6 +107,8 @@ def test_preflight_reports_ready_when_all_privileged_checks_pass(monkeypatch):
             return subprocess.CompletedProcess(args, 0, 'ok\n', '')
         if command.startswith('test -x ') or command.startswith('test -r '):
             return subprocess.CompletedProcess(args, 0, '', '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
         if '/reports/evolution-*.json' in command:
             return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
         if command == f'cat {latest_report}' or command == f'sudo -n cat {latest_report}':
@@ -176,8 +189,12 @@ def test_preflight_uses_sudo_mediated_checks_when_passwordless_sudo_is_available
             return subprocess.CompletedProcess(args, 0, '', '')
         if command.startswith('test -x ') or command.startswith('test -r '):
             return subprocess.CompletedProcess(args, 1, '', 'permission denied')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
         if command.startswith('sudo -n test -x ') or command.startswith('sudo -n test -r ') or command.startswith('sudo -n sh -lc '):
             return subprocess.CompletedProcess(args, 0, '', '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
         if '/reports/evolution-*.json' in command:
             return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
         if command == f'cat {latest_report}' or command == f'sudo -n cat {latest_report}':
@@ -209,6 +226,8 @@ def test_preflight_blocks_exact_sudo_mediated_capability_when_sudo_check_fails(m
             return subprocess.CompletedProcess(args, 0, '', '')
         if command.startswith('test -x ') or command.startswith('test -r '):
             return subprocess.CompletedProcess(args, 1, '', 'permission denied')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
         if command.startswith('sudo -n sh -lc '):
             return subprocess.CompletedProcess(args, 0, '', '')
         if command.startswith('sudo -n test -x '):
@@ -217,6 +236,8 @@ def test_preflight_blocks_exact_sudo_mediated_capability_when_sudo_check_fails(m
             return subprocess.CompletedProcess(args, 1, '', 'missing')
         if 'goals/registry.json' in command and command.startswith('sudo -n test -r '):
             return subprocess.CompletedProcess(args, 0, '', '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
         if '/reports/evolution-*.json' in command:
             return subprocess.CompletedProcess(args, 1, '', '')
         raise AssertionError(command)
@@ -229,3 +250,87 @@ def test_preflight_blocks_exact_sudo_mediated_capability_when_sudo_check_fails(m
     assert payload['ready'] is False
     assert payload['blocked_capabilities'] == ['read_authority_outbox']
     assert payload['checks']['read_authority_outbox']['via'] == 'sudo'
+
+
+def test_preflight_blocks_current_venv_symlink_loop_risk(monkeypatch):
+    module = _load_module()
+    state_root = '/var/lib/eeepc-agent/self-evolving-agent/state'
+    latest_report = f'{state_root}/reports/evolution-ready.json'
+    report_payload = {'result_status': 'PASS', 'goal_id': 'goal-bootstrap'}
+
+    def fake_run(args, timeout=20):
+        command = args[-1]
+        if command == 'hostname; whoami; id':
+            return subprocess.CompletedProcess(args, 0, 'ok\n', '')
+        if command == 'sudo -n true':
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if command.startswith('test -x ') or command.startswith('test -r '):
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if command.startswith('sudo -n test -x ') or command.startswith('sudo -n test -r '):
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, '\n'.join([
+                'EEEBOT_VENV_GUARD=1',
+                'current=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260430-bad',
+                'venv_link=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv',
+                'python=',
+            ]), '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
+        if '/reports/evolution-*.json' in command:
+            return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
+        if command == f'cat {latest_report}' or command == f'sudo -n cat {latest_report}':
+            return subprocess.CompletedProcess(args, 0, json.dumps(report_payload), '')
+        raise AssertionError(command)
+
+    monkeypatch.setattr(module, 'run_command', fake_run)
+
+    payload = module.build_preflight(host='eeepc', state_root=state_root, key='/tmp/key')
+
+    assert payload['state'] == 'blocked_privileged_access'
+    assert payload['ready'] is False
+    assert 'venv_symlink_loop_risk' in payload['blocked_capabilities']
+    assert payload['checks']['self_evolving_release_venv']['ok'] is False
+    assert 'venv_symlink_loop_risk' in payload['checks']['self_evolving_release_venv']['reasons']
+
+
+def test_preflight_accepts_release_venv_resolved_to_previous_release(monkeypatch):
+    module = _load_module()
+    state_root = '/var/lib/eeepc-agent/self-evolving-agent/state'
+    latest_report = f'{state_root}/reports/evolution-ready.json'
+    report_payload = {'result_status': 'PASS', 'goal_id': 'goal-bootstrap'}
+
+    def fake_run(args, timeout=20):
+        command = args[-1]
+        if command == 'hostname; whoami; id':
+            return subprocess.CompletedProcess(args, 0, 'ok\n', '')
+        if command == 'sudo -n true':
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if command.startswith('test -x ') or command.startswith('test -r '):
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if command.startswith('sudo -n test -x ') or command.startswith('sudo -n test -r '):
+            return subprocess.CompletedProcess(args, 0, '', '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, '\n'.join([
+                'EEEBOT_VENV_GUARD=1',
+                'current=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260430-new',
+                'venv_link=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260430-old/.venv',
+                'python=/usr/bin/python3.11',
+            ]), '')
+        if 'EEEBOT_VENV_GUARD' in command:
+            return subprocess.CompletedProcess(args, 0, _good_venv_guard_stdout(), '')
+        if '/reports/evolution-*.json' in command:
+            return subprocess.CompletedProcess(args, 0, latest_report + '\n', '')
+        if command == f'cat {latest_report}' or command == f'sudo -n cat {latest_report}':
+            return subprocess.CompletedProcess(args, 0, json.dumps(report_payload), '')
+        raise AssertionError(command)
+
+    monkeypatch.setattr(module, 'run_command', fake_run)
+
+    payload = module.build_preflight(host='eeepc', state_root=state_root, key='/tmp/key')
+
+    assert payload['state'] == 'ready'
+    assert payload['ready'] is True
+    assert payload['blocked_capabilities'] == []
+    assert payload['checks']['self_evolving_release_venv']['ok'] is True
+    assert payload['checks']['self_evolving_release_venv']['python'] == '/usr/bin/python3.11'

--- a/tests/test_eeepc_privileged_rollout_runbooks.py
+++ b/tests/test_eeepc_privileged_rollout_runbooks.py
@@ -31,4 +31,5 @@ def test_live_repair_plan_requires_privileged_preflight_before_parity_claim():
     assert "Ready for privileged rollout requires all of these" in text
     assert "the opencode Nanobot venv can be executed" in text
     assert "outbox/report.index.json`, `goals/registry.json`, and the newest report can be read" in text
+    assert "without a `.venv -> current/.venv` symlink loop" in text
     assert "not claim HADI/follow-through host-emitter parity from readable reports alone" in text


### PR DESCRIPTION
## Summary

Fixes #412.

The #405 live rollout exposed an `/opt` self-evolving runtime deployment hazard: a new release can be built with `.venv -> /opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv`; after `current` is repointed to that same release, systemd fails with `203/EXEC` / `Too many levels of symbolic links`.

This PR makes the repo-owned privileged preflight catch that class of failure before activation:

- adds a side-effect-free self-evolving release venv guard to `scripts/eeepc_privileged_rollout_preflight.py`;
- detects `.venv -> current/.venv` and self-referential release venv risk;
- reports machine-readable blockers such as `venv_symlink_loop_risk` and `venv_python_missing`;
- preserves existing SSH/sudo/read-only preflight behavior;
- updates the live repair runbook so privileged readiness explicitly includes non-looping executable `/opt` venv proof.

## HADI

Hypothesis: rollout safety must be encoded in repo tooling, not only operator memory/skills, otherwise every future self-evolving deployment can recreate the #405 service failure.

Action: add a preflight guard and regression tests for the exact `.venv -> current/.venv` loop shape.

Data: live #405 rollout failed with `ExecMainStatus=203` because `/opt/.../current/.venv/bin/python` resolved through a symlink loop.

Insight: preflight must verify the actual release venv resolution before claiming privileged rollout readiness.

## Verification

- RED: new regression tests failed before implementation.
- `python3 -m py_compile scripts/eeepc_privileged_rollout_preflight.py`
- `python3 -m pytest tests/test_eeepc_privileged_rollout_preflight.py tests/test_eeepc_privileged_rollout_runbooks.py tests/test_eeepc_service_guard.py -q` -> 14 passed
- `python3 -m pytest tests -q` -> 686 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 138 passed
- `git diff --check` -> passed

## Rollout/live proof plan

After merge:

- run the updated preflight against live `eeepc`;
- verify `checks.self_evolving_release_venv.ok=true` for the repaired release;
- verify no `venv_symlink_loop_risk` blocker is present;
- post proof and close #412.
