### PR TITLE
Scope subagent verification identity by generation

### DIFF
--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -517,8 +517,7 @@ def _subagent_rollup_snapshot(
             }
             telemetry_records.append(telemetry_record)
             if task_id and status.lower() in completed_statuses:
-                result_key = str(task_id)
-                terminal_telemetry_results.setdefault(result_key, {
+                terminal_result = {
                     'path': str(path),
                     'task_id': task_id,
                     'semantic_task_id': semantic_task_id,
@@ -531,7 +530,10 @@ def _subagent_rollup_snapshot(
                     'summary': payload.get('summary') or payload.get('result'),
                     'age_seconds': max(0, int(time.time() - path.stat().st_mtime)),
                     'materialized_from': 'telemetry',
-                })
+                }
+                if request_id:
+                    terminal_telemetry_results.setdefault(str(request_id), terminal_result)
+                terminal_telemetry_results.setdefault(str(task_id), terminal_result)
 
     request_records: list[dict[str, Any]] = []
     if request_dir.exists():
@@ -550,7 +552,7 @@ def _subagent_rollup_snapshot(
             verification_task_id = payload.get('verification_task_id') or request_id
             original_status = str(payload.get('request_status') or payload.get('status') or 'queued')
             materialized_result = terminal_telemetry_results.get(str(request_id)) if request_id else None
-            if materialized_result is None:
+            if materialized_result is None and not request_id:
                 materialized_result = terminal_telemetry_results.get(str(task_id)) if task_id else None
             effective_status = 'completed' if materialized_result else original_status
             age_seconds = max(0, int(time.time() - path.stat().st_mtime))
@@ -623,7 +625,7 @@ def _subagent_rollup_snapshot(
             (results_by_request_id.get(str(request_id)) if request_id else None)
             or results_by_request_path.get(str(request.get('path')))
             or (results_by_cycle_id.get(str(cycle_id)) if cycle_id else None)
-            or (results_by_task_id.get(str(task_id)) if task_id else None)
+            or (results_by_task_id.get(str(task_id)) if task_id and not request_id else None)
         )
         if isinstance(materialized_result, dict):
             request['materialized_result_path'] = materialized_result.get('path')
@@ -685,7 +687,15 @@ def _subagent_rollup_snapshot(
     preferred_task_id = current_task_id
     request_match = _match_record(request_records, preferred_task_id) if preferred_task_id else None
     telemetry_match = _match_record(telemetry_records, preferred_task_id) if preferred_task_id else None
-    result_match = _match_record(result_records, preferred_task_id) if preferred_task_id else None
+    result_match = None
+    request_match_id = (request_match or {}).get('request_id')
+    if request_match_id:
+        for record in result_records:
+            if record.get('request_id') == request_match_id:
+                result_match = record
+                break
+    elif preferred_task_id:
+        result_match = _match_record(result_records, preferred_task_id)
 
     linkage_source = 'task_plan' if preferred_task_id else None
     if preferred_task_id is None:

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -2096,6 +2096,55 @@ def test_subagent_rollup_materializes_terminal_telemetry_for_matching_request(tm
     assert rollup["latest_request"]["materialized_result_path"].endswith("terminal-result.json")
 
 
+def test_subagent_rollup_does_not_attach_older_telemetry_to_new_generation(tmp_path):
+    from nanobot.runtime.state import _subagent_rollup_snapshot
+
+    state_root = tmp_path / "state"
+    requests = state_root / "subagents" / "requests"
+    telemetry = state_root / "subagents"
+    requests.mkdir(parents=True)
+    old_request_id = "subagent-verify-materialized-improvement-cycle-old-11111111"
+    new_request_id = "subagent-verify-materialized-improvement-cycle-new-22222222"
+    semantic = "subagent-verify-materialized-improvement"
+    (requests / "request-cycle-old.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": semantic,
+        "semantic_task_id": semantic,
+        "request_id": old_request_id,
+        "verification_task_id": old_request_id,
+        "cycle_id": "cycle-old",
+    }), encoding="utf-8")
+    (requests / "request-cycle-new.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": semantic,
+        "semantic_task_id": semantic,
+        "request_id": new_request_id,
+        "verification_task_id": new_request_id,
+        "cycle_id": "cycle-new",
+    }), encoding="utf-8")
+    (telemetry / "telemetry-old.json").write_text(json.dumps({
+        "schema_version": "subagent-result-v1",
+        "status": "completed",
+        "task_id": semantic,
+        "semantic_task_id": semantic,
+        "request_id": old_request_id,
+        "verification_task_id": old_request_id,
+        "cycle_id": "cycle-old",
+        "summary": "old generation completed",
+    }), encoding="utf-8")
+
+    rollup = _subagent_rollup_snapshot(state_root=state_root, current_task_id=semantic)
+
+    assert rollup["latest_request"]["request_id"] == new_request_id
+    assert rollup["latest_request"]["status"] == "queued"
+    assert rollup["active_task_linkage"]["request_id"] == new_request_id
+    assert rollup["active_task_linkage"].get("result_path") is None
+    assert rollup["latest_result"]["request_id"] == old_request_id
+
+
+
 def test_subagent_request_artifact_uses_generation_scoped_identity(tmp_path):
     state_root = tmp_path / "state"
     artifact_a = state_root / "improvements" / "materialized-cycle-a.json"


