### PR TITLE
fix: update dashboard browser title

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/templates/base.html
+++ b/ops/dashboard/src/nanobot_ops_dashboard/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="30">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ title or 'eeebot Ops Dashboard' }}</title>
+    <title>{{ title or 'eeebot Mission Control' }}</title>
     <style>
       :root {
         color-scheme: dark;

--- a/ops/dashboard/tests/test_app.py
+++ b/ops/dashboard/tests/test_app.py
@@ -326,6 +326,7 @@ def test_app_overview_renders(tmp_path: Path):
 
     status, body = _call_app(app, '/')
     assert status.startswith('200')
+    assert '<title>eeebot Mission Control</title>' in body
     assert 'eeebot Mission Control' in body
     assert 'Human-readable self-improvement dashboard' in body
     assert 'Mission Control' in body


### PR DESCRIPTION
## Summary
- update the browser title from `eeebot Ops Dashboard` to `eeebot Mission Control`
- keep the visible header/subtitle/nav mission-control copy already present on `origin/main`
- add regression coverage for the title tag

## Issue
Completes #444

## Verification
- `(cd ops/dashboard && python3 -m pytest tests/test_app.py::test_app_overview_renders tests/test_app.py::test_app_overview_prioritizes_mission_control_before_technical_evidence -q)`
- `git diff --check`
