### PR TITLE
feat(host): add eeepc host deployment playbook

### DIFF
--- a/host/eeepc/README.md
+++ b/host/eeepc/README.md
@@ -1,0 +1,68 @@
+# eeepc host configuration — source of truth
+#
+# This directory contains everything needed to reproduce the eeepc
+# self-evolving agent runtime on a fresh host.
+#
+# Directory layout:
+#
+#   host/eeepc/
+#   ├── scripts/
+#   │   ├── install.sh          — first-time host setup (run once as root)
+#   │   └── deploy_release.sh   — push a new code release from dev machine
+#   ├── systemd/
+#   │   ├── *.service / *.timer — systemd unit files → /etc/systemd/system/
+#   │   └── drop-ins/           — override drop-ins → /etc/systemd/system/*.d/
+#   ├── libexec/
+#   │   ├── eeepc-self-evolving-approval-keeper.py  → /usr/local/libexec/
+#   │   └── eeepc-self-evolving-subagent-bridge.py  → /usr/local/libexec/
+#   └── etc/
+#       ├── instances/          → /etc/eeepc-agent/instances/*.env
+#       ├── litellm.env.example → /etc/eeepc-agent/litellm.env  (fill key!)
+#       ├── models.yaml         → /etc/eeepc-agent/models.yaml
+#       └── nanobot-config.template.json → /home/opencode/.nanobot-eeepc/config.template.json
+#
+# ## Fresh host setup
+#
+# 1. Clone the repo:
+#    git clone https://github.com/ozand/eeebot /opt/eeebot-src
+#    cd /opt/eeebot-src
+#
+# 2. Set credentials:
+#    export LITELLM_API_KEY=sk-...
+#    export LITELLM_BASE_URL=https://litellm.ayga.tech:9443/v1
+#
+# 3. Run install:
+#    sudo bash host/eeepc/scripts/install.sh
+#
+# 4. Set nanobot gateway config key:
+#    sudo nano /home/opencode/.nanobot-eeepc/config.template.json
+#    # replace sk-REDACTED with real key in providers.custom.apiKey
+#
+# 5. Start the agent:
+#    sudo systemctl start eeepc-self-evolving-agent.service
+#    sudo journalctl -u eeepc-self-evolving-agent.service -f
+#
+# ## Deploying a code update (from dev machine)
+#
+#    bash host/eeepc/scripts/deploy_release.sh --host eeepc
+#
+# ## Host-specific things NOT in this repo (secrets, runtime state)
+#
+# These must be created manually or restored from backup:
+# - /etc/eeepc-agent/litellm.env           (real LITELLM_API_KEY)
+# - /home/opencode/.nanobot-eeepc/config.template.json (real apiKey in providers.custom)
+# - /var/lib/eeepc-agent/self-evolving-agent/state/    (runtime state — not in git)
+# - /home/opencode/.venvs/nanobot/                     (opencode user venv for gateway)
+#
+# ## Runtime architecture
+#
+# Component                  | Managed by
+# ---------------------------|------------------------------------------
+# eeepc-self-evolving-agent  | systemd timer (continuous evolution loop)
+# eeepc-self-evolving-subagent-bridge | systemd timer (every 15min, real LLM review)
+# eeepc-self-evolving-approval-keeper | systemd timer (keeps apply gate open)
+# eeepc-self-evolving-agent-health    | systemd timer (dry-run health check)
+# eeepc-strong-reflection    | systemd timer (every 6h, deep review)
+# nanobot gateway            | opencode user systemd (WebSocket/Telegram bridge)
+#
+# See docs/EEEPC_AGENT_RUNTIME_INSTRUCTIONS.md for full operational runbook.

--- a/host/eeepc/etc/instances/self-evolving-agent.env
+++ b/host/eeepc/etc/instances/self-evolving-agent.env
@@ -1,0 +1,24 @@
+# LITELLM credentials — см. /etc/eeepc-agent/litellm.env
+# Для обновления ключа редактируйте ТОЛЬКО litellm.env
+
+TARGET_WORKSPACE=/home/opencode/servers_team/repo_research/nanobot
+STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
+POLICY_FILE=/opt/eeepc-agent/runtimes/self-evolving-agent/current/config/policy.yaml
+
+MAX_CYCLES=1
+DRY_RUN=false
+ALLOW_CODE_EDITS=false
+LOCAL_AUTONOMY_ON_MODEL_FAILURE=false
+CYCLE_END_SYNC_ENABLED=true
+CYCLE_END_SYNC_TIMEOUT_S=60
+CYCLE_END_SYNC_PUBLISH_REPORT=true
+CYCLE_END_SYNC_EXPORT_MANIFEST=true
+CYCLE_END_SYNC_REPO_DIR=/home/opencode/.eeepc-git-sync/eeepc-host-evidence
+CYCLE_END_SYNC_REMOTE_URL=https://github.com/mrsmileystoke92/eeepc-host-evidence.git
+CYCLE_END_SYNC_BRANCH=main
+CYCLE_END_SYNC_OWNER=mrsmileystoke92
+CYCLE_END_SYNC_REPO_NAME=eeepc-host-evidence
+CYCLE_END_SYNC_PUSH=false
+CYCLE_END_SYNC_GITHUB_ENABLED=false
+NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane
+NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state

--- a/host/eeepc/etc/instances/self-evolving-approval-keeper.env
+++ b/host/eeepc/etc/instances/self-evolving-approval-keeper.env
@@ -1,0 +1,4 @@
+APPROVAL_KEEPER_ENABLED=1
+APPROVAL_KEEPER_TTL_SECONDS=7200
+APPROVAL_KEEPER_REASON=autonomous_apply_window
+STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state

--- a/host/eeepc/etc/instances/self-evolving-subagent-bridge-workspace.env
+++ b/host/eeepc/etc/instances/self-evolving-subagent-bridge-workspace.env
@@ -1,0 +1,2 @@
+# Managed by servers_team HOST-015 on 2026-06-05.
+TARGET_WORKSPACE=/var/lib/eeepc-agent/self-evolving-agent/workspace/subagents

--- a/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
+++ b/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
@@ -1,0 +1,7 @@
+SUBAGENT_BRIDGE_ENABLED=1
+STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
+TARGET_WORKSPACE=/home/opencode/servers_team/repo_research/nanobot
+NANOBOT_CONFIG_PATH=/run/user/1001/nanobot-eeepc/config.json
+SUBAGENT_BRIDGE_STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state/subagent_bridge
+SUBAGENT_BRIDGE_MODEL=cl/gpt-5.4-mini
+SUBAGENT_BRIDGE_FORCE_BUDGET=extended

