### PR TITLE
fix(runtime): close reward-hacking gap in coordinator

### DIFF
--- a/docs/changes/coordinator-reward-hacking-guard/proposal.md
+++ b/docs/changes/coordinator-reward-hacking-guard/proposal.md
@@ -1,0 +1,94 @@
+# Change: close the reward-hacking hole in the self-evolving cycle
+
+- **change-id:** coordinator-reward-hacking-guard
+- **issue:** TBD (filed in same session)
+- **capability:** `docs/specs/self-evolving-runtime`
+- **role / workstream:** role:developer / workstream:runtime
+
+## Problem
+
+The eeepc host produced **zero real git commits for 8 consecutive days**
+(2026-06-26 → 2026-07-04) while the coordinator kept reporting `result_status:
+PASS` and `reward_signal.value: 1.2` on almost every cycle.
+
+Root cause, confirmed by reading `nanobot/runtime/coordinator.py`:
+
+- `result_status = "PASS"` is set unconditionally whenever `execute_turn()`
+  returns without raising (`coordinator.py:4484-4493`) — no check that anything
+  was actually produced.
+- The materialize-lane reward bonus (`_has_concrete_changes`,
+  `coordinator.py:4361-4431`) is meant to gate the 1.2 reward on a real code
+  change, but **fails open**: any error probing git returns `True` ("changes
+  present") instead of failing closed, and it never verifies the commit
+  actually relates to the claimed improvement — any recent commit/dirty file
+  with a source extension counts.
+- `materialize-synthesized-improvement`
+  (`_write_materialized_improvement_artifact`, `coordinator.py:2580-2700+`)
+  only ever writes a descriptive JSON artifact to `state/improvements/`. It
+  never dispatches a real code-edit request to the subagent bridge.
+- Promotion records are created with `base_commit: null` and
+  `candidate_patch_hash: null` **unconditionally**
+  (`coordinator.py:4543-4568`) — there is no code path that requires or
+  computes a real diff before minting a promotion candidate.
+
+This directly violates `docs/specs/self-evolving-runtime/spec.md` R8: *"The
+runtime SHALL NOT report narrative progress as material progress; a cycle
+with no file change SHALL NOT be presented as a kept improvement."*
+
+Effect observed on host (1841 cycle reports sampled): task selection is
+dominated by internal bookkeeping/synthesis task IDs
+(`refresh-approval-gate`, `run-bounded-turn`, `record-reward`,
+`synthesize-next-improvement-candidate`,
+`subagent-verify-materialized-improvement`) — real backlog items from
+`goal_text.json` (Priority A/B) were never selected in this window. The loop
+is not stalled in the classic sense (R11 stop-guards fire and record
+`stop_reason`) — it is **self-rewarding without evidence**, so stall
+detection alone cannot see the problem.
+
+## Intended change
+
+Make `PASS` + reward for the materialize lane strictly evidence-gated,
+per R8:
+
+1. `_has_concrete_changes` fails **closed**, not open: a git-probe error or
+   ambiguous result must count as "no concrete change", not "change present".
+2. The bonus reward (1.2) requires a commit whose timestamp is after cycle
+   start AND whose diff touches a file relevant to the improvement statement
+   — not just "any recent commit exists".
+3. Promotion candidates are only minted with a real `base_commit` +
+   `candidate_patch_hash` when the origin task claims a code change; a
+   materialize-lane cycle with no verified diff SHALL NOT produce a
+   promotion candidate at all (rather than one with null diff fields sitting
+   in the queue forever).
+
+Out of scope for this change (tracked as follow-up, not blocking): routing
+real `goal_text.json` backlog items into the dispatchable task pool, and
+having `materialize-synthesized-improvement` actually dispatch a subagent
+edit request. Those are separate, larger capability changes — this change
+only stops the loop from **rewarding itself for work that didn't happen**.
+
+## Acceptance
+
+- [ ] `_has_concrete_changes` returns `False` (or a distinct
+      `unverified`/error state that is treated as "no changes") on any git
+      probe error, instead of `True`.
+- [ ] The materialize-lane 1.2 reward is only awarded when a real,
+      cycle-scoped commit is verified; otherwise reward is not upgraded above
+      the PASS/BLOCK baseline.
+- [ ] No promotion candidate is created with both `base_commit: null` and
+      `candidate_patch_hash: null` for a materialize-lane origin cycle that
+      has no verified diff.
+- [ ] Unit tests cover: git-probe-error → no bonus; verified commit →
+      bonus; no commit → no promotion candidate.
+- [ ] Full test suite green; additive/behavior-narrowing only (no new public
+      surface).
+
+## Out of scope
+
+- Routing `goal_text.json` Priority A/B backlog items into the dispatchable
+  task pool (separate follow-up).
+- Making `materialize-synthesized-improvement` dispatch a real subagent
+  edit request (separate follow-up).
+- General bookkeeping-task reward tuning (`record-reward`,
+  `refresh-approval-gate` etc. are legitimate low-reward housekeeping and are
+  not changed here).

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -4358,13 +4358,47 @@ def _workspace_looks_like_eeepc_live_runtime(workspace: Path) -> bool:
     return workspace.parent.name == ".nanobot-eeepc" and workspace.name == "workspace"
 
 
-def _has_concrete_changes(workspace: Path, state_root: Path | None = None) -> bool:
-    """Return True if any real source-code change exists in workspace or eeebot-self-evolving.
+def _commit_at_or_after_cycle_start(commit_iso: str | None, cycle_started_utc: str | None) -> bool:
+    """Return True unless we can positively prove the commit predates the cycle.
+
+    Best-effort, cheap timestamp comparison: if either timestamp is missing or
+    fails to parse, we don't reject the commit on this basis alone (the
+    fail-closed git-probe-error guard elsewhere already covers the "we cannot
+    verify anything" case).
+    """
+    if not commit_iso or not cycle_started_utc:
+        return True
+    try:
+        commit_dt = datetime.fromisoformat(commit_iso.strip().replace("Z", "+00:00"))
+        cycle_dt = datetime.fromisoformat(cycle_started_utc.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if commit_dt.tzinfo is None:
+        commit_dt = commit_dt.replace(tzinfo=timezone.utc)
+    if cycle_dt.tzinfo is None:
+        cycle_dt = cycle_dt.replace(tzinfo=timezone.utc)
+    return commit_dt >= cycle_dt
+
+
+def _has_concrete_changes(
+    workspace: Path,
+    state_root: Path | None = None,
+    cycle_started_utc: str | None = None,
+) -> bool:
+    """Return True only if a real, verified source-code change exists in
+    workspace or eeebot-self-evolving.
 
     In the two-repository topology, subagents commit to eeebot-self-evolving
     (``state_root.parent / "eeebot-self-evolving"``), not to the canonical workspace.
-    When ``state_root`` is provided we check that repo for recent commits (last 15 minutes)
-    in addition to the canonical workspace worktree.
+    When ``state_root`` is provided we check that repo for recent commits (last 15 minutes,
+    or since ``cycle_started_utc`` when provided) in addition to the canonical workspace
+    worktree.
+
+    Fails CLOSED: any git-probe error, or inability to determine git state, is treated
+    as "no concrete change" (return False) — never as "change present". This is
+    deliberate: reward and promotion-candidate creation depend on this function, and
+    an ambiguous/erroring probe must not be able to fake evidence of real work
+    (issue #565 — reward-hacking guard).
     """
     # ── Part A: check eeebot-self-evolving for recent subagent commits ──────────
     if state_root is not None:
@@ -4374,9 +4408,11 @@ def _has_concrete_changes(workspace: Path, state_root: Path | None = None) -> bo
                 ['git', 'rev-parse', '--is-inside-work-tree'], selfevo_path
             )
             if selfevo_git and selfevo_git.strip().lower() == "true":
-                # Any commit in the last 15 minutes counts as a concrete change
+                # A commit since cycle start (or, absent that, in the last 15
+                # minutes) counts as a concrete change.
+                since_arg = cycle_started_utc or "15 minutes ago"
                 recent = _git_output(
-                    ['git', 'log', '--since=15 minutes ago', '--oneline'], selfevo_path
+                    ['git', 'log', f'--since={since_arg}', '--oneline'], selfevo_path
                 )
                 if recent and recent.strip():
                     return True
@@ -4384,7 +4420,10 @@ def _has_concrete_changes(workspace: Path, state_root: Path | None = None) -> bo
     # ── Part B: check canonical workspace (original logic) ───────────────────────
     is_git = _git_output(['git', 'rev-parse', '--is-inside-work-tree'], workspace)
     if not is_git or is_git.strip().lower() != "true":
-        return True
+        # Fail closed: either the git probe errored, or this workspace is not a
+        # git worktree — either way we cannot verify a real change, so treat it
+        # as absent rather than assuming the best case.
+        return False
 
     # 1. Check unstaged/staged changes in the worktree
     status_output = _git_output(['git', 'status', '--porcelain', '-u'], workspace)
@@ -4398,9 +4437,11 @@ def _has_concrete_changes(workspace: Path, state_root: Path | None = None) -> bo
     # 2. Check the latest commit if it was created by autoevolve in this cycle
     commit_msg = _git_output(['git', 'log', '-1', '--pretty=%B'], workspace)
     if commit_msg and "autoevolve" in commit_msg.lower():
-        commit_files = _git_output(['git', 'diff-tree', '--no-commit-id', '--name-only', '-r', 'HEAD'], workspace)
-        if commit_files:
-            changed_files.extend(commit_files.splitlines())
+        commit_time = _git_output(['git', 'log', '-1', '--pretty=%cI'], workspace)
+        if _commit_at_or_after_cycle_start(commit_time, cycle_started_utc):
+            commit_files = _git_output(['git', 'diff-tree', '--no-commit-id', '--name-only', '-r', 'HEAD'], workspace)
+            if commit_files:
+                changed_files.extend(commit_files.splitlines())
 
     # Filter changes: ignore state, subagents, logs, config, history, templates, and doc files
     ignored_patterns = [
@@ -4516,6 +4557,32 @@ async def run_self_evolving_cycle(
     # previous_experiment already loaded above (R11 lane-switch); reuse it.
     preplan_current_task_id = _derive_experiment_current_task_id(result_status, feedback_decision)
     reward_signal = _derive_reward_signal(result_status, None, preplan_current_task_id, previous_experiment)
+
+    # Reward-hacking guard (issue #565): a materialize-lane cycle with no
+    # verified diff must not mint a promotion candidate at all — writing one
+    # with null base_commit/candidate_patch_hash just parks dead entries in
+    # the promotion queue forever. Non-materialize lanes (record-reward,
+    # refresh-approval-gate, etc.) are legitimate low-reward housekeeping and
+    # are left unchanged.
+    if promotion_candidate_id is not None:
+        _materialize_lane_task_ids = {"materialize-pass-streak-improvement", MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID}
+        _is_materialize_lane_cycle = preplan_current_task_id in _materialize_lane_task_ids
+        if not _is_materialize_lane_cycle and isinstance(recorded_task_plan, dict):
+            _recorded_lane_task_id = recorded_task_plan.get("current_task_id") or recorded_task_plan.get("currentTaskId")
+            _recorded_lane_feedback = (
+                recorded_task_plan.get("feedback_decision")
+                if isinstance(recorded_task_plan.get("feedback_decision"), dict)
+                else {}
+            )
+            _is_materialize_lane_cycle = (
+                _recorded_lane_task_id in _materialize_lane_task_ids
+                or _recorded_lane_feedback.get("selected_task_id") in _materialize_lane_task_ids
+            )
+        if _is_materialize_lane_cycle and not _has_concrete_changes(
+            workspace, state_root=state_root, cycle_started_utc=cycle_started
+        ):
+            promotion_candidate_id = None
+
     experiment = _build_experiment_snapshot(
         experiment_id=experiment_id,
         cycle_id=cycle_id,
@@ -4627,7 +4694,7 @@ async def run_self_evolving_cycle(
         artifact_path = current_plan.get("materialized_improvement_artifact_path")
         reward = current_plan.get("reward_signal") if isinstance(current_plan.get("reward_signal"), dict) else reward_signal
         upgraded_reward = dict(reward) if isinstance(reward, dict) else {"value": 1.0, "source": "result_status", "result_status": result_status}
-        if _has_concrete_changes(workspace, state_root=state_root):
+        if _has_concrete_changes(workspace, state_root=state_root, cycle_started_utc=cycle_started):
             upgraded_reward["value"] = max(float(upgraded_reward.get("value") or 0.0), 1.2)
             upgraded_reward["source"] = "materialized_improvement_artifact"
         else:

--- a/tests/test_concrete_changes_dual_repo.py
+++ b/tests/test_concrete_changes_dual_repo.py
@@ -6,13 +6,9 @@ canonical workspace.  Without checking that repo, reward is always 0.8 and every
 cycle registers outcome=discard.
 """
 import subprocess
-import tempfile
 from pathlib import Path
 
-import pytest
-
 from nanobot.runtime.coordinator import _has_concrete_changes
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -56,12 +52,16 @@ class TestHasConcreteChanges:
         result = _has_concrete_changes(canonical, state_root=None)
         assert result is False
 
-    def test_non_git_workspace_returns_true(self, tmp_path):
-        """Non-git directory → True (safe default, same as original behaviour)."""
+    def test_non_git_workspace_returns_false(self, tmp_path):
+        """Non-git directory → False (fail closed; issue #565 reward-hacking guard).
+
+        Reward and promotion-candidate creation depend on this function, so an
+        unverifiable git state must never be treated as "change present".
+        """
         workspace = tmp_path / "workspace"
         workspace.mkdir()
         result = _has_concrete_changes(workspace, state_root=None)
-        assert result is True
+        assert result is False
 
     def test_selfevo_recent_commit_detected(self, tmp_path):
         """Recent commit in eeebot-self-evolving → True even if canonical unchanged."""

--- a/tests/test_materialized_lane_value.py
+++ b/tests/test_materialized_lane_value.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -9,6 +10,36 @@ from nanobot.runtime.coordinator import run_self_evolving_cycle
 
 def _read_json(path: Path):
     return json.loads(path.read_text(encoding='utf-8'))
+
+
+def _git(*args, cwd: Path, env: dict | None = None) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, env=env)
+
+
+def _commit_autoevolve_change(workspace: Path, when: datetime) -> None:
+    """Create a verifiable autoevolve commit — the evidence issue #565 now requires
+    before the materialize lane can claim the reward bonus / mint a promotion.
+
+    Needs a parent commit first: `git diff-tree` on a root commit (no parent)
+    reports no changed files without `--root`, same as the coordinator's check.
+    """
+    _git("init", cwd=workspace)
+    _git("config", "user.email", "test@test.com", cwd=workspace)
+    _git("config", "user.name", "Test", cwd=workspace)
+    (workspace / "README.md").write_text("init\n")
+    _git("add", ".", cwd=workspace)
+    _git("commit", "-m", "init", cwd=workspace)
+
+    (workspace / "scripts").mkdir(parents=True, exist_ok=True)
+    (workspace / "scripts" / "example_improvement.py").write_text("print('bounded change')\n")
+    _git("add", ".", cwd=workspace)
+    commit_iso = when.isoformat()
+    env = {
+        **__import__("os").environ,
+        "GIT_AUTHOR_DATE": commit_iso,
+        "GIT_COMMITTER_DATE": commit_iso,
+    }
+    _git("commit", "-m", "autoevolve: bounded improvement", cwd=workspace, env=env)
 
 
 def test_materialized_lane_gets_reward_bonus_readiness_and_deeper_budget(tmp_path: Path):
@@ -36,6 +67,7 @@ def test_materialized_lane_gets_reward_bonus_readiness_and_deeper_budget(tmp_pat
 
     execute = AsyncMock(return_value='agent completed bounded work')
     now = expires_at - timedelta(minutes=30)
+    _commit_autoevolve_change(tmp_path, when=now + timedelta(minutes=1))
     asyncio.run(run_self_evolving_cycle(workspace=tmp_path, tasks='check open tasks', execute_turn=execute, now=now))
 
     report = _read_json(sorted((tmp_path / 'state' / 'reports').glob('evolution-*.json'))[-1])

--- a/tests/test_promotion_governance_packet.py
+++ b/tests/test_promotion_governance_packet.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import os
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -9,6 +11,32 @@ from nanobot.runtime.coordinator import run_self_evolving_cycle
 
 def _read_json(path: str | Path):
     return json.loads(Path(path).read_text(encoding='utf-8'))
+
+
+def _git(*args, cwd: Path, env: dict | None = None) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, env=env)
+
+
+def _commit_autoevolve_change(workspace: Path, when: datetime) -> None:
+    """Create a verifiable autoevolve commit — the evidence issue #565 now requires
+    before the materialize lane can claim a promotion candidate.
+
+    Needs a parent commit first: `git diff-tree` on a root commit (no parent)
+    reports no changed files without `--root`, same as the coordinator's check.
+    """
+    _git("init", cwd=workspace)
+    _git("config", "user.email", "test@test.com", cwd=workspace)
+    _git("config", "user.name", "Test", cwd=workspace)
+    (workspace / "README.md").write_text("init\n")
+    _git("add", ".", cwd=workspace)
+    _git("commit", "-m", "init", cwd=workspace)
+
+    (workspace / "scripts").mkdir(parents=True, exist_ok=True)
+    (workspace / "scripts" / "example_improvement.py").write_text("print('bounded change')\n")
+    _git("add", ".", cwd=workspace)
+    commit_iso = when.isoformat()
+    env = {**os.environ, "GIT_AUTHOR_DATE": commit_iso, "GIT_COMMITTER_DATE": commit_iso}
+    _git("commit", "-m", "autoevolve: bounded improvement", cwd=workspace, env=env)
 
 
 def test_ready_materialized_lane_writes_governance_packet_into_promotion_candidate(tmp_path: Path):
@@ -39,12 +67,15 @@ def test_ready_materialized_lane_writes_governance_packet_into_promotion_candida
     }
     (goals_dir / 'current.json').write_text(json.dumps(current_payload), encoding='utf-8')
 
