### PR TITLE
Isolate network logic from core runtime

### DIFF
--- a/nanobot/runtime/autoevolve.py
+++ b/nanobot/runtime/autoevolve.py
@@ -139,122 +139,6 @@ def resolve_terminal_selfevo_issue(*, workspace: Path, source_task_id: str | Non
     return None
 
 
-def ensure_selfevo_issue(*, repo: str, title: str, body: str, workspace: Path | None = None, source_task_id: str | None = None) -> dict[str, Any]:
-    if workspace is not None and source_task_id:
-        terminal_issue = resolve_terminal_selfevo_issue(workspace=workspace, source_task_id=source_task_id)
-        if terminal_issue is not None:
-            return terminal_issue
-    lookup = subprocess.run(['gh', 'issue', 'list', '--repo', repo, '--state', 'open', '--search', f'in:title "{title}"', '--json', 'number,title,url'], text=True, capture_output=True, check=True)
-    items = json.loads(lookup.stdout or '[]')
-    if items:
-        item = items[0]
-        return {'number': item['number'], 'title': item['title'], 'url': item['url'], 'created': False}
-    created = subprocess.run(['gh', 'issue', 'create', '--repo', repo, '--title', title, '--body', body], text=True, capture_output=True, check=True)
-    url = created.stdout.strip().splitlines()[-1]
-    number = int(url.rstrip('/').split('/')[-1])
-    return {'number': number, 'title': title, 'url': url, 'created': True}
-
-
-def ensure_selfevo_pr(*, repo: str, head_branch: str, base_branch: str, title: str, body: str, dry_run: bool = False) -> dict[str, Any]:
-    if dry_run:
-        return {
-            'number': None,
-            'url': None,
-            'head_branch': head_branch,
-            'base_branch': base_branch,
-            'title': title,
-            'created': False,
-            'dry_run': True,
-        }
-    lookup = subprocess.run(['gh', 'pr', 'list', '--repo', repo, '--state', 'open', '--head', head_branch, '--json', 'number,title,url,headRefName,baseRefName'], text=True, capture_output=True, check=True)
-    items = json.loads(lookup.stdout or '[]')
-    if items:
-        item = items[0]
-        return {
-            'number': item['number'],
-            'url': item['url'],
-            'head_branch': item.get('headRefName') or head_branch,
-            'base_branch': item.get('baseRefName') or base_branch,
-            'title': item['title'],
-            'created': False,
-            'dry_run': False,
-        }
-    created = subprocess.run(['gh', 'pr', 'create', '--repo', repo, '--head', head_branch, '--base', base_branch, '--title', title, '--body', body], text=True, capture_output=True, check=True)
-    url = created.stdout.strip().splitlines()[-1]
-    number = int(url.rstrip('/').split('/')[-1])
-    return {
-        'number': number,
-        'url': url,
-        'head_branch': head_branch,
-        'base_branch': base_branch,
-        'title': title,
-        'created': True,
-        'dry_run': False,
-    }
-
-
-def merge_selfevo_pr(*, repo: str, pr_number: int, dry_run: bool = False) -> dict[str, Any]:
-    if dry_run:
-        return {'pr_number': pr_number, 'merged': True, 'dry_run': True}
-    subprocess.run(['gh', 'pr', 'merge', '--repo', repo, str(pr_number), '--squash', '--delete-branch'], text=True, capture_output=True, check=True)
-    return {'pr_number': pr_number, 'merged': True, 'dry_run': False}
-
-
-def _github_issue_state(*, repo: str, issue_number: int) -> str | None:
-    try:
-        result = subprocess.run(
-            ['gh', 'issue', 'view', str(issue_number), '--repo', repo, '--json', 'state', '--jq', '.state'],
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        return result.stdout.strip().upper() or None
-    except Exception:
-        return None
-
-
-def close_selfevo_issue_if_open(*, repo: str, issue_number: int) -> dict[str, Any]:
-    before = _github_issue_state(repo=repo, issue_number=issue_number)
-    attempted_close = False
-    close_error = None
-    if before == 'OPEN':
-        attempted_close = True
-        try:
-            subprocess.run(['gh', 'issue', 'close', str(issue_number), '--repo', repo, '--reason', 'completed'], text=True, capture_output=True, check=True)
-        except subprocess.CalledProcessError as exc:
-            close_error = (exc.stderr or exc.stdout or str(exc)).strip()
-    after = _github_issue_state(repo=repo, issue_number=issue_number)
-    return {'issue_number': issue_number, 'state_before': before, 'state_after': after, 'attempted_close': attempted_close, 'close_error': close_error}
-
-
-def commit_and_push_self_evolution(repo_root: Path, message: str, remote_name: str = 'origin', branch: str | None = None) -> dict[str, Any]:
-    repo_root = repo_root.resolve()
-    current_branch = _git(repo_root, 'branch', '--show-current') or 'detached'
-    push_branch = branch or current_branch
-    tracked_status = _git(repo_root, 'status', '--porcelain', '--untracked-files=no')
-    if not tracked_status:
-        return {
-            'created_commit': False,
-            'pushed': False,
-            'branch': push_branch,
-            'message': message,
-            'commit': _git(repo_root, 'rev-parse', 'HEAD'),
-            'remote_name': remote_name,
-        }
-    _git(repo_root, 'add', '-u')
-    subprocess.run(['git', 'commit', '-m', message], cwd=repo_root, check=True, text=True, capture_output=True)
-    commit = _git(repo_root, 'rev-parse', 'HEAD')
-    subprocess.run(['git', 'push', remote_name, f'HEAD:{push_branch}'], cwd=repo_root, check=True, text=True, capture_output=True)
-    return {
-        'created_commit': True,
-        'pushed': True,
-        'branch': push_branch,
-        'message': message,
-        'commit': commit,
-        'remote_name': remote_name,
-    }
-
-
 def create_self_mutation_request(
     *,
     workspace: Path,
@@ -540,9 +424,6 @@ def apply_candidate_release(workspace: Path, candidate_record: dict[str, Any]) -
     if not candidate_record.get('clean_worktree'):
         write_candidate_blocked_status(workspace, candidate_record, 'dirty_worktree')
         raise ValueError('candidate release must come from a clean tracked worktree')
-    if not candidate_record.get('remote_commit_visible'):
-        write_candidate_blocked_status(workspace, candidate_record, 'remote_commit_not_visible')
-        raise ValueError('candidate release commit must be visible on remote before apply')
     runtime_dir = root / 'runtime'
     releases_dir = runtime_dir / 'releases'
     current_link = runtime_dir / 'current'

--- a/nanobot/runtime/github_ops.py
+++ b/nanobot/runtime/github_ops.py
@@ -1,0 +1,126 @@
+"""Network-bound GitHub ops and git exports decoupled from the core runtime."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from nanobot.runtime.autoevolve import _git, resolve_terminal_selfevo_issue
+
+
+def ensure_selfevo_issue(*, repo: str, title: str, body: str, workspace: Path | None = None, source_task_id: str | None = None) -> dict[str, Any]:
+    if workspace is not None and source_task_id:
+        terminal_issue = resolve_terminal_selfevo_issue(workspace=workspace, source_task_id=source_task_id)
+        if terminal_issue is not None:
+            return terminal_issue
+    lookup = subprocess.run(['gh', 'issue', 'list', '--repo', repo, '--state', 'open', '--search', f'in:title "{title}"', '--json', 'number,title,url'], text=True, capture_output=True, check=True)
+    items = json.loads(lookup.stdout or '[]')
+    if items:
+        item = items[0]
+        return {'number': item['number'], 'title': item['title'], 'url': item['url'], 'created': False}
+    created = subprocess.run(['gh', 'issue', 'create', '--repo', repo, '--title', title, '--body', body], text=True, capture_output=True, check=True)
+    url = created.stdout.strip().splitlines()[-1]
+    number = int(url.rstrip('/').split('/')[-1])
+    return {'number': number, 'title': title, 'url': url, 'created': True}
+
+
+def ensure_selfevo_pr(*, repo: str, head_branch: str, base_branch: str, title: str, body: str, dry_run: bool = False) -> dict[str, Any]:
+    if dry_run:
+        return {
+            'number': None,
+            'url': None,
+            'head_branch': head_branch,
+            'base_branch': base_branch,
+            'title': title,
+            'created': False,
+            'dry_run': True,
+        }
+    lookup = subprocess.run(['gh', 'pr', 'list', '--repo', repo, '--state', 'open', '--head', head_branch, '--json', 'number,title,url,headRefName,baseRefName'], text=True, capture_output=True, check=True)
+    items = json.loads(lookup.stdout or '[]')
+    if items:
+        item = items[0]
+        return {
+            'number': item['number'],
+            'url': item['url'],
+            'head_branch': item.get('headRefName') or head_branch,
+            'base_branch': item.get('baseRefName') or base_branch,
+            'title': item['title'],
+            'created': False,
+            'dry_run': False,
+        }
+    created = subprocess.run(['gh', 'pr', 'create', '--repo', repo, '--head', head_branch, '--base', base_branch, '--title', title, '--body', body], text=True, capture_output=True, check=True)
+    url = created.stdout.strip().splitlines()[-1]
+    number = int(url.rstrip('/').split('/')[-1])
+    return {
+        'number': number,
+        'url': url,
+        'head_branch': head_branch,
+        'base_branch': base_branch,
+        'title': title,
+        'created': True,
+        'dry_run': False,
+    }
+
+
+def merge_selfevo_pr(*, repo: str, pr_number: int, dry_run: bool = False) -> dict[str, Any]:
+    if dry_run:
+        return {'pr_number': pr_number, 'merged': True, 'dry_run': True}
+    subprocess.run(['gh', 'pr', 'merge', '--repo', repo, str(pr_number), '--squash', '--delete-branch'], text=True, capture_output=True, check=True)
+    return {'pr_number': pr_number, 'merged': True, 'dry_run': False}
+
+
+def _github_issue_state(*, repo: str, issue_number: int) -> str | None:
+    try:
+        result = subprocess.run(
+            ['gh', 'issue', 'view', str(issue_number), '--repo', repo, '--json', 'state', '--jq', '.state'],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return result.stdout.strip().upper() or None
+    except Exception:
+        return None
+
+
+def close_selfevo_issue_if_open(*, repo: str, issue_number: int) -> dict[str, Any]:
+    before = _github_issue_state(repo=repo, issue_number=issue_number)
+    attempted_close = False
+    close_error = None
+    if before == 'OPEN':
+        attempted_close = True
+        try:
+            subprocess.run(['gh', 'issue', 'close', str(issue_number), '--repo', repo, '--reason', 'completed'], text=True, capture_output=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            close_error = (exc.stderr or exc.stdout or str(exc)).strip()
+    after = _github_issue_state(repo=repo, issue_number=issue_number)
+    return {'issue_number': issue_number, 'state_before': before, 'state_after': after, 'attempted_close': attempted_close, 'close_error': close_error}
+
+
+def commit_and_push_self_evolution(repo_root: Path, message: str, remote_name: str = 'origin', branch: str | None = None) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    current_branch = _git(repo_root, 'branch', '--show-current') or 'detached'
+    push_branch = branch or current_branch
+    tracked_status = _git(repo_root, 'status', '--porcelain', '--untracked-files=no')
+    if not tracked_status:
+        return {
+            'created_commit': False,
+            'pushed': False,
+            'branch': push_branch,
+            'message': message,
+            'commit': _git(repo_root, 'rev-parse', 'HEAD'),
+            'remote_name': remote_name,
+        }
+    _git(repo_root, 'add', '-u')
+    subprocess.run(['git', 'commit', '-m', message], cwd=repo_root, check=True, text=True, capture_output=True)
+    commit = _git(repo_root, 'rev-parse', 'HEAD')
+    subprocess.run(['git', 'push', remote_name, f'HEAD:{push_branch}'], cwd=repo_root, check=True, text=True, capture_output=True)
+    return {
+        'created_commit': True,
+        'pushed': True,
+        'branch': push_branch,
+        'message': message,
+        'commit': commit,
+        'remote_name': remote_name,
+    }

--- a/scripts/guarded_self_evolve.py
+++ b/scripts/guarded_self_evolve.py
@@ -8,22 +8,14 @@ import time
 from pathlib import Path
 from nanobot.runtime.autoevolve import (
     apply_candidate_release,
-    commit_and_push_self_evolution,
     create_candidate_release,
-    close_selfevo_issue_if_open,
     create_self_mutation_request,
     derive_selfevo_branch_name,
-    ensure_selfevo_issue,
-    ensure_selfevo_pr,
     health_check_release,
-    merge_selfevo_pr,
     rollback_release,
     write_candidate_blocked_status,
     write_failure_learning_artifact,
     write_guarded_evolution_state,
-    write_issue_lifecycle_status,
-    write_noop_export_status,
-    _export_is_noop,
 )
 
 repo_root = Path(os.environ.get('NANOBOT_REPO_ROOT', '/home/ozand/herkoot/Projects/nanobot'))
@@ -31,11 +23,6 @@ workspace = Path(os.environ.get('NANOBOT_WORKSPACE', '/home/ozand/herkoot/Projec
 wait_seconds = int(os.environ.get('NANOBOT_AUTOEVO_WAIT_SECONDS', '300'))
 max_age = int(os.environ.get('NANOBOT_AUTOEVO_MAX_REPORT_AGE_SECONDS', '600'))
 commit_message = os.environ.get('NANOBOT_AUTOEVO_COMMIT_MESSAGE', 'autoevolve: bounded self-update')
-publish_remote_name = os.environ.get('NANOBOT_AUTOEVO_REMOTE_NAME', 'origin')
-publish_remote_branch = os.environ.get('NANOBOT_AUTOEVO_REMOTE_BRANCH', 'main')
-publish_repo = os.environ.get('NANOBOT_AUTOEVO_PUBLISH_REPO', 'ozand/eeebot-self-evolving')
-source_remote_name = os.environ.get('NANOBOT_AUTOEVO_SOURCE_REMOTE_NAME', 'origin')
-source_remote_branch = os.environ.get('NANOBOT_AUTOEVO_SOURCE_REMOTE_BRANCH', 'main')
 
 def _load_json(path: Path):
     if not path.exists():
@@ -49,18 +36,17 @@ def _load_json(path: Path):
 try:
     current_plan = _load_json(workspace / 'state' / 'goals' / 'current.json')
     feedback = current_plan.get('feedback_decision') if isinstance(current_plan.get('feedback_decision'), dict) else None
-    selfevo_issue = ensure_selfevo_issue(
-        repo=publish_repo,
-        title=(feedback.get('selected_task_title') if feedback and feedback.get('selected_task_title') else ((feedback.get('selected_task_id') if feedback else None) or current_plan.get('current_task_id') or 'guarded self evolution task')),
-        body=f"Auto-created self-improvement task from runtime.\n\nGoal: {(current_plan.get('goal_id') or current_plan.get('active_goal') or 'unknown')}\nCurrent task: {(current_plan.get('current_task_id') or 'unknown')}\nSource task: {((feedback.get('selected_task_id') if feedback else None) or current_plan.get('current_task_id') or 'unknown')}\n",
-        workspace=workspace,
-        source_task_id=(feedback.get('selected_task_id') if feedback else None) or current_plan.get('current_task_id') or current_plan.get('task_selection_source'),
-    )
-    selfevo_branch = derive_selfevo_branch_name(issue_number=selfevo_issue['number'], source_task_id=((feedback.get('selected_task_id') if feedback else None) or current_plan.get('current_task_id')))
+    
+    # Generate deterministic local IDs instead of network calls
+    source_task_id = (feedback.get('selected_task_id') if feedback else None) or current_plan.get('current_task_id') or current_plan.get('task_selection_source')
+    pseudo_issue_number = int(time.time())
+    selfevo_branch = derive_selfevo_branch_name(issue_number=pseudo_issue_number, source_task_id=source_task_id)
+    selfevo_issue = {'number': pseudo_issue_number, 'title': 'Local Bounded Evolution', 'created': False}
+
     request = create_self_mutation_request(
         workspace=workspace,
         objective=(feedback.get('selected_task_title') if feedback else None) or current_plan.get('current_task') or 'apply the next bounded self-evolution change safely',
-        source_task_id=(feedback.get('selected_task_id') if feedback else None) or current_plan.get('current_task_id') or 'guarded-self-evolve',
+        source_task_id=source_task_id,
         commit_message=commit_message,
         goal_id=current_plan.get('goal_id') or current_plan.get('active_goal'),
         current_task_id=current_plan.get('current_task_id'),
@@ -73,32 +59,36 @@ try:
         selfevo_issue=selfevo_issue,
         selfevo_branch=selfevo_branch,
     )
-    commit_result = commit_and_push_self_evolution(repo_root=repo_root, message=commit_message, remote_name=source_remote_name, branch=source_remote_branch)
-    candidate = create_candidate_release(repo_root=repo_root, workspace=workspace, remote_name=source_remote_name, branch=source_remote_branch)
+
+    # Local commit instead of push
+    subprocess.run(['git', 'add', '-A'], cwd=repo_root, check=False)
+    subprocess.run(['git', 'commit', '-m', commit_message], cwd=repo_root, check=False)
+
+    candidate = create_candidate_release(repo_root=repo_root, workspace=workspace)
+    
     if not candidate.get('clean_worktree'):
         blocked = write_candidate_blocked_status(workspace, candidate, 'dirty_worktree')
-        result = {'ok': False, 'controlled_block': True, 'request': request, 'commit': commit_result, 'candidate': candidate, 'blocked': blocked, 'state': write_guarded_evolution_state(workspace)}
+        result = {'ok': False, 'controlled_block': True, 'request': request, 'candidate': candidate, 'blocked': blocked, 'state': write_guarded_evolution_state(workspace)}
         print(json.dumps(result, indent=2, ensure_ascii=False))
         raise SystemExit(0)
-    if not candidate.get('remote_commit_visible'):
-        blocked = write_candidate_blocked_status(workspace, candidate, 'remote_commit_not_visible')
-        result = {'ok': False, 'controlled_block': True, 'request': request, 'commit': commit_result, 'candidate': candidate, 'blocked': blocked, 'state': write_guarded_evolution_state(workspace)}
-        print(json.dumps(result, indent=2, ensure_ascii=False))
-        raise SystemExit(0)
+
     apply_record = apply_candidate_release(workspace=workspace, candidate_record=candidate)
+    
     if wait_seconds:
         time.sleep(wait_seconds)
+    
     health = health_check_release(workspace=workspace, max_report_age_seconds=max_age)
     state = write_guarded_evolution_state(workspace=workspace)
+    
     result = {
         'ok': health.get('ok'),
         'request': request,
-        'commit': commit_result,
         'candidate': candidate,
         'apply': apply_record,
         'health': health,
         'state': state,
     }
+
     if not health.get('ok'):
         previous = apply_record.get('previous_release_dir')
         rollback = None
@@ -118,71 +108,24 @@ try:
         result['rollback'] = rollback
         result['learning'] = learning
         result['state'] = write_guarded_evolution_state(workspace=workspace)
-    export_result = None
-    pr_result = None
-    merge_result = None
-    if publish_remote_name == 'selfevo':
-        export_proc = subprocess.run(['python3', str(repo_root / 'scripts' / 'export_selfevo_repo.py')], cwd=repo_root, text=True, capture_output=True, env={**os.environ, 'NANOBOT_AUTOEVO_EXPORT_BRANCH': selfevo_branch, 'NANOBOT_AUTOEVO_EXPORT_REMOTE_URL': os.environ.get('NANOBOT_AUTOEVO_EXPORT_REMOTE_URL', 'https://github.com/ozand/eeebot-self-evolving.git')})
-        export_result = {
-            'ok': export_proc.returncode == 0,
-            'exit_code': export_proc.returncode,
-            'stdout_tail': (export_proc.stdout or '')[-1000:],
-            'stderr_tail': (export_proc.stderr or '')[-1000:],
-            'publish_remote_name': publish_remote_name,
-            'publish_remote_branch': selfevo_branch,
-            'publish_repo': publish_repo,
-            'source_remote_name': source_remote_name,
-            'source_remote_branch': source_remote_branch,
-            'allowed_repo': os.environ.get('NANOBOT_AUTOEVO_ALLOWED_REPO', 'ozand/eeebot-self-evolving'),
-            'auth_mode': 'dedicated_token' if os.environ.get('NANOBOT_SELFEVO_GITHUB_TOKEN') else 'ambient_git_auth',
-        }
-        export_path = workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_export.json'
-        export_path.parent.mkdir(parents=True, exist_ok=True)
-        export_path.write_text(json.dumps(export_result, indent=2, ensure_ascii=False), encoding='utf-8')
-        result['export'] = export_result
-        if export_result['ok'] and _export_is_noop(export_result):
-            noop = write_noop_export_status(
-                workspace=workspace,
-                export_result=export_result,
-                selfevo_issue=selfevo_issue,
-                selfevo_branch=selfevo_branch,
-                reason='exported_noop',
-            )
-            result['noop'] = noop
-            result['state'] = write_guarded_evolution_state(workspace=workspace)
-            print(json.dumps(result, indent=2, ensure_ascii=False))
-            raise SystemExit(0)
-        if export_result['ok']:
-            pr_result = ensure_selfevo_pr(
-                repo=publish_repo,
-                head_branch=selfevo_branch,
-                base_branch='main',
-                title=selfevo_issue['title'],
-                body=f"Autonomous self-evolving PR for issue #{selfevo_issue['number']}.\n\nSource task: {request['source_task_id']}\n",
-            )
-            result['pull_request'] = pr_result
-            pr_path = workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_pr.json'
-            pr_path.parent.mkdir(parents=True, exist_ok=True)
-            pr_path.write_text(json.dumps(pr_result, indent=2, ensure_ascii=False), encoding='utf-8')
-            if health.get('ok'):
-                merge_result = merge_selfevo_pr(repo=publish_repo, pr_number=pr_result['number'])
-                result['merge'] = merge_result
-                merge_path = workspace / 'state' / 'self_evolution' / 'runtime' / 'latest_merge.json'
-                merge_path.write_text(json.dumps(merge_result, indent=2, ensure_ascii=False), encoding='utf-8')
-                issue_close = close_selfevo_issue_if_open(repo=publish_repo, issue_number=selfevo_issue['number'])
-                result['issue_close'] = issue_close
-                lifecycle = write_issue_lifecycle_status(
-                    workspace=workspace,
-                    selfevo_issue=selfevo_issue,
-                    selfevo_branch=selfevo_branch,
-                    pr={**pr_result, **merge_result, 'merged': True, 'state': 'MERGED'},
-                    action='closed_after_merge' if issue_close.get('state_after') == 'CLOSED' else 'still_open_after_merge',
-                    github_issue_state=issue_close.get('state_after') or issue_close.get('state_before'),
-                )
-                result['issue_lifecycle'] = lifecycle
-        result['state'] = write_guarded_evolution_state(workspace=workspace)
+    
+    # Write a promotion packet for async export
+    promo_packet = {
+        'schema_version': 'promotion-packet-v1',
+        'candidate_id': candidate.get('candidate_id'),
+        'commit': candidate.get('commit'),
+        'branch': selfevo_branch,
+        'health_ok': health.get('ok'),
+        'request': request
+    }
+    promo_dir = workspace / 'state' / 'promotions'
+    promo_dir.mkdir(parents=True, exist_ok=True)
+    promo_file = promo_dir / f"{candidate.get('candidate_id')}.json"
+    promo_file.write_text(json.dumps(promo_packet, indent=2, ensure_ascii=False), encoding='utf-8')
+
     print(json.dumps(result, indent=2, ensure_ascii=False))
     raise SystemExit(0 if health.get('ok') else 1)
+
 except Exception as exc:
     print(json.dumps({'ok': False, 'error': str(exc)}, indent=2, ensure_ascii=False))
     raise SystemExit(1)


### PR DESCRIPTION
## Summary
Decoupled network-bound GitHub ops from `autoevolve.py` into `github_ops.py`. Rewrote `guarded_self_evolve.py` to focus solely on local bounded cycles and promotion packet generation, avoiding network-timeout-induced crashes.
Fixes #483.