### PR TITLE
fix(runtime): route coordinator off dead cl/gemini-2.5-flash

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,9 +17,10 @@ DEFAULT_TASKS = "Run one bounded self-evolving cycle and persist canonical runti
 # LiteLLM proxy env vars — set by /etc/eeepc-agent/litellm.env via systemd drop-in
 _LITELLM_BASE_URL = os.environ.get("LITELLM_BASE_URL", "https://litellm.ayga.tech:9443/v1")
 _LITELLM_API_KEY = os.environ.get("LITELLM_API_KEY", "")
-# cl/ prefix models work via openai-compatible client pointed at the proxy;
-# fall back to gemini-2.5-flash which is confirmed working
-_LITELLM_MODEL = os.environ.get("LITELLM_MODEL", "cl/gemini-2.5-flash")
+# Prefixed models route via openai-compatible client pointed at the proxy.
+# Default to an/gemini-3.5-flash-low; the old cl/gemini-2.5-flash Cliproxy route
+# now returns "unknown provider for model gemini-2.5-flash" (BadGateway).
+_LITELLM_MODEL = os.environ.get("LITELLM_MODEL", "an/gemini-3.5-flash-low")
 _LITELLM_TIMEOUT = int(os.environ.get("LITELLM_TIMEOUT_S", "45"))
 
 _SYSTEM_PROMPT = """\

--- a/host/eeepc/etc/models.yaml
+++ b/host/eeepc/etc/models.yaml
@@ -17,6 +17,7 @@ allowed:
   anthropic_native:
     - an/claude-sonnet-4-6
     - an/gemini-3-flash
+    - an/gemini-3.5-flash-low      # ← текущая LITELLM_MODEL агента (coordinator)
 
   claude:
     - cl/claude-3-5-haiku-20241022
@@ -54,7 +55,7 @@ allowed:
     - cl/gpt-5.2
     - cl/gpt-5.3-codex
     - cl/gpt-5.4
-    - cl/gemini-3.5-flash-low     # ← текущая LITELLM_MODEL агента
+    - cl/gemini-3.5-flash-low
     - cl/gpt-5.5
     - cl/gpt-image-2
     - cl/gpt-oss-120b-medium

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/override.conf
@@ -1,7 +1,7 @@
 [Service]
 WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 Environment=POLICY_FILE=/opt/eeepc-agent/runtimes/self-evolving-agent/current/config/policy.yaml
-Environment=LITELLM_MODEL=cl/gemini-2.5-flash
+Environment=LITELLM_MODEL=an/gemini-3.5-flash-low
 Environment=LITELLM_TIMEOUT_S=45
 Environment=LITELLM_TOTAL_BUDGET_MS=70000
 Environment=LITELLM_RETRY_MAX_ATTEMPTS=3


### PR DESCRIPTION
## Problem

Logs show every coordinator cycle (`cl/gemini-2.5-flash`) failing:

```
litellm.BadGatewayError: OpenAIException - unknown provider for model gemini-2.5-flash
No fallback model group found for original model_group=cl/gemini-2.5-flash
LiteLLM Retried: 3 times
```

The Cliproxy upstream route for `cl/gemini-2.5-flash` is dead and has no fallback group, so the self-evolving runtime burns 3 retries and aborts each cycle (e.g. `Record cycle reward`).

## Fix

Switch the default `LITELLM_MODEL` to **`an/gemini-3.5-flash-low`**:

- `app/main.py` — default value + comment
- `host/eeepc/systemd/drop-ins/…-health.service.d/override.conf` — `Environment=LITELLM_MODEL=`
- `host/eeepc/etc/models.yaml` — add `an/gemini-3.5-flash-low` to the `anthropic_native` allowlist and move the "current LITELLM_MODEL" marker off `cl/gemini-3.5-flash-low`

Authoritative LiteLLM credentials in `/etc/eeepc-agent/litellm.env` are untouched (only the model id changes; that env file still wins at runtime).

## Verify after deploy

```bash
curl -sS -H "Authorization: Bearer $LITELLM_API_KEY" \
  -d '{"model":"an/gemini-3.5-flash-low","messages":[{"role":"user","content":"Reply with OK"}],"max_tokens":8}' \
  "$LITELLM_BASE_URL/chat/completions"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)