### PR TITLE
fix(coordinator): subagent-verify uses bounded_execution + standard budget (#510)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -1976,8 +1976,8 @@ def _derive_generated_candidates(
             "acceptance": "create one bounded subagent request that reviews the materialized improvement artifact and reports a verification recommendation",
             "selection_source": "generated_from_hadi_materialized_improvement" if current_task_id == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID else "generated_from_materialized_improvement",
             "parent_task_id": current_task_id,
-            "subagent_profile": "research_only",
-            "subagent_budget": "micro",
+            "subagent_profile": "bounded_execution",
+            "subagent_budget": "standard",
         })
     elif current_task_id == SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID and pass_streak >= 3:
         candidates.append({
@@ -2308,8 +2308,8 @@ def _write_subagent_request_artifact(
         "task": materialized_task or current_plan.get("selected_task_title") or current_plan.get("current_task"),
         "recommended_next_action": recommended_next_action,
         "request_status": "queued",
-        "profile": "research_only",
-        "budget": "micro",
+        "profile": "bounded_execution",
+        "budget": "standard",
         "source_artifact": source_artifact,
         "feedback_decision": current_plan.get("feedback_decision"),
         "lessons_context": lessons_context,
@@ -2880,8 +2880,8 @@ def _build_task_plan_snapshot(
                 "acceptance": "create one bounded subagent request that reviews the HADI materialized improvement artifact and reports a verification recommendation",
                 "selection_source": "generated_from_hadi_materialized_improvement_completion",
                 "parent_task_id": MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
-                "subagent_profile": "research_only",
-                "subagent_budget": "micro",
+                "subagent_profile": "bounded_execution",
+                "subagent_budget": "standard",
             }
             if not any(task.get("task_id") == next_candidate.get("task_id") for task in tasks):
                 tasks.append(dict(next_candidate))

--- a/tests/test_subagent_profile_bounded_execution.py
+++ b/tests/test_subagent_profile_bounded_execution.py
@@ -1,0 +1,167 @@
+"""
+Tests for issue #510: subagent-verify-materialized-improvement must use
+bounded_execution profile and standard budget (not research_only / micro).
+
+research_only prevents the LLM from using write/exec tools, causing subagents
+to exit with 0 meaningful tool calls. bounded_execution grants full tool access.
+micro budget (~2 tool calls) is insufficient for: git pull + implement + test +
+git commit + MEMORY.md update.
+"""
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nanobot.runtime.coordinator import (
+    _derive_generated_candidates,
+    _write_materialized_improvement_artifact,
+)
+
+MATERIALIZE_SYNTHESIZED_ID = "materialize-synthesized-improvement"
+VERIFY_TASK_ID = "subagent-verify-materialized-improvement"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_goals_dir(tmp_path: Path) -> Path:
+    """Create a minimal goals directory with empty history."""
+    goals_dir = tmp_path / "goals"
+    (goals_dir / "history").mkdir(parents=True)
+    return goals_dir
+
+
+def _get_verify_candidates(goals_dir: Path, parent_task_id: str) -> list[dict]:
+    candidates = _derive_generated_candidates(
+        goals_dir=goals_dir,
+        result_status="PASS",
+        current_task_id=parent_task_id,
+    )
+    return [c for c in candidates if c.get("task_id") == VERIFY_TASK_ID]
+
+
+# ---------------------------------------------------------------------------
+# Tests — _derive_generated_candidates
+# ---------------------------------------------------------------------------
+
+class TestSubagentVerifyProfile:
+
+    def test_verify_candidate_profile_is_bounded_execution_from_materialize_pass(self, tmp_path):
+        """materialize-pass-streak-improvement → verify candidate uses bounded_execution."""
+        goals_dir = _make_goals_dir(tmp_path)
+        candidates = _get_verify_candidates(goals_dir, "materialize-pass-streak-improvement")
+        assert candidates, f"No {VERIFY_TASK_ID} candidate generated"
+        for c in candidates:
+            assert c.get("subagent_profile") == "bounded_execution", (
+                f"Got {c.get('subagent_profile')!r}, expected bounded_execution"
+            )
+
+    def test_verify_candidate_budget_is_standard_from_materialize_pass(self, tmp_path):
+        """materialize-pass-streak-improvement → verify candidate uses standard budget."""
+        goals_dir = _make_goals_dir(tmp_path)
+        candidates = _get_verify_candidates(goals_dir, "materialize-pass-streak-improvement")
+        assert candidates
+        for c in candidates:
+            assert c.get("subagent_budget") == "standard", (
+                f"Got {c.get('subagent_budget')!r}, expected standard"
+            )
+
+    def test_verify_candidate_profile_from_synthesized_materialization(self, tmp_path):
+        """materialize-synthesized-improvement → verify candidate uses bounded_execution."""
+        goals_dir = _make_goals_dir(tmp_path)
+        candidates = _get_verify_candidates(goals_dir, MATERIALIZE_SYNTHESIZED_ID)
+        assert candidates, f"No {VERIFY_TASK_ID} from {MATERIALIZE_SYNTHESIZED_ID}"
+        for c in candidates:
+            assert c.get("subagent_profile") == "bounded_execution"
+            assert c.get("subagent_budget") == "standard"
+
+    def test_no_research_only_in_any_verify_candidate(self, tmp_path):
+        """Confirm research_only is absent from all verify candidates."""
+        goals_dir = _make_goals_dir(tmp_path)
+        for parent in ["materialize-pass-streak-improvement", MATERIALIZE_SYNTHESIZED_ID]:
+            candidates = _get_verify_candidates(goals_dir, parent)
+            for c in candidates:
+                assert c.get("subagent_profile") != "research_only", (
+                    f"research_only found in candidate from {parent} — blocks tool use"
+                )
+
+    def test_no_micro_budget_in_any_verify_candidate(self, tmp_path):
+        """Confirm micro budget is absent from all verify candidates."""
+        goals_dir = _make_goals_dir(tmp_path)
+        for parent in ["materialize-pass-streak-improvement", MATERIALIZE_SYNTHESIZED_ID]:
+            candidates = _get_verify_candidates(goals_dir, parent)
+            for c in candidates:
+                assert c.get("subagent_budget") != "micro", (
+                    f"micro budget found in candidate from {parent} — insufficient for commit flow"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Tests — _write_materialized_improvement_artifact (profile in request JSON)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Tests — _write_subagent_request_artifact (profile in queued request JSON)
+# ---------------------------------------------------------------------------
+
+class TestWriteSubagentRequestProfile:
+
+    def test_subagent_request_file_profile_is_bounded_execution(self, tmp_path):
+        """The queued request JSON in state/subagents/requests/ must use bounded_execution."""
+        from nanobot.runtime.coordinator import _write_subagent_request_artifact
+
+        state_root = tmp_path / "state"
+        requests_dir = state_root / "subagents" / "requests"
+        requests_dir.mkdir(parents=True)
+        (state_root / "improvements").mkdir(parents=True)
+
+        # Create a dummy improvement artifact so source_artifact is found
+        art_path = state_root / "improvements" / "materialized-cycle-test456.json"
+        art_path.write_text(json.dumps({"cycle_id": "cycle-test456"}), encoding="utf-8")
+
+        current_plan = {
+            "current_task_id": "subagent-verify-materialized-improvement",
+            "tasks": [
+                {
+                    "task_id": "subagent-verify-materialized-improvement",
+                    "title": "Verify the artifact",
+                    "subagent_profile": "bounded_execution",
+                    "subagent_budget": "standard",
+                }
+            ],
+            "materialized_improvement_artifact_path": str(art_path),
+        }
+
+        result = _write_subagent_request_artifact(
+            state_root=state_root,
+            cycle_id="cycle-test456",
+            goal_id="goal-bootstrap",
+            current_plan=current_plan,
+        )
+        assert result is not None, "Expected request path, got None"
+        data = json.loads(Path(result).read_text(encoding="utf-8"))
+        assert data["profile"] == "bounded_execution", (
+            f"profile={data['profile']!r}, expected bounded_execution"
+        )
+        assert data["budget"] == "standard", (
+            f"budget={data['budget']!r}, expected standard"
+        )
+
+    def test_subagent_request_not_written_for_wrong_task(self, tmp_path):
+        """_write_subagent_request_artifact returns None for non-verify tasks."""
+        from nanobot.runtime.coordinator import _write_subagent_request_artifact
+
+        state_root = tmp_path / "state"
+        (state_root / "subagents" / "requests").mkdir(parents=True)
+
+        current_plan = {"current_task_id": "synthesize-next-improvement-candidate"}
+        result = _write_subagent_request_artifact(
+            state_root=state_root,
+            cycle_id="cycle-other",
+            goal_id="goal-bootstrap",
+            current_plan=current_plan,
+        )
+        assert result is None


### PR DESCRIPTION
Closes #510

## Problem

All `subagent-verify-materialized-improvement` requests were created with `profile=research_only, budget=micro`. The LLM inferred it should not use write/exec tools and exited immediately with 0 tool calls and `"no final response was generated"`.

## Changes

Three sites in `nanobot/runtime/coordinator.py` updated:

| Location | Before | After |
|---|---|---|
| `_derive_generated_candidates()` line ~1979 | `research_only` / `micro` | `bounded_execution` / `standard` |
| `_write_subagent_request_artifact()` line ~2311 | `research_only` / `micro` | `bounded_execution` / `standard` |
| HADI completion `next_candidate` line ~2883 | `research_only` / `micro` | `bounded_execution` / `standard` |

## Why these values

- `bounded_execution`: grants `write_file`, `edit_file`, `exec`, `list_dir`, `read_file` tools
- `standard` budget: sufficient for git pull → implement → test → commit → MEMORY.md update

## Tests

7 new tests in `tests/test_subagent_profile_bounded_execution.py`:
- 5 tests on candidate generation (both parent task IDs)
- 2 tests on `_write_subagent_request_artifact` output JSON