### PR TITLE
Prefer canonical material progress evidence

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -689,6 +689,11 @@ def _control_plane_summary(repo_latest, eeepc_latest, current_experiment, curren
     waiting_dispatch = False if completion_terminal else (bool(live_task) and not has_executor_linkage)
     execution_state = 'completed' if completion_terminal else 'stale' if stale_exec else 'live' if live_exec else 'waiting_for_dispatch' if waiting_dispatch else 'idle'
     source_skew = _snapshot_source_skew(repo_latest, eeepc_latest)
+    material_progress_source = (
+        (eeepc_raw.get('material_progress') if isinstance(eeepc_raw, dict) else None)
+        or (producer_summary.get('material_progress') if isinstance(producer_summary, dict) else None)
+        or (repo_raw.get('material_progress') if isinstance(repo_raw, dict) else None)
+    )
     return {
         'active_goal': (eeepc_latest or {}).get('active_goal') or (repo_latest or {}).get('active_goal'),
         'repo_status': (repo_latest or {}).get('status'),
@@ -714,7 +719,7 @@ def _control_plane_summary(repo_latest, eeepc_latest, current_experiment, curren
         'prompt_mass': (producer_summary.get('prompt_mass') if isinstance(producer_summary, dict) else None),
         'owner_utility': (producer_summary.get('owner_utility') if isinstance(producer_summary, dict) else None),
         'subagent_rollup': (repo_raw.get('subagent_rollup') if isinstance(repo_raw, dict) else None) or (producer_summary.get('subagent_rollup') if isinstance(producer_summary, dict) else None),
-        'material_progress': _material_progress_summary((repo_raw.get('material_progress') if isinstance(repo_raw, dict) else None) or (eeepc_raw.get('material_progress') if isinstance(eeepc_raw, dict) else None) or (producer_summary.get('material_progress') if isinstance(producer_summary, dict) else None)),
+        'material_progress': _material_progress_summary(material_progress_source),
         'human_review_boundary': human_review_boundary,
         'governance_enforcement': governance_enforcement,
         'launch_criteria': {

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -3132,3 +3132,70 @@ def test_remote_subagent_fetch_uses_sudo_password_and_record_limit(tmp_path: Pat
     assert '/remote/state' in remote_command
     assert remote_command.rstrip().endswith(' 7')
 
+
+
+def test_control_plane_material_progress_prefers_canonical_eeepc_over_stale_local(tmp_path: Path):
+    cfg = DashboardConfig(
+        project_root=tmp_path,
+        db_path=tmp_path / 'dashboard.sqlite3',
+        nanobot_repo_root=tmp_path / 'repo',
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root='/var/lib/eeepc-agent/self-evolving-agent/state',
+    )
+    repo_latest = {
+        'active_goal': 'goal-bootstrap',
+        'status': 'PASS',
+        'raw_json': json.dumps({
+            'material_progress': {
+                'schema_version': 'material-progress-v1',
+                'state': 'blocked',
+                'blocking_reason': 'missing_current_material_progress',
+                'proofs': [{
+                    'kind': 'consumed_subagent_result',
+                    'present': False,
+                    'reason': 'subagent_result_missing',
+                    'evidence': {'latest_result_path': str(tmp_path / 'repo' / 'workspace' / 'state' / 'subagents' / 'results' / 'stale.json')},
+                }],
+                'qualifying_proofs': [],
+            }
+        }),
+    }
+    eeepc_latest = {
+        'active_goal': 'goal-bootstrap',
+        'status': 'PASS',
+        'raw_json': json.dumps({
+            'material_progress': {
+                'schema_version': 'material-progress-v1',
+                'state': 'blocked',
+                'blocking_reason': 'delegated_verification_terminal_blocked',
+                'proofs': [{
+                    'kind': 'consumed_subagent_result',
+                    'present': True,
+                    'reason': 'subagent_result_terminal_blocked',
+                    'evidence': {
+                        'source': 'eeepc',
+                        'source_root': '/var/lib/eeepc-agent/self-evolving-agent/state',
+                        'request_id': 'subagent-verify-materialized-improvement-cycle-live-12345678',
+                        'verification_task_id': 'subagent-verify-materialized-improvement-cycle-live-12345678',
+                        'latest_result_path': '/var/lib/eeepc-agent/self-evolving-agent/state/subagents/results/result-live.json',
+                        'terminal_reason': 'local_executor_unavailable',
+                    },
+                }],
+                'qualifying_proofs': [],
+            }
+        }),
+    }
+
+    summary = dashboard_app._control_plane_summary(repo_latest, eeepc_latest, {}, {}, cfg)
+
+    material = summary['material_progress']
+    assert material['blocking_reason'] == 'delegated_verification_terminal_blocked'
+    assert material['proofs'][0]['present'] is True
+    assert material['proofs'][0]['reason'] == 'subagent_result_terminal_blocked'
+    assert material['proofs'][0]['evidence']['source_root'] == '/var/lib/eeepc-agent/self-evolving-agent/state'
+    assert material['proofs'][0]['evidence']['request_id'] == 'subagent-verify-materialized-improvement-cycle-live-12345678'
+    encoded = json.dumps(material)
+    assert 'subagent_result_missing' not in encoded
+    assert '/workspace/state/subagents/results/stale.json' not in encoded
+


### PR DESCRIPTION
## Summary

Fixes #420.

This PR aligns top-level material-progress proof selection with canonical eeepc authority.

What changed:

- `_control_plane_summary` now selects material progress in canonical order:
  1. `eeepc_raw.material_progress`
  2. producer summary material progress
  3. local repo material progress
- This prevents stale local workspace material-progress evidence from overriding canonical eeepc runtime truth.
- Return shape is unchanged; only source precedence changes.

## Why

After #418, `/api/subagents` correctly selected canonical remote eeepc state and exposed generation-scoped request/result identity, but `/api/system.autonomy_verdict.material_progress` could still report `subagent_result_missing` based on local workspace evidence.

That made the dashboard contradictory: canonical subagent evidence existed, but top-level autonomy said it was missing.

## Verification

TDD:

- Added `test_control_plane_material_progress_prefers_canonical_eeepc_over_stale_local`.
- RED: local `subagent_result_missing` won over canonical eeepc material progress.
- GREEN: canonical eeepc material progress wins and stale local path/reason disappears.

Final local validation:

- `python3 -m py_compile ops/dashboard/src/nanobot_ops_dashboard/app.py`
- `(cd ops/dashboard && python3 -m pytest tests/test_dashboard_truth_audit_gaps.py -q)` -> 61 passed
- `python3 -m pytest tests -q` -> 689 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 143 passed
- `git diff --check` -> passed

Review:

- delegated final review: PASS
- focused reviewer verification: `3 passed, 58 deselected`

## Rollout/live proof plan

After merge:

- restart dashboard services;
- call `/collect`;
- verify `/api/subagents` still selects canonical eeepc source;
- verify `/api/system.autonomy_verdict.material_progress` no longer reports local `subagent_result_missing` when canonical material progress exists;
- close #420 only after live proof.
