### PR TITLE
Prioritize eeepc promotion readiness source

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -3475,10 +3475,8 @@ def create_app(cfg: DashboardConfig):
         ))
         eeepc_cycle_events = [row for row in cycles if row.get('source') == 'eeepc']
         promotions = _filter_rows(
-            _sort_rows_desc(_decorate_rows(
-                fetch_events(cfg.db_path, 'eeepc', 'promotion', limit=100) +
-                fetch_events(cfg.db_path, 'repo', 'promotion', limit=100)
-            )),
+            _sort_rows_desc(_decorate_rows(fetch_events(cfg.db_path, 'eeepc', 'promotion', limit=100))) +
+            _sort_rows_desc(_decorate_rows(fetch_events(cfg.db_path, 'repo', 'promotion', limit=100))),
             promotion_source,
             promotion_status,
         )

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -2654,7 +2654,7 @@ def test_api_system_prefers_eeepc_promotion_readiness_over_stale_repo(tmp_path: 
     repo_root = tmp_path / 'nanobot'
     db = tmp_path / 'dashboard.sqlite3'
     init_db(db)
-    insert_collection(db, {'collected_at': '2999-04-27T21:00:00Z', 'source': 'repo', 'status': 'PASS', 'active_goal': 'goal-bootstrap', 'current_task': 'Analyze', 'raw_json': '{}'})
+    insert_collection(db, {'collected_at': '2999-04-27T21:02:00Z', 'source': 'repo', 'status': 'PASS', 'active_goal': 'goal-bootstrap', 'current_task': 'Analyze', 'raw_json': '{}'})
     insert_collection(db, {'collected_at': '2999-04-27T21:01:00Z', 'source': 'eeepc', 'status': 'PASS', 'active_goal': 'goal-bootstrap', 'current_task': 'Analyze', 'raw_json': '{}'})
     upsert_event(db, {
         'collected_at': '2999-04-27T21:00:00Z',


### PR DESCRIPTION
## Summary

Second dashboard follow-up for #429 live proof.

PR #431 added eeepc promotion events, but live proof showed a newer local repo promotion row could still override canonical eeepc readiness. This patch makes source authority explicit: `/api/system` evaluates eeepc promotion events first, then repo fallback.

Changes:
- Keep newest sorting within each source.
- Prefer canonical `eeepc` promotion replay readiness over local repo rows even if the local row is newer.
- Strengthen regression by making the stale repo row newer than the canonical eeepc row.

Verification:
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> passed
- `git diff --check` -> passed

This is required for #429 DoD because canonical eeepc proof has `promotion-readiness-inputs-blocker-v1` and exact `supply_source_commit_or_policy_override`, while local repo workspace can lag with stale `supply_missing_promotion_readiness_inputs`.