--- a/host/eeepc/etc/litellm.env.example
+++ b/host/eeepc/etc/litellm.env.example
@@ -1,0 +1,17 @@
+# =============================================================================
+# eeepc LiteLLM gateway — Single Source of Truth for credentials
+# Copy to /etc/eeepc-agent/litellm.env and fill in real values.
+# After changing LITELLM_API_KEY: sudo systemctl restart eeepc-self-evolving-agent.service
+# =============================================================================
+
+LITELLM_BASE_URL=https://litellm.ayga.tech:9443/v1
+LITELLM_API_KEY=sk-YOUR_KEY_HERE
+
+# Primary model and fallback
+LITELLM_MODEL=cl/gpt-5.4-mini
+LITELLM_FALLBACK_MODELS=cl/gemini-3.1-pro-preview
+
+# Request parameters
+LITELLM_TIMEOUT_S=20
+LITELLM_TOTAL_BUDGET_MS=30000
+LITELLM_RETRY_MAX_ATTEMPTS=2

--- a/host/eeepc/etc/models.yaml
+++ b/host/eeepc/etc/models.yaml
@@ -1,0 +1,66 @@
+# =============================================================================
+# eeepc allowed models — обновлено 2026-06-08 (alias eeepc-20260320, suffix 049A)
+# Источник: litellm.ayga.tech:9443, allowed_models_count: 41
+# =============================================================================
+
+api_base: "https://litellm.ayga.tech:9443/v1"
+
+# Рекомендованные модели для агента (cost-effective + надёжные)
+recommended:
+  code:    "cl/gemini-3.1-pro-preview"
+  general: "cl/gemini-3.5-flash"
+  vision:  "cl/gemini-3.5-flash"
+  mini:    "cl/gpt-5.4-mini"
+
+# Полный разрешённый список
+allowed:
+  anthropic_native:
+    - an/claude-sonnet-4-6
+    - an/gemini-3-flash
+
+  claude:
+    - cl/claude-3-5-haiku-20241022
+    - cl/claude-3-7-sonnet-20250219
+    - cl/claude-haiku-4-5-20251001
+    - cl/claude-opus-4-1-20250805
+    - cl/claude-opus-4-20250514
+    - cl/claude-opus-4-5-20251101
+    - cl/claude-opus-4-6
+    - cl/claude-opus-4-6-thinking
+    - cl/claude-opus-4-7
+    - cl/claude-sonnet-4-20250514
+    - cl/claude-sonnet-4-5-20250929
+    - cl/claude-sonnet-4-6
+
+  gemini:
+    - cl/gemini-2.5-flash
+    - cl/gemini-2.5-flash-lite
+    - cl/gemini-2.5-pro
+    - cl/gemini-3-flash
+    - cl/gemini-3-flash-preview
+    - cl/gemini-3-pro-high
+    - cl/gemini-3-pro-low
+    - cl/gemini-3-pro-preview
+    - cl/gemini-3.1-flash-image
+    - cl/gemini-3.1-flash-lite
+    - cl/gemini-3.1-flash-lite-preview
+    - cl/gemini-3.1-pro-high
+    - cl/gemini-3.1-pro-low
+    - cl/gemini-3.1-pro-preview   # ← текущая code-модель агента
+    - cl/gemini-3.5-flash         # ← текущая general/vision-модель агента
+
+  openai:
+    - cl/codex-auto-review
+    - cl/gpt-5.2
+    - cl/gpt-5.3-codex
+    - cl/gpt-5.4
+    - cl/gpt-5.4-mini             # ← текущая LITELLM_MODEL агента
+    - cl/gpt-5.5
+    - cl/gpt-image-2
+    - cl/gpt-oss-120b-medium
+
+  kimi:
+    - cl/kimi-k2
+    - cl/kimi-k2-thinking
+    - cl/kimi-k2.5
+    - cl/kimi-k2.6

