### PR TITLE
fix: redact subagent key learnings

### DIFF
--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -73,7 +73,7 @@ def _coerce_key_learnings(value: Any) -> list[str]:
         else:
             text = str(item).strip()
         if text:
-            learnings.append(text)
+            learnings.append(_redact_secret_text(text, limit=1000))
     return learnings
 
 

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -2291,7 +2291,7 @@ def test_subagent_materializer_records_executor_failure_without_leaking_command_
     summary = materialize_subagent_requests(
         state_root=state_root,
         now=datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc),
-        executor_command="python3 -c 'import sys; sys.stderr.write(\"bad sk-secret\"); raise SystemExit(7)'",
+        executor_command="python3 -c 'import sys, json; print(json.dumps({\"key_learnings\":[\"do not leak sk-secret-token in learnings\"]})); sys.stderr.write(\"bad sk-secret\"); raise SystemExit(7)'",
     )
 
     assert summary["executed_count"] == 0
@@ -2300,7 +2300,7 @@ def test_subagent_materializer_records_executor_failure_without_leaking_command_
     assert result["status"] == "blocked"
     assert result["terminal_reason"] == "local_executor_failed"
     assert result["learning_classification"] == "reported_failure_with_learning"
-    assert result["key_learnings"] == ["subagent request did not complete because local_executor_failed; treat this as a reported failure, not material progress"]
+    assert result["key_learnings"] == ["do not leak [REDACTED]-token in learnings"]
     assert result["executor"]["base_url"] == "https://litellm.ayga.tech:9443/v1"
     serialized = json.dumps(result)
     assert "sk-secret" not in serialized


### PR DESCRIPTION
## Summary
- preserve the gnhf-inspired `key_learnings` feedback channel while redacting executor-provided learning strings before durable storage
- add regression coverage proving secret-like text in executor `key_learnings` is redacted in `subagent-result-v1`

## Issues
Completes the safety follow-up for #440, #441, and #442 after the autonomous self-update commit `92f03622` landed the main implementation.

## Verification
- `python3 -m pytest tests/test_runtime_coordinator.py::test_subagent_materializer_records_executor_failure_without_leaking_command_secrets tests/test_runtime_coordinator.py::test_subagent_materializer_executes_research_only_request_with_local_executor tests/test_runtime_coordinator.py::test_subagent_materializer_terminalizes_queued_request_and_rollup_correlates_result -q`
- `(cd ops/dashboard && python3 -m pytest tests/test_app.py -k 'mission_control or experiments_renders_discard' -q)`
- `git diff --check`
- `python3 -m pytest tests -q`
- `(cd ops/dashboard && python3 -m pytest tests -q)`

## Review
- Subagent review initially requested changes for secret safety in `key_learnings`.
- Final subagent review: APPROVED.
