### PR TITLE
feat(bridge): bounded mutation surfaces (#528)

### DIFF
--- a/scripts/eeepc_self_evolving_subagent_bridge.py
+++ b/scripts/eeepc_self_evolving_subagent_bridge.py
@@ -322,6 +322,24 @@ def build_task(req: dict, goal_text: str, report_source: str,
         'You have up to 15 iterations. Use them.',
     ]
 
+    # Mutation surfaces: list the 7 approved surfaces for structured evolution
+    lines += [
+        '',
+        '## Mutation surfaces (preferred targets for improvements)',
+        'These 7 files define evolvable aspects of agent behaviour.',
+        'Prefer editing files in surfaces/ for clean, bounded changes:',
+        '  surfaces/task_selector.json    — how coordinator picks the next task',
+        '  surfaces/prompt_template.md    — main subagent instruction template',
+        '  surfaces/retry_policy.json     — max retries, backoff, give-up criteria',
+        '  surfaces/tool_policy.json      — which tools subagent may use',
+        '  surfaces/memory_policy.json    — what to read from MEMORY.md',
+        '  surfaces/score_weights.json    — reward component weights',
+        '  surfaces/lesson_policy.json    — when and what to record as a lesson',
+        'You may also edit scripts/ and memory/ files when the task requires it.',
+        'Do NOT modify: state/, .env files, tokens, secrets, or systemd units.',
+        '',
+    ]
+
     # Repair context: injected when previous commit broke tests (closed-loop repair loop)
     if repair_context:
         lines += [
@@ -520,6 +538,14 @@ async def main():
                             capture_output=True, text=True)
             if _diff.returncode == 0:
                 files_changed = [f for f in _diff.stdout.splitlines() if f.strip()]
+                # Validate mutation surfaces (warn but don't block)
+                _violations = _validate_mutation_surfaces(files_changed)
+                if _violations:
+                    print(f'mutation surfaces: {len(_violations)} violation(s):')
+                    for v in _violations:
+                        print(f'  ! {v}')
+                else:
+                    print(f'mutation surfaces: clean ({len(files_changed)} file(s) changed)')
             _push = _sp.run(_git_se + ['push', 'origin', 'main'],
                             capture_output=True, text=True)
             if _push.returncode == 0:
@@ -674,6 +700,42 @@ async def main():
             pass  # never block on lesson recording failure
 
     return 0
+
+
+# Blocked filename substrings — any changed file matching these is a violation
+_BLOCKED_FILE_PATTERNS = (
+    '.env', 'secret', 'credential', 'token', 'private_key',
+    'id_rsa', '.git', '.npmrc', 'package-lock', 'yarn.lock',
+)
+
+# Allowed path prefixes for changed files (relative to repo root)
+_ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/')
+
+
+def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
+    """Validate that changed files respect the bounded mutation surface contract.
+
+    Returns a list of VIOLATIONS (empty list = clean).
+    Violations are logged as warnings but do NOT block execution in v1.
+
+    Inspired by Darwin Mode safety.ts (ruvnet/agent-harness-generator):
+    BLOCKED_FILENAME_PATTERNS, APPROVED_FILES, inspectVariant().
+    """
+    violations: list[str] = []
+    for f in changed_files:
+        lower = f.lower()
+        # Blocked filename patterns
+        for pat in _BLOCKED_FILE_PATTERNS:
+            if pat in lower:
+                violations.append(f'blocked filename pattern "{pat}" in: {f}')
+                break
+        else:
+            # Must be in an allowed path prefix
+            if not any(f.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES):
+                violations.append(
+                    f'file outside allowed paths {_ALLOWED_PATH_PREFIXES}: {f}'
+                )
+    return violations
 
 
 def _run_smoke_tests(repo_root: 'Path', timeout: int = 60) -> 'tuple[bool, str]':

--- a/tests/test_mutation_surfaces.py
+++ b/tests/test_mutation_surfaces.py
@@ -1,0 +1,134 @@
+"""Tests for #528: bounded mutation surfaces validation.
+
+Verifies _validate_mutation_surfaces() correctly flags violations and
+allows clean changes. Also checks that build_task() prompt includes
+the mutation surfaces section.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_BRIDGE_PATH = Path(__file__).parent.parent / 'scripts' / 'eeepc_self_evolving_subagent_bridge.py'
+
+
+def _extract_fn(name: str, extra_setup: str = '') -> object:
+    source = _BRIDGE_PATH.read_text()
+    tree = ast.parse(source)
+    func_src = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            func_src = ast.get_source_segment(source, node)
+            break
+    assert func_src, f'{name} not found in bridge'
+    # Also extract module-level constants needed by the function
+    constants = ''
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            src = ast.get_source_segment(source, node)
+            if src and any(
+                n in src for n in ('_BLOCKED_FILE_PATTERNS', '_ALLOWED_PATH_PREFIXES')
+            ):
+                constants += src + '\n'
+    ns: dict = {}
+    exec(f'{constants}\n{extra_setup}\n{func_src}', ns)
+    return ns[name]
+
+
+def _get_validate() -> object:
+    return _extract_fn('_validate_mutation_surfaces')
+
+
+# ─── _validate_mutation_surfaces ─────────────────────────────────────────────
+
+def test_surfaces_file_is_clean():
+    """surfaces/retry_policy.json → no violation."""
+    fn = _get_validate()
+    violations = fn(['surfaces/retry_policy.json'])
+    assert violations == []
+
+
+def test_scripts_file_is_clean():
+    """scripts/cycle_logger.py → no violation."""
+    fn = _get_validate()
+    violations = fn(['scripts/cycle_logger.py'])
+    assert violations == []
+
+
+def test_memory_file_is_clean():
+    """memory/MEMORY.md → no violation."""
+    fn = _get_validate()
+    violations = fn(['memory/MEMORY.md'])
+    assert violations == []
+
+
+def test_env_file_is_violation():
+    """.env file → violation (blocked filename pattern)."""
+    fn = _get_validate()
+    violations = fn(['.env'])
+    assert len(violations) == 1
+    assert '.env' in violations[0]
+
+
+def test_state_file_is_violation():
+    """state/goals/history.json → outside allowed paths → violation."""
+    fn = _get_validate()
+    violations = fn(['state/goals/history.json'])
+    assert len(violations) == 1
+    assert 'outside allowed paths' in violations[0]
+
+
+def test_blocked_filename_in_surfaces_is_violation():
+    """surfaces/secret_key.json → 'secret' is a blocked pattern."""
+    fn = _get_validate()
+    violations = fn(['surfaces/secret_key.json'])
+    assert len(violations) == 1
+    assert 'secret' in violations[0]
+
+
+def test_empty_changed_files_is_clean():
+    """Empty list → no violations."""
+    fn = _get_validate()
+    assert fn([]) == []
+
+
+def test_multiple_violations_returned():
+    """Multiple bad files → multiple violations."""
+    fn = _get_validate()
+    violations = fn(['.env', 'state/goals/history.json'])
+    assert len(violations) == 2
+
+
+def test_mixed_clean_and_violation():
+    """One clean + one violation → only violation reported."""
+    fn = _get_validate()
+    violations = fn(['surfaces/task_selector.json', 'state/bad_file.json'])
+    assert len(violations) == 1
+    assert 'state/bad_file.json' in violations[0]
+
+
+# ─── build_task prompt includes mutation surfaces section ─────────────────────
+
+def test_build_task_prompt_includes_mutation_surfaces():
+    """build_task() prompt must include '## Mutation surfaces' section."""
+    source = _BRIDGE_PATH.read_text()
+    assert '## Mutation surfaces' in source, \
+        'build_task() must include ## Mutation surfaces section in the prompt'
+
+
+def test_build_task_lists_all_7_surfaces():
+    """All 7 surface files must be named in build_task() prompt output."""
+    source = _BRIDGE_PATH.read_text()
+    expected = [
+        'task_selector.json',
+        'prompt_template.md',
+        'retry_policy.json',
+        'tool_policy.json',
+        'memory_policy.json',
+        'score_weights.json',
+        'lesson_policy.json',
+    ]
+    for surface_file in expected:
+        assert surface_file in source, f'{surface_file} missing from bridge source'


### PR DESCRIPTION
Closes #528

## Changes
- `_validate_mutation_surfaces()` — validates changed files against 7-surface contract
- `build_task()` — adds Mutation surfaces section to all subagent prompts
- Deployed `surfaces/` directory to eeebot-self-evolving (7 stub files)
- 11 tests, all pass

Inspired by Darwin Mode safety.ts: *SURFACES — the 7 approved mutation surfaces, each owning exactly one file.*