### PR TITLE
docs(changes): cycle stop-guards (no-progress, bounded revisions, stop conditions)

### DIFF
--- a/docs/changes/loop-stop-guards/design.md
+++ b/docs/changes/loop-stop-guards/design.md
@@ -1,0 +1,73 @@
+# Design: cycle stop-guards
+
+Source of the three new requirements: a sverka of our
+`self-evolving-runtime/spec.md` against the `loop.yaml` model of
+[`ksimback/looper`](https://github.com/ksimback/looper) (example
+`ai-workflow-mapping`).
+
+## What we already cover (no change)
+
+| Looper `loop.yaml` invariant | Where we already have it |
+|---|---|
+| `goal.statement` + `context_sources` + `definition_of_done` | R1 (Specify), experiment contract |
+| `loop_control.budget` (usd/tokens/wall_clock) | R2 (`max_requests`, `max_tool_calls`, `max_subagents`, `max_timeout_seconds`, `mutation_scope`) — broader |
+| `verification` (programmatic) | smoke gate (import/syntax), R3 |
+| `execution.side_effects.requires_approval` | apply.ok gate (host-runtime) |
+| `observability.state_file` / `run_log` | R3 durable evidence, R7 |
+| run outcome | R4 `keep\|discard\|blocked\|crash` vs baseline/current/frontier — stronger than Looper's pass/fail |
+
+We also have capabilities Looper lacks entirely (so nothing to borrow): HADI
+learning loop (R5/R6), multi-cycle durable state, promotion/release + rollback,
+subagent lifecycle.
+
+## The three gaps → R11/R12/R13
+
+### R11 — no-progress STOP guard
+Looper: `loop_control.no_progress.max_stalled_iterations: 2` + enumerated
+`signals` (`same blocking issue repeats`, `delivery artifact has no material
+change`, `verifier output is unchanged`) + `action: stop`.
+
+We have R8 (no-file-change ≠ kept improvement) and R6 (empty backlog not
+terminal), but nothing requires the loop to **stop** when stalled. Add a
+normative stall counter in durable state and a STOP action at the threshold.
+
+Stall signals (observable, in durable state):
+- same blocker repeats across N consecutive cycles, or
+- consecutive cycle with no `changed_files`, or
+- identical verifier/evaluation result with no frontier movement.
+
+### R12 — bounded revisions
+Looper: `gates.*.verdict_policy: revise_until_clean` + `max_revisions: 3`.
+
+Our smoke gate has no revision cap — a subagent can keep retrying. Add: a failed
+gate is retried at most K times (default 3), after which the experiment ends
+`blocked` (R4) with the revision count recorded.
+
+### R13 — enumerated stop conditions
+Looper: explicit `stop_conditions` list. Ours are implicit (budget exhaustion).
+Make the terminating set explicit and normative:
+1. all gates clean (experiment reaches `keep`/`discard`),
+2. `max_iterations` reached,
+3. R11 no-progress guard tripped,
+4. any R2 budget cap exceeded.
+
+Each stop terminates with a recorded `stop_reason` in the cycle report so R7 can
+answer "why did the loop stop".
+
+## Durable-state surface (checkability)
+
+| Requirement | New/used field in `state/reports/evolution-*.json` |
+|---|---|
+| R11 | `stall.consecutive`, `stall.signal`, `stop_reason="no_progress"` |
+| R12 | `experiment.revisions` (int), `experiment.outcome="blocked"` when cap hit |
+| R13 | `stop_reason ∈ {gate_clean, max_iterations, no_progress, budget_<name>}` |
+
+These are additive to the existing R3 report contract — no field is renamed or
+removed.
+
+## Why spec-only here
+
+The contract (what STOP means, the thresholds, the stop-reason enum) should be
+agreed before touching `coordinator.py`. Implementation is a separate Issue that
+references this archived change; CI test coverage lands with the implementation,
+not the spec.

