### PR TITLE
fix: clarify mission control progress blockers

### DIFF
--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -503,9 +503,7 @@ def _mission_control_summary(*, context: dict, control_plane: dict | None, curre
         if latest_sub_status_key in successful_subagent_statuses or proof_status in successful_subagent_statuses:
             latest_consumed = True
             break
-    latest_result_blocker = latest_result.get('blocker') if isinstance(latest_result.get('blocker'), dict) else {}
-    latest_result_blocker_reason = latest_result_blocker.get('reason') or latest_result.get('terminal_reason') or latest_result.get('failure_class')
-    if latest_sub_status_key in terminal_subagent_statuses and latest_result_blocker_reason and str(latest_result_blocker_reason).lower() not in {'unknown', 'none', 'clear'}:
+    if latest_sub_status_key in terminal_subagent_statuses:
         latest_consumed_as_blocker_evidence = True
         latest_consumed = False
 
@@ -657,7 +655,12 @@ def _mission_control_summary(*, context: dict, control_plane: dict | None, curre
         },
         'last_material_progress': {
             'state': material_state,
-            'reason': material.get('reason') or material.get('blocking_reason'),
+            'canonical_state': material.get('state') or material_state,
+            'available': material_state in {'available', 'proven'},
+            'reason': material.get('blocking_reason') or material.get('reason'),
+            'blocking_reason': material.get('blocking_reason') or material.get('reason'),
+            'source_reason': material.get('reason'),
+            'reason_mismatch': bool(material.get('reason') and material.get('blocking_reason') and material.get('reason') != material.get('blocking_reason')),
             'proof_count': material.get('proof_count') or 0,
             'qualifying_proofs': material.get('qualifying_proofs') or [],
             'healthy_autonomy_allowed': bool(material.get('healthy_autonomy_allowed')),

--- a/ops/dashboard/tests/test_app.py
+++ b/ops/dashboard/tests/test_app.py
@@ -601,6 +601,55 @@ def test_mission_control_preserves_canonical_material_progress_state_when_proven
     assert progress['proof_count'] == 3
 
 
+def test_mission_control_marks_sparse_blocked_subagent_as_blocker_evidence():
+    payload = _mission_control_summary(
+        context=_minimal_mission_context(),
+        control_plane={},
+        current_blocker={'reason': 'source_commit_missing'},
+        material_progress={'schema_version': 'material-progress-v1', 'state': 'proven', 'proof_count': 3, 'healthy_autonomy_allowed': False},
+        runtime_parity={'state': 'authority_resolved_with_source_skew'},
+        autonomy_verdict={'state': 'stagnant'},
+        hypotheses_visibility={},
+        experiment_visibility={},
+        subagent_visibility={'latest_result': {'request_id': 'blocked-sparse', 'status': 'blocked'}},
+        analytics={},
+    )
+
+    assert payload['subagents']['latest_consumed_as_material_progress'] is False
+    assert payload['subagents']['latest_consumed_as_blocker_evidence'] is True
+
+
+def test_mission_control_material_progress_available_and_reason_are_unambiguous():
+    payload = _mission_control_summary(
+        context=_minimal_mission_context(),
+        control_plane={},
+        current_blocker={'reason': 'source_commit_missing'},
+        material_progress={
+            'schema_version': 'material-progress-v1',
+            'state': 'blocked',
+            'available': True,
+            'reason': 'legacy_available_reason',
+            'blocking_reason': 'delegated_verification_terminal_blocked',
+            'proof_count': 0,
+            'healthy_autonomy_allowed': False,
+        },
+        runtime_parity={'state': 'authority_resolved_with_source_skew'},
+        autonomy_verdict={'state': 'stagnant'},
+        hypotheses_visibility={},
+        experiment_visibility={},
+        subagent_visibility={},
+        analytics={},
+    )
+
+    progress = payload['last_material_progress']
+    assert progress['state'] == 'blocked'
+    assert progress['available'] is False
+    assert progress['reason'] == 'delegated_verification_terminal_blocked'
+    assert progress['blocking_reason'] == 'delegated_verification_terminal_blocked'
+    assert progress['source_reason'] == 'legacy_available_reason'
+    assert progress['reason_mismatch'] is True
+
+
 def test_mission_control_deduplicates_discarded_attempts_and_populates_learning_fallback():
     duplicate = {
         'experiment_id': 'experiment-cycle-a539af6a2dc5',


### PR DESCRIPTION
## Summary

Fixes two Mission Control truth gaps found by the repeat live semantic audit.

Closes #452.
Closes #453.

## Changes

- Treat every terminal latest subagent result (`blocked`, `failed`, `error`, etc.) as blocker evidence in Mission Control, even when the material-progress proof list contains only other qualifying proofs.
- Preserve canonical material-progress state from `/api/system` in `/api/mission-control.last_material_progress` instead of coercing explicit states such as `proven` to `available`.
- Add unambiguous material-progress projection fields:
  - `canonical_state`
  - `available`
  - `blocking_reason`
  - `source_reason`
  - `reason_mismatch`
- Add regressions for the live #452/#453 shapes and reviewer-found edge cases.

## Verification

Local:

```text
Focused tests: passed
ops/dashboard tests: 164 passed
git diff --check: passed
root tests: 694 passed, 5 skipped
```

Subagent review:

- Delegated code-path analysis for #452 and #453 before implementation.
- Delegated diff review after first green suite.
- Review found three edge cases; added RED regressions and fixed them before PR.

## Live proof plan after merge

- Restart dashboard services.
- Run `/collect`.
- Fetch `/api/mission-control`, `/api/system`, `/api/plan`, `/api/hypotheses`, `/api/experiments`, `/api/analytics`, `/api/subagents`.
- Assert:
  - blocked latest subagent is blocker evidence;
  - blocked latest subagent is not material progress;
  - Mission Control material-progress state matches canonical system truth;
  - previous #446-#450 invariants still pass.
