### PR TITLE
Prefer canonical subagent state in dashboard

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import subprocess
 import time
 from datetime import datetime, timezone, timedelta
@@ -12,7 +13,7 @@ from urllib.parse import parse_qs
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from .collector import collect_once
+from .collector import collect_once, _build_ssh_command
 from .config import DashboardConfig
 from .storage import count_collections, count_events, fetch_events, fetch_latest_collections
 from nanobot.runtime.state import _subagent_rollup_snapshot
@@ -819,11 +820,57 @@ def _subagent_detail_value(detail: dict | None, *keys: str):
 
 
 
+def _remote_subagent_state_payload(cfg: DashboardConfig, state_root: str) -> dict:
+    remote_root = str(state_root).rstrip('/')
+    if not remote_root or not getattr(cfg, 'eeepc_ssh_host', None):
+        return {'ok': False, 'error': 'remote_root_or_host_missing'}
+    script = f'''
+import json, pathlib, time
+root=pathlib.Path(__import__('sys').argv[1])
+limit=max(0, int(__import__('sys').argv[2]))
+now=time.time()
+def read(p):
+    try:
+        return json.loads(p.read_text())
+    except Exception as exc:
+        return {{'_error': str(exc)}}
+requests=[]
+for p in sorted((root/'subagents'/'requests').glob('*.json'), key=lambda x:x.stat().st_mtime, reverse=True)[:limit]:
+    payload=read(p)
+    request_id=payload.get('request_id') or payload.get('id')
+    semantic=payload.get('semantic_task_id') or payload.get('task_id')
+    status=payload.get('request_status') or payload.get('status') or 'queued'
+    requests.append({{'path': str(p), 'source': 'eeepc', 'source_root': str(root), 'task_id': payload.get('task_id'), 'semantic_task_id': semantic, 'request_id': request_id, 'verification_task_id': payload.get('verification_task_id') or request_id, 'verification_role': payload.get('verification_role'), 'cycle_id': payload.get('cycle_id'), 'profile': payload.get('profile'), 'status': status, 'request_status': status, 'age_seconds': max(0, int(now-p.stat().st_mtime)), 'source_artifact': payload.get('source_artifact')}})
+results=[]
+for p in sorted((root/'subagents'/'results').glob('*.json'), key=lambda x:x.stat().st_mtime, reverse=True)[:limit]:
+    payload=read(p)
+    request_id=payload.get('request_id') or payload.get('id')
+    semantic=payload.get('semantic_task_id') or payload.get('task_id')
+    results.append({{'path': str(p), 'source': 'eeepc', 'source_root': str(root), 'request_path': payload.get('request_path'), 'request_id': request_id, 'semantic_task_id': semantic, 'verification_task_id': payload.get('verification_task_id') or request_id, 'verification_role': payload.get('verification_role'), 'report_path': payload.get('report_path') or payload.get('report_source'), 'task_id': payload.get('task_id'), 'cycle_id': payload.get('cycle_id'), 'status': payload.get('status') or payload.get('result_status') or 'completed', 'terminal_reason': payload.get('terminal_reason') or payload.get('reason'), 'summary': payload.get('summary'), 'age_seconds': max(0, int(now-p.stat().st_mtime)), 'source_artifact': payload.get('source_artifact')}})
+print(json.dumps({{'ok': True, 'source_root': str(root), 'requests': requests, 'results': results}}, sort_keys=True))
+'''
+    limit = max(0, int(getattr(cfg, 'max_subagent_records', 200) or 0))
+    remote_command = f"python3 -c {shlex.quote(script)} {shlex.quote(remote_root)} {limit}"
+    ssh_cmd = _build_ssh_command(cfg, remote_command)
+    try:
+        proc = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=8, check=True)
+        payload = json.loads(proc.stdout or '{}')
+        return payload if isinstance(payload, dict) else {'ok': False, 'error': 'remote_payload_not_dict'}
+    except Exception as exc:
+        return {'ok': False, 'error': str(exc)[:500], 'source_root': remote_root}
+
+
 def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int = 3600) -> dict:
     local_state_root = cfg.nanobot_repo_root / 'workspace' / 'state'
     canonical_state_root = Path(str(cfg.eeepc_state_root)) if getattr(cfg, 'eeepc_state_root', None) else None
     local_has_activity = (local_state_root / 'subagents' / 'requests').exists() or (local_state_root / 'subagents' / 'results').exists()
     canonical_has_activity = bool(canonical_state_root and ((canonical_state_root / 'subagents' / 'requests').exists() or (canonical_state_root / 'subagents' / 'results').exists()))