### PR DESCRIPTION
## Summary

Fixes #413.

This PR preserves the stable semantic subagent verification role while adding generation-scoped identity to materialized verification requests/results.

What changed:

- `subagent-request-v1` now includes:
  - stable `task_id = subagent-verify-materialized-improvement` for compatibility;
  - `semantic_task_id` for grouping by role;
  - generation-scoped `request_id`;
  - generation-scoped `verification_task_id`;
  - `verification_role = materialized_improvement_review`.
- `subagent-result-v1` now propagates `request_id`, `semantic_task_id`, `verification_task_id`, and `verification_role` from the request.
- Runtime subagent rollups now expose those fields in latest request/result and active task linkage.
- Dashboard `/api/subagents` discovery now preserves the same identity fields.
- Correlation is request-id first. Legacy task-id fallback is preserved only for records without request ids, avoiding stale semantic-task collisions across generations.

## HADI

Hypothesis: a single stable task id is useful as a semantic role, but unsafe as the identity of a concrete verification lane. Generation-scoped request/result identity prevents stale verification records from suppressing or being misattributed to a fresh materialized artifact.

Action: add generation-scoped identity at request creation, propagate it into result artifacts, and make state/dashboard rollups prefer request-id correlation.

Data: previous live cycles required special retirement handling because `subagent-verify-materialized-improvement` was reused across materialized artifacts. Review also found telemetry-only result records could be incorrectly matched to newer requests by stable task id.

Insight: keep compatibility role fields, but treat `request_id`/`verification_task_id` as the concrete generation identity.

## Verification

RED/GREEN:

- `test_subagent_request_artifact_uses_generation_scoped_identity` failed before request fields existed, then passed.
- `test_subagent_materializer_executes_research_only_request_with_local_executor` failed before result identity propagation, then passed.
- Dashboard visibility test failed before `/api/subagents` preserved identity fields, then passed.
- Reviewer-identified telemetry regression failed before request-id-first correlation, then passed.

Final local validation:

- `python3 -m py_compile nanobot/runtime/coordinator.py nanobot/runtime/subagent_materializer.py nanobot/runtime/state.py ops/dashboard/src/nanobot_ops_dashboard/app.py`
- `python3 -m pytest tests/test_runtime_coordinator.py -q` -> 53 passed
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -q)` -> 57 passed
- `python3 -m pytest tests -q` -> 689 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 139 passed
- `git diff --check` -> passed

## Rollout/live proof plan

After merge:

- run privileged preflight against `eeepc`;
- deploy merged commit to gateway and canonical self-evolving runtime using the safe old-current venv pattern from #412;
- run live self-evolving cycles;
- prove canonical request/result artifacts contain stable semantic role plus generation-scoped `request_id` and `verification_task_id`;
- prove dashboard `/api/subagents` exposes those fields;
- close #413 only after live proof comment.
