### PR TITLE
Formalize minimal schemas for runtime state

### DIFF
--- a/nanobot/runtime/health.py
+++ b/nanobot/runtime/health.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from nanobot.runtime.state import load_runtime_state_from_root
+from nanobot.runtime.schemas import CycleHealth
 
 _DEFAULT_BRIDGE_SERVICE = "eeepc-self-evolving-subagent-bridge.service"
 
@@ -144,7 +145,7 @@ def build_cycle_health_summary(
     source_kind: str = "host_control_plane",
     service_name: str = _DEFAULT_BRIDGE_SERVICE,
     runner: CommandRunner | None = None,
-) -> dict[str, Any]:
+) -> CycleHealth:
     """Build an operator-friendly health summary from runtime state and systemd."""
     runtime = load_runtime_state_from_root(state_root, source_kind=source_kind)
     service_status = read_service_status(service_name, runner=runner)
@@ -182,7 +183,7 @@ def build_cycle_health_summary(
     return summary
 
 
-def format_cycle_health_summary(summary: dict[str, Any]) -> list[str]:
+def format_cycle_health_summary(summary: CycleHealth) -> list[str]:
     """Format cycle health summary as stable text lines."""
     service = summary.get("service_status") if isinstance(summary.get("service_status"), dict) else {}
     promotion = summary.get("promotion_readiness") if isinstance(summary.get("promotion_readiness"), dict) else {}
@@ -208,5 +209,5 @@ def format_cycle_health_summary(summary: dict[str, Any]) -> list[str]:
     ]
 
 
-def dumps_cycle_health_summary(summary: dict[str, Any]) -> str:
+def dumps_cycle_health_summary(summary: CycleHealth) -> str:
     return json.dumps(summary, indent=2, ensure_ascii=False)

--- a/nanobot/runtime/schemas.py
+++ b/nanobot/runtime/schemas.py
@@ -1,0 +1,54 @@
+"""Formalized minimal schemas for runtime state."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+class CycleReport(TypedDict, total=False):
+    schema_version: str
+    cycle_id: str
+    cycle_started_utc: str | None
+    cycle_ended_utc: str | None
+    goal_id: str | None
+    goal_text: str | None
+    current_task_id: str | None
+    result_status: str | None
+    decision: str | None
+    improvement_score: int | float | None
+    promotion_candidate_id: str | None
+    review_status: str | None
+    evidence_ref_id: str | None
+    experiment: dict[str, Any] | None
+    follow_through: dict[str, Any] | None
+    result: dict[str, Any] | None
+
+class PromotionCandidate(TypedDict, total=False):
+    schema_version: str
+    promotion_candidate_id: str
+    review_status: str | None
+    decision: str | None
+    decision_reason: str | None
+    candidate_path: str | None
+    artifact_path: str | None
+    readiness_checks: Any
+    readiness_reasons: Any
+    recommended_next_action: str | None
+    governance_packet: dict[str, Any] | None
+    decision_record: str | None
+    accepted_record: str | None
+    promotion_provenance: dict[str, Any] | None
+
+class CycleHealth(TypedDict, total=False):
+    schema_version: str
+    runtime_state_source: str | None
+    runtime_state_root: str | None
+    latest_cycle_id: str | None
+    latest_report_path: str | None
+    latest_subagent_telemetry_id: str | None
+    latest_subagent_telemetry_path: str | None
+    service_status: dict[str, Any]
+    failed_units_count: int | None
+    promotion_readiness: dict[str, Any]
+    severity: str
+    exit_code: int
+    next_recommended_action: str


### PR DESCRIPTION
## Summary
Created `nanobot/runtime/schemas.py` with explicit TypedDicts for `CycleReport`, `PromotionCandidate`, and `CycleHealth`. Updated `health.py` to use the `CycleHealth` schema.
Fixes #480.