### PR TITLE
Execute promotion readiness input follow-through

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 from nanobot.runtime.autoevolve import resolve_terminal_selfevo_issue
-from nanobot.runtime.promotion import complete_promotion_readiness_packet, review_promotion_candidate
+from nanobot.runtime.promotion import (
+    complete_promotion_readiness_packet,
+    review_promotion_candidate,
+    supply_missing_promotion_readiness_inputs,
+)
 from nanobot.runtime.state import _subagent_rollup_snapshot
 from nanobot.runtime.subagent_materializer import materialize_subagent_requests
 from nanobot.utils.helpers import estimate_prompt_tokens
@@ -3729,18 +3733,30 @@ async def run_self_evolving_cycle(
                 candidate_id=promotion_candidate_id,
                 now=_utc_now(now),
             )
+            readiness_inputs_result = supply_missing_promotion_readiness_inputs(
+                workspace=state_root.parent,
+                state_root=state_root,
+                candidate_id=promotion_candidate_id,
+                now=_utc_now(now),
+            )
             decision_record_value = str(readiness_result.get("readiness_packet_path"))
             accepted_record_value = str(readiness_result.get("readiness_packet_path"))
             experiment["decision_record"] = "blocked_not_ready"
             experiment["accepted_record"] = "not_created_not_ready"
             experiment["readiness_packet_path"] = readiness_result.get("readiness_packet_path")