--- a/host/eeepc/etc/nanobot-config.template.json
+++ b/host/eeepc/etc/nanobot-config.template.json
@@ -1,0 +1,346 @@
+{
+  "agents": {
+    "defaults": {
+      "workspace": "/home/opencode/.nanobot-eeepc/workspace",
+      "model": "cl/gemini-3.1-pro-preview",
+      "provider": "custom",
+      "maxTokens": 8192,
+      "contextWindowTokens": 65536,
+      "temperature": 0.1,
+      "maxToolIterations": 100,
+      "reasoningEffort": null,
+      "modelRouting": {
+        "enabled": true,
+        "taskModels": {
+          "general": [
+            "cl/gemini-3.5-flash",
+            "cl/gemini-3.1-pro-preview"
+          ],
+          "code": [
+            "cl/gemini-3.1-pro-preview",
+            "cl/gemini-3.5-flash"
+          ],
+          "vision": [
+            "cl/gemini-3.5-flash",
+            "cl/gemini-3.1-pro-preview"
+          ]
+        },
+        "fallbackOn": [
+          "key not allowed",
+          "model not found",
+          "unsupported model",
+          "access denied",
+          "does not exist"
+        ],
+        "codeIntentMarkers": [
+          "```",
+          "pytest",
+          "npm",
+          "pip ",
+          "git ",
+          ".py",
+          ".js",
+          ".ts",
+          ".json",
+          ".yaml",
+          ".yml"
+        ],
+        "executorModels": {
+          "general": "cl/gemini-3.5-flash",
+          "code": "cl/gemini-3.1-pro-preview",
+          "vision": "cl/gemini-3.5-flash"
+        }
+      }
+    }
+  },
+  "channels": {
+    "sendProgress": true,
+    "sendToolHints": false,
+    "dingtalk": {
+      "enabled": false,
+      "clientId": "",
+      "clientSecret": "",
+      "allowFrom": []
+    },
+    "email": {
+      "enabled": false,
+      "consentGranted": false,
+      "imapHost": "",
+      "imapPort": 993,
+      "imapUsername": "",
+      "imapPassword": "",
+      "imapMailbox": "INBOX",
+      "imapUseSsl": true,
+      "smtpHost": "",
+      "smtpPort": 587,
+      "smtpUsername": "",
+      "smtpPassword": "",
+      "smtpUseTls": true,
+      "smtpUseSsl": false,
+      "fromAddress": "",
+      "autoReplyEnabled": true,
+      "pollIntervalSeconds": 30,
+      "markSeen": true,
+      "maxBodyChars": 12000,
+      "subjectPrefix": "Re: ",
+      "allowFrom": []
+    },
+    "feishu": {
+      "enabled": false,
+      "appId": "",
+      "appSecret": "",
+      "encryptKey": "",
+      "verificationToken": "",
+      "allowFrom": [],
+      "reactEmoji": "THUMBSUP",
+      "groupPolicy": "mention",
+      "replyToMessage": false
+    },
+    "mochat": {
+      "enabled": false,
+      "baseUrl": "https://mochat.io",
+      "socketUrl": "",
+      "socketPath": "/socket.io",
+      "socketDisableMsgpack": false,
+      "socketReconnectDelayMs": 1000,
+      "socketMaxReconnectDelayMs": 10000,
+      "socketConnectTimeoutMs": 10000,
+      "refreshIntervalMs": 30000,
+      "watchTimeoutMs": 25000,
+      "watchLimit": 100,
+      "retryDelayMs": 500,
+      "maxRetryAttempts": 0,
+      "clawToken": "",
+      "agentUserId": "",
+      "sessions": [],
+      "panels": [],
+      "allowFrom": [],
+      "mention": {
+        "requireInGroups": false
+      },
+      "groups": {},
+      "replyDelayMode": "non-mention",
+      "replyDelayMs": 120000
+    },
+    "qq": {
+      "enabled": false,
+      "appId": "",
+      "secret": "",
+      "allowFrom": [],
+      "msgFormat": "plain"
+    },
+    "wecom": {
+      "enabled": false,
+      "botId": "",
+      "secret": "",
+      "allowFrom": [],
+      "welcomeMessage": ""
+    },
+    "whatsapp": {
+      "enabled": false,
+      "bridgeUrl": "ws://localhost:3001",
+      "bridgeToken": "",
+      "allowFrom": []
+    },
+    "telegram": {
+      "enabled": true,
+      "token": "",
+      "allowFrom": [
+        "117157463"
+      ]
+    },
+    "telegramLocal": {
+      "enabled": true,
+      "allowFrom": [
+        "*"
+      ],
+      "inboxDir": "/home/opencode/.nanobot-eeepc/sim_telegram/inbox",
+      "outboxDir": "/home/opencode/.nanobot-eeepc/sim_telegram/outbox",
+      "archiveDir": "/home/opencode/.nanobot-eeepc/sim_telegram/archive",
+      "pollIntervalMs": 200
+    }
+  },
+  "providers": {
+    "custom": {
+      "apiKey": "sk-REDACTED",
+      "apiBase": "https://litellm.ayga.tech:9443/v1"
+    },
+    "azureOpenai": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "anthropic": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "openai": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "openrouter": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "deepseek": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "groq": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "zhipu": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "dashscope": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "vllm": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "ollama": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "gemini": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "moonshot": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "minimax": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "aihubmix": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "siliconflow": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "volcengine": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "volcengineCodingPlan": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "byteplus": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    },
+    "byteplusCodingPlan": {
+      "apiKey": "",
+      "apiBase": null,
+      "extraHeaders": null
+    }
+  },
+  "gateway": {
+    "host": "0.0.0.0",
+    "port": 18790,
+    "heartbeat": {
+      "enabled": true,
+      "intervalS": 1800
+    }
+  },
+  "tools": {
+    "web": {
+      "proxy": null,
+      "search": {
+        "provider": "brave",
+        "apiKey": "",
+        "baseUrl": "",
+        "maxResults": 5
+      }
+    },
+    "exec": {
+      "enable": true,
+      "timeout": 30,
+      "pathAppend": "",
+      "allowPatterns": [
+        "^pwd$",
+        "^ls(?:\\s+-[A-Za-z]+)*(?:\\s+[^;&|<>`$]+)?$",
+        "^find\\s+\\.(?:\\s+[^;&|<>`$]+)?$",
+        "^(?:rg|grep)(?:\\s+[^;&|<>`$]+)+$",
+        "^(?:fd|fdfind|tree)(?:\\s+[^;&|<>`$]+)*$",
+        "^git\\s+(?:status|diff|log(?:\\s+--oneline)?(?:\\s+-n\\s+\\d+)?|show\\s+[A-Za-z0-9._:/-]+|branch\\s+--show-current)$",
+        "^(?:python|python3|git|node|npm|pytest|ruff|uv|jq|sqlite3)\\s+(?:-V|--version|-v)$",
+        "^ps(?:\\s+aux)?$",
+        "^ss\\s+-lntp$",
+        "^lsof(?:\\s+[^;&|<>`$]+)*$",
+        "^df\\s+-h$",
+        "^du\\s+-sh(?:\\s+[^;&|<>`$]+)?$",
+        "^free\\s+-m$",
+        "^uptime$",
+        "^htop$"
+      ],
+      "denyPatterns": [
+        "[;&|><`]",
+        "\\$\\("
+      ]
+    },
+    "restrictToWorkspace": true,
+    "mcpServers": {
+      "openspace": {
+        "type": "sse",
+        "url": "http://192.168.1.35:8080/sse",
+        "toolTimeout": 120,
+        "enabledTools": [
+          "*"
+        ]
+      }
+    },
+    "autonomy": {
+      "enabled": true,
+      "dryRunDefault": false,
+      "enabledActions": [
+        "workspace.inventory",
+        "policy.snapshot",
+        "capability.truth-check",
+        "runtime.diagnostics_snapshot",
+        "workspace.runtime.probe",
+        "workspace.venv.ensure",
+        "workspace.python.run",
+        "workspace.pip.install_local",
+        "workspace.experiment.tiny_runtime_check",
+        "workspace.repo_status",
+        "autonomy.cycle.run_once"
+      ],
+      "safetyClassAllowlist": [
+        "class_a_read_only",
+        "class_b_bounded_mutation"
+      ],
+      "targetAllowlist": [
+        "/home/opencode/.nanobot-eeepc/workspace"
+      ],
+      "sourceRepoPath": "/home/opencode/servers_team/repo_research/nanobot",
+      "source_repo_path": "/home/opencode/servers_team/repo_research/nanobot"
+    }
+  }
+}

--- a/host/eeepc/libexec/eeepc-self-evolving-approval-keeper.py
+++ b/host/eeepc/libexec/eeepc-self-evolving-approval-keeper.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json
+import os
+import time
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state'))
+ENABLED = os.environ.get('APPROVAL_KEEPER_ENABLED', '1').strip().lower() in {'1','true','yes','on'}
+TTL_SECONDS = max(300, int(os.environ.get('APPROVAL_KEEPER_TTL_SECONDS', '7200')))
+REASON = os.environ.get('APPROVAL_KEEPER_REASON', 'autonomous_apply_window')
+
+approvals_dir = STATE_DIR / 'approvals'
+approvals_dir.mkdir(parents=True, exist_ok=True)
+gate_file = approvals_dir / 'apply.ok'
+
+if not ENABLED:
+    if gate_file.exists():
+        gate_file.unlink()
+    print('disabled')
+    raise SystemExit(0)
+
+payload = {
+    'expires_at_epoch': int(time.time()) + TTL_SECONDS,
+    'managed_by': 'eeepc-self-evolving-approval-keeper',
+    'reason': REASON,
+}
+gate_file.write_text(json.dumps(payload, indent=2), encoding='utf-8')
+print(gate_file)
+print(json.dumps(payload))

