### PR TITLE
Add cycle health summary command

### DIFF
--- a/docs/EEEPC_AGENT_RUNTIME_INSTRUCTIONS.md
+++ b/docs/EEEPC_AGENT_RUNTIME_INSTRUCTIONS.md
@@ -26,6 +26,27 @@ Bounded apply requires a valid approval file:
 Expected schema:
 - JSON with `expires_at_epoch`
 
+## Operator health check
+
+Use the compact cycle health command for read-only operator triage after the runtime containing it is deployed:
+
+```bash
+eeebot cycle-health \
+  --runtime-state-root /var/lib/eeepc-agent/self-evolving-agent/state \
+  --runtime-state-source host_control_plane
+```
+
+For automation or dashboard ingestion:
+
+```bash
+eeebot cycle-health \
+  --runtime-state-root /var/lib/eeepc-agent/self-evolving-agent/state \
+  --runtime-state-source host_control_plane \
+  --json
+```
+
+It reports the latest cycle id, report path, subagent telemetry id/path, bridge service status, failed units count, promotion readiness, and the next recommended action.
+
 ## Operator expectations
 
 The dashboard should be able to observe:

--- a/eeebot/runtime/health.py
+++ b/eeebot/runtime/health.py
@@ -1,0 +1,3 @@
+"""eeebot runtime health compatibility shim."""
+
+from nanobot.runtime.health import *  # noqa: F401,F403

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -1087,6 +1087,44 @@ def subagents_materialize(
 # ============================================================================
 
 
+@app.command("cycle-health")
+def cycle_health(
+    runtime_state_source: str = typer.Option(
+        "host_control_plane",
+        "--runtime-state-source",
+        help="Runtime state source: workspace_state or host_control_plane",
+    ),
+    runtime_state_root: str = typer.Option(
+        "/var/lib/eeepc-agent/self-evolving-agent/state",
+        "--runtime-state-root",
+        help="Runtime state root path",
+    ),
+    service_name: str = typer.Option(
+        "eeepc-self-evolving-subagent-bridge.service",
+        "--service-name",
+        help="Systemd service to include in the health summary",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON"),
+):
+    """Show a compact eeepc cycle health summary."""
+    from nanobot.runtime.health import (
+        build_cycle_health_summary,
+        dumps_cycle_health_summary,
+        format_cycle_health_summary,
+    )
+
+    summary = build_cycle_health_summary(
+        Path(runtime_state_root).expanduser(),
+        source_kind=runtime_state_source,
+        service_name=service_name,
+    )
+    if json_output:
+        console.out(dumps_cycle_health_summary(summary))
+        return
+    for line in format_cycle_health_summary(summary):
+        console.print(line, soft_wrap=True)
+
+
 @app.command()
 def status(
     runtime_state_source: str = typer.Option(

--- a/nanobot/runtime/health.py
+++ b/nanobot/runtime/health.py
@@ -1,0 +1,167 @@
+"""Cycle health summary helpers for eeebot runtime state."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+from nanobot.runtime.state import load_runtime_state_from_root
+
+_DEFAULT_BRIDGE_SERVICE = "eeepc-self-evolving-subagent-bridge.service"
+
+CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _default_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, text=True, capture_output=True, timeout=10, check=False)
+
+
+def _run_systemctl(runner: CommandRunner, args: list[str]) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return runner(["systemctl", *args, "--no-pager"])
+    except Exception:
+        return None
+
+
+def read_service_status(
+    service_name: str = _DEFAULT_BRIDGE_SERVICE,
+    *,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    """Read a compact systemd service snapshot without raising on non-systemd hosts."""
+    run = runner or _default_runner
+    active = _run_systemctl(run, ["is-active", service_name])
+    result = _run_systemctl(run, ["show", service_name, "-p", "Result", "-p", "ActiveState", "-p", "SubState"])
+
+    details: dict[str, str] = {}
+    if result and result.returncode == 0:
+        for line in result.stdout.splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                details[key] = value
+
+    active_state = (active.stdout.strip() if active and active.stdout.strip() else None) or details.get("ActiveState")
+    return {
+        "service": service_name,
+        "active_state": active_state or "unknown",
+        "sub_state": details.get("SubState") or "unknown",
+        "result": details.get("Result") or "unknown",
+        "available": bool(active and active.returncode in {0, 3} or result and result.returncode == 0),
+    }
+
+
+def read_failed_units_count(*, runner: CommandRunner | None = None) -> int | None:
+    """Return the number of failed systemd units, or None when unavailable."""
+    run = runner or _default_runner
+    proc = _run_systemctl(run, ["--failed", "--plain", "--legend=false"])
+    if not proc or proc.returncode not in {0, 1}:
+        return None
+    return len([line for line in proc.stdout.splitlines() if line.strip()])
+
+
+def _promotion_readiness(runtime: dict[str, Any]) -> dict[str, Any]:
+    replay = runtime.get("promotion_replay_readiness")
+    if isinstance(replay, dict):
+        return {
+            "state": replay.get("state") or "unknown",
+            "reason": replay.get("reason"),
+            "recommended_next_action": replay.get("recommended_next_action"),
+        }
+    candidate_id = runtime.get("promotion_candidate_id")
+    if candidate_id:
+        return {
+            "state": runtime.get("review_status") or runtime.get("decision") or "pending",
+            "reason": runtime.get("decision_reason"),
+            "recommended_next_action": "review_promotion_candidate",
+        }
+    return {
+        "state": "absent",
+        "reason": "no_promotion_candidate",
+        "recommended_next_action": "run_bounded_cycle_or_generate_candidate",
+    }
+
+
+def _recommended_next_action(
+    *,
+    runtime: dict[str, Any],
+    service_status: dict[str, Any],
+    failed_units_count: int | None,
+    promotion_readiness: dict[str, Any],
+) -> str:
+    if failed_units_count and failed_units_count > 0:
+        return "inspect_failed_systemd_units"
+    if service_status.get("active_state") not in {"active", "inactive", "unknown"}:
+        return "inspect_bridge_service_status"
+    if runtime.get("next_hint") and runtime.get("next_hint") != "none":
+        return str(runtime["next_hint"])
+    promo_action = promotion_readiness.get("recommended_next_action")
+    if promo_action and promotion_readiness.get("state") not in {"absent", "ready"}:
+        return str(promo_action)
+    material = runtime.get("material_progress") if isinstance(runtime.get("material_progress"), dict) else {}
+    if material.get("state") in {"missing", "blocked"}:
+        return str(material.get("blocking_reason") or "select_small_improvement_task")
+    return "observe_next_timer_cycle"
+
+
+def build_cycle_health_summary(
+    state_root: Path,
+    *,
+    source_kind: str = "host_control_plane",
+    service_name: str = _DEFAULT_BRIDGE_SERVICE,
+    runner: CommandRunner | None = None,
+) -> dict[str, Any]:
+    """Build an operator-friendly health summary from runtime state and systemd."""
+    runtime = load_runtime_state_from_root(state_root, source_kind=source_kind)
+    service_status = read_service_status(service_name, runner=runner)
+    failed_units_count = read_failed_units_count(runner=runner)
+    promotion_readiness = _promotion_readiness(runtime)
+    summary = {
+        "schema_version": "cycle-health-summary-v1",
+        "runtime_state_source": runtime.get("runtime_state_source"),
+        "runtime_state_root": runtime.get("runtime_state_root"),
+        "latest_cycle_id": runtime.get("cycle_id"),
+        "latest_report_path": runtime.get("report_path"),
+        "latest_subagent_telemetry_id": runtime.get("subagent_telemetry_latest_id"),
+        "latest_subagent_telemetry_path": runtime.get("subagent_telemetry_path"),
+        "service_status": service_status,
+        "failed_units_count": failed_units_count,
+        "promotion_readiness": promotion_readiness,
+        "next_recommended_action": _recommended_next_action(
+            runtime=runtime,
+            service_status=service_status,
+            failed_units_count=failed_units_count,
+            promotion_readiness=promotion_readiness,
+        ),
+    }
+    return summary
+
+
+def format_cycle_health_summary(summary: dict[str, Any]) -> list[str]:
+    """Format cycle health summary as stable text lines."""
+    service = summary.get("service_status") if isinstance(summary.get("service_status"), dict) else {}
+    promotion = summary.get("promotion_readiness") if isinstance(summary.get("promotion_readiness"), dict) else {}
+    return [
+        "Cycle health summary:",
+        f"  Runtime state source: {summary.get('runtime_state_source') or 'unknown'}",
+        f"  Runtime state root: {summary.get('runtime_state_root') or 'unknown'}",
+        f"  Latest cycle id: {summary.get('latest_cycle_id') or 'unknown'}",
+        f"  Latest report path: {summary.get('latest_report_path') or 'unknown'}",
+        f"  Latest subagent telemetry id: {summary.get('latest_subagent_telemetry_id') or 'unknown'}",
+        f"  Latest subagent telemetry path: {summary.get('latest_subagent_telemetry_path') or 'unknown'}",
+        "  Service status: "
+        f"{service.get('service') or 'unknown'} "
+        f"active={service.get('active_state') or 'unknown'} "
+        f"sub={service.get('sub_state') or 'unknown'} "
+        f"result={service.get('result') or 'unknown'}",
+        f"  Failed units count: {summary.get('failed_units_count') if summary.get('failed_units_count') is not None else 'unknown'}",
+        "  Promotion readiness: "
+        f"state={promotion.get('state') or 'unknown'} "
+        f"reason={promotion.get('reason') or 'none'}",
+        f"  Next recommended action: {summary.get('next_recommended_action') or 'unknown'}",
+    ]
+
+
+def dumps_cycle_health_summary(summary: dict[str, Any]) -> str:
+    return json.dumps(summary, indent=2, ensure_ascii=False)

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -97,6 +97,8 @@ def _governance_coverage_snapshot(runtime: dict[str, Any]) -> dict[str, Any]:
 def _promotion_replay_next_action(reason: str | None, state: str | None = None) -> str:
     if state == 'ready':
         return 'replay_promotion_candidate'
+    if state == 'ready_for_policy_review':
+        return 'review_promotion_candidate'
     if reason == 'promotion_candidate_not_ready_for_policy_review':
         return 'supply_missing_promotion_readiness_inputs' if state == 'blocked' else 'complete_promotion_readiness_packet'
     if reason == 'patch_bundle_missing':

--- a/tests/test_cycle_health_summary.py
+++ b/tests/test_cycle_health_summary.py
@@ -1,0 +1,70 @@
+import json
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from nanobot.cli.commands import app
+from nanobot.runtime.health import build_cycle_health_summary, format_cycle_health_summary
+
+
+def _write_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+    if command[:3] == ["systemctl", "is-active", "eeepc-self-evolving-subagent-bridge.service"]:
+        return subprocess.CompletedProcess(command, 0, "active\n", "")
+    if command[:3] == ["systemctl", "show", "eeepc-self-evolving-subagent-bridge.service"]:
+        return subprocess.CompletedProcess(command, 0, "Result=success\nActiveState=active\nSubState=exited\n", "")
+    if command[:2] == ["systemctl", "--failed"]:
+        return subprocess.CompletedProcess(command, 0, "", "")
+    return subprocess.CompletedProcess(command, 1, "", "unexpected")
+
+
+def test_build_cycle_health_summary_reads_state_and_systemd(tmp_path: Path):
+    state = tmp_path / "state"
+    _write_json(
+        state / "reports" / "evolution-001.json",
+        {"cycle_id": "cycle-001", "result_status": "PASS"},
+    )
+    _write_json(
+        state / "subagents" / "telemetry-001.json",
+        {"subagent_id": "sub-001", "status": "ok"},
+    )
+    _write_json(
+        state / "promotions" / "latest.json",
+        {"promotion_candidate_id": "promo-001", "review_status": "ready_for_policy_review", "decision": "ready_for_policy_review"},
+    )
+    _write_json(state / "outbox" / "latest.json", {"approval_gate": {"state": "fresh"}})
+
+    summary = build_cycle_health_summary(state, runner=_fake_runner)
+
+    assert summary["schema_version"] == "cycle-health-summary-v1"
+    assert summary["latest_cycle_id"] == "cycle-001"
+    assert summary["latest_subagent_telemetry_id"] == "sub-001"
+    assert summary["service_status"]["active_state"] == "active"
+    assert summary["failed_units_count"] == 0
+    assert summary["promotion_readiness"]["state"] == "ready_for_policy_review"
+    assert summary["next_recommended_action"] == "review_promotion_candidate"
+
+    lines = format_cycle_health_summary(summary)
+    assert any("Latest cycle id: cycle-001" in line for line in lines)
+    assert any("Next recommended action: review_promotion_candidate" in line for line in lines)
+
+
+def test_cycle_health_cli_json(tmp_path: Path, monkeypatch):
+    state = tmp_path / "state"
+    _write_json(state / "reports" / "evolution-001.json", {"cycle_id": "cycle-cli"})
+    monkeypatch.setattr("nanobot.runtime.health._default_runner", _fake_runner)
+
+    result = CliRunner().invoke(
+        app,
+        ["cycle-health", "--runtime-state-root", str(state), "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["latest_cycle_id"] == "cycle-cli"
+    assert payload["failed_units_count"] == 0


### PR DESCRIPTION
## Summary
- add read-only cycle health summary builder and CLI command
- include latest cycle/report/subagent telemetry, systemd bridge status, failed unit count, promotion readiness, and next recommended action
- document eeepc operator usage

## Validation
- python -m py_compile nanobot/runtime/health.py eeebot/runtime/health.py nanobot/cli/commands.py tests/test_cycle_health_summary.py nanobot/runtime/state.py
- manual health summary unit probe with fake runtime state/systemd
- uv pytest attempted but blocked by PyPI hatchling TLS/connect timeout
- read-only SSH probe on eeepc: bridge last run 0/SUCCESS, failed units 0, telemetry landing in canonical state/subagents