### PR TITLE
fix: read release metadata for promotion source commits

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -430,6 +430,39 @@ def _observed_product_head_source_fingerprint(workspace: Path) -> dict[str, Any]
     }
 
 
+def _release_metadata_source_fingerprint(search_roots: list[Path]) -> dict[str, Any] | None:
+    """Read source provenance from archive/release metadata when .git is absent.
+
+    eeepc deploys the system emitter from git archives, so the runtime tree has no
+    `.git` directory.  A release-side `SOURCE_COMMIT` file is the auditable source
+    of truth for those pinned trees and must win over unrelated cwd git repos.
+    """
+
+    def _read_first(root: Path, names: tuple[str, ...]) -> str | None:
+        for name in names:
+            path = root / name
+            try:
+                value = path.read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if value:
+                return value
+        return None
+
+    for root in search_roots:
+        commit = _read_first(root, ("SOURCE_COMMIT", "REVISION", "COMMIT"))
+        if not commit:
+            continue
+        return {
+            "source_repo_root": str(root),
+            "source_commit": commit,
+            "source_branch": _read_first(root, ("SOURCE_BRANCH", "BRANCH")),
+            "source_tree": _read_first(root, ("SOURCE_TREE", "TREE")),
+            "source_authority": "release_metadata",
+        }
+    return None
+
+
 def _runtime_source_fingerprint(workspace: Path) -> dict[str, Any]:
     env_commit = os.environ.get('NANOBOT_SOURCE_COMMIT') or os.environ.get('SOURCE_COMMIT')
     if env_commit:
@@ -441,6 +474,9 @@ def _runtime_source_fingerprint(workspace: Path) -> dict[str, Any]:
             'source_authority': 'environment',
         }
     search_roots = [workspace, Path(__file__).resolve().parents[2], Path.cwd()]
+    release_metadata = _release_metadata_source_fingerprint(search_roots)
+    if release_metadata:
+        return release_metadata
     for candidate_root in search_roots:
         repo_root = candidate_root
         while repo_root != repo_root.parent and not (repo_root / '.git').exists():

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -35,6 +35,24 @@ def test_runtime_source_fingerprint_prefers_explicit_release_env_for_archived_ru
     }
 
 
+def test_runtime_source_fingerprint_reads_release_metadata_before_git_for_archived_runtime(tmp_path, monkeypatch):
+    (tmp_path / "SOURCE_COMMIT").write_text("release-file-commit-789\n", encoding="utf-8")
+    (tmp_path / "SOURCE_BRANCH").write_text("main\n", encoding="utf-8")
+    (tmp_path / "SOURCE_TREE").write_text("tree-file-123\n", encoding="utf-8")
+    monkeypatch.delenv("NANOBOT_SOURCE_COMMIT", raising=False)
+    monkeypatch.delenv("SOURCE_COMMIT", raising=False)
+
+    fingerprint = _runtime_source_fingerprint(tmp_path)
+
+    assert fingerprint == {
+        "source_repo_root": str(tmp_path),
+        "source_commit": "release-file-commit-789",
+        "source_branch": "main",
+        "source_tree": "tree-file-123",
+        "source_authority": "release_metadata",
+    }
+
+
 def test_runtime_source_fingerprint_falls_back_to_observed_product_head_when_git_is_unavailable(tmp_path, monkeypatch):
     state_dir = tmp_path / "state" / "self_evolution"
     state_dir.mkdir(parents=True)


### PR DESCRIPTION
Closes #456.

## Summary
- Teach runtime source fingerprinting to read SOURCE_COMMIT/SOURCE_BRANCH/SOURCE_TREE release metadata from git-archive deployments before falling through to unrelated cwd git repos.
- This gives eeepc /opt self-evolving emitter an auditable source_commit even though pinned release trees do not include .git.
- Add regression coverage for archived-runtime release metadata precedence.

## Test plan
- RED before fix: tests/test_runtime_coordinator.py::test_runtime_source_fingerprint_reads_release_metadata_before_git_for_archived_runtime failed; runtime returned local repo git HEAD instead of release metadata.
- `python3 -m pytest tests/test_runtime_coordinator.py -k "runtime_source_fingerprint or promotion" -q` -> 3 passed.
- `python3 -m pytest tests/test_promotion_workflow.py -q` -> 10 passed.
- `python3 -m pytest tests -q` -> 697 passed, 5 skipped.
- `PYTHONPATH=ops/dashboard/src:ops/dashboard python3 -m pytest ops/dashboard/tests -q` -> 165 passed.

## Live follow-up after merge
- Deploy archived runtime to eeepc /opt with SOURCE_COMMIT metadata files.
- Trigger eeepc-self-evolving-agent-health.service.
- Verify /api/promotions latest promotion detail.provenance.source_commit and governance_packet.promotion_provenance.source_commit are non-null.
