### PR TITLE
Reconcile material progress with canonical subagents

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -335,6 +335,72 @@ def _material_progress_summary(material_progress: dict | None) -> dict:
     return material_progress
 
 
+def _reconcile_material_progress_with_subagent_visibility(material_progress: dict | None, subagent_visibility: dict | None) -> dict:
+    material = _material_progress_summary(material_progress)
+    visibility = dict(subagent_visibility) if isinstance(subagent_visibility, dict) else {}
+    source = visibility.get('source') if isinstance(visibility.get('source'), dict) else {}
+    latest_result = visibility.get('latest_result') if isinstance(visibility.get('latest_result'), dict) else {}
+    latest_request = visibility.get('latest_request') if isinstance(visibility.get('latest_request'), dict) else {}
+    selected_source = source.get('selected') or latest_result.get('source') or latest_request.get('source')
+    request_id = latest_result.get('request_id') or latest_request.get('request_id')
+    if selected_source != 'eeepc' or not request_id or not latest_result:
+        return material
+    result_status = str(latest_result.get('status') or latest_result.get('result_status') or '').lower()
+    terminal_reason = latest_result.get('terminal_reason') or latest_result.get('reason')
+    evidence = {
+        'source': latest_result.get('source') or selected_source,
+        'source_root': latest_result.get('source_root') or source.get('state_root'),
+        'latest_result_path': latest_result.get('path'),
+        'request_path': latest_result.get('request_path') or latest_request.get('path'),
+        'request_id': request_id,
+        'semantic_task_id': latest_result.get('semantic_task_id') or latest_request.get('semantic_task_id'),
+        'verification_task_id': latest_result.get('verification_task_id') or latest_request.get('verification_task_id') or request_id,
+        'verification_role': latest_result.get('verification_role') or latest_request.get('verification_role'),
+        'status': latest_result.get('status') or latest_result.get('result_status'),
+        'terminal_reason': terminal_reason,
+        'source_artifact': latest_result.get('source_artifact') or latest_request.get('source_artifact'),
+    }
+    if result_status == 'blocked':
+        reason = 'subagent_result_terminal_blocked'
+        material['blocking_reason'] = 'delegated_verification_terminal_blocked'
+    elif result_status in {'completed', 'pass', 'passed', 'success'}:
+        reason = 'subagent_result_available'
+    else:
+        reason = 'subagent_result_present'
+    replacement = {
+        'kind': 'consumed_subagent_result',
+        'present': True,
+        'reason': reason,
+        'evidence': evidence,
+    }
+    proofs = material.get('proofs') if isinstance(material.get('proofs'), list) else []
+    replaced = False
+    reconciled_proofs = []
+    for proof in proofs:
+        if isinstance(proof, dict) and proof.get('kind') == 'consumed_subagent_result':
+            reconciled_proofs.append(replacement)
+            replaced = True
+        else:
+            reconciled_proofs.append(proof)
+    if not replaced:
+        reconciled_proofs.append(replacement)
+    material['proofs'] = reconciled_proofs
+    if result_status in {'completed', 'pass', 'passed', 'success'}:
+        qualifying = material.get('qualifying_proofs') if isinstance(material.get('qualifying_proofs'), list) else []
+        if not any(isinstance(proof, dict) and proof.get('kind') == 'consumed_subagent_result' for proof in qualifying):
+            qualifying = list(qualifying) + [replacement]
+        material['qualifying_proofs'] = qualifying
+        material['proof_count'] = len(qualifying)
+        material['healthy_autonomy_allowed'] = True
+        if material.get('blocking_reason') == 'missing_current_material_progress':
+            material['blocking_reason'] = None
+    else:
+        material['qualifying_proofs'] = material.get('qualifying_proofs') if isinstance(material.get('qualifying_proofs'), list) else []
+        material['proof_count'] = len(material['qualifying_proofs'])
+        material['healthy_autonomy_allowed'] = False
+    return material
+
+
 def _task_plan_truth(task_plan: dict | None) -> dict:
     task_plan = dict(task_plan) if isinstance(task_plan, dict) else {}
     current_task_id = _first_present(task_plan, ('current_task_id', 'currentTaskId'))
@@ -3498,6 +3564,10 @@ def create_app(cfg: DashboardConfig):
         promotion_replay_readiness = _promotion_replay_readiness_from_promotions(promotions)
         if isinstance(control_plane, dict):
             control_plane = dict(control_plane)
+            control_plane['material_progress'] = _reconcile_material_progress_with_subagent_visibility(
+                control_plane.get('material_progress'),
+                subagent_visibility,
+            )
             if promotion_replay_readiness is not None:
                 control_plane['promotion_replay_readiness'] = promotion_replay_readiness
         overview_subagent_cycle_id = None

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -3199,3 +3199,63 @@ def test_control_plane_material_progress_prefers_canonical_eeepc_over_stale_loca
     assert 'subagent_result_missing' not in encoded
     assert '/workspace/state/subagents/results/stale.json' not in encoded
 