--- a/host/eeepc/libexec/eeepc-self-evolving-subagent-bridge.py
+++ b/host/eeepc/libexec/eeepc-self-evolving-subagent-bridge.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""eeepc self-evolving subagent bridge.
+
+Reads the latest queued subagent request from state/subagents/requests/,
+builds a concrete task prompt from the source_artifact, and spawns a
+bounded subagent via the nanobot SubagentManager.
+
+Treats "blocked/local_executor_unavailable" results as NOT handled —
+those are created by the coordinator materializer when no executor is
+configured, and should be superseded by a real LLM bridge run.
+"""
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+from nanobot.agent.subagent import SubagentManager
+from nanobot.bus.queue import MessageBus
+from nanobot.cli.commands import _make_provider
+from nanobot.config.loader import load_config, set_config_path
+
+STATE_DIR = Path(os.environ.get('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state'))
+TARGET_WORKSPACE = Path(os.environ.get('TARGET_WORKSPACE', '/home/opencode/servers_team/repo_research/nanobot'))
+CONFIG_PATH = Path(os.environ.get('NANOBOT_CONFIG_PATH', '/run/user/1001/nanobot-eeepc/config.json'))
+BRIDGE_STATE_DIR = Path(os.environ.get('SUBAGENT_BRIDGE_STATE_DIR', str(STATE_DIR / 'subagent_bridge')))
+BRIDGE_ENABLED = os.environ.get('SUBAGENT_BRIDGE_ENABLED', '1').strip().lower() in {'1', 'true', 'yes', 'on'}
+FORCE_PROFILE = os.environ.get('SUBAGENT_BRIDGE_FORCE_PROFILE', '').strip()
+FORCE_BUDGET = os.environ.get('SUBAGENT_BRIDGE_FORCE_BUDGET', '').strip()
+BRIDGE_MODEL = os.environ.get('SUBAGENT_BRIDGE_MODEL', 'cl/gpt-5.4-mini').strip() or 'cl/gpt-5.4-mini'
+
+
+def load_json(path: Path):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def approval_open() -> bool:
+    gate = load_json(STATE_DIR / 'approvals' / 'apply.ok') or {}
+    return int(gate.get('expires_at_epoch', 0) or 0) > int(time.time())
+
+
+def _is_real_result(result: dict) -> bool:
+    """Return True only if this result represents actual LLM execution, not a blocked stub."""
+    status = str(result.get('result_status') or result.get('status') or '').lower()
+    terminal = str(result.get('terminal_reason') or '').lower()
+    materialized_from = str(result.get('materialized_from') or '').lower()
+    blocker = result.get('blocker') or {}
+    blocker_reason = str(blocker.get('reason') or '') if isinstance(blocker, dict) else ''
+
+    # Blocked stubs from queued_request_terminalizer or unconfigured executor
+    if status == 'blocked':
+        return False
+    if terminal == 'local_executor_unavailable':
+        return False
+    if materialized_from == 'queued_request_terminalizer':
+        return False
+    if blocker_reason == 'local_executor_unavailable':
+        return False
+    return True
+
+
+def find_pending_request() -> tuple[Path | None, dict]:
+    """Find the oldest queued subagent request not yet handled by a real executor."""
+    req_dir = STATE_DIR / 'subagents' / 'requests'
+    if not req_dir.exists():
+        return None, {}
+
+    # Collect request_ids/paths that have REAL results (not blocked stubs)
+    real_handled: set[str] = set()
+    result_dir = STATE_DIR / 'subagents' / 'results'
+    if result_dir.exists():
+        for rp in result_dir.glob('*.json'):
+            rd = load_json(rp) or {}
+            if not _is_real_result(rd):
+                continue  # skip blocked stubs — still eligible for bridge
+            if rid := rd.get('request_id') or rd.get('verification_task_id'):
+                real_handled.add(rid)
+            if rpath := rd.get('request_path'):
+                real_handled.add(str(rpath))
+
+    # Also check bridge's own handled markers (those ARE real LLM runs)
+    if BRIDGE_STATE_DIR.exists():
+        for m in BRIDGE_STATE_DIR.glob('handled_*.txt'):
+            content = m.read_text(encoding='utf-8').strip()
+            real_handled.add(content)
+            # marker name encodes request_id
+            stem = m.stem[len('handled_'):]
+            real_handled.add(stem)
+
+    candidates = sorted(
+        [p for p in req_dir.glob('*.json') if p.is_file()],
+        key=lambda p: p.stat().st_mtime,
+    )
+    for path in candidates:
+        req = load_json(path) or {}
+        status = str(req.get('request_status') or req.get('status') or 'queued').lower()
+        if status not in ('queued', 'pending'):
+            continue
+        rid = req.get('request_id') or req.get('verification_task_id') or str(path)
+        if rid in real_handled or str(path) in real_handled:
+            continue
+        return path, req
+    return None, {}
+
+
+def build_task(req: dict, goal_text: str, report_source: str) -> str:
+    """Build a concrete task prompt for the subagent from the request payload."""
+    task_title = req.get('task_title') or req.get('semantic_task_id') or 'subagent review task'
+    request_id = req.get('request_id') or req.get('verification_task_id') or '?'
+    cycle_id = req.get('cycle_id') or '?'
+    goal_id = req.get('goal_id') or '?'
+    source_artifact = req.get('source_artifact') or ''
+
+    # Read the source artifact content inline so subagent has concrete data
+    artifact_content = ''
+    if source_artifact and Path(source_artifact).exists():
+        try:
+            raw = Path(source_artifact).read_text(encoding='utf-8')
+            artifact_content = raw[:4000]
+            if len(raw) > 4000:
+                artifact_content += '\n... [truncated]'
+        except Exception as e:
+            artifact_content = f'[could not read artifact: {e}]'
+    else:
+        artifact_content = '[source artifact not found or not specified]'
+
+    lines = [
+        'You are a bounded review subagent for the eeepc self-evolving runtime.',
+        '',
+        f'Task: {task_title}',
+        f'Request ID: {request_id}',
+        f'Cycle ID: {cycle_id}',
+        f'Goal ID: {goal_id}',
+        f'Origin report: {report_source}',
+        '',
+        '## Source artifact to review',
+        f'Path: {source_artifact}',
+        '',
+        '```json',
+        artifact_content,
+        '```',
+        '',
+        '## Your instructions',
+        '- Review the source artifact above and provide concise findings.',
+        '- Identify: what improvement was proposed, whether it is sound, what risks exist.',
+        '- If the artifact describes a code change, assess if it is safe and reversible.',
+        '- Do NOT mutate files or make network calls.',
+        '- Return a short structured summary with: findings[], key_learnings[], recommendation.',
+    ]
+    return '\n'.join(lines)
+
+
+async def main():
+    if not BRIDGE_ENABLED:
+        print('bridge_disabled')
+        return 0
+
+    outbox = load_json(STATE_DIR / 'outbox' / 'report.index.json') or {}
+    goals = load_json(STATE_DIR / 'goals' / 'registry.json') or {}
+    report_source = (outbox.get('source') or '').strip()
+    goal_id = (
+        (outbox.get('goal') or {}).get('goal_id')
+        or goals.get('active_goal_id')
+        or ''
+    ).strip()
+
+    if not report_source or not goal_id:
+        print('no_active_goal')
+        return 0
+
+    BRIDGE_STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    req_path, req = find_pending_request()
+    if not req_path:
+        print('already_handled')
+        return 0
+
+    request_id = req.get('request_id') or req.get('verification_task_id') or str(req_path)
+    safe_id = request_id.replace('/', '_')[:120]
+    handled_marker = BRIDGE_STATE_DIR / f'handled_{safe_id}.txt'
+    if handled_marker.exists():
+        print('already_handled')
+        return 0
+
+    goal_text = (
+        (goals.get('goals') or {}).get(goal_id, {}).get('text') or goal_id
+    )
+    subagent_policy = (goals.get('goals') or {}).get(goal_id, {}).get('subagent_policy') or {}
+    profile = FORCE_PROFILE or req.get('profile') or subagent_policy.get('preferred_profile') or 'research_only'
+    budget_class = FORCE_BUDGET or subagent_policy.get('budget_class') or req.get('budget') or 'standard'
+    gate_open = approval_open()
+    mode_at_start = 'auto' if gate_open else 'strict'
+
+    task = build_task(req, goal_text, report_source)
+
+    set_config_path(CONFIG_PATH)
+    config = load_config(CONFIG_PATH)
+    config.agents.defaults.model = BRIDGE_MODEL
+    provider = _make_provider(config)
+    bus = MessageBus()
+    TARGET_WORKSPACE.mkdir(parents=True, exist_ok=True)
+    (TARGET_WORKSPACE / '.nanobot' / 'subagents').mkdir(parents=True, exist_ok=True)
+
+    mgr = SubagentManager(
+        provider=provider,
+        workspace=TARGET_WORKSPACE,
+        bus=bus,
+        model=config.agents.defaults.model,
+        web_search_config=config.tools.web.search,
+        web_proxy=config.tools.web.proxy,
+        exec_config=config.tools.exec,
+        subagent_config=config.tools.subagent,
+        restrict_to_workspace=True,
+        max_running=config.tools.subagent.max_running,
+    )
+
+    msg = await mgr.spawn(
+        task=task,
+        label=f'selfevo-{goal_id[:8]}',
+        origin_channel='system',
+        origin_chat_id='self-evolving-agent',
+        profile=profile,
+        mode_at_start=mode_at_start,
+        approval_gate_open=gate_open,
+        budget_class=budget_class,
+        escalate_on_budget=True,
+    )
+    print(msg)
+    if mgr._running_tasks:
+        await asyncio.gather(*list(mgr._running_tasks.values()), return_exceptions=True)
+
+    handled_marker.write_text(str(req_path), encoding='utf-8')
+    latest = TARGET_WORKSPACE / '.nanobot' / 'subagents' / 'latest.json'
+    print(latest)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# =============================================================================
+# eeepc deploy: push a new code release to the running host and activate it
+#
+# Usage (from dev machine, not on eeepc):
+#   bash host/eeepc/scripts/deploy_release.sh [--host eeepc] [--dry-run]
+#
+# What it does:
+#   1. Bundles current repo HEAD into a timestamped release archive
+#   2. Sends it to eeepc via scp
+#   3. On eeepc: extracts, creates venv, symlinks current, restarts agent
+#
+# Prerequisites on dev machine:
+#   - ssh access to eeepc (key-based)
+#   - gh CLI authenticated
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HOST="eeepc"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --host)    HOST="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+log()  { echo "[deploy] $*"; }
+run()  { if [[ $DRY_RUN -eq 1 ]]; then echo "[DRY] $*"; else "$@"; fi; }
+
+COMMIT=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+RELEASE_NAME="${TIMESTAMP}-canonical-${COMMIT}"
+ARCHIVE="/tmp/eeebot-release-${RELEASE_NAME}.tar.gz"
+
+log "repo:    $REPO_ROOT"
+log "commit:  $COMMIT ($BRANCH)"
+log "release: $RELEASE_NAME"
+log "host:    $HOST"
+
+# 1. Create archive from git HEAD (excludes .git, .venv, __pycache__)
+log "creating archive..."
+run git -C "$REPO_ROOT" archive --format=tar.gz --prefix="${RELEASE_NAME}/" HEAD \
+  -o "$ARCHIVE"
+log "archive: $ARCHIVE ($(du -sh "$ARCHIVE" | cut -f1))"
+
+# 2. Copy to host
+REMOTE_ARCHIVE="/tmp/$(basename "$ARCHIVE")"
+log "uploading to $HOST:$REMOTE_ARCHIVE..."
+run scp "$ARCHIVE" "ozand@${HOST}:${REMOTE_ARCHIVE}"
+
+# 3. Extract, build venv, update symlink, restart
+log "installing on $HOST..."
+run ssh "ozand@${HOST}" bash -s -- "$REMOTE_ARCHIVE" "$RELEASE_NAME" "$COMMIT" <<'REMOTE'
+set -euo pipefail
+ARCHIVE="$1"
+RELEASE_NAME="$2"
+COMMIT="$3"
+
+RELEASES_DIR=/opt/eeepc-agent/runtimes/self-evolving-agent/releases
+RELEASE_DIR="$RELEASES_DIR/$RELEASE_NAME"
+VENV_BASE=/opt/eeepc-agent/runtimes/self-evolving-agent/venv
+
+echo "[remote] extracting to $RELEASE_DIR"
+sudo mkdir -p "$RELEASES_DIR"
+cd /tmp
+sudo tar xzf "$ARCHIVE" -C "$RELEASES_DIR"
+
+echo "[remote] creating/updating venv"
+if [[ ! -d "$VENV_BASE" ]]; then
+  sudo python3 -m venv "$VENV_BASE"
+fi
+sudo "$VENV_BASE/bin/pip" install --quiet --upgrade pip
+sudo "$VENV_BASE/bin/pip" install --quiet -e "$RELEASE_DIR"
+
+echo "[remote] linking venv into release"
+sudo ln -sfn "$VENV_BASE" "$RELEASE_DIR/.venv"
+
+echo "[remote] updating current symlink"
+sudo ln -sfn "$RELEASE_DIR" /opt/eeepc-agent/runtimes/self-evolving-agent/current
+
+echo "[remote] fixing ownership"
+sudo chown -R eeepc-agent:eeepc-agent "$RELEASE_DIR" "$VENV_BASE" 2>/dev/null || true
+
+echo "[remote] syncing libexec scripts from release"
+sudo cp "$RELEASE_DIR/host/eeepc/libexec/"*.py /usr/local/libexec/ 2>/dev/null || true
+sudo chmod +x /usr/local/libexec/eeepc-self-evolving-*.py
+
+echo "[remote] reloading systemd + restarting agent"
+sudo systemctl daemon-reload
+sudo systemctl restart eeepc-self-evolving-agent.service || true
+
+echo "[remote] current release: $(readlink /opt/eeepc-agent/runtimes/self-evolving-agent/current)"
+echo "[remote] done — commit $COMMIT"
+REMOTE
+
+log "cleaning up local archive"
+run rm -f "$ARCHIVE"
+
+log ""
+log "=== Deploy complete ==="
+log "Release: $RELEASE_NAME"
+log "To verify:"
+log "  ssh ozand@$HOST 'sudo journalctl -u eeepc-self-evolving-agent.service --since \"1 min ago\" --no-pager'"
+log "  ssh ozand@$HOST 'sudo systemctl status eeepc-self-evolving-agent.service'"

--- a/host/eeepc/scripts/install.sh
+++ b/host/eeepc/scripts/install.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# =============================================================================
+# eeepc host deploy script
+# Installs / updates the self-evolving agent runtime on a fresh or existing host.
+#
+# Usage:
+#   sudo bash host/eeepc/scripts/install.sh [--dry-run]
+#
+# What it does:
+#   1. Creates system user eeepc-agent
+#   2. Creates directory layout (/opt, /var/lib, /etc/eeepc-agent)
+#   3. Copies systemd units + drop-ins
+#   4. Copies libexec scripts
+#   5. Copies env files (skips litellm.env if it already has a real key)
+#   6. Creates Python venv and installs the package
+#   7. Enables and starts timers
+#
+# Prerequisites:
+#   - Debian/Ubuntu host with systemd
+#   - python3.11+ available
+#   - git, curl installed
+#   - LITELLM_API_KEY and LITELLM_BASE_URL set in environment OR
+#     /etc/eeepc-agent/litellm.env already present with real values
+#
+# After first install:
+#   sudo systemctl start eeepc-self-evolving-agent.service
+#   sudo journalctl -u eeepc-self-evolving-agent.service -f
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HOST_DIR="$REPO_ROOT/host/eeepc"
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+log()  { echo "[install] $*"; }
+run()  { if [[ $DRY_RUN -eq 1 ]]; then echo "[DRY] $*"; else "$@"; fi; }
+warn() { echo "[WARN] $*" >&2; }
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "ERROR: must run as root (sudo bash $0)" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. System user
+# ---------------------------------------------------------------------------
+create_user() {
+  if id eeepc-agent &>/dev/null; then
+    log "user eeepc-agent already exists"
+  else
+    log "creating system user eeepc-agent"
+    run useradd --system --no-create-home --shell /usr/sbin/nologin \
+        --home-dir /opt/eeepc-agent eeepc-agent
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 2. Directory layout
+# ---------------------------------------------------------------------------
+DIRS=(
+  /opt/eeepc-agent/runtimes/self-evolving-agent/releases
+  /var/lib/eeepc-agent/self-evolving-agent/state
+  /var/lib/eeepc-agent/self-evolving-agent/workspace/subagents
+  /etc/eeepc-agent/instances
+  /usr/local/libexec
+)
+
+create_dirs() {
+  for d in "${DIRS[@]}"; do
+    if [[ ! -d "$d" ]]; then
+      log "mkdir -p $d"
+      run mkdir -p "$d"
+    fi
+  done
+  run chown -R eeepc-agent:eeepc-agent /opt/eeepc-agent /var/lib/eeepc-agent
+}
+
+# ---------------------------------------------------------------------------
+# 3. Python venv + package install
+# ---------------------------------------------------------------------------
+VENV_DIR=/opt/eeepc-agent/runtimes/self-evolving-agent/venv
+
+install_package() {
+  local python
+  python=$(command -v python3.13 || command -v python3.12 || command -v python3.11 || command -v python3)
+  log "using python: $python ($($python --version))"
+
+  if [[ ! -d "$VENV_DIR" ]]; then
+    log "creating venv at $VENV_DIR"
+    run "$python" -m venv "$VENV_DIR"
+  fi
+
+  log "installing eeebot package from $REPO_ROOT"
+  run "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+  run "$VENV_DIR/bin/pip" install --quiet -e "$REPO_ROOT[dev]"
+
+  # Create/update 'current' symlink to a release dir
+  local release_dir
+  release_dir="/opt/eeepc-agent/runtimes/self-evolving-agent/releases/$(date -u +%Y%m%dT%H%M%SZ)-install"
+  if [[ $DRY_RUN -eq 0 ]]; then
+    mkdir -p "$release_dir"
+    cp -r "$REPO_ROOT"/. "$release_dir/"
+    ln -sfn "$release_dir/.venv" "$release_dir/../../../venv" 2>/dev/null || true
+    # point venv into release for systemd ExecStart compatibility
+    ln -sfn "$VENV_DIR" "$release_dir/.venv"
+    ln -sfn "$release_dir" /opt/eeepc-agent/runtimes/self-evolving-agent/current
+    log "current → $release_dir"
+  else
+    echo "[DRY] would create release at $release_dir and update current symlink"
+  fi
+  run chown -R eeepc-agent:eeepc-agent /opt/eeepc-agent
+}
+
+# ---------------------------------------------------------------------------
+# 4. systemd units
+# ---------------------------------------------------------------------------
+install_units() {
+  local src="$HOST_DIR/systemd"
+
+  log "installing systemd unit files"
+  for f in "$src"/*.service "$src"/*.timer; do
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f")
+    run cp "$f" "/etc/systemd/system/$name"
+    log "  ✓ $name"
+  done
+
+  log "installing systemd drop-ins"
+  for f in "$src"/drop-ins/**/*.conf; do
+    [[ -f "$f" ]] || continue
+    # path: drop-ins/eeepc-foo.service.d/bar.conf
+    local rel="${f#"$src/drop-ins/"}"
+    local dest="/etc/systemd/system/$rel"
+    run mkdir -p "$(dirname "$dest")"
+    run cp "$f" "$dest"
+    log "  ✓ $rel"
+  done
+
+  run systemctl daemon-reload
+}
+
+# ---------------------------------------------------------------------------
+# 5. libexec scripts
+# ---------------------------------------------------------------------------
+install_libexec() {
+  log "installing /usr/local/libexec scripts"
+  for f in "$HOST_DIR/libexec"/*.py; do
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f")
+    run cp "$f" "/usr/local/libexec/$name"
+    run chmod +x "/usr/local/libexec/$name"
+    log "  ✓ $name"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# 6. /etc/eeepc-agent env files
+# ---------------------------------------------------------------------------
+install_etc() {
+  log "installing /etc/eeepc-agent config files"
+
+  # instances/ env files (always overwrite — no secrets inside)
+  for f in "$HOST_DIR/etc/instances"/*.env; do
+    [[ -f "$f" ]] || continue
+    local name
+    name=$(basename "$f")
+    run cp "$f" "/etc/eeepc-agent/instances/$name"
+    run chmod 640 "/etc/eeepc-agent/instances/$name"
+    log "  ✓ instances/$name"
+  done
+
+  # models.yaml
+  run cp "$HOST_DIR/etc/models.yaml" /etc/eeepc-agent/models.yaml
+  log "  ✓ models.yaml"
+
+  # litellm.env — only install example if real file absent
+  if [[ ! -f /etc/eeepc-agent/litellm.env ]] || grep -q 'sk-YOUR_KEY_HERE' /etc/eeepc-agent/litellm.env 2>/dev/null; then
+    run cp "$HOST_DIR/etc/litellm.env.example" /etc/eeepc-agent/litellm.env
+    run chmod 600 /etc/eeepc-agent/litellm.env
+    warn "IMPORTANT: edit /etc/eeepc-agent/litellm.env and set LITELLM_API_KEY before starting the agent!"
+  else
+    log "  ✓ litellm.env already configured (skipping)"
+  fi
+
+  # Inject real key from env if provided
+  if [[ -n "${LITELLM_API_KEY:-}" && -n "${LITELLM_BASE_URL:-}" ]]; then
+    log "  Injecting LITELLM_API_KEY and LITELLM_BASE_URL from environment"
+    run sed -i "s|sk-YOUR_KEY_HERE|${LITELLM_API_KEY}|g" /etc/eeepc-agent/litellm.env
+    run sed -i "s|https://litellm.ayga.tech:9443/v1|${LITELLM_BASE_URL}|g" /etc/eeepc-agent/litellm.env
+  fi
+
+  # nanobot gateway config template
+  local nanobot_dir=/home/opencode/.nanobot-eeepc
+  if [[ -d "$nanobot_dir" ]]; then
+    if [[ ! -f "$nanobot_dir/config.template.json" ]]; then
+      run cp "$HOST_DIR/etc/nanobot-config.template.json" "$nanobot_dir/config.template.json"
+      warn "Installed nanobot config template — set real LITELLM_API_KEY inside it!"
+      log "  ✓ $nanobot_dir/config.template.json"
+    else
+      log "  ✓ $nanobot_dir/config.template.json already exists (skipping)"
+    fi
+  else
+    warn "opencode home $nanobot_dir not found — skipping nanobot config template"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 7. State dir initial structure
+# ---------------------------------------------------------------------------
+init_state() {
+  local state=/var/lib/eeepc-agent/self-evolving-agent/state
+  log "initialising state directory structure"
+  for subdir in reports subagents/requests subagents/results improvements approvals goals outbox subagent_bridge workspace/subagents; do
+    run mkdir -p "$state/$subdir"
+  done
+  run chown -R eeepc-agent:eeepc-agent /var/lib/eeepc-agent
+}
+
+# ---------------------------------------------------------------------------
+# 8. Enable timers
+# ---------------------------------------------------------------------------
+enable_timers() {
+  log "enabling systemd timers"
+  local timers=(
+    eeepc-self-evolving-subagent-bridge.timer
+    eeepc-self-evolving-approval-keeper.timer
+    eeepc-self-evolving-agent-health.timer
+    eeepc-strong-reflection.timer
+  )
+  for t in "${timers[@]}"; do
+    run systemctl enable "$t"
+    log "  ✓ enabled $t"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+require_root
+
+log "=== eeepc host deploy ==="
+log "REPO_ROOT: $REPO_ROOT"
+log "DRY_RUN:   $DRY_RUN"
+echo
+
+create_user
+create_dirs
+install_package
+install_units
+install_libexec
+install_etc
+init_state
+enable_timers
+
+echo
+log "=== Deploy complete ==="
+echo
+if grep -q 'sk-YOUR_KEY_HERE' /etc/eeepc-agent/litellm.env 2>/dev/null; then
+  warn "litellm.env still has placeholder key — agent will NOT start until you set LITELLM_API_KEY"
+  warn "  sudo nano /etc/eeepc-agent/litellm.env"
+else
+  log "To start the agent:"
+  log "  sudo systemctl start eeepc-self-evolving-agent.service"
+  log "  sudo journalctl -u eeepc-self-evolving-agent.service -f"
+fi

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/91-runtime-state-root.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/91-runtime-state-root.conf
@@ -1,0 +1,3 @@
+[Service]
+Environment=NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state
+Environment=NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/95-issue57-timeout.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/95-issue57-timeout.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=LITELLM_TIMEOUT_S=25

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/96-subagent-executor.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/96-subagent-executor.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="NANOBOT_SUBAGENT_EXECUTOR_COMMAND=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m nanobot.runtime.bounded_subagent_executor"

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/override.conf
@@ -1,0 +1,11 @@
+[Service]
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=POLICY_FILE=/opt/eeepc-agent/runtimes/self-evolving-agent/current/config/policy.yaml
+Environment=LITELLM_MODEL=gpt-5.4-mini
+Environment=LITELLM_TIMEOUT_S=45
+Environment=LITELLM_TOTAL_BUDGET_MS=70000
+Environment=LITELLM_RETRY_MAX_ATTEMPTS=3
+Environment=DRY_RUN=false
+Environment=ALLOW_CODE_EDITS=false
+ExecStart=
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/litellm-env.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/litellm-env.conf
@@ -1,0 +1,2 @@
+[Service]
+EnvironmentFile=/etc/eeepc-agent/litellm.env

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/override.conf
@@ -1,0 +1,12 @@
+[Service]
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=POLICY_FILE=
+Environment=LITELLM_MODEL=gpt-5.4-mini
+Environment=LITELLM_FALLBACK_MODELS=
+Environment=LITELLM_TIMEOUT_S=35
+Environment=LITELLM_TOTAL_BUDGET_MS=45000
+Environment=LITELLM_RETRY_MAX_ATTEMPTS=2
+Environment=DRY_RUN=false
+Environment=ALLOW_CODE_EDITS=false
+ExecStart=
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/90-runtime-pinned-pythonpath.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/90-runtime-pinned-pythonpath.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=PYTHONPATH=/home/opencode/.nanobot-eeepc/runtime/pinned/current

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/91-runtime-state-root.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/91-runtime-state-root.conf
@@ -1,0 +1,3 @@
+[Service]
+Environment=NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state
+Environment=NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/92-canonical-workspace.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/92-canonical-workspace.conf
@@ -1,0 +1,6 @@
+# Managed by servers_team HOST-015 on 2026-06-05.
+# Move subagent bridge away from dirty legacy checkout.
+[Service]
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-subagent-bridge-workspace.env
+Environment=TARGET_WORKSPACE=/var/lib/eeepc-agent/self-evolving-agent/workspace/subagents

--- a/host/eeepc/systemd/eeepc-agent-workspace-export@.service
+++ b/host/eeepc/systemd/eeepc-agent-workspace-export@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Generate eeepc workspace export manifest for instance %i
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260324-staged
+EnvironmentFile=-/etc/default/eeepc-agent
+EnvironmentFile=-/etc/eeepc-agent/common.env
+EnvironmentFile=-/etc/eeepc-agent/instances/%i.env
+ExecStart=/bin/sh /opt/eeepc-agent/runtimes/self-evolving-agent/releases/20260324-staged/scripts/export_workspace_manifest.sh
+Nice=10
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=false
+ProtectSystem=full
+ReadWritePaths=/var/lib/eeepc-agent /home/opencode/servers_team/repo_research/nanobot
+
+[Install]
+WantedBy=multi-user.target

--- a/host/eeepc/systemd/eeepc-agent-workspace-export@.timer
+++ b/host/eeepc/systemd/eeepc-agent-workspace-export@.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run eeepc workspace export every 10 minutes for instance %i
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+RandomizedDelaySec=30s
+Persistent=true
+Unit=eeepc-agent-workspace-export@%i.service
+
+[Install]
+WantedBy=timers.target

--- a/host/eeepc/systemd/eeepc-network-fallback.service
+++ b/host/eeepc/systemd/eeepc-network-fallback.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=eeepc network fallback route maintainer
+After=network.target NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/eeepc-network-fallback.sh

--- a/host/eeepc/systemd/eeepc-network-fallback.timer
+++ b/host/eeepc/systemd/eeepc-network-fallback.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run eeepc network fallback route maintainer
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Unit=eeepc-network-fallback.service
+
+[Install]
+WantedBy=timers.target

--- a/host/eeepc/systemd/eeepc-self-evolving-agent-health.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-agent-health.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=eeepc Self-Evolving Agent Health Check
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-agent.env
+Environment=MAX_CYCLES=1
+Environment=DRY_RUN=true
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main

--- a/host/eeepc/systemd/eeepc-self-evolving-agent-health.timer
+++ b/host/eeepc/systemd/eeepc-self-evolving-agent-health.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run eeepc Self-Evolving Agent health checks
+
+[Timer]
+OnBootSec=2m
+OnUnitActiveSec=15m
+Unit=eeepc-self-evolving-agent-health.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/host/eeepc/systemd/eeepc-self-evolving-agent.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-agent.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=eeepc Self-Evolving Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=eeepc-agent
+Group=eeepc-agent
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-agent.env
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main
+Restart=on-failure
+RestartSec=15
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=false
+ProtectSystem=full
+ReadWritePaths=/var/lib/eeepc-agent /home/opencode/servers_team/repo_research/nanobot
+
+[Install]
+WantedBy=multi-user.target

--- a/host/eeepc/systemd/eeepc-self-evolving-approval-keeper.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-approval-keeper.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Keep eeepc self-evolving apply approval window open
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-approval-keeper.env
+ExecStart=/usr/local/libexec/eeepc-self-evolving-approval-keeper.py

--- a/host/eeepc/systemd/eeepc-self-evolving-approval-keeper.timer
+++ b/host/eeepc/systemd/eeepc-self-evolving-approval-keeper.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Refresh eeepc self-evolving apply approval window
+
+[Timer]
+OnBootSec=1m
+OnUnitActiveSec=5m
+Unit=eeepc-self-evolving-approval-keeper.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run eeepc self-evolving subagent bridge
+After=network-online.target eeepc-self-evolving-approval-keeper.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/opencode/servers_team/repo_research/nanobot
+EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
+Environment=PYTHONPATH=/home/opencode/servers_team/repo_research/nanobot
+ExecStart=/home/opencode/.venvs/nanobot/bin/python /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py

--- a/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.timer
+++ b/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically run eeepc self-evolving subagent bridge
+
+[Timer]
+OnBootSec=4m
+OnUnitActiveSec=15m
+Unit=eeepc-self-evolving-subagent-bridge.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/host/eeepc/systemd/eeepc-strong-reflection.service
+++ b/host/eeepc/systemd/eeepc-strong-reflection.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Run eeepc strong reflection lane
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=-/etc/default/eeepc-agent
+EnvironmentFile=-/etc/eeepc-agent/common.env
+EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-agent.env
+ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main strong-reflection
+Nice=10
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=false
+ProtectSystem=full
+ReadWritePaths=/var/lib/eeepc-agent /home/opencode/servers_team/repo_research/nanobot
+
+[Install]
+WantedBy=default.target

--- a/host/eeepc/systemd/eeepc-strong-reflection.timer
+++ b/host/eeepc/systemd/eeepc-strong-reflection.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run eeepc strong reflection every 6 hours
+
+[Timer]
+OnBootSec=12min
+OnUnitActiveSec=6h
+RandomizedDelaySec=10min
+Persistent=true
+Unit=eeepc-strong-reflection.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Captures all host-specific configuration from the live eeepc system into `host/eeepc/` so the agent runtime can be reproduced on a fresh host from a single `git clone` + `sudo bash host/eeepc/scripts/install.sh`.

## What's in the playbook

### Scripts
- `host/eeepc/scripts/install.sh` — first-time host setup (creates user, dirs, venv, installs units)
- `host/eeepc/scripts/deploy_release.sh` — push a code update from dev machine via SSH

### systemd
All 13 unit files and 9 drop-in overrides, exactly as installed on live eeepc.

### /usr/local/libexec
- `eeepc-self-evolving-approval-keeper.py`
- `eeepc-self-evolving-subagent-bridge.py` (same as `scripts/eeepc_self_evolving_subagent_bridge.py`)

### /etc/eeepc-agent
- `instances/*.env` — per-service env files (no secrets)
- `litellm.env.example` — credential template with placeholder key
- `models.yaml` — full allowed model registry (41 models)
- `nanobot-config.template.json` — gateway config (apiKey redacted)

## What is NOT in git (must be set manually)
- `/etc/eeepc-agent/litellm.env` — real `LITELLM_API_KEY`
- `nanobot-config.template.json` — real provider apiKey
- `/var/lib/eeepc-agent/*/state/` — runtime state (never in git)

## Fresh host deploy sequence
```bash
git clone https://github.com/ozand/eeebot /opt/eeebot-src
cd /opt/eeebot-src
export LITELLM_API_KEY=sk-...
export LITELLM_BASE_URL=https://litellm.ayga.tech:9443/v1
sudo bash host/eeepc/scripts/install.sh
sudo systemctl start eeepc-self-evolving-agent.service
```