### PR TITLE
feat(coordinator): curriculum-style staged backlog (#525)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2041,10 +2041,66 @@ def _inferred_generated_candidates_from_tasks(tasks: list[dict[str, Any]]) -> li
     return inferred
 
 
+def _curriculum_level(selfevo_repo_root: Path) -> int:
+    """Return the curriculum level: the priority number of the first non-Done backlog item.
+
+    Checks both [Done] marker in title AND git log (via a simple search for the title words
+    in recent commits).  Returns 9999 if all priorities are done (backlog exhausted).
+    Inspired by Darwin Mode curriculum.ts: only admit difficulty <= L, raise L when mastered.
+    """
+    memory_path = selfevo_repo_root / "memory" / "MEMORY.md"
+    if not memory_path.exists():
+        return 9  # default: start at P9
+    try:
+        text = memory_path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return 9
+
+    import re as _re
+    import subprocess as _sp
+
+    backlog_match = _re.search(r"## (?:Concrete backlog|Active backlog).*?(?=\n## |\Z)", text, _re.DOTALL)
+    if not backlog_match:
+        return 9
+    backlog_text = backlog_match.group(0)
+
+    priority_blocks = _re.findall(
+        r"###\s+Priority\s+(\d+):\s+(.+?)\n(.*?)(?=###\s+Priority|\Z)",
+        backlog_text,
+        _re.DOTALL,
+    )
+
+    git_cmd = [
+        "git", "-c", f"safe.directory={selfevo_repo_root}",
+        "-C", str(selfevo_repo_root),
+        "log", "--oneline", "--since=14 days ago",
+    ]
+    try:
+        git_log = _sp.check_output(git_cmd, stderr=_sp.DEVNULL, timeout=10).decode(errors="replace")
+    except Exception:
+        git_log = ""
+
+    for num, title, _body in priority_blocks:
+        title = title.strip()
+        # Done by explicit marker
+        if _re.search(r"\[Done\]", title, _re.IGNORECASE):
+            continue
+        # Done by git log: ≥2 keywords (4+ chars) found in recent commits
+        if git_log:
+            words = [w.lower() for w in _re.findall(r'[A-Za-z]{4,}', title)]
+            if len(words) >= 2:
+                matches = sum(1 for w in words if w in git_log.lower())
+                if matches >= 2:
+                    continue  # treat as done
+        return int(num)
+    return 9999  # all done
+
+
 def _parse_backlog_task_from_memory(selfevo_repo_root: Path) -> dict[str, Any] | None:
     """Read the first incomplete priority from memory/MEMORY.md in eeebot-self-evolving.
 
     Returns a dict with 'title', 'instructions', 'priority' or None if unavailable.
+    Enforces curriculum ordering: only returns the task at the current curriculum level.
     """
     memory_path = selfevo_repo_root / "memory" / "MEMORY.md"
     if not memory_path.exists():
@@ -2073,6 +2129,15 @@ def _parse_backlog_task_from_memory(selfevo_repo_root: Path) -> dict[str, Any] |
         # Skip if marked as Done — check ONLY the title line (not body, which may reference [Done])
         if _re.search(r"\[Done\]", title, _re.IGNORECASE):
             continue
+        # Curriculum gate: only return task at or below current curriculum level
+        curr_level = _curriculum_level(selfevo_repo_root)
+        if int(num) > curr_level:
+            # Higher-difficulty task blocked until current level is mastered
+            _logger.debug(
+                "[curriculum] blocking Priority %s (current level=%s) — master P%s first",
+                num, curr_level, curr_level,
+            )
+            return None
         # Extract first meaningful instruction line (not empty, not a label)
         instructions_lines = [ln.strip() for ln in body.splitlines() if ln.strip() and not ln.strip().startswith("#")]
         instructions = " ".join(instructions_lines[:3])  # first 3 lines as summary
@@ -2080,6 +2145,7 @@ def _parse_backlog_task_from_memory(selfevo_repo_root: Path) -> dict[str, Any] |
             "priority": int(num),
             "title": title,
             "instructions": instructions,
+            "curriculum_level": curr_level,
         }
     return None
 

