### PR TITLE
Terminalize subagent requests during cycles

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -14,6 +14,7 @@ from typing import Any, Awaitable, Callable
 from nanobot.runtime.autoevolve import resolve_terminal_selfevo_issue
 from nanobot.runtime.promotion import review_promotion_candidate
 from nanobot.runtime.state import _subagent_rollup_snapshot
+from nanobot.runtime.subagent_materializer import materialize_subagent_requests
 from nanobot.utils.helpers import estimate_prompt_tokens
 
 PROMOTION_RECORD_VERSION = 'promotion-record-v1'
@@ -3560,6 +3561,20 @@ async def run_self_evolving_cycle(
     if subagent_request_path:
         current_plan["subagent_request_path"] = subagent_request_path
         experiment["budget_used"]["subagents"] = max(int(experiment["budget_used"].get("subagents") or 0), 1)
+    subagent_materialization_summary = materialize_subagent_requests(
+        state_root=state_root,
+        now=_utc_now(now),
+        limit=1,
+    )
+    if subagent_materialization_summary.get("terminalized_count") or subagent_materialization_summary.get("existing_result_count"):
+        current_plan["subagent_materialization_summary"] = subagent_materialization_summary
+        experiment["subagent_materialization_summary"] = subagent_materialization_summary
+        if subagent_materialization_summary.get("terminalized_count"):
+            experiment["budget_used"]["subagents"] = max(
+                int(experiment["budget_used"].get("subagents") or 0),
+                int(subagent_materialization_summary.get("terminalized_count") or 0),
+            )
+            current_plan["budget_used"] = experiment["budget_used"]
     subagent_rollup = _subagent_rollup_snapshot(
         state_root=state_root,
         current_task_id=current_plan.get("current_task_id"),
@@ -3731,6 +3746,7 @@ async def run_self_evolving_cycle(
         "execution_error": execution_error,
         "artifact_paths": artifact_paths,
         "subagent_consumption": subagent_consumption,
+        "subagent_materialization_summary": current_plan.get("subagent_materialization_summary"),
         "materialized_improvement_artifact_path": current_plan.get("materialized_improvement_artifact_path"),
     }
     report_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
@@ -3747,6 +3763,7 @@ async def run_self_evolving_cycle(
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
         "subagent_consumption": subagent_consumption,
+        "subagent_materialization_summary": current_plan.get("subagent_materialization_summary"),
         "experiment": experiment,
         "goal": {
             "goal_id": active_goal,
@@ -3807,6 +3824,7 @@ async def run_self_evolving_cycle(
         "budget": experiment["budget"],
         "budget_used": experiment["budget_used"],
         "subagent_consumption": subagent_consumption,
+        "subagent_materialization_summary": current_plan.get("subagent_materialization_summary"),
         "experiment": experiment,
         "feedback_decision": resolved_feedback_decision,
         "goal": {

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -788,10 +789,70 @@ def test_cycle_materializes_synthesized_execution_lane_artifact_and_completes(tm
     assert request["schema_version"] == "subagent-request-v1"
     assert request["task_id"] == "subagent-verify-materialized-improvement"
     assert request["source_artifact"] == artifact_path
+    materialization_summary = current.get("subagent_materialization_summary")
+    assert materialization_summary["schema_version"] == "subagent-materializer-summary-v1"
+    assert materialization_summary["terminalized_count"] == 1
+    assert materialization_summary["blocked_result_count"] == 1
+    result_path = Path(materialization_summary["results"][0]["path"])
+    result = _read_json(result_path)
+    assert result["schema_version"] == "subagent-result-v1"
+    assert result["status"] == "blocked"
+    assert result["request_path"] == request_path
+    latest_report = _read_json(tmp_path / "state" / "outbox" / "report.index.json")
+    assert latest_report["subagent_materialization_summary"]["terminalized_count"] == 1
     assert current["budget_used"]["subagents"] >= 1
     assert any(task.get("task_id") == "materialize-synthesized-improvement" and task.get("status") == "done" for task in current["tasks"])
     assert any(task.get("task_id") == "subagent-verify-materialized-improvement" and task.get("status") == "active" for task in current["tasks"])
     assert all(task.get("task_id") != "materialize-synthesized-improvement" or task.get("status") != "active" for task in current["tasks"])
+
+
+def test_cycle_executes_configured_subagent_executor_and_consumes_completed_result(tmp_path, monkeypatch):
+    approvals_dir = tmp_path / "state" / "approvals"
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)
+    (approvals_dir / "apply.ok").write_text(json.dumps({"expires_at_utc": expires_at.isoformat(), "ttl_minutes": 60}), encoding="utf-8")
+
+    executor = tmp_path / "fake_executor.py"
+    executor.write_text("import sys; _=sys.stdin.read(); print('FAKE EXECUTOR COMPLETE')", encoding="utf-8")
+    monkeypatch.setenv("NANOBOT_SUBAGENT_EXECUTOR_COMMAND", f"{sys.executable} {executor}")
+
+    goals_dir = tmp_path / "state" / "goals"
+    goals_dir.mkdir(parents=True)
+    (goals_dir / "current.json").write_text(
+        json.dumps({
+            "schema_version": "task-plan-v1",
+            "current_task_id": "materialize-synthesized-improvement",
+            "tasks": [
+                {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
+                {"task_id": "materialize-synthesized-improvement", "title": "Materialize one bounded improvement from the synthesized candidate", "status": "active", "kind": "execution"},
+            ],
+            "generated_candidates": [
+                {"task_id": "materialize-synthesized-improvement", "title": "Materialize one bounded improvement from the synthesized candidate", "status": "active", "kind": "execution"}
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    summary = asyncio.run(
+        run_self_evolving_cycle(
+            workspace=tmp_path,
+            tasks="materialize synthesized improvement",
+            execute_turn=AsyncMock(return_value="agent completed synthesized materialization"),
+            now=expires_at - timedelta(minutes=30),
+        )
+    )
+
+    assert "PASS" in summary
+    current = _read_json(tmp_path / "state" / "goals" / "current.json")
+    materialization = current["subagent_materialization_summary"]
+    assert materialization["terminalized_count"] == 1
+    assert materialization["executed_count"] == 1
+    result = _read_json(materialization["results"][0]["path"])
+    assert result["status"] == "completed"
+    assert "FAKE EXECUTOR COMPLETE" in result["summary"]
+    assert current["subagent_consumption"]["consumed_count"] == 1
+    assert current["subagent_consumption"]["result_paths"] == [materialization["results"][0]["path"]]
+
 
 
 def test_completed_synthesized_candidate_pair_returns_to_reward_instead_of_replaying_parent(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #414.

After #402/#406, the runtime could write a durable queued subagent request and truthfully avoid overclaiming progress without fresh result/blocker evidence. The remaining autonomy gap was that the cycle itself did not terminalize queued requests, so evidence could remain queued/stale unless a separate CLI/manual step ran.

This PR integrates bounded request terminalization into the self-evolving cycle:

- after a cycle writes a `subagent-request-v1`, it calls `materialize_subagent_requests(..., limit=1)`;
- without an executor, the queued request becomes an explicit `subagent-result-v1` blocked artifact instead of silent queue debt;
- with a configured bounded executor (`NANOBOT_SUBAGENT_EXECUTOR_COMMAND` or `NANOBOT_SUBAGENT_EXECUTOR=pi_dev`), the result is completed;
- report, outbox, report index, experiment, and current task plan expose `subagent_materialization_summary`;
- completed executor results are immediately visible to `subagent_consumption` in the same cycle;
- behavior remains bounded: at most one request terminalized per cycle.

## HADI

Hypothesis: the next bottleneck is not dispatch, but terminalization. If the cycle converts queued requests into completed/blocked result artifacts, reward/readiness surfaces can progress from stale/degraded evidence to explicit terminal evidence.

Action: invoke the existing deterministic materializer inside the cycle after request creation and surface its summary everywhere reports are emitted.

Data: live #402/#406 proved request creation and truth blocking, but not automatic request completion/blocking.

Insight: autonomous delegated verification requires the runtime to close the request loop, even if the only safe terminal state is an explicit blocked result when no executor is configured.

## Verification

- RED: existing materialized-cycle test failed because no `subagent_materialization_summary` was present.
- Focused tests:
  - queued request terminalizes into blocked result in same cycle -> passed
  - configured fake executor writes completed result and same-cycle consumption -> passed
- `python3 -m pytest tests/test_runtime_coordinator.py -q` -> 51 passed
- `python3 -m pytest tests -q` -> 687 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 138 passed
- `git diff --check` -> passed

## Rollout/live proof plan

After merge:

- deploy to eeepc gateway and canonical self-evolving runtime;
- run live cycles;
- inspect canonical state for `subagent_materialization_summary` and fresh `subagent-result-v1` artifact correlated to request;
- verify service health and dashboard truth;
- close #414 only after proof comment.
