### PR TITLE
fix(coordinator): _has_concrete_changes checks eeebot-self-evolving for recent subagent commits (#509)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -3768,8 +3768,30 @@ def _workspace_looks_like_eeepc_live_runtime(workspace: Path) -> bool:
     return workspace.parent.name == ".nanobot-eeepc" and workspace.name == "workspace"
 
 
-def _has_concrete_changes(workspace: Path) -> bool:
-    # Check if we are inside a git repository (default to True in non-git test envs)
+def _has_concrete_changes(workspace: Path, state_root: Path | None = None) -> bool:
+    """Return True if any real source-code change exists in workspace or eeebot-self-evolving.
+
+    In the two-repository topology, subagents commit to eeebot-self-evolving
+    (``state_root.parent / "eeebot-self-evolving"``), not to the canonical workspace.
+    When ``state_root`` is provided we check that repo for recent commits (last 15 minutes)
+    in addition to the canonical workspace worktree.
+    """
+    # ── Part A: check eeebot-self-evolving for recent subagent commits ──────────
+    if state_root is not None:
+        selfevo_path = state_root.parent / "eeebot-self-evolving"
+        if selfevo_path.is_dir():
+            selfevo_git = _git_output(
+                ['git', 'rev-parse', '--is-inside-work-tree'], selfevo_path
+            )
+            if selfevo_git and selfevo_git.strip().lower() == "true":
+                # Any commit in the last 15 minutes counts as a concrete change
+                recent = _git_output(
+                    ['git', 'log', '--since=15 minutes ago', '--oneline'], selfevo_path
+                )
+                if recent and recent.strip():
+                    return True
+
+    # ── Part B: check canonical workspace (original logic) ───────────────────────
     is_git = _git_output(['git', 'rev-parse', '--is-inside-work-tree'], workspace)
     if not is_git or is_git.strip().lower() != "true":
         return True
@@ -4005,7 +4027,7 @@ async def run_self_evolving_cycle(
         artifact_path = current_plan.get("materialized_improvement_artifact_path")
         reward = current_plan.get("reward_signal") if isinstance(current_plan.get("reward_signal"), dict) else reward_signal
         upgraded_reward = dict(reward) if isinstance(reward, dict) else {"value": 1.0, "source": "result_status", "result_status": result_status}
-        if _has_concrete_changes(workspace):
+        if _has_concrete_changes(workspace, state_root=state_root):
             upgraded_reward["value"] = max(float(upgraded_reward.get("value") or 0.0), 1.2)
             upgraded_reward["source"] = "materialized_improvement_artifact"
         else:

--- a/tests/test_concrete_changes_dual_repo.py
+++ b/tests/test_concrete_changes_dual_repo.py
@@ -1,0 +1,147 @@
+"""
+Tests for issue #509: _has_concrete_changes must also check eeebot-self-evolving repo.
+
+In the two-repo topology, subagents commit to eeebot-self-evolving, not to the
+canonical workspace.  Without checking that repo, reward is always 0.8 and every
+cycle registers outcome=discard.
+"""
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime.coordinator import _has_concrete_changes
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _git(*args, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   capture_output=True)
+
+
+def _init_repo(path: Path, initial_file: str = "README.md") -> None:
+    """Initialise a minimal git repo with one commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", cwd=path)
+    _git("config", "user.email", "test@test.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    (path / initial_file).write_text("init\n")
+    _git("add", ".", cwd=path)
+    _git("commit", "-m", "init", cwd=path)
+
+
+def _add_commit(repo: Path, filename: str, content: str, msg: str) -> None:
+    fpath = repo / filename
+    fpath.parent.mkdir(parents=True, exist_ok=True)
+    fpath.write_text(content)
+    _git("add", ".", cwd=repo)
+    _git("commit", "-m", msg, cwd=repo)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestHasConcreteChanges:
+
+    def test_no_state_root_canonical_only(self, tmp_path):
+        """Without state_root, behaves as before: checks canonical workspace only."""
+        canonical = tmp_path / "canonical"
+        _init_repo(canonical)
+        # No uncommitted changes, no autoevolve commit → should be False
+        result = _has_concrete_changes(canonical, state_root=None)
+        assert result is False
+
+    def test_non_git_workspace_returns_true(self, tmp_path):
+        """Non-git directory → True (safe default, same as original behaviour)."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        result = _has_concrete_changes(workspace, state_root=None)
+        assert result is True
+
+    def test_selfevo_recent_commit_detected(self, tmp_path):
+        """Recent commit in eeebot-self-evolving → True even if canonical unchanged."""
+        # state structure: state_root.parent / "eeebot-self-evolving"
+        state_root = tmp_path / "self-evolving-agent" / "state"
+        state_root.mkdir(parents=True)
+        selfevo = tmp_path / "self-evolving-agent" / "eeebot-self-evolving"
+        _init_repo(selfevo)
+
+        canonical = tmp_path / "canonical"
+        _init_repo(canonical)
+
+        # Add a recent commit to selfevo (just now)
+        _add_commit(selfevo, "nanobot/utils/new_tool.py", "# new\n", "feat: add new tool")
+
+        result = _has_concrete_changes(canonical, state_root=state_root)
+        assert result is True, (
+            "Should return True when eeebot-self-evolving has commits in last 15 min"
+        )
+
+    def test_selfevo_missing_does_not_crash(self, tmp_path):
+        """If eeebot-self-evolving directory doesn't exist, falls back to canonical check."""
+        state_root = tmp_path / "state"
+        state_root.mkdir(parents=True)
+        # eeebot-self-evolving does NOT exist → should not crash
+
+        canonical = tmp_path / "canonical"
+        _init_repo(canonical)
+
+        result = _has_concrete_changes(canonical, state_root=state_root)
+        # canonical has no changes → False
+        assert result is False
+
+    def test_selfevo_non_git_dir_skipped(self, tmp_path):
+        """If eeebot-self-evolving exists but isn't a git repo, skip it gracefully."""
+        state_root = tmp_path / "state"
+        state_root.mkdir(parents=True)
+        selfevo = tmp_path / "eeebot-self-evolving"
+        selfevo.mkdir()
+        (selfevo / "some_file.txt").write_text("not a repo")
+
+        canonical = tmp_path / "canonical"
+        _init_repo(canonical)
+
+        result = _has_concrete_changes(canonical, state_root=state_root)
+        assert result is False  # canonical clean, selfevo not git → False
+
+    def test_canonical_unstaged_change_still_detected(self, tmp_path):
+        """Unstaged changes in canonical workspace are still detected (original path)."""
+        state_root = tmp_path / "state"
+        state_root.mkdir(parents=True)
+
+        canonical = tmp_path / "canonical"
+        _init_repo(canonical)
+
+        # Create unstaged .py change
+        (canonical / "nanobot" / "runtime").mkdir(parents=True)
+        (canonical / "nanobot" / "runtime" / "fix.py").write_text("# fix\n")
+        _git("add", ".", cwd=canonical)
+        # do NOT commit — leave it staged
+
+        result = _has_concrete_changes(canonical, state_root=state_root)
+        assert result is True
+
+    def test_selfevo_path_is_state_root_parent_slash_name(self, tmp_path):
+        """Verifies correct path derivation: state_root.parent / 'eeebot-self-evolving'."""
+        # state_root = /tmp/xyz/self-evolving-agent/state
+        # expected selfevo = /tmp/xyz/self-evolving-agent/eeebot-self-evolving
+        agent_dir = tmp_path / "self-evolving-agent"
+        state_root = agent_dir / "state"
+        state_root.mkdir(parents=True)
+
+        selfevo = agent_dir / "eeebot-self-evolving"
+        _init_repo(selfevo)
+        _add_commit(selfevo, "scripts/new_script.sh", "#!/bin/bash\n", "feat: new script")
+
+        canonical = tmp_path / "canonical"
+        _init_repo(canonical)
+
+        result = _has_concrete_changes(canonical, state_root=state_root)
+        assert result is True, (
+            "Path derivation state_root.parent/'eeebot-self-evolving' must point to selfevo repo"
+        )


### PR DESCRIPTION
Closes #509

## Root cause

`_has_concrete_changes(workspace)` only examined the **canonical workspace** (`/opt/eeepc-agent/runtimes/.../current`). Subagents commit to `eeebot-self-evolving`, a separate repo. Canonical is never modified at runtime. So `_has_concrete_changes` always returned `False`, reward was always `0.8`, baseline was `1.2`, and **60 out of 61 cycles recorded `outcome=discard`**.

## Changes

### `nanobot/runtime/coordinator.py`
Extended `_has_concrete_changes(workspace, state_root=None)`:

**Part A** (new): if `state_root` provided, derive `selfevo_path = state_root.parent / "eeebot-self-evolving"` and run `git log --since=15 minutes ago --oneline`. Any result → `return True`.

**Part B** (unchanged): original canonical workspace check.

Call site updated to pass `state_root=state_root`.

### `tests/test_concrete_changes_dual_repo.py`
7 new tests covering:
- No state_root → original behaviour unchanged
- Non-git workspace → True
- Recent selfevo commit → True
- Missing selfevo dir → no crash, falls through to canonical
- Non-git selfevo dir → skipped gracefully
- Unstaged canonical change still detected
- Path derivation `state_root.parent/eeebot-self-evolving` is correct

## Expected on-host effect
When subagent commits to `eeebot-self-evolving`, the next coordinator cycle will see the commit (within 15-min window) and set `reward_signal.value=1.2`, `outcome=keep` instead of `discard`.