### PR TITLE
fix: repair two pre-existing CI failures (executor profile gate + test loader)

### DIFF
--- a/memory/HISTORY.md
+++ b/memory/HISTORY.md
@@ -212,3 +212,10 @@
   Verified on host: cycle-d47f0ef5d3 → handoff_to_subagent_verification in same synthesize cycle.
   Also: P18 marked [Done] in eeebot-self-evolving MEMORY.md (commit f4928d5).
   Also: backlog_title now written to bridge result payload (commit 685d1b1, hotfix).
+[2026-06-23 05:44] Fixed 2 pre-existing main CI failures blocking all PRs (todo.md #7).
+  Bug 2 (production): subagent_materializer.py gate dropped coordinator-emitted "bounded_execution"
+    requests, so materialization never ran on a configured executor — added it to the eligible profile
+    set (gated on configured_executor, so executor-less hosts unaffected). executed_count now 1.
+  Bug 1 (test-only): stubbed _task_already_done->False in test_auto_seed_adds_priorities_when_empty
+    (AST loader extracts only named funcs; real fn returns False for fresh titles anyway).
+  Full suite 993 passed (was 991+2 fail). Branch fix/ci-pre-existing-failures; canonical PR + rollout PR to eeebot-self-evolving.

--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -343,7 +343,7 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 continue
             executor_result: dict[str, Any] | None = None
             executor_ok = False
-            if configured_executor and str(request.get("profile") or "").lower() in {"research_only", "review_only", "bounded_review"}:
+            if configured_executor and str(request.get("profile") or "").lower() in {"research_only", "review_only", "bounded_review", "bounded_execution"}:
                 executor_ok, executor_result = _run_local_executor(
                     configured_executor,
                     request,

--- a/tests/test_research_feed_backlog_fallback.py
+++ b/tests/test_research_feed_backlog_fallback.py
@@ -123,6 +123,10 @@ def test_auto_seed_adds_priorities_when_empty():
         "_active_backlog_is_empty",
         "_auto_seed_backlog_from_research",
     )
+    # _task_already_done is a module-level git-history filter not under test here;
+    # the loader extracts only the named functions, so stub it to its real result
+    # for this fixture (a fresh temp repo has no matching commits -> False).
+    ns["_task_already_done"] = lambda *args, **kwargs: False
     with tempfile.TemporaryDirectory() as td:
         repo, state, memory_path = _make_env(Path(td), ALL_DONE_MEMORY, FEED_ENTRIES)
         result = ns["_auto_seed_backlog_from_research"](repo, ALL_DONE_MEMORY, memory_path)

--- a/todo.md
+++ b/todo.md
@@ -50,3 +50,15 @@ Goal: bring live behavior and operator surfaces closer to the canonical operatin
 - [ ] 6. Verification and proof
   - Run targeted tests and live checks after each slice.
   - Capture final proof note if all slices land cleanly.
+
+## CI stability
+
+- [x] 7. Fix two pre-existing `main` test failures blocking all PR CI (done — 2026-06-23)
+  - Problem: `main` CI is red on every PR due to two failures unrelated to the PR under test:
+    - `tests/test_research_feed_backlog_fallback.py::test_auto_seed_adds_priorities_when_empty` — `NameError: _task_already_done` (the AST test-loader extracts `_auto_seed_backlog_from_research` but not its `_task_already_done` dependency).
+    - `tests/test_runtime_coordinator.py::test_cycle_executes_configured_subagent_executor_and_consumes_completed_result` — `executed_count` stays 0 (`assert 0 == 1`): a configured subagent executor's completed result is not consumed.
+  - Fix (minimal, no over-engineering):
+    - Bug 1 (test-only): stub `_task_already_done -> False` in the one test that reaches it (real fn returns False for fresh titles in a temp repo; the function is not under test here). No change to the fragile AST loader.
+    - Bug 2 (production): `nanobot/runtime/subagent_materializer.py:346` — add `"bounded_execution"` to the executor-eligible profile gate. The coordinator emits `bounded_execution` requests (coordinator.py:2056/2488/3083) but the gate dropped them, so materialization could never run on a configured executor. Gated on `configured_executor` being set, so hosts without the executor env are unaffected.
+  - Proof: both target tests pass; full suite `993 passed` (was `991 passed, 2 failed`); zero new ruff findings on changed files.
+  - Rollout: dev = canonical `eeebot` (PR); rollout to running `eeebot-self-evolving` (PR) — see commit/PR links in HISTORY.


### PR DESCRIPTION
Two failures live on `main`, unrelated to any PR — red CI has been blocking every pull request (including #535). This greens the suite.

## Bug 2 — production (`nanobot/runtime/subagent_materializer.py`)
The configured-executor gate ran only for profiles `{research_only, review_only, bounded_review}`, but the coordinator emits materialization requests with profile **`bounded_execution`** (`coordinator.py:2056/2488/3083`). Those requests therefore never ran on a configured executor and were terminalized as `blocked` (`executed_count` stayed 0). Added `bounded_execution` to the gate.

- Still gated on `configured_executor` being set → hosts **without** the executor env are unaffected (same `blocked` path as before). Safe rollout.
- The `accepted_executor_profiles` set was originally written by an autoevolve commit (`a3ee2bd`), i.e. an incomplete self-generated set, not a deliberate exclusion.
- Fixes `test_cycle_executes_configured_subagent_executor_and_consumes_completed_result`.

## Bug 1 — test-only (`tests/test_research_feed_backlog_fallback.py`)
`_load_bridge_functions` AST-extracts only the *named* functions into an isolated namespace, so `_auto_seed_backlog_from_research`'s call to the module-level `_task_already_done` raised `NameError`. Stubbed it to `False` in the one test that reaches it — the real function returns `False` for fresh titles in a temp repo with no matching git history, and it is **not under test here**. No change to the fragile loader; smallest faithful fix (chose this over extending the loader to avoid over-engineering).

## Verification
- Full suite: **993 passed** (was `991 passed, 2 failed`).
- Zero new ruff findings on the changed files (4/16 baseline == current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)