### PR TITLE
Report bare Python subagent executor misconfiguration

### DIFF
--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -81,6 +81,19 @@ def _executor_unavailable_blocker(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _executor_misconfiguration_blocker(request: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": "subagent-executor-misconfiguration-v1",
+        "reason": reason,
+        "recommended_next_action": "quote_systemd_executor_command_or_set_argv_command",
+        "executor_selection_source": "configured_but_invalid",
+        "required_env": ["NANOBOT_SUBAGENT_EXECUTOR_COMMAND"],
+        "safe_example": "NANOBOT_SUBAGENT_EXECUTOR_COMMAND=/path/to/python -m nanobot.runtime.bounded_subagent_executor",
+        "systemd_hint": "When configuring via systemd Environment=, quote the full NAME=value assignment if the value contains spaces.",
+        "request_profile": request.get("profile"),
+    }
+
+
 def _request_prompt(request: dict[str, Any]) -> str:
     title = request.get("task_title") or request.get("title") or request.get("task_id") or "subagent task"
     source = request.get("source_artifact") or "source artifact unavailable"
@@ -99,8 +112,26 @@ def _executor_argv(command: str | list[str] | tuple[str, ...]) -> list[str]:
     return shlex.split(str(command))
 
 
+def _bare_python_executor_reason(argv: list[str]) -> str | None:
+    if len(argv) != 1:
+        return None
+    executable = Path(argv[0]).name.lower()
+    if executable in {"python", "python3"} or executable.startswith("python3.") or executable.startswith("python2."):
+        return "bare_python_executor_command"
+    return None
+
+
 def _run_local_executor(command: str | list[str] | tuple[str, ...], request: dict[str, Any], *, timeout_seconds: int) -> tuple[bool, dict[str, Any]]:
     argv = _executor_argv(command)
+    misconfiguration_reason = _bare_python_executor_reason(argv)
+    if misconfiguration_reason:
+        return False, {
+            "returncode": None,
+            "stdout": "",
+            "stderr": "executor command resolves to a bare Python interpreter; expected argv that reads stdin intentionally, for example: python -m nanobot.runtime.bounded_subagent_executor",
+            "failure_reason": "local_executor_misconfigured",
+            "blocker": _executor_misconfiguration_blocker(request, misconfiguration_reason),
+        }
     try:
         completed = subprocess.run(
             argv,
@@ -202,10 +233,14 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 )
             terminal_reason = None if executor_ok else ((executor_result or {}).get("failure_reason") or "local_executor_unavailable")
             status_value = "completed" if executor_ok else "blocked"
-            blocker = _executor_unavailable_blocker(request) if terminal_reason == "local_executor_unavailable" and not configured_executor else None
+            blocker = (executor_result or {}).get("blocker") if executor_result else None
+            if not blocker and terminal_reason == "local_executor_unavailable" and not configured_executor:
+                blocker = _executor_unavailable_blocker(request)
             summary = (executor_result or {}).get("stdout") if executor_ok else "Subagent request terminalized as blocked because no local executor is available"
             if blocker:
-                summary = f"Subagent request terminalized as blocked because no local executor is configured. Set {blocker['required_env'][0]} or {blocker['required_env'][1]}."
+                required = blocker.get("required_env") if isinstance(blocker.get("required_env"), list) else []
+                required_text = " or ".join(str(item) for item in required) or "a valid executor command"
+                summary = f"Subagent request terminalized as blocked because the local executor is unavailable or misconfigured. Set {required_text}."
             if executor_result and not executor_ok:
                 summary = "Subagent request executor failed; request was materialized as blocked"
             result = {

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -2979,3 +2979,39 @@ def test_bounded_subagent_executor_command_completes_request(tmp_path):
     assert payload["status"] == "completed"
     assert payload["recommendation"] == "completed_bounded_review"
     assert result["request_id"] == "bounded-executor-request"
+
+
+def test_subagent_materializer_reports_bare_python_executor_misconfiguration(tmp_path):
+    from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    (request_dir / "request-cycle-bare-python.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "request_id": "subagent-verify-materialized-improvement-cycle-bare-python",
+        "task_id": "subagent-verify-materialized-improvement",
+        "task_title": "Use one bounded subagent-assisted review to verify the materialized improvement artifact",
+        "cycle_id": "cycle-bare-python",
+        "profile": "research_only",
+        "source_artifact": str(state_root / "improvements" / "materialized-cycle-bare-python.json"),
+        "verification_task_id": "subagent-verify-materialized-improvement-cycle-bare-python",
+        "verification_role": "materialized_improvement_review",
+    }), encoding="utf-8")
+
+    summary = materialize_subagent_requests(
+        state_root=state_root,
+        now=datetime(2026, 5, 1, 1, 45, tzinfo=timezone.utc),
+        executor_command="python3",
+    )
+
+    assert summary["terminalized_count"] == 1
+    assert summary["blocked_result_count"] == 1
+    result = _read_json(Path(summary["results"][0]["path"]))
+    assert result["status"] == "blocked"
+    assert result["terminal_reason"] == "local_executor_misconfigured"
+    assert result["recommended_next_action"] == "quote_systemd_executor_command_or_set_argv_command"
+    assert result["blocker"]["schema_version"] == "subagent-executor-misconfiguration-v1"
+    assert result["blocker"]["reason"] == "bare_python_executor_command"
+    assert "stderr" not in result["executor_result"] or "Cycle id" not in result["executor_result"].get("stderr", "")


### PR DESCRIPTION
## Summary

Closes #434 after live proof.

Post-#429 audit found the latest scheduled materialized subagent result blocked with `terminal_reason=local_executor_failed`. Canonical result stderr showed Python interpreting the request prompt as source:

```text
SyntaxError: invalid decimal literal
Cycle id: cycle-6360e5a74309.
```

Root cause: the live systemd drop-in used an unquoted `Environment=` assignment containing spaces, so `NANOBOT_SUBAGENT_EXECUTOR_COMMAND` effectively became only the Python executable. A bare Python interpreter reads stdin as source, so the natural-language prompt failed.

Changes:
- Add `subagent-executor-misconfiguration-v1` blocker for bare Python executor commands.
- Return `terminal_reason=local_executor_misconfigured` and `recommended_next_action=quote_systemd_executor_command_or_set_argv_command` instead of opaque `local_executor_failed`.
- Add regression for `executor_command="python3"`.

Live remediation already applied:
- Rewrote `/etc/systemd/system/eeepc-self-evolving-agent-health.service.d/96-subagent-executor.conf` with a quoted full `Environment="NAME=value with spaces"` assignment.
- Started the health service successfully.
- Fresh normal scheduled-shape proof request completed with bounded executor:
  - proof file `/tmp/issue434-live-proof.json`
  - `status=completed`
  - `terminal_reason=null`
  - `executor_returncode=0`

Verification:
- Focused tests: passed
- `python3 -m pytest tests -q` -> 694 passed, 5 skipped
- `(cd ops/dashboard && python3 -m pytest tests -q)` -> 149 passed
- `git diff --check` -> passed

Safety:
- No secrets printed or committed.
- Executor remains bounded/no network/no file mutation.
- The live systemd command was redacted in service status proof.