### PR TITLE
feat(memory): auto-seed backlog from research/feed.json when empty (#517)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2084,6 +2084,36 @@ def _parse_backlog_task_from_memory(selfevo_repo_root: Path) -> dict[str, Any] |
     return None
 
 
+def _pick_candidate_from_research_feed(state_root: Path) -> dict[str, Any] | None:
+    """Read state/research/feed.json and return the top entry as a backlog_task dict.
+
+    Returns None if feed is missing, empty, or unreadable.
+    Used as fallback when MEMORY.md backlog is exhausted (all priorities Done).
+    """
+    feed_path = state_root / "research" / "feed.json"
+    if not feed_path.exists():
+        return None
+    try:
+        raw = feed_path.read_text(encoding="utf-8", errors="replace")
+        feed = json.loads(raw)
+    except Exception:
+        return None
+    entries = feed.get("entries") if isinstance(feed.get("entries"), list) else []
+    if not entries:
+        return None
+    top = entries[0]
+    title = str(top.get("title") or top.get("hypothesis") or "Research candidate").strip()
+    acceptance = str(top.get("acceptance") or top.get("action") or "").strip()
+    instructions = acceptance or f"Implement: {title}"
+    # Use a synthetic high priority number so it sorts after real backlog
+    return {
+        "priority": 99,
+        "title": title,
+        "instructions": instructions,
+        "source": "research_feed",
+    }
+
+
 def _write_materialized_improvement_artifact(
     *,
     state_root: Path,
@@ -2110,6 +2140,10 @@ def _write_materialized_improvement_artifact(
     _selfevo_root = selfevo_repo_root or (state_root.parent / "eeebot-self-evolving")
     if _selfevo_root.is_dir():
         backlog_task = _parse_backlog_task_from_memory(_selfevo_root)
+
+    # Fallback: if backlog is empty (all Done), pick top candidate from research/feed.json
+    if backlog_task is None:
+        backlog_task = _pick_candidate_from_research_feed(state_root)
 
     concrete_statement = (
         "A synthesized review lane was materialized into a concrete bounded improvement artifact."

--- a/scripts/eeepc_self_evolving_subagent_bridge.py
+++ b/scripts/eeepc_self_evolving_subagent_bridge.py
@@ -403,6 +403,106 @@ async def main():
     return 0
 
 
+def _active_backlog_is_empty(memory_text: str) -> bool:
+    """Return True if ## Active backlog section has no undone Priority blocks."""
+    import re as _re
+    # Extract Active backlog section (between BACKLOG_START and BACKLOG_END comments, or between headers)
+    section_match = _re.search(
+        r'## Active backlog.*?(?=\n## |\Z)',
+        memory_text,
+        _re.DOTALL,
+    )
+    if not section_match:
+        return True  # no active section → treat as empty
+    section = section_match.group(0)
+    # Check for any Priority block NOT marked Done
+    undone = _re.findall(r'###\s+Priority\s+\d+:(?!.*\[Done\])', section)
+    return len(undone) == 0
+
+
+def _auto_seed_backlog_from_research(
+    repo_root: Path,
+    memory_text: str,
+    memory_path: Path,
+) -> bool:
+    """If Active backlog is empty, add 2 new priorities from state/research/feed.json.
+
+    Returns True if MEMORY.md was updated.
+    """
+    import re as _re
+    import json as _json
+
+    if not _active_backlog_is_empty(memory_text):
+        return False
+
+    # Find research/feed.json — state root is ../state relative to repo
+    # Convention: repo at .../eeebot-self-evolving, state at .../state
+    state_root = repo_root.parent / 'state'
+    feed_path = state_root / 'research' / 'feed.json'
+    if not feed_path.exists():
+        return False
+
+    try:
+        feed = _json.loads(feed_path.read_text(encoding='utf-8'))
+    except Exception:
+        return False
+
+    entries = feed.get('entries') if isinstance(feed.get('entries'), list) else []
+    if not entries:
+        return False
+
+    # Find next priority number
+    existing_nums = [int(m) for m in _re.findall(r'###\s+Priority\s+(\d+):', memory_text)]
+    next_num = max(existing_nums, default=8) + 1
+
+    new_blocks: list[str] = []
+    added = 0
+    for entry in entries:
+        if added >= 2:
+            break
+        title = str(entry.get('title') or entry.get('hypothesis') or '').strip()
+        if not title or title in memory_text:
+            continue
+        acceptance = str(entry.get('acceptance') or entry.get('action') or '').strip()
+        instructions = acceptance or f'Research candidate from synthesize cycle: {title}'
+        block = (
+            f'### Priority {next_num}: {title}\n'
+            f'{instructions}\n'
+            f'Test: verify the change runs without errors.\n'
+            f'Commit: git add <file> && git commit -m "feat: {title[:50]}"\n'
+        )
+        new_blocks.append(block)
+        next_num += 1
+        added += 1
+
+    if not new_blocks:
+        return False
+
+    # Insert new blocks before BACKLOG_END comment (or before ## Completed)
+    insertion = '\n'.join(new_blocks)
+    if '<!-- BACKLOG_END -->' in memory_text:
+        updated = memory_text.replace(
+            '<!-- BACKLOG_END -->',
+            insertion + '\n<!-- BACKLOG_END -->',
+            1,
+        )
+    elif '## Completed' in memory_text:
+        updated = memory_text.replace(
+            '## Completed',
+            insertion + '\n---\n\n## Completed',
+            1,
+        )
+    else:
+        updated = memory_text.rstrip() + '\n\n' + insertion
+
+    if updated == memory_text:
+        return False
+
+    memory_path.write_text(updated, encoding='utf-8')
+    print(f'bridge-memory: auto-seeded {added} priorities from research/feed.json')
+    return True
+
+
 def _move_priority_to_completed(
     text: str,
     title_escaped: str,
@@ -526,7 +626,23 @@ def _try_mark_backlog_done(
         _git + ['commit', '-m', f'chore: move "{backlog_title[:60]}" to Completed (bridge safety-net)'],
         capture_output=True, text=True,
     )
-    return result.returncode == 0
+    committed = result.returncode == 0
+
+    # Auto-seed: if Active backlog is now empty, add new priorities from research feed
+    if committed:
+        try:
+            fresh_text = memory_path.read_text(encoding='utf-8')
+            seeded = _auto_seed_backlog_from_research(repo_root, fresh_text, memory_path)
+            if seeded:
+                _sp.run(_git + ['add', 'memory/MEMORY.md'], capture_output=True)
+                _sp.run(
+                    _git + ['commit', '-m', 'chore: auto-seed backlog from research/feed.json (backlog empty)'],
+                    capture_output=True,
+                )
+        except Exception:
+            pass  # never block on auto-seed failure
+
+    return committed
 
 
 def _write_bridge_completed_result(

--- a/tests/test_research_feed_backlog_fallback.py
+++ b/tests/test_research_feed_backlog_fallback.py
@@ -1,0 +1,212 @@
+"""Tests for Issue #517: auto-seed backlog from research/feed.json when empty,
+and _pick_candidate_from_research_feed coordinator fallback."""
+from __future__ import annotations
+import ast
+import json
+import re
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# ── Bridge function extraction (avoid full loguru import) ─────────────────────
+
+def _load_bridge_functions(*names: str):
+    """Extract named functions from bridge script via AST without importing module."""
+    bridge_path = Path(__file__).parent.parent / "scripts" / "eeepc_self_evolving_subagent_bridge.py"
+    source = bridge_path.read_text()
+    ns: dict = {"re": re, "Path": Path, "json": json}
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name in names:
+            func_src = ast.get_source_segment(source, node)
+            exec(func_src, ns)  # noqa: S102
+    return ns
+
+
+# ── Test 1: _active_backlog_is_empty ─────────────────────────────────────────
+
+def test_active_backlog_is_empty_when_all_done():
+    ns = _load_bridge_functions("_active_backlog_is_empty")
+    text = """\
+## Active backlog — pick one each session
+
+### Priority 9: Task A [Done]
+Done.
+
+### Priority 10: Task B [Done]
+Done too.
+
+## Completed
+"""
+    assert ns["_active_backlog_is_empty"](text) is True
+
+
+def test_active_backlog_not_empty_when_undone():
+    ns = _load_bridge_functions("_active_backlog_is_empty")
+    text = """\
+## Active backlog — pick one each session
+
+### Priority 9: Task A
+Not done yet.
+
+### Priority 10: Task B [Done]
+Done.
+"""
+    assert ns["_active_backlog_is_empty"](text) is False
+
+
+# ── Test 2: _auto_seed_backlog_from_research ──────────────────────────────────
+
+def _make_env(tmp: Path, memory_text: str, feed_entries: list | None = None) -> tuple:
+    """Create test repo structure with optional research feed."""
+    repo = tmp / "eeebot-self-evolving"
+    state = tmp / "state"
+    (repo / "memory").mkdir(parents=True)
+    (state / "research").mkdir(parents=True)
+    memory_path = repo / "memory" / "MEMORY.md"
+    memory_path.write_text(memory_text)
+
+    if feed_entries is not None:
+        feed = {
+            "schema_version": "research-feed-v1",
+            "cycle_id": "cycle-test",
+            "goal_id": "goal-bootstrap",
+            "entry_count": len(feed_entries),
+            "entries": feed_entries,
+        }
+        (state / "research" / "feed.json").write_text(json.dumps(feed))
+
+    return repo, state, memory_path
+
+
+ALL_DONE_MEMORY = """\
+# Project Memory
+
+## Active backlog — pick one each session
+
+<!-- BACKLOG_START -->
+<!-- BACKLOG_END -->
+
+---
+
+## Completed
+
+### Priority 8: Old task [Done]
+Done.
+"""
+
+FEED_ENTRIES = [
+    {
+        "id": "exploit-dashboard",
+        "title": "Exploit and expand dashboard improvements",
+        "hypothesis": "Dashboard improvements drive operator value",
+        "acceptance": "Extend scripts/eeebot_dashboard.py with new metrics",
+        "action": "Add 3 new metrics to dashboard CLI output",
+    },
+    {
+        "id": "inspect-pass-streak",
+        "title": "Inspect PASS streak for new bounded improvement",
+        "acceptance": "Identify a concrete bounded improvement from the PASS streak",
+        "action": "Analyze recent reward trend and propose next experiment",
+    },
+]
+
+
+def test_auto_seed_adds_priorities_when_empty():
+    """Auto-seed inserts 2 new Priority blocks when backlog is empty."""
+    ns = _load_bridge_functions(
+        "_active_backlog_is_empty",
+        "_auto_seed_backlog_from_research",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        repo, state, memory_path = _make_env(Path(td), ALL_DONE_MEMORY, FEED_ENTRIES)
+        result = ns["_auto_seed_backlog_from_research"](repo, ALL_DONE_MEMORY, memory_path)
+        assert result is True, "Should return True when seeding"
+        new_text = memory_path.read_text()
+        # Two new Priority blocks added
+        priorities = re.findall(r"### Priority (\d+):", new_text)
+        active_section = new_text.split("## Completed")[0]
+        active_priorities = re.findall(r"### Priority (\d+):", active_section)
+        assert len(active_priorities) >= 2, f"Expected 2 new priorities, got: {active_priorities}"
+        assert "Exploit and expand dashboard" in new_text
+        assert "Inspect PASS streak" in new_text
+
+
+def test_auto_seed_skips_when_backlog_has_undone():
+    """Auto-seed does nothing when Active backlog has undone priorities."""
+    ns = _load_bridge_functions(
+        "_active_backlog_is_empty",
+        "_auto_seed_backlog_from_research",
+    )
+    memory_with_active = ALL_DONE_MEMORY.replace(
+        "<!-- BACKLOG_END -->",
+        "### Priority 9: Active task\nNot done yet.\n<!-- BACKLOG_END -->",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        repo, state, memory_path = _make_env(Path(td), memory_with_active, FEED_ENTRIES)
+        result = ns["_auto_seed_backlog_from_research"](repo, memory_with_active, memory_path)
+        assert result is False, "Should skip when backlog has active priorities"
+        assert memory_path.read_text() == memory_with_active
+
+
+def test_auto_seed_graceful_when_no_feed():
+    """Auto-seed returns False gracefully when feed.json missing."""
+    ns = _load_bridge_functions(
+        "_active_backlog_is_empty",
+        "_auto_seed_backlog_from_research",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        repo, state, memory_path = _make_env(Path(td), ALL_DONE_MEMORY, feed_entries=None)
+        result = ns["_auto_seed_backlog_from_research"](repo, ALL_DONE_MEMORY, memory_path)
+        assert result is False
+
+
+# ── Test 3: coordinator _pick_candidate_from_research_feed ───────────────────
+
+def test_pick_candidate_from_feed_returns_top_entry():
+    """_pick_candidate_from_research_feed returns top entry as backlog_task."""
+    from nanobot.runtime.coordinator import _pick_candidate_from_research_feed
+
+    with tempfile.TemporaryDirectory() as td:
+        state_root = Path(td)
+        (state_root / "research").mkdir()
+        feed = {
+            "schema_version": "research-feed-v1",
+            "entry_count": 2,
+            "entries": FEED_ENTRIES,
+        }
+        (state_root / "research" / "feed.json").write_text(json.dumps(feed))
+
+        result = _pick_candidate_from_research_feed(state_root)
+        assert result is not None
+        assert "Exploit" in result["title"]
+        assert result["priority"] == 99
+        assert result["source"] == "research_feed"
+
+
+def test_pick_candidate_returns_none_when_no_feed():
+    """_pick_candidate_from_research_feed returns None when feed missing."""
+    from nanobot.runtime.coordinator import _pick_candidate_from_research_feed
+
+    with tempfile.TemporaryDirectory() as td:
+        result = _pick_candidate_from_research_feed(Path(td))
+        assert result is None
+
+
+def test_pick_candidate_returns_none_when_feed_empty():
+    """_pick_candidate_from_research_feed returns None when feed has no entries."""
+    from nanobot.runtime.coordinator import _pick_candidate_from_research_feed
+
+    with tempfile.TemporaryDirectory() as td:
+        state_root = Path(td)
+        (state_root / "research").mkdir()
+        feed = {"schema_version": "research-feed-v1", "entry_count": 0, "entries": []}
+        (state_root / "research" / "feed.json").write_text(json.dumps(feed))
+
+        result = _pick_candidate_from_research_feed(state_root)
+        assert result is None


### PR DESCRIPTION
Closes #517

## Changes
- **coordinator**: `_pick_candidate_from_research_feed()` — reads `state/research/feed.json`, returns top entry as `backlog_task` fallback when MEMORY.md backlog is exhausted
- **coordinator**: `_write_materialized_improvement_artifact()` — falls back to research feed when all priorities Done
- **bridge**: `_auto_seed_backlog_from_research()` — inserts 2 new Priority blocks from feed into MEMORY.md after backlog empties
- **bridge**: `_active_backlog_is_empty()` — detects empty Active backlog section

## Tests: 8/8 PASS
```
python3 -m pytest tests/test_research_feed_backlog_fallback.py -v
```