--- a/scripts/eeepc_self_evolving_subagent_bridge.py
+++ b/scripts/eeepc_self_evolving_subagent_bridge.py
@@ -263,10 +263,16 @@ def build_task(req: dict, goal_text: str, report_source: str,
             lines += prev_lines
 
     if backlog_title and backlog_instructions:
+        curriculum_level = artifact_data.get('next_bounded_candidate', {}).get('curriculum_level')
+        curriculum_note = (
+            f'Curriculum level: P{curriculum_level} — complete THIS priority before attempting any higher-numbered priority.'
+            if curriculum_level else ''
+        )
         lines += [
             '## Concrete task to implement',
             f'Priority: {backlog_priority}' if backlog_priority else '',
             f'Title: {backlog_title}',
+            curriculum_note,
             '',
             backlog_instructions,
             '',

--- a/tests/test_curriculum_backlog.py
+++ b/tests/test_curriculum_backlog.py
@@ -1,0 +1,171 @@
+"""Tests for #525: curriculum-style staged backlog.
+
+Verifies that _curriculum_level() and _parse_backlog_task_from_memory()
+enforce Darwin-Mode-style progression: only return task at the current
+curriculum level; block higher-numbered priorities until lower ones are done.
+"""
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.runtime.coordinator import (
+    _curriculum_level,
+    _parse_backlog_task_from_memory,
+)
+
+
+MEMORY_P9_DONE_P10_ACTIVE = textwrap.dedent("""\
+    # Project Memory
+
+    ## Active backlog
+
+    ### Priority 9: Restructure MEMORY.md [Done]
+    File: memory/MEMORY.md
+    Move done blocks to Completed section.
+
+    ### Priority 10: HISTORY.md newest-first — update cycle_logger.py to prepend
+    File: scripts/cycle_logger.py (already exists).
+    Change append_cycle_summary() to prepend new entries.
+
+    ### Priority 11: Auto-seed backlog from research/feed.json
+    File: scripts/eeepc_self_evolving_subagent_bridge.py
+    After marking last priority Done, auto-seed.
+
+    ## Completed
+    """)
+
+MEMORY_P9_ACTIVE = textwrap.dedent("""\
+    # Project Memory
+
+    ## Active backlog
+
+    ### Priority 9: Restructure MEMORY.md — active backlog first
+    File: memory/MEMORY.md
+    Move done blocks to Completed section.
+
+    ### Priority 10: HISTORY.md newest-first
+    File: scripts/cycle_logger.py
+
+    ## Completed
+    """)
+
+MEMORY_ALL_DONE = textwrap.dedent("""\
+    # Project Memory
+
+    ## Active backlog
+
+    ### Priority 9: Restructure MEMORY.md [Done]
+    File: memory/MEMORY.md
+
+    ### Priority 10: HISTORY.md newest-first [Done]
+    File: scripts/cycle_logger.py
+
+    ## Completed
+    """)
+
+
+def _make_selfevo(tmp_path: Path, content: str) -> Path:
+    """Create a fake eeebot-self-evolving with a MEMORY.md."""
+    repo = tmp_path / "eeebot-self-evolving"
+    (repo / "memory").mkdir(parents=True)
+    (repo / "memory" / "MEMORY.md").write_text(content)
+    return repo
+
+
+# ─── _curriculum_level tests ──────────────────────────────────────────────────
+
+def test_curriculum_level_p9_done_returns_10(tmp_path):
+    """P9 has [Done] marker → curriculum level = 10."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_DONE_P10_ACTIVE)
+    with patch("subprocess.check_output", return_value=b""):
+        level = _curriculum_level(repo)
+    assert level == 10
+
+
+def test_curriculum_level_p9_active_returns_9(tmp_path):
+    """P9 has no [Done] marker → curriculum level = 9."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_ACTIVE)
+    with patch("subprocess.check_output", return_value=b""):
+        level = _curriculum_level(repo)
+    assert level == 9
+
+
+def test_curriculum_level_all_done_returns_9999(tmp_path):
+    """All priorities Done → level = 9999 (backlog exhausted)."""
+    repo = _make_selfevo(tmp_path, MEMORY_ALL_DONE)
+    with patch("subprocess.check_output", return_value=b""):
+        level = _curriculum_level(repo)
+    assert level == 9999
+
+
+def test_curriculum_level_git_detection(tmp_path):
+    """P9 found via git log keywords → treated as done, level advances to 10."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_ACTIVE)
+    # Simulate git log showing P9-related commit
+    fake_log = b"abc1234 restructure MEMORY.md backlog first\n"
+    with patch("subprocess.check_output", return_value=fake_log):
+        level = _curriculum_level(repo)
+    assert level == 10
+
+
+def test_curriculum_level_missing_memory(tmp_path):
+    """Missing MEMORY.md → returns default level 9."""
+    repo = tmp_path / "eeebot-self-evolving"
+    repo.mkdir()
+    level = _curriculum_level(repo)
+    assert level == 9
+
+
+# ─── _parse_backlog_task_from_memory with curriculum gate ─────────────────────
+
+def test_parse_returns_p10_when_p9_done(tmp_path):
+    """When P9 is [Done], parse returns P10."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_DONE_P10_ACTIVE)
+    with patch("subprocess.check_output", return_value=b""):
+        result = _parse_backlog_task_from_memory(repo)
+    assert result is not None
+    assert result["priority"] == 10
+    assert "curriculum_level" in result
+    assert result["curriculum_level"] == 10
+
+
+def test_parse_returns_p9_when_active(tmp_path):
+    """When P9 is active, parse returns P9 (not P10)."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_ACTIVE)
+    with patch("subprocess.check_output", return_value=b""):
+        result = _parse_backlog_task_from_memory(repo)
+    assert result is not None
+    assert result["priority"] == 9
+
+
+def test_parse_blocks_p11_when_p10_active(tmp_path):
+    """P10 active but P11 is in backlog — parse must NOT return P11."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_DONE_P10_ACTIVE)
+    with patch("subprocess.check_output", return_value=b""):
+        result = _parse_backlog_task_from_memory(repo)
+    # Should return P10, never P11
+    assert result is not None
+    assert result["priority"] == 10
+
+
+def test_parse_returns_none_when_all_done(tmp_path):
+    """All priorities Done → parse returns None (triggers research feed fallback)."""
+    repo = _make_selfevo(tmp_path, MEMORY_ALL_DONE)
+    with patch("subprocess.check_output", return_value=b""):
+        result = _parse_backlog_task_from_memory(repo)
+    assert result is None
+
+
+def test_parse_includes_curriculum_level_in_result(tmp_path):
+    """Result dict must include curriculum_level field for build_task() to use."""
+    repo = _make_selfevo(tmp_path, MEMORY_P9_DONE_P10_ACTIVE)
+    with patch("subprocess.check_output", return_value=b""):
+        result = _parse_backlog_task_from_memory(repo)
+    assert result is not None
+    assert "curriculum_level" in result
+    assert isinstance(result["curriculum_level"], int)


### PR DESCRIPTION
Closes #525

## Changes
- `nanobot/runtime/coordinator.py`: new `_curriculum_level()` + updated `_parse_backlog_task_from_memory()`
- `scripts/eeepc_self_evolving_subagent_bridge.py`: `build_task()` shows curriculum level
- `tests/test_curriculum_backlog.py`: 10 tests, all pass

Inspired by Darwin Mode curriculum.ts: *admit only difficulty ≤ L, raise L once population masters current tier.*