### PR TITLE
fix(bridge): write completed result to results/ after subagent execution (#498)

### DIFF
--- a/scripts/eeepc_self_evolving_subagent_bridge.py
+++ b/scripts/eeepc_self_evolving_subagent_bridge.py
@@ -304,7 +304,12 @@ async def main():
     _git = ['git', '-c', f'safe.directory={_repo}', '-C', _repo]
     _ahead = _sp.run(_git + ['rev-list', '--count', 'origin/main..HEAD'],
                      capture_output=True, text=True).stdout.strip()
+    files_changed: list[str] = []
     if _ahead and _ahead != '0':
+        _diff = _sp.run(_git + ['diff', '--name-only', f'HEAD~{_ahead}', 'HEAD'],
+                        capture_output=True, text=True)
+        if _diff.returncode == 0:
+            files_changed = [f for f in _diff.stdout.splitlines() if f.strip()]
         _push = _sp.run(_git + ['push', 'origin', 'main'],
                         capture_output=True, text=True)
         if _push.returncode == 0:
@@ -312,7 +317,84 @@ async def main():
         else:
             print(f'auto-push failed: {_push.stderr.strip()[:200]}')
 
+    # Write a real completed result to state/subagents/results/ so the coordinator
+    # can see that the subagent actually ran (not just a blocked stub).
+    # This prevents the coordinator from marking subagents_unused=true every cycle.
+    _write_bridge_completed_result(
+        state_dir=STATE_DIR,
+        req=req,
+        request_id=request_id,
+        cycle_id=req.get('cycle_id') or '',
+        goal_id=goal_id,
+        files_changed=files_changed,
+        commits_pushed=int(_ahead) if _ahead and _ahead.isdigit() else 0,
+    )
+
     return 0
+
+
+def _write_bridge_completed_result(
+    *,
+    state_dir: Path,
+    req: dict,
+    request_id: str,
+    cycle_id: str,
+    goal_id: str,
+    files_changed: list[str],
+    commits_pushed: int,
+) -> None:
+    """Write a real subagent-result-v1 artifact after bridge LLM execution.
+
+    Overwrites any blocked stub left by the coordinator materializer so that
+    the coordinator's _ambition_underutilization_reasons() sees a completed
+    result instead of always flagging subagents_unused=true.
+    """
+    import datetime as _dt
+    results_dir = state_dir / 'subagents' / 'results'
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_id = request_id.replace('/', '_')[:120]
+    result_path = results_dir / f'result-{safe_id}.json'
+
+    summary = (
+        f'Bridge subagent completed: {commits_pushed} commit(s) pushed, '
+        f'{len(files_changed)} file(s) changed.'
+        if commits_pushed
+        else 'Bridge subagent completed (no new commits).'
+    )
+
+    payload = {
+        'schema_version': 'subagent-result-v1',
+        'request_id': request_id,
+        'request_path': str(state_dir / 'subagents' / 'requests' / f'request-{cycle_id}.json'),
+        'cycle_id': cycle_id,
+        'goal_id': goal_id,
+        'task_id': req.get('task_id') or req.get('semantic_task_id') or 'subagent-verify-materialized-improvement',
+        'semantic_task_id': req.get('semantic_task_id') or req.get('task_id') or 'subagent-verify-materialized-improvement',
+        'verification_task_id': request_id,
+        'result_status': 'completed',
+        'status': 'completed',
+        'materialized_from': 'bridge_llm_execution',
+        'executor': 'bridge',
+        'created_at': _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        'files_changed': files_changed,
+        'commits_pushed': commits_pushed,
+        'summary': summary,
+        'key_learnings': [
+            f'Bridge executed subagent successfully; {commits_pushed} commit(s) pushed to origin/main.',
+        ] if commits_pushed else [
+            'Bridge executed subagent; no new commits were produced.',
+        ],
+        'learning_classification': 'completed_with_evidence' if files_changed else 'completed_no_change',
+        'profile': req.get('profile') or 'bounded_execution',
+        'source_artifact': req.get('source_artifact') or '',
+    }
+
+    try:
+        result_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding='utf-8')
+        print(f'bridge-result: wrote completed result to {result_path.name}')
+    except Exception as exc:
+        print(f'bridge-result: failed to write result: {exc}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #498

## Что изменено

После завершения LLM-субагента мост теперь записывает настоящий артефакт `subagent-result-v1` с `result_status: completed` в `state/subagents/results/`.

**До:** там оставалась только `blocked`-заглушка от координатора → координатор видел `subagents_unused=true` каждый цикл → эскалация каждые 5 циклов.

**После:** координатор видит `result_status: completed` с `materialized_from: bridge_llm_execution` → `subagents_unused` не выставляется → петля замыкается корректно.

## Детали реализации

- Сбор `files_changed` через `git diff --name-only HEAD~N HEAD` после push
- Новый хелпер `_write_bridge_completed_result()` пишет `result-<safe_id>.json`
- Поля: `result_status=completed`, `files_changed`, `commits_pushed`, `key_learnings`, `materialized_from=bridge_llm_execution`
- `_is_real_result()` уже корректно возвращает `True` для `status=completed`

## Тесты
830 passed ✓