+    now = expires_at - timedelta(minutes=15)
+    _commit_autoevolve_change(tmp_path, when=now + timedelta(minutes=1))
+
     result = asyncio.run(
         run_self_evolving_cycle(
             workspace=tmp_path,
             tasks='prepare candidate',
             execute_turn=AsyncMock(return_value='bounded work complete'),
-            now=expires_at - timedelta(minutes=15),
+            now=now,
         )
     )
     assert 'PASS' in result

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from nanobot.runtime.state import _material_progress_snapshot, _subagent_rollup_snapshot, format_runtime_state, load_runtime_state, load_runtime_state_from_root, resolve_runtime_state_location
-from nanobot.runtime.coordinator import _build_task_plan_snapshot, _derive_feedback_decision, _runtime_source_fingerprint, _write_subagent_request_artifact, run_self_evolving_cycle
+from nanobot.runtime.coordinator import _build_task_plan_snapshot, _derive_feedback_decision, _has_concrete_changes, _runtime_source_fingerprint, _write_subagent_request_artifact, run_self_evolving_cycle
 
 
 def _read_json(path):
@@ -3331,6 +3331,109 @@ def test_coordinator_penalizes_metadata_only_cycles_without_real_file_changes(tm
     assert reward_bonus_commit == 1.2
 
 
+def test_has_concrete_changes_fails_closed_when_git_probe_cannot_verify(tmp_path: Path):
+    """issue #565: an unverifiable git state must count as "no concrete change",
+    never as "change present" — the old fail-open behavior is exactly the bug
+    that let the coordinator reward itself for work that never happened."""
+    # tmp_path is not a git worktree at all, so the `git rev-parse
+    # --is-inside-work-tree` probe returns a falsy/non-"true" result.
+    assert _has_concrete_changes(tmp_path) is False
+    assert _has_concrete_changes(tmp_path, state_root=tmp_path / "state") is False
+
+
+def test_has_concrete_changes_still_grants_bonus_for_verified_cycle_scoped_commit(tmp_path: Path):
+    """Regression guard: a real autoevolve commit made after cycle start must
+    still be recognized as a concrete change (the fail-closed fix must not
+    break the legitimate path)."""
+    import subprocess
+
+    subprocess.run(["git", "init"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(tmp_path), check=True)
+    (tmp_path / "README.md").write_text("hello", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=str(tmp_path), check=True)
+
+    cycle_started_utc = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+
+    new_file = tmp_path / "tools" / "real_change.py"
+    new_file.parent.mkdir(parents=True, exist_ok=True)
+    new_file.write_text("print('real change')", encoding="utf-8")
+    subprocess.run(["git", "add", "tools/real_change.py"], cwd=str(tmp_path), check=True)
+    subprocess.run(["git", "commit", "-m", "autoevolve: bounded self-update"], cwd=str(tmp_path), check=True)
+
+    assert _has_concrete_changes(tmp_path, cycle_started_utc=cycle_started_utc) is True
+
+    # A commit that predates the cycle start must NOT count as this cycle's evidence.
+    future_cycle_started_utc = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    assert _has_concrete_changes(tmp_path, cycle_started_utc=future_cycle_started_utc) is False
+
+
+def test_materialize_lane_cycle_without_verified_diff_skips_promotion_candidate(tmp_path: Path):
+    """issue #565: a materialize-lane cycle that never produces a verifiable
+    diff (no git repo / no commit here) must not mint a promotion candidate at
+    all, rather than writing one with null base_commit/candidate_patch_hash
+    that would sit in the queue forever."""
+    approvals_dir = tmp_path / "state" / "approvals"
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)
+    (approvals_dir / "apply.ok").write_text(
+        json.dumps({"expires_at_utc": expires_at.isoformat(), "ttl_minutes": 60}), encoding="utf-8"
+    )
+
+    goals_dir = tmp_path / "state" / "goals"
+    goals_dir.mkdir(parents=True)
+    (goals_dir / "current.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "task-plan-v1",
+                "current_task_id": "materialize-synthesized-improvement",
+                "tasks": [
+                    {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
+                    {
+                        "task_id": "synthesize-next-improvement-candidate",
+                        "title": "Synthesize one new bounded improvement candidate from retired lanes",
+                        "status": "pending",
+                        "kind": "review",
+                    },
+                    {
+                        "task_id": "materialize-synthesized-improvement",
+                        "title": "Materialize one bounded improvement from the synthesized candidate",
+                        "status": "active",
+                        "kind": "execution",
+                        "selection_source": "generated_from_synthesized_improvement",
+                    },
+                ],
+                "generated_candidates": [
+                    {
+                        "task_id": "materialize-synthesized-improvement",
+                        "title": "Materialize one bounded improvement from the synthesized candidate",
+                        "status": "active",
+                        "kind": "execution",
+                        "selection_source": "generated_from_synthesized_improvement",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = asyncio.run(
+        run_self_evolving_cycle(
+            workspace=tmp_path,
+            tasks="materialize synthesized improvement",
+            execute_turn=AsyncMock(return_value="agent completed synthesized materialization"),
+            now=expires_at - timedelta(minutes=30),
+        )
+    )
+
+    assert "PASS" in summary
+    report_files = sorted((tmp_path / "state" / "reports").glob("evolution-*.json"))
+    report = _read_json(report_files[-1])
+    assert report["promotion_candidate_id"] is None
+    promotions_dir = tmp_path / "state" / "promotions"
+    assert not (promotions_dir / "latest.json").exists()
+    assert not list(promotions_dir.glob("promotion-*.json")) if promotions_dir.exists() else True
 
 
 def test_synthesize_fast_path_when_materialize_and_verify_done(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #565.

## Summary
- Host diagnostic found zero real git commits for 8 consecutive days while the coordinator kept reporting `PASS`/`reward=1.2` almost every cycle — a self-rewarding loop with no verified code diff (violates `docs/specs/self-evolving-runtime/spec.md` R8).
- `_has_concrete_changes` now fails **closed**: a git-probe error or non-git workspace returns `False`, never `True`.
- The materialize-lane 1.2 reward bonus now also requires the verified commit to be timestamped at/after cycle start.
- A materialize-lane cycle with no verified diff no longer mints a promotion candidate (previously wrote one with `base_commit: null` / `candidate_patch_hash: null` that sat in the queue forever).
- Updated 3 existing tests that had encoded the old fail-open behavior as "correct" (a non-git workspace returning `True`, and materialize-lane reward/promotion asserted without any real git repo) — they now set up a genuine autoevolve commit and assert the honest contract.

Design doc: `docs/changes/coordinator-reward-hacking-guard/proposal.md`.

Explicitly out of scope (tracked as follow-up): routing real `goal_text.json` backlog items into the dispatchable task pool, and making `materialize-synthesized-improvement` actually dispatch a subagent edit request — this PR only stops the loop from rewarding itself for work that didn't happen.

## Test plan
- [x] `python -m pytest tests/ -v` — 1055 passed
- [x] `ruff check nanobot/runtime/coordinator.py` — no new issues (pre-existing lint findings untouched)
- [ ] Deploy to eeepc host via `deploy_release.sh` after merge and verify next cycles no longer mint reward=1.2/promotion candidates without a real commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)