+
+
+def test_material_progress_reconciles_canonical_subagent_terminal_blocker():
+    material = {
+        'schema_version': 'material-progress-v1',
+        'state': 'blocked',
+        'blocking_reason': 'missing_current_material_progress',
+        'proofs': [{
+            'kind': 'consumed_subagent_result',
+            'present': False,
+            'reason': 'subagent_result_missing',
+            'evidence': {'latest_result_path': '/local/workspace/state/subagents/results/stale.json'},
+        }],
+        'qualifying_proofs': [],
+    }
+    request_id = 'subagent-verify-materialized-improvement-cycle-live-abcdef12'
+    subagents = {
+        'source': {
+            'selected': 'eeepc',
+            'state_root': '/var/lib/eeepc-agent/self-evolving-agent/state',
+            'canonical_remote': True,
+        },
+        'latest_request': {
+            'request_id': request_id,
+            'verification_task_id': request_id,
+            'semantic_task_id': 'subagent-verify-materialized-improvement',
+            'source': 'eeepc',
+            'source_root': '/var/lib/eeepc-agent/self-evolving-agent/state',
+        },
+        'latest_result': {
+            'path': f'/var/lib/eeepc-agent/self-evolving-agent/state/subagents/results/result-{request_id}.json',
+            'request_id': request_id,
+            'verification_task_id': request_id,
+            'semantic_task_id': 'subagent-verify-materialized-improvement',
+            'verification_role': 'materialized_improvement_review',
+            'source': 'eeepc',
+            'source_root': '/var/lib/eeepc-agent/self-evolving-agent/state',
+            'status': 'blocked',
+            'terminal_reason': 'local_executor_unavailable',
+        },
+    }
+
+    reconciled = dashboard_app._reconcile_material_progress_with_subagent_visibility(material, subagents)
+
+    proof = next(p for p in reconciled['proofs'] if p.get('kind') == 'consumed_subagent_result')
+    assert reconciled['blocking_reason'] == 'delegated_verification_terminal_blocked'
+    assert proof['present'] is True
+    assert proof['reason'] == 'subagent_result_terminal_blocked'
+    assert proof['evidence']['source'] == 'eeepc'
+    assert proof['evidence']['source_root'] == '/var/lib/eeepc-agent/self-evolving-agent/state'
+    assert proof['evidence']['request_id'] == request_id
+    assert proof['evidence']['verification_task_id'] == request_id
+    assert proof['evidence']['terminal_reason'] == 'local_executor_unavailable'
+    assert reconciled['healthy_autonomy_allowed'] is False
+    assert reconciled['proof_count'] == 0
+    assert reconciled['qualifying_proofs'] == []
+    encoded = json.dumps(reconciled)
+    assert 'subagent_result_missing' not in encoded
+    assert '/local/workspace/state/subagents/results/stale.json' not in encoded
+


### PR DESCRIPTION
## Summary

Continues #420 after live proof of PR #422 showed the first source-precedence fix was insufficient.

PR #422 made `_control_plane_summary` prefer canonical `eeepc_raw.material_progress`, but live `/api/system` still reported a stale `consumed_subagent_result` proof with `reason=subagent_result_missing`. Root cause: the canonical material-progress payload itself could still carry stale/local subagent proof fields, while `/api/subagents` had the authoritative canonical request/result pair.

This PR reconciles material progress with canonical `/api/subagents` visibility before computing the autonomy verdict.

What changed:

- Added `_reconcile_material_progress_with_subagent_visibility`.
- When `/api/subagents` selected source is `eeepc` and has a generation-scoped latest result/request:
  - replace stale `consumed_subagent_result` missing proof with a present canonical proof;
  - include source/source_root/request_id/verification_task_id/verification_role/status/terminal_reason/source_artifact in evidence;
  - if the canonical result is blocked, classify as `subagent_result_terminal_blocked` and set `blocking_reason=delegated_verification_terminal_blocked`;
  - keep `healthy_autonomy_allowed=false` and do not inflate `proof_count` for blocked terminal evidence;
  - only completed/pass/success canonical result can become a qualifying proof.
- Wired reconciliation into dashboard system assembly before `_autonomy_verdict`.

## Verification

TDD:

- Added `test_material_progress_reconciles_canonical_subagent_terminal_blocker`.
- RED: helper did not exist.
- GREEN: stale local `subagent_result_missing` is replaced by canonical terminal-blocked evidence.
- Reviewer requested schema-consistency fix; updated test to assert blocked result stays conservative:
  - `healthy_autonomy_allowed=false`
  - `proof_count=0`
  - `qualifying_proofs=[]`

Final local validation:

- `python3 -m py_compile ops/dashboard/src/nanobot_ops_dashboard/app.py`
- focused #420 tests -> 2 passed
- dashboard truth suite -> 62 passed
- root suite -> 689 passed, 5 skipped
- dashboard suite -> 144 passed
- `git diff --check` -> passed

Review:

- delegated initial review: required schema consistency fix
- delegated re-review after fix: PASS

## Rollout/live proof plan

After merge:

- restart dashboard services;
- call `/collect`;
- verify `/api/subagents` selects canonical eeepc state and exposes matching request/result identity;
- verify `/api/system.autonomy_verdict.material_progress` no longer contains `subagent_result_missing` or stale local subagent result path;
- verify blocked canonical result is reported as `subagent_result_terminal_blocked` / `delegated_verification_terminal_blocked` while autonomy remains conservative;
- close #420 only after live proof.