-            experiment["recommended_next_action"] = readiness_result.get("recommended_next_action")
+            experiment["readiness_checks"] = readiness_inputs_result.get("readiness_checks")
+            experiment["readiness_reasons"] = readiness_inputs_result.get("readiness_reasons")
+            experiment["readiness_blocker"] = readiness_inputs_result
+            experiment["recommended_next_action"] = readiness_inputs_result.get("recommended_next_action")
             final_promotion_record = {
                 **final_promotion_record,
                 "decision_record": "blocked_not_ready",
                 "accepted_record": "not_created_not_ready",
                 "readiness_packet_path": readiness_result.get("readiness_packet_path"),
-                "recommended_next_action": readiness_result.get("recommended_next_action"),
+                "readiness_checks": readiness_inputs_result.get("readiness_checks"),
+                "readiness_reasons": readiness_inputs_result.get("readiness_reasons"),
+                "readiness_blocker": readiness_inputs_result,
+                "recommended_next_action": readiness_inputs_result.get("recommended_next_action"),
                 "governance_packet": {
                     **(final_promotion_record.get("governance_packet") if isinstance(final_promotion_record.get("governance_packet"), dict) else {}),
                     "review_packet_status": "blocked_not_ready",
@@ -3749,6 +3765,7 @@ async def run_self_evolving_cycle(
                     "decision_record": "blocked_not_ready",
                     "accepted_record": "not_created_not_ready",
                     "readiness_packet_path": readiness_result.get("readiness_packet_path"),
+                    "readiness_blocker": readiness_inputs_result,
                 },
             }
             promotion_path.write_text(json.dumps(final_promotion_record, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/nanobot/runtime/promotion.py
+++ b/nanobot/runtime/promotion.py
@@ -13,6 +13,7 @@ _CANDIDATE_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 PROMOTION_RECORD_VERSION = 'promotion-record-v1'
 PATCH_BUNDLE_VERSION = 'promotion-patch-v1'
 READINESS_PACKET_VERSION = 'promotion-readiness-packet-v1'
+READINESS_INPUTS_BLOCKER_VERSION = 'promotion-readiness-inputs-blocker-v1'
 
 
 def _utc_iso(now: datetime | None = None) -> str:
@@ -100,6 +101,118 @@ def complete_promotion_readiness_packet(
     _write_json(candidate_path, updated)
     _write_json(promotions_dir / "latest.json", {**updated, "candidate_path": str(candidate_path)})
     return {**packet, "readiness_packet_path": str(packet_path)}
+
+
+def _missing_provenance_inputs(candidate: dict[str, Any]) -> list[str]:
+    provenance = candidate.get("promotion_provenance") if isinstance(candidate.get("promotion_provenance"), dict) else {}
+    deployment_fingerprint = provenance.get("deployment_fingerprint") if isinstance(provenance.get("deployment_fingerprint"), dict) else {}
+    values = {
+        "source_commit": provenance.get("source_commit") or candidate.get("source_commit"),
+        "build_recipe_hash": provenance.get("build_recipe_hash") or candidate.get("build_recipe_hash"),
+        "artifact_id": provenance.get("artifact_id") or candidate.get("promotion_candidate_id"),
+        "artifact_version": provenance.get("artifact_version") or candidate.get("origin_cycle_id"),
+        "release_channel": provenance.get("release_channel"),
+        "target_host_profile": provenance.get("target_host_profile"),
+        "target_authority": provenance.get("target_authority"),
+        "deployment_fingerprint_id": deployment_fingerprint.get("deployment_fingerprint_id") or provenance.get("deployment_fingerprint_id"),
+        "rollback_evidence": provenance.get("rollback_evidence") or candidate.get("rollback_plan"),
+    }
+    missing: list[str] = []
+    for key, value in values.items():
+        if value is None:
+            missing.append(key)
+        elif isinstance(value, str) and not value.strip():
+            missing.append(key)
+        elif isinstance(value, (list, dict, tuple, set)) and not value:
+            missing.append(key)
+    return missing
+
+
+def supply_missing_promotion_readiness_inputs(
+    workspace: Path,
+    candidate_id: str,
+    now: datetime | None = None,
+    state_root: Path | None = None,
+) -> dict[str, Any]:
+    """Derive objective readiness inputs or write a stronger blocker without accepting."""
+    if not candidate_id or not _CANDIDATE_ID_RE.fullmatch(candidate_id) or candidate_id.startswith("."):
+        raise ValueError("candidate_id is invalid")
+    promotions_dir = (state_root if state_root is not None else workspace / "state") / "promotions"
+    candidate_path = promotions_dir / f"{candidate_id}.json"
+    if not candidate_path.exists():
+        raise FileNotFoundError(candidate_path)
+    candidate = _read_json(candidate_path)
+    if candidate.get("decision_record") != "blocked_not_ready" or candidate.get("accepted_record") != "not_created_not_ready":
+        raise ValueError("promotion candidate is not a blocked not-ready readiness packet")
+
+    completed_at = _utc_iso(now)
+    artifact_path = candidate.get("artifact_path")
+    artifact_present = bool(artifact_path and Path(str(artifact_path)).exists())
+    evidence_refs = candidate.get("evidence_refs") if isinstance(candidate.get("evidence_refs"), list) else []
+    missing_inputs = _missing_provenance_inputs(candidate)
+    readiness_checks = {
+        "schema_version": "promotion-readiness-inputs-v1",
+        "artifact_present": artifact_present,
+        "evidence_refs_present": bool(evidence_refs),
+        "provenance_complete": not missing_inputs,
+        "missing_inputs": missing_inputs,
+    }
+    readiness_reasons = [f"{field}_missing" for field in missing_inputs]
+    if not artifact_present:
+        readiness_reasons.append("artifact_missing")
+    if not evidence_refs:
+        readiness_reasons.append("evidence_refs_missing")
+
+    recommended_next_action = "ready_for_policy_review" if not readiness_reasons else f"supply_{readiness_reasons[0].removesuffix('_missing')}_or_policy_override"
+    blocker = {
+        "schema_version": READINESS_INPUTS_BLOCKER_VERSION,
+        "state": "blocked" if readiness_reasons else "ready_for_policy_review",
+        "reason": "promotion_readiness_inputs_missing" if readiness_reasons else "promotion_readiness_inputs_supplied",
+        "promotion_candidate_id": candidate_id,
+        "missing_inputs": missing_inputs + (["artifact"] if not artifact_present else []) + (["evidence_refs"] if not evidence_refs else []),
+        "readiness_checks": readiness_checks,
+        "readiness_reasons": readiness_reasons,
+        "recommended_next_action": recommended_next_action,
+        "completed_at_utc": completed_at,
+    }
+
+    packet_path = promotions_dir / "readiness_packets" / f"{candidate_id}.json"
+    packet = _read_json(packet_path) if packet_path.exists() else {}
+    packet_updated = {
+        **packet,
+        "schema_version": READINESS_PACKET_VERSION,
+        "promotion_candidate_id": candidate_id,
+        "state": blocker["state"],
+        "reason": blocker["reason"],
+        "readiness_checks": readiness_checks,
+        "readiness_reasons": readiness_reasons,
+        "readiness_blocker": blocker,
+        "recommended_next_action": recommended_next_action,
+        "readiness_inputs_completed_at_utc": completed_at,
+    }
+    governance = candidate.get("governance_packet") if isinstance(candidate.get("governance_packet"), dict) else {}
+    updated = {
+        **candidate,
+        "review_status": "not_ready_for_policy_review" if readiness_reasons else "ready_for_policy_review",
+        "decision": "not_ready_for_policy_review" if readiness_reasons else "ready_for_policy_review",
+        "decision_record": "blocked_not_ready",
+        "accepted_record": "not_created_not_ready",
+        "readiness_packet_path": str(packet_path),
+        "readiness_checks": readiness_checks,
+        "readiness_reasons": readiness_reasons,
+        "readiness_blocker": blocker,
+        "recommended_next_action": recommended_next_action,
+        "governance_packet": {
+            **governance,
+            "review_packet_status": "blocked_not_ready" if readiness_reasons else "pending_operator_review",
+            "readiness_packet_path": str(packet_path),
+            "readiness_blocker": blocker,
+        },
+    }
+    _write_json(packet_path, packet_updated)
+    _write_json(candidate_path, updated)
+    _write_json(promotions_dir / "latest.json", {**updated, "candidate_path": str(candidate_path)})
+    return blocker
 
 
 def review_promotion_candidate(

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -122,6 +122,7 @@ def _promotion_replay_readiness_payload(
     promotion_patch_bundle_path: str | None = None,
     promotion_readiness_checks: Any = None,
     promotion_readiness_reasons: Any = None,
+    promotion_recommended_next_action: str | None = None,
 ) -> dict[str, Any]:
     missing_records = [
         name
@@ -148,7 +149,7 @@ def _promotion_replay_readiness_payload(
         'missing_records': missing_records,
         'readiness_checks': promotion_readiness_checks,
         'readiness_reasons': promotion_readiness_reasons or [],
-        'recommended_next_action': _promotion_replay_next_action(reason, state),
+        'recommended_next_action': promotion_recommended_next_action or _promotion_replay_next_action(reason, state),
     }
 
 
@@ -1044,6 +1045,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     promotion_artifact_path = None
     promotion_readiness_checks = None
     promotion_readiness_reasons = None
+    promotion_recommended_next_action = None
     promotion_governance_packet = None
     promotion_provenance = None
     credits_balance = None
@@ -1165,6 +1167,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         promotion_artifact_path = promotion_data.get("artifact_path") or promotion_data.get("artifactPath") or promotion_artifact_path
         promotion_readiness_checks = promotion_data.get("readiness_checks") or promotion_data.get("readinessChecks") or promotion_readiness_checks
         promotion_readiness_reasons = promotion_data.get("readiness_reasons") or promotion_data.get("readinessReasons") or promotion_readiness_reasons
+        promotion_recommended_next_action = promotion_data.get("recommended_next_action") or promotion_data.get("recommendedNextAction") or promotion_recommended_next_action
         promotion_governance_packet = promotion_data.get("governance_packet") or promotion_data.get("governancePacket") or promotion_governance_packet
         promotion_decision_record = promotion_data.get("decision_record") or promotion_data.get("decisionRecord") or promotion_decision_record
         promotion_accepted_record = promotion_data.get("accepted_record") or promotion_data.get("acceptedRecord") or promotion_accepted_record
@@ -1203,6 +1206,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
                 promotion_accepted_record = readiness_packet.get("accepted_record") or "not_created_not_ready"
                 promotion_readiness_reasons = readiness_packet.get("readiness_reasons") or promotion_readiness_reasons
                 promotion_readiness_checks = readiness_packet.get("readiness_checks") or promotion_readiness_checks
+                promotion_recommended_next_action = readiness_packet.get("recommended_next_action") or promotion_recommended_next_action
         if decision_record_path.exists():
             decision_record = _safe_read_json(decision_record_path)
             if isinstance(decision_record, dict):
@@ -1272,6 +1276,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
                 promotion_patch_bundle_path=promotion_patch_bundle_path,
                 promotion_readiness_checks=promotion_readiness_checks,
                 promotion_readiness_reasons=promotion_readiness_reasons,
+                promotion_recommended_next_action=promotion_recommended_next_action,
             )
         elif decision in {'not_ready_for_policy_review', 'pending'} or review_status == 'not_ready_for_policy_review':
             not_ready_state = 'blocked' if promotion_decision_record == 'blocked_not_ready' or promotion_accepted_record == 'not_created_not_ready' else 'not_ready'
@@ -1288,6 +1293,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
                 promotion_patch_bundle_path=promotion_patch_bundle_path,
                 promotion_readiness_checks=promotion_readiness_checks,
                 promotion_readiness_reasons=promotion_readiness_reasons,
+                promotion_recommended_next_action=promotion_recommended_next_action,
             )
         elif decision:
             promotion_replay_readiness = _promotion_replay_readiness_payload(
@@ -1303,6 +1309,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
                 promotion_patch_bundle_path=promotion_patch_bundle_path,
                 promotion_readiness_checks=promotion_readiness_checks,
                 promotion_readiness_reasons=promotion_readiness_reasons,
+                promotion_recommended_next_action=promotion_recommended_next_action,
             )
 
     subagent_telemetry_latest_goal_id = None

--- a/tests/test_promotion_workflow.py
+++ b/tests/test_promotion_workflow.py
@@ -8,7 +8,7 @@ import pytest
 
 from nanobot.runtime.coordinator import run_self_evolving_cycle
 from nanobot.runtime.state import load_runtime_state
-from nanobot.runtime.promotion import complete_promotion_readiness_packet, review_promotion_candidate
+from nanobot.runtime.promotion import complete_promotion_readiness_packet, review_promotion_candidate, supply_missing_promotion_readiness_inputs
 
 
 def _read_json(path: str | Path):
@@ -347,3 +347,71 @@ def test_complete_promotion_readiness_packet_writes_review_packet_without_accept
     assert runtime["promotion_replay_readiness"]["review_packet_status"] == "blocked_not_ready"
     assert runtime["promotion_replay_readiness"]["reason"] == "promotion_candidate_not_ready_for_policy_review"
     assert runtime["promotion_replay_readiness"]["recommended_next_action"] == "supply_missing_promotion_readiness_inputs"
+
+
+def test_supply_missing_promotion_readiness_inputs_writes_stronger_blocker_without_accepting(tmp_path):
+    candidate_id = "promotion-readiness-inputs"
+    promotions_dir = tmp_path / "state" / "promotions"
+    promotions_dir.mkdir(parents=True)
+    artifact_path = tmp_path / "state" / "improvements" / "materialized-cycle-inputs.json"
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_text(json.dumps({"cycle_id": "cycle-inputs"}), encoding="utf-8")
+    candidate_path = promotions_dir / f"{candidate_id}.json"
+    candidate_path.write_text(json.dumps({
+        "schema_version": "promotion-record-v1",
+        "promotion_candidate_id": candidate_id,
+        "origin_cycle_id": "cycle-inputs",
+        "review_status": "not_ready_for_policy_review",
+        "decision": "not_ready_for_policy_review",
+        "decision_record": "blocked_not_ready",
+        "accepted_record": "not_created_not_ready",
+        "artifact_path": str(artifact_path),
+        "evidence_refs": ["evidence-inputs"],
+        "readiness_checks": None,
+        "readiness_reasons": None,
+        "recommended_next_action": "supply_missing_promotion_readiness_inputs",
+        "promotion_provenance": {
+            "artifact_id": candidate_id,
+            "artifact_version": "cycle-inputs",
+            "build_recipe_hash": "hash-inputs",
+            "source_commit": None,
+            "release_channel": "self-evolving",
+            "target_host_profile": "weak-host",
+            "target_authority": "runtime-promotion-policy",
+            "rollback_evidence": {"evidence_refs": ["evidence-inputs"]},
+            "deployment_fingerprint": {"deployment_fingerprint_id": f"{candidate_id}:cycle-inputs"},
+        },
+        "governance_packet": {"review_packet_status": "blocked_not_ready"},
+    }), encoding="utf-8")
+    packet = complete_promotion_readiness_packet(workspace=tmp_path, candidate_id=candidate_id)
+    assert packet["recommended_next_action"] == "supply_missing_promotion_readiness_inputs"
+
+    result = supply_missing_promotion_readiness_inputs(workspace=tmp_path, candidate_id=candidate_id)
+
+    assert result["schema_version"] == "promotion-readiness-inputs-blocker-v1"
+    assert result["state"] == "blocked"
+    assert result["recommended_next_action"] == "supply_source_commit_or_policy_override"
+    assert result["missing_inputs"] == ["source_commit"]
+    assert result["readiness_checks"]["artifact_present"] is True
+    assert result["readiness_checks"]["evidence_refs_present"] is True
+    assert result["readiness_checks"]["provenance_complete"] is False
+    assert result["readiness_reasons"] == ["source_commit_missing"]
+
+    updated = _read_json(candidate_path)
+    assert updated["decision_record"] == "blocked_not_ready"
+    assert updated["accepted_record"] == "not_created_not_ready"
+    assert updated["recommended_next_action"] == "supply_source_commit_or_policy_override"
+    assert updated["readiness_blocker"]["schema_version"] == "promotion-readiness-inputs-blocker-v1"
+    assert not (promotions_dir / "accepted" / f"{candidate_id}.json").exists()
+    assert not (promotions_dir / "patches" / f"{candidate_id}.json").exists()
+
+    readiness_packet = _read_json(Path(updated["readiness_packet_path"]))
+    assert readiness_packet["recommended_next_action"] == "supply_source_commit_or_policy_override"
+    assert readiness_packet["readiness_blocker"]["missing_inputs"] == ["source_commit"]
+
+    runtime = load_runtime_state(tmp_path)
+    replay = runtime["promotion_replay_readiness"]
+    assert replay["state"] == "blocked"
+    assert replay["recommended_next_action"] == "supply_source_commit_or_policy_override"
+    assert replay["readiness_checks"]["provenance_complete"] is False
+    assert replay["readiness_reasons"] == ["source_commit_missing"]

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -260,13 +260,20 @@ def test_cycle_writes_pass_report_when_gate_is_fresh(tmp_path):
     assert candidate["evidence_refs"] == [report["evidence_ref_id"]]
     assert candidate["decision_record"] == "blocked_not_ready"
     assert candidate["accepted_record"] == "not_created_not_ready"
-    assert candidate["recommended_next_action"] == "supply_missing_promotion_readiness_inputs"
+    assert candidate["recommended_next_action"] == "supply_artifact_or_policy_override"
+    assert candidate["readiness_blocker"]["schema_version"] == "promotion-readiness-inputs-blocker-v1"
+    assert candidate["readiness_checks"]["artifact_present"] is False
+    assert "artifact_missing" in candidate["readiness_reasons"]
+    assert not (tmp_path / "state" / "promotions" / "accepted" / f"{report['promotion_candidate_id']}.json").exists()
+    assert not (tmp_path / "state" / "promotions" / "patches" / f"{report['promotion_candidate_id']}.json").exists()
     readiness_packet_path = Path(candidate["readiness_packet_path"])
     assert readiness_packet_path.exists()
     readiness_packet = _read_json(readiness_packet_path)
     assert readiness_packet["schema_version"] == "promotion-readiness-packet-v1"
     assert readiness_packet["promotion_candidate_id"] == report["promotion_candidate_id"]
-    assert readiness_packet["reason"] == "promotion_candidate_not_ready_for_policy_review"
+    assert readiness_packet["reason"] == "promotion_readiness_inputs_missing"
+    assert readiness_packet["recommended_next_action"] == "supply_artifact_or_policy_override"
+    assert readiness_packet["readiness_blocker"]["schema_version"] == "promotion-readiness-inputs-blocker-v1"
 
     current = _read_json(tmp_path / "state" / "goals" / "current.json")
     assert current["schema_version"] == "task-plan-v1"


### PR DESCRIPTION
## Summary

Closes #429 after live proof.

Implements the `supply_missing_promotion_readiness_inputs` follow-through introduced by #424 and surfaced by the live #427 audit. The runtime no longer leaves a not-ready promotion candidate repeating the generic `supply_missing_promotion_readiness_inputs` action.

Changes:
- Add `promotion-readiness-inputs-blocker-v1` and `supply_missing_promotion_readiness_inputs(...)`.
- Derive objective readiness checks from the candidate: artifact presence, evidence refs, and provenance completeness.
- Preserve governance safety: blocked-not-ready candidates still do not create accepted records or patch bundles.
- Write the stronger blocker into the candidate and readiness packet.
- Preserve explicit readiness-packet/candidate `recommended_next_action` in runtime-state replay.
- Integrate the follow-through in the coordinator after `complete_promotion_readiness_packet`.

Expected safe behavior:
- If objective inputs are missing, write a stronger blocker such as `supply_artifact_or_policy_override` or `supply_source_commit_or_policy_override`.
- If objective readiness inputs are complete, move only to `ready_for_policy_review` / pending operator review; do not auto-accept.

Verification:
- Focused #429 regressions: passed
- `python3 -m pytest tests -q` -> 693 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 147 passed
- `git diff --check` -> passed

Safety:
- No secrets printed or committed.
- No auto-acceptance of not-ready promotion candidates.
- No accepted record or patch bundle is created by this follow-through.