+    remote_payload: dict | None = None
+    canonical_remote = False
+    if canonical_state_root and not canonical_has_activity:
+        remote_payload = _remote_subagent_state_payload(cfg, str(cfg.eeepc_state_root))
+        canonical_remote = bool(remote_payload.get('ok') and (remote_payload.get('requests') or remote_payload.get('results')))
+        canonical_has_activity = canonical_remote
     if canonical_has_activity:
         state_root = canonical_state_root
         selected_source = 'eeepc'
@@ -836,7 +883,9 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
     result_dir = state_root / 'subagents' / 'results'
     now = time.time()
     requests: list[dict] = []
-    if request_dir.exists():
+    if canonical_remote and isinstance(remote_payload, dict):
+        requests = [dict(item) for item in remote_payload.get('requests', []) if isinstance(item, dict)]
+    elif request_dir.exists():
         for path in sorted(request_dir.glob('*.json'), key=lambda p: p.stat().st_mtime, reverse=True):
             payload = _json_file(path)
             status = payload.get('request_status') or payload.get('status') or 'queued'
@@ -846,6 +895,8 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             verification_task_id = payload.get('verification_task_id') or request_id
             requests.append({
                 'path': str(path),
+                'source': selected_source,
+                'source_root': str(state_root),
                 'task_id': payload.get('task_id'),
                 'semantic_task_id': semantic_task_id,
                 'request_id': request_id,
@@ -863,37 +914,10 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
     results_by_request_id: dict[str, dict] = {}
     results_by_cycle_id: dict[str, dict] = {}
     results_by_task_id: dict[str, dict] = {}
-    result_dirs = [result_dir, cfg.nanobot_repo_root / '.nanobot' / 'subagents']
-    for current_result_dir in result_dirs:
-        if not current_result_dir.exists():
-            continue
-        for path in sorted(current_result_dir.glob('*.json'), key=lambda p: p.stat().st_mtime, reverse=True):
-            payload = _json_file(path)
-            hydrated_report = _canonical_report_payload(cfg, {'report_source': payload.get('report_path') or payload.get('report_source')}) if (payload.get('report_path') or payload.get('report_source')) else {}
-            hydrated_budget = hydrated_report.get('budget_used') if isinstance(hydrated_report.get('budget_used'), dict) else None
-            follow_through = hydrated_report.get('follow_through') if isinstance(hydrated_report.get('follow_through'), dict) else {}
-            hydrated_artifacts = hydrated_report.get('artifact_paths') or follow_through.get('artifact_paths')
-            result = {
-                'path': str(path),
-                'request_path': payload.get('request_path'),
-                'request_id': payload.get('request_id') or payload.get('id'),
-                'semantic_task_id': payload.get('semantic_task_id') or payload.get('task_id') or hydrated_report.get('current_task_id'),
-                'verification_task_id': payload.get('verification_task_id') or payload.get('request_id') or payload.get('id'),
-                'verification_role': payload.get('verification_role'),
-                'report_path': payload.get('report_path') or payload.get('report_source'),
-                'task_id': payload.get('task_id') or hydrated_report.get('current_task_id'),
-                'cycle_id': payload.get('cycle_id') or hydrated_report.get('cycle_id'),
-                'status': payload.get('status') or payload.get('result_status') or 'completed',
-                'terminal_reason': payload.get('terminal_reason') or payload.get('reason'),
-                'summary': payload.get('summary'),
-                'age_seconds': max(0, int(now - path.stat().st_mtime)),
-                'hydrated_report_current_task_id': hydrated_report.get('current_task_id'),
-                'hydrated_report_result_status': hydrated_report.get('result_status') or hydrated_report.get('status'),
-                'budget_used': hydrated_budget,
-                'artifact_paths': hydrated_artifacts,
-                'canonical_report_hydrated': bool(hydrated_report),
-            }
-            results.append(result)
+    result_dirs = [result_dir, cfg.nanobot_repo_root / '.nanobot' / 'subagents'] if selected_source == 'local' else [result_dir]
+    if canonical_remote and isinstance(remote_payload, dict):
+        results = [dict(item) for item in remote_payload.get('results', []) if isinstance(item, dict)]
+        for result in results:
             if result.get('request_path'):
                 results_by_request_path.setdefault(str(result['request_path']), result)
             if result.get('request_id'):
@@ -902,6 +926,47 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
                 results_by_cycle_id.setdefault(str(result['cycle_id']), result)
             if result.get('task_id'):
                 results_by_task_id.setdefault(str(result['task_id']), result)
+    else:
+        for current_result_dir in result_dirs:
+            if not current_result_dir.exists():
+                continue
+            for path in sorted(current_result_dir.glob('*.json'), key=lambda p: p.stat().st_mtime, reverse=True):
+                payload = _json_file(path)
+                hydrated_report = _canonical_report_payload(cfg, {'report_source': payload.get('report_path') or payload.get('report_source')}) if (payload.get('report_path') or payload.get('report_source')) else {}
+                hydrated_budget = hydrated_report.get('budget_used') if isinstance(hydrated_report.get('budget_used'), dict) else None
+                follow_through = hydrated_report.get('follow_through') if isinstance(hydrated_report.get('follow_through'), dict) else {}
+                hydrated_artifacts = hydrated_report.get('artifact_paths') or follow_through.get('artifact_paths')
+                result = {
+                    'path': str(path),
+                    'source': selected_source,
+                    'source_root': str(state_root),
+                    'request_path': payload.get('request_path'),
+                    'request_id': payload.get('request_id') or payload.get('id'),
+                    'semantic_task_id': payload.get('semantic_task_id') or payload.get('task_id') or hydrated_report.get('current_task_id'),
+                    'verification_task_id': payload.get('verification_task_id') or payload.get('request_id') or payload.get('id'),
+                    'verification_role': payload.get('verification_role'),
+                    'report_path': payload.get('report_path') or payload.get('report_source'),
+                    'task_id': payload.get('task_id') or hydrated_report.get('current_task_id'),
+                    'cycle_id': payload.get('cycle_id') or hydrated_report.get('cycle_id'),
+                    'status': payload.get('status') or payload.get('result_status') or 'completed',
+                    'terminal_reason': payload.get('terminal_reason') or payload.get('reason'),
+                    'summary': payload.get('summary'),
+                    'age_seconds': max(0, int(now - path.stat().st_mtime)),
+                    'hydrated_report_current_task_id': hydrated_report.get('current_task_id'),
+                    'hydrated_report_result_status': hydrated_report.get('result_status') or hydrated_report.get('status'),
+                    'budget_used': hydrated_budget,
+                    'artifact_paths': hydrated_artifacts,
+                    'canonical_report_hydrated': bool(hydrated_report),
+                }
+                results.append(result)
+                if result.get('request_path'):
+                    results_by_request_path.setdefault(str(result['request_path']), result)
+                if result.get('request_id'):
+                    results_by_request_id.setdefault(str(result['request_id']), result)
+                if result.get('cycle_id'):
+                    results_by_cycle_id.setdefault(str(result['cycle_id']), result)
+                if result.get('task_id'):
+                    results_by_task_id.setdefault(str(result['task_id']), result)
     for request in requests:
         materialized_result = (
             (results_by_request_id.get(str(request.get('request_id'))) if request.get('request_id') else None)
@@ -921,7 +986,7 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
     queued_count = sum(1 for item in requests if item.get('request_status') in {'queued', 'pending'} and not item.get('materialized_result_path'))
     blocked_count = sum(1 for item in results if str(item.get('status') or '').lower() in {'blocked', 'terminal_blocked'})
     result_count = len(results)
-    rollup = _subagent_rollup_snapshot(state_root=state_root)
+    rollup = None if canonical_remote else _subagent_rollup_snapshot(state_root=state_root)
     if isinstance(rollup, dict):
         stale_count = int(rollup.get('stale_request_count') or 0)
         queued_count = int(rollup.get('queued_request_count') or 0)
@@ -945,6 +1010,19 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
     fresh_result_count = max(0, result_count - stale_result_count)
     return {
         'schema_version': 'subagent-visibility-v1',
+        'source': {
+            'selected': selected_source,
+            'state_root': str(state_root),
+            'local_state_root': str(local_state_root),
+            'canonical_state_root': str(canonical_state_root) if canonical_state_root else None,
+            'local_available': bool(local_has_activity),
+            'canonical_available': bool(canonical_has_activity),
+            'canonical_remote': bool(canonical_remote),
+        },
+        'source_skew': {
+            'state': source_skew_state,
+            'reasons': source_skew_reasons,
+        },
         'requests': requests,
         'results': results,
         'subagent_rollup': rollup,
@@ -959,6 +1037,7 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             'latest_result_age_seconds': (results[0].get('age_seconds') if results else ((rollup or {}).get('latest_result') or {}).get('age_seconds') if isinstance((rollup or {}).get('latest_result'), dict) else None),
             'freshness_state': 'fresh' if fresh_result_count else ('stale' if stale_result_count else state),
             'freshness_window_seconds': 6 * 60 * 60,
+            'sources': [selected_source] if requests or results or isinstance(rollup, dict) else [],
             'state': state,
             'reason': reason,
         },

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from wsgiref.util import setup_testing_defaults
 
+from nanobot_ops_dashboard import app as dashboard_app
 from nanobot_ops_dashboard.app import create_app, _dashboard_runtime_parity, _selected_hypothesis_terminal_evidence, _material_progress_summary, _approval_snapshot, _autonomy_verdict, _ambition_utilization_verdict, _experiment_snapshot_from_payload, _discover_subagent_requests
 from nanobot_ops_dashboard.config import DashboardConfig
 from nanobot_ops_dashboard.storage import init_db, insert_collection, upsert_event
@@ -3035,4 +3036,99 @@ def test_subagent_visibility_prefers_canonical_eeepc_state_over_stale_local(tmp_
     assert visibility['latest_result']['request_id'] == request_id
     assert visibility['latest_result']['verification_task_id'] == request_id
     assert visibility['summary']['sources'] == ['eeepc']
+
+
+
+def test_subagent_visibility_uses_remote_canonical_state_when_not_local(tmp_path: Path, monkeypatch):
+    repo = tmp_path / 'repo'
+    local_state = repo / 'workspace' / 'state'
+    (local_state / 'subagents' / 'requests').mkdir(parents=True)
+    (local_state / 'subagents' / 'requests' / 'request-cycle-local.json').write_text(json.dumps({
+        'schema_version': 'subagent-request-v1',
+        'request_status': 'queued',
+        'task_id': 'subagent-verify-materialized-improvement',
+        'cycle_id': 'cycle-local',
+    }), encoding='utf-8')
+    request_id = 'subagent-verify-materialized-improvement-cycle-remote-abcdef12'
+    remote_root = '/var/lib/eeepc-agent/self-evolving-agent/state'
+    monkeypatch.setattr(dashboard_app, '_remote_subagent_state_payload', lambda cfg, state_root: {
+        'ok': True,
+        'source_root': remote_root,
+        'requests': [{
+            'path': f'{remote_root}/subagents/requests/request-cycle-remote.json',
+            'source': 'eeepc',
+            'source_root': remote_root,
+            'task_id': 'subagent-verify-materialized-improvement',
+            'semantic_task_id': 'subagent-verify-materialized-improvement',
+            'request_id': request_id,
+            'verification_task_id': request_id,
+            'verification_role': 'materialized_improvement_review',
+            'cycle_id': 'cycle-remote',
+            'request_status': 'queued',
+            'status': 'queued',
+            'age_seconds': 3,
+        }],
+        'results': [{
+            'path': f'{remote_root}/subagents/results/result-{request_id}.json',
+            'source': 'eeepc',
+            'source_root': remote_root,
+            'request_path': f'{remote_root}/subagents/requests/request-cycle-remote.json',
+            'task_id': 'subagent-verify-materialized-improvement',
+            'semantic_task_id': 'subagent-verify-materialized-improvement',
+            'request_id': request_id,
+            'verification_task_id': request_id,
+            'verification_role': 'materialized_improvement_review',
+            'cycle_id': 'cycle-remote',
+            'status': 'blocked',
+            'age_seconds': 3,
+        }],
+    })
+    cfg = DashboardConfig(
+        project_root=tmp_path,
+        db_path=tmp_path / 'dashboard.sqlite3',
+        nanobot_repo_root=repo,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root=remote_root,
+    )
+
+    visibility = _discover_subagent_requests(cfg)
+
+    assert visibility['source']['selected'] == 'eeepc'
+    assert visibility['source']['canonical_remote'] is True
+    assert visibility['latest_request']['request_id'] == request_id
+    assert visibility['latest_result']['request_id'] == request_id
+    assert visibility['summary']['sources'] == ['eeepc']
+    assert visibility['source_skew']['state'] == 'skewed'
+
+
+
+def test_remote_subagent_fetch_uses_sudo_password_and_record_limit(tmp_path: Path, monkeypatch):
+    captured = {}
+    class Completed:
+        stdout = json.dumps({'ok': True, 'source_root': '/remote/state', 'requests': [], 'results': []})
+    def fake_run(cmd, capture_output, text, timeout, check):
+        captured['cmd'] = cmd
+        captured['timeout'] = timeout
+        return Completed()
+    monkeypatch.setattr(dashboard_app.subprocess, 'run', fake_run)
+    cfg = DashboardConfig(
+        project_root=tmp_path,
+        db_path=tmp_path / 'dashboard.sqlite3',
+        nanobot_repo_root=tmp_path / 'repo',
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root='/remote/state',
+        eeepc_sudo_password='dummy-password',
+        max_subagent_records=7,
+    )
+
+    payload = dashboard_app._remote_subagent_state_payload(cfg, '/remote/state')
+
+    assert payload['ok'] is True
+    remote_command = captured['cmd'][-1]
+    assert "sudo -S -p ''" in remote_command
+    assert 'dummy-password' in remote_command
+    assert '/remote/state' in remote_command
+    assert remote_command.rstrip().endswith(' 7')
 


### PR DESCRIPTION
## Summary

Fixes #418.

This PR makes `/api/subagents` prefer the authoritative canonical eeepc self-evolving state root when it is available, instead of silently serving stale local workspace artifacts.

What changed:

- `_discover_subagent_requests` now evaluates both:
  - local workspace state: `repo/workspace/state`
  - canonical eeepc state: `cfg.eeepc_state_root`
- If canonical subagent artifacts are available locally, they are selected.
- If `cfg.eeepc_state_root` is a remote-only path such as `/var/lib/eeepc-agent/self-evolving-agent/state`, the dashboard fetches request/result summaries over SSH.
- Remote SSH fetch reuses the existing dashboard collector `_build_ssh_command`, so existing sudo-password handling remains supported.
- Remote fetch honors `cfg.max_subagent_records` instead of hardcoded history limits.
- `/api/subagents` now exposes source metadata:
  - `source.selected`
  - `source.state_root`
  - `source.local_state_root`
  - `source.canonical_state_root`
  - `source.local_available`
  - `source.canonical_available`
  - `source.canonical_remote`
- `/api/subagents` now exposes source skew metadata:
  - `source_skew.state`
  - `source_skew.reasons`
- request/result records include source labels:
  - `source`
  - `source_root`
- summary includes `sources`.

## Why

During #413 live proof, canonical eeepc runtime state correctly showed fresh generation-scoped subagent request/result pairs, but dashboard `/api/subagents` selected stale local workspace artifacts and hid the canonical evidence. This PR aligns dashboard subagent visibility with the canonical self-evolving authority.

## Verification

TDD / regressions:

- `test_subagent_visibility_prefers_canonical_eeepc_state_over_stale_local`
  - RED: missing `source` metadata and local stale artifacts won.
  - GREEN: canonical local state wins and source skew is explicit.
- `test_subagent_visibility_uses_remote_canonical_state_when_not_local`
  - RED: no remote canonical fetch seam.
  - GREEN: remote canonical payload wins over stale local artifacts.
- `test_remote_subagent_fetch_uses_sudo_password_and_record_limit`
  - verifies remote fetch uses existing sudo-password SSH command path and honors `max_subagent_records`.

Final local validation:

- `python3 -m py_compile ops/dashboard/src/nanobot_ops_dashboard/app.py`
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -q)` -> 60 passed
- `python3 -m pytest tests -q` -> 689 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 142 passed
- `git diff --check` -> passed

## Rollout/live proof plan

After merge:

- deploy merged commit to the live dashboard/runtime release using the safe eeepc rollout pattern;
- restart dashboard services;
- trigger `/collect`;
- verify `/api/subagents` selects `source.selected=eeepc`, `source.canonical_remote=true`, and exposes fresh canonical generation-scoped request/result identity from `/var/lib/eeepc-agent/self-evolving-agent/state`;
- post proof to #418 and close only after live proof.
