### PR TITLE
Harden mission-control dashboard transparency

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -463,8 +463,14 @@ def _mission_control_summary(*, context: dict, control_plane: dict | None, curre
     latest_result = subagents.get('latest_result') if isinstance(subagents.get('latest_result'), dict) else {}
     latest_request = subagents.get('latest_request') if isinstance(subagents.get('latest_request'), dict) else {}
     latest_sub_status = (latest_result.get('status') or latest_result.get('result_status') or latest_request.get('request_status') or 'unknown')
+    latest_sub_status_key = str(latest_sub_status).lower()
     if latest_result:
-        subagent_state = 'completed' if str(latest_sub_status).lower() in {'completed', 'pass', 'passed', 'success'} else 'blocked' if str(latest_sub_status).lower() in {'blocked', 'failed', 'error'} else 'unknown'
+        if latest_sub_status_key in {'completed', 'complete', 'pass', 'passed', 'success', 'ok', 'done'}:
+            subagent_state = 'completed'
+        elif latest_sub_status_key in {'blocked', 'failed', 'failure', 'error', 'crash'}:
+            subagent_state = 'blocked'
+        else:
+            subagent_state = 'unknown'
     elif latest_request:
         subagent_state = 'requested'
     else:
@@ -555,6 +561,13 @@ def _mission_control_summary(*, context: dict, control_plane: dict | None, curre
         'current_blocker': {
             'state': blocker_state,
             'reason': blocker_reason or 'none',
+            'failure_class': current_blocker.get('failure_class') or blocker_reason,
+            'blocked_next_step': current_blocker.get('blocked_next_step') or next_action_label,
+            'improvement_score': current_blocker.get('improvement_score'),
+            'feedback_decision': current_blocker.get('feedback_decision') if isinstance(current_blocker.get('feedback_decision'), dict) else {},
+            'selected_tasks_text': current_blocker.get('selected_tasks_text'),
+            'selected_task_title': current_blocker.get('selected_task_title'),
+            'task_selection_source': current_blocker.get('task_selection_source'),
             'recommended_next_action': next_action_label,
             'source': current_blocker.get('source') or (control_plane.get('blocker_summary') or {}).get('source') if isinstance(control_plane.get('blocker_summary'), dict) else current_blocker.get('source') or 'unknown',
         },

--- a/ops/dashboard/src/nanobot_ops_dashboard/templates/index.html
+++ b/ops/dashboard/src/nanobot_ops_dashboard/templates/index.html
@@ -56,6 +56,10 @@
       </div>
       <div class="detail-stack">
         <div class="detail-row"><span class="detail-label">Reason</span><span><strong>{{ mission_control.current_blocker.reason }}</strong></span></div>
+        <div class="detail-row"><span class="detail-label">Failure class</span><span>{{ mission_control.current_blocker.failure_class or 'none' }}</span></div>
+        <div class="detail-row"><span class="detail-label">Improvement score</span><span>{{ mission_control.current_blocker.improvement_score if mission_control.current_blocker.improvement_score is not none else 'unknown' }}</span></div>
+        <div class="detail-row"><span class="detail-label">Feedback decision</span><span>{{ mission_control.current_blocker.feedback_decision.mode if mission_control.current_blocker.feedback_decision else 'unknown' }}</span></div>
+        <div class="detail-row"><span class="detail-label">Blocked next step</span><span>{{ mission_control.current_blocker.blocked_next_step }}</span></div>
         <div class="detail-row"><span class="detail-label">Recommended next action</span><span>{{ mission_control.current_blocker.recommended_next_action }}</span></div>
       </div>
     </div>

--- a/ops/dashboard/tests/test_app.py
+++ b/ops/dashboard/tests/test_app.py
@@ -394,6 +394,10 @@ def test_app_api_mission_control_summarizes_self_improvement_process(tmp_path: P
     assert payload['hadi']['stage_label']
     assert payload['last_material_progress']['state'] in {'available', 'missing', 'stale', 'unknown'}
     assert payload['current_blocker']['reason'] == 'no_concrete_change'
+    assert payload['current_blocker']['failure_class'] == 'no_concrete_change'
+    assert payload['current_blocker']['blocked_next_step'].startswith('Rewrite the cycle')
+    assert payload['current_blocker']['improvement_score'] == 30
+    assert payload['current_blocker']['feedback_decision']['mode'] == 'force_remediation'
     assert payload['current_blocker']['recommended_next_action'].startswith('Rewrite the cycle')
     assert payload['truth_status']['canonical_source'] in {'eeepc', 'repo', 'local', 'unknown'}
     assert payload['truth_status']['runtime_parity_state']
@@ -403,6 +407,31 @@ def test_app_api_mission_control_summarizes_self_improvement_process(tmp_path: P
     assert payload['debug_links']['subagents'] == '/api/subagents'
     assert payload['process_timeline']
     assert {event['kind'] for event in payload['process_timeline']} & {'hypothesis', 'action', 'data', 'blocker'}
+
+
+def test_app_api_mission_control_treats_ok_subagent_result_as_completed(tmp_path: Path):
+    root = tmp_path / 'dashboard'
+    db = root / 'data' / 'db.sqlite3'
+    repo = tmp_path / 'nanobot'
+    state_root = repo / 'workspace' / 'state'
+    result_dir = state_root / 'subagents' / 'results'
+    result_dir.mkdir(parents=True, exist_ok=True)
+    init_db(db)
+    _seed_dashboard_data(db)
+    (result_dir / 'result-ok.json').write_text(json.dumps({
+        'schema_version': 'subagent-result-v1',
+        'request_id': 'subagent-ok-proof',
+        'status': 'ok',
+        'summary': 'review completed',
+    }), encoding='utf-8')
+    app = create_app(_cfg(tmp_path, db))
+
+    status, body = _call_app(app, '/api/mission-control')
+
+    assert status.startswith('200')
+    payload = json.loads(body)
+    assert payload['subagents']['latest_status'] == 'ok'
+    assert payload['subagents']['state'] == 'completed'
 
 
 def test_app_overview_prioritizes_mission_control_before_technical_evidence(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes #436.
Closes #437.
Closes #438.

This finalizes the self-improvement mission-control dashboard slice by hardening the existing mission-control API/UI contract:

- `/api/mission-control` now preserves auditable blocker details instead of collapsing them to only reason/action:
  - `failure_class`
  - `blocked_next_step`
  - `improvement_score`
  - `feedback_decision`
  - selected task context fields
- The mission-control overview renders those blocker fields in the first viewport.
- Subagent status normalization now treats common success aliases (`ok`, `done`) as `completed`, not `unknown`.
- Added regression coverage for blocker transparency and `ok` subagent results.

## Why

The dashboard goal is not to be a raw log viewer. It should explain the autonomous self-improvement process in human terms while preserving proof transparency:

- current HADI process stage
- last material progress
- current blocker and next action
- truth/canonical source status
- subagent consumed-vs-visible status
- process timeline
- debug links for raw evidence

## Verification

Local:

```text
python3 -m py_compile ops/dashboard/src/nanobot_ops_dashboard/app.py
python3 -m pytest ops/dashboard/tests/test_app.py::test_app_api_mission_control_summarizes_self_improvement_process ops/dashboard/tests/test_app.py::test_app_api_mission_control_treats_ok_subagent_result_as_completed ops/dashboard/tests/test_app.py::test_app_overview_prioritizes_mission_control_before_technical_evidence -q
3 passed

(cd ops/dashboard && python3 -m pytest tests -q)
152 passed

python3 -m pytest tests -q
694 passed, 5 skipped

git diff --check
passed
```

Review:

- Subagent UX/spec review completed.
- Subagent implementation seam review completed.
- Subagent code-quality review requested changes.
- Follow-up subagent re-review approved after fixes.

## Safety

- No new request-time SSH/log/systemd reads.
- No secrets printed or committed.
- Existing raw/debug evidence pages and APIs remain available.
- Blockers are surfaced, not hidden behind healthy styling.