--- a/docs/changes/loop-stop-guards/proposal.md
+++ b/docs/changes/loop-stop-guards/proposal.md
@@ -1,0 +1,64 @@
+# Change: cycle stop-guards (no-progress, bounded revisions, stop conditions)
+
+- **change-id:** loop-stop-guards
+- **issue:** (linked on open)
+- **capability:** `docs/specs/self-evolving-runtime`
+- **role / workstream:** role:developer / workstream:runtime
+
+## Problem
+
+The self-evolving runtime can spend long stretches of wall-clock making no
+material progress: cycles repeat the same blocker, re-emit a delivery with no
+file change, or re-run a verifier whose output is unchanged. This is the
+observed "~95% of cycles on bookkeeping" stagnation (the "не маловато за 12
+часов" finding). The current spec asserts that a no-file-change cycle is not a
+kept improvement (R8) and that an empty backlog must not stall (R6), but it has
+**no normative requirement that the loop actually STOP** when it is making no
+progress, **no cap on how many times a failed gate may be revised**, and **no
+enumerated set of stop conditions**. So a stalled loop is "incorrect" by R8 but
+nothing requires it to terminate.
+
+External reference: [`ksimback/looper`](https://github.com/ksimback/looper)
+(MIT) is a Claude-Code loop-design tool whose `loop.yaml` makes exactly these
+guards normative and machine-checkable: `loop_control.no_progress`
+(`max_stalled_iterations` + enumerated stall signals + `action: stop`),
+`gates.*.max_revisions` with `verdict_policy: revise_until_clean`, and an
+explicit `stop_conditions` list. We are not adopting its code — only the three
+invariants we lack.
+
+## Intended change
+
+Add three normative requirements to `self-evolving-runtime/spec.md`:
+
+- **R11 — no-progress STOP guard.** After a bounded number of consecutive
+  stalled cycles (default 2), the runtime SHALL stop the current goal/lane and
+  record the stall, rather than continue. Stall is defined by enumerated,
+  observable signals.
+- **R12 — bounded revisions.** A failed gate (e.g. smoke gate) SHALL be retried
+  at most a bounded number of times (default 3) before the experiment ends with
+  `blocked`; revisions SHALL NOT be unbounded.
+- **R13 — enumerated stop conditions.** The cycle/lane SHALL terminate on an
+  explicit, enumerated set of stop conditions (gate clean, max iterations,
+  no-progress guard tripped, any budget cap exceeded) — not on budget exhaustion
+  alone, implicitly.
+
+Each maps to an observable signal in durable state so the stop reason is
+answerable per R7.
+
+## Acceptance
+
+- [ ] `self-evolving-runtime/spec.md` contains R11, R12, R13 with SHALL wording
+      and a corresponding scenario each.
+- [ ] Each new requirement names the durable-state field / signal that makes it
+      checkable (stall counter, revision counter, stop-reason).
+- [ ] The capability map / references note Looper as an external reference.
+- [ ] No code or runtime behavior is changed in this PR (spec-only); the
+      implementation lands as a separate Issue once the contract is agreed.
+
+## Out of scope
+
+- Implementing the guards in `coordinator.py` / the bridge (separate Issue).
+- The optional Looper-derived items: independent cross-family review gate before
+  promotion, and egress redaction on model calls (separate optional Issues).
+- Any change to budget fields (R2) or outcome taxonomy (R4) — those already
+  exist and are stronger than Looper's.

--- a/docs/changes/loop-stop-guards/specs/self-evolving-runtime/spec.md
+++ b/docs/changes/loop-stop-guards/specs/self-evolving-runtime/spec.md
@@ -1,0 +1,52 @@
+# Spec delta — self-evolving-runtime: cycle stop-guards
+
+This is the **delta** to apply into `docs/specs/self-evolving-runtime/spec.md`
+when this change lands. It adds R11–R13 and three scenarios; it changes nothing
+existing.
+
+## Add under `## Requirements`, after the "Roles" subsection
+
+### Termination and progress
+
+- R11. The runtime SHALL track consecutive stalled cycles and, on reaching a
+  bounded threshold (default 2), SHALL stop the active goal/lane and record
+  `stop_reason="no_progress"` — it SHALL NOT continue iterating. A cycle is
+  **stalled** when at least one observable signal holds: the same blocker
+  repeats, the cycle produced no `changed_files`, or the verifier/evaluation
+  result is unchanged with no frontier movement.
+- R12. A failed gate (e.g. the smoke gate) SHALL be revised at most a bounded
+  number of times (default 3) before the experiment ends with
+  `experiment.outcome="blocked"`; the revision count SHALL be recorded and
+  revisions SHALL NOT be unbounded.
+- R13. A cycle/lane SHALL terminate on an explicit, enumerated stop condition
+  and SHALL record which one in `stop_reason`: `gate_clean` (experiment reached
+  `keep`/`discard`), `max_iterations`, `no_progress` (R11), or `budget_<name>`
+  (any R2 cap exceeded). Termination SHALL NOT rely on budget exhaustion alone.
+
+## Add under `## Scenarios`
+
+### Scenario: stalled loop stops instead of spinning
+- Given two consecutive cycles whose deliveries have no `changed_files` and the
+  same blocker
+- When the next cycle would start
+- Then the runtime stops the lane and writes `stop_reason="no_progress"` with
+  `stall.consecutive >= 2`, rather than running another bookkeeping cycle.
+
+### Scenario: a failing gate is not retried forever
+- Given a subagent change that fails the smoke gate
+- When it has been revised the bounded number of times (default 3) without
+  passing
+- Then the experiment ends with `outcome="blocked"` and `experiment.revisions`
+  records the attempts.
+
+### Scenario: every stop has a recorded reason
+- Given any terminating cycle/lane
+- When the cycle report is written
+- Then `stop_reason` is set to exactly one enumerated value, so R7 can answer
+  "why did the loop stop" from durable state alone.
+
+## Add to `## References`
+
+- External reference (design input, not a dependency):
+  [`ksimback/looper`](https://github.com/ksimback/looper) `loop.yaml`
+  (`loop_control.no_progress`, `gates.*.max_revisions`, `stop_conditions`).


### PR DESCRIPTION
## What

Adds a spec-only change folder `docs/changes/loop-stop-guards/` proposing three new normative requirements for the self-evolving runtime, derived from a sverka of `docs/specs/self-evolving-runtime/spec.md` against the `loop.yaml` model of [`ksimback/looper`](https://github.com/ksimback/looper) (MIT, design input only — no code adopted).

The three guards we currently lack:

- **R11 — no-progress STOP guard.** After N consecutive stalled cycles (default 2) the runtime SHALL stop the lane and record `stop_reason="no_progress"`. Directly targets the observed "~95% of cycles on bookkeeping" stagnation.
- **R12 — bounded revisions.** A failed gate is revised at most K times (default 3), then ends `blocked`. No unbounded retry.
- **R13 — enumerated stop conditions.** Cycle terminates on an explicit set (`gate_clean | max_iterations | no_progress | budget_<name>`) with a recorded `stop_reason`, not on budget exhaustion alone.

## Files

- `proposal.md` — problem, intended change, acceptance, out-of-scope
- `design.md` — full sverka table (what we already cover vs the 3 gaps) + durable-state surface
- `specs/self-evolving-runtime/spec.md` — the spec delta (R11–R13 + 3 scenarios) to apply on merge

## Scope

Spec/design only — **no runtime code changes**. Implementation in `coordinator.py`/bridge lands as a separate Issue once the contract is agreed. Optional Looper-derived items (independent cross-family review gate, egress redaction) are deferred to separate optional Issues.

## On merge

Archive `docs/changes/loop-stop-guards/` → `docs/changes/archive/`, apply the delta into `docs/specs/self-evolving-runtime/spec.md`, set Project #7 `Status=Done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)