### PR TITLE
feat(runtime): route goal_text.json backlog + prefer real dispatch on lane-switch

### DIFF
--- a/docs/changes/backlog-routing-real-dispatch/proposal.md
+++ b/docs/changes/backlog-routing-real-dispatch/proposal.md
@@ -1,0 +1,90 @@
+# Change: route goal_text.json backlog into real dispatch, prefer backlog progress on lane-switch
+
+- **change-id:** backlog-routing-real-dispatch
+- **issue:** #568
+- **capability:** `docs/specs/self-evolving-runtime`
+- **role / workstream:** role:developer / workstream:runtime
+
+## Problem
+
+#565/#566 closed the reward-hacking evidence gap, but the underlying reason
+there was no real work to reward is still present: the eeepc host has zero
+new git commits since 2026-06-26.
+
+Contrary to issue #568's original framing, the coordinator already **has** a
+working dispatch mechanism — `_write_materialized_improvement_artifact`
+(`coordinator.py:2580-2711`) → `_write_subagent_request_artifact`
+(`coordinator.py:2758-2843`) already writes real "implement and commit"
+requests into `state/subagents/requests/` when it has a concrete backlog
+task. Two separate things are broken upstream of that mechanism:
+
+1. **The one backlog source that's actually current is never read.**
+   `_write_materialized_improvement_artifact` falls back through, in order:
+   `memory/MEMORY.md` (curriculum-gated) → `workspace/todo.md` →
+   `state/research/feed.json`. On the host: MEMORY.md's backlog is exhausted
+   (`Priority 12 [Done]`, nothing after it), `todo.md` is stale (references
+   already-closed GitHub issues #549-554), so every materialize cycle falls
+   through to the vague, self-invented research-feed candidate ("Priority 99:
+   exploit and expand improvements in scripts/eeebot_dashboard.py") — which is
+   exactly the pattern that produced fake progress before #566. Meanwhile
+   `state/goals/goal_text.json` — freshly seeded on every deploy
+   (`deploy_release.sh`) and containing the operator's actual current
+   priorities ("Priority 5 — write scripts/cycle_logger.py", "Priority 6 —
+   write scripts/smoke_test_loop.py") — is **never read by the coordinator at
+   all**. It's only used by the bridge to build an LLM prompt string.
+
+2. **Lane-switch has no backlog-priority awareness.** `pick_alternative_task`
+   (`stop_guards.py:209-227`) picks "the first task whose id differs from
+   current" from whatever list `_switch_off_stalled_lane`
+   (`coordinator.py:4280-4311`) hands it — no ordering. Across 1841 sampled
+   host cycles, only 231 ever reached `subagent-verify-materialized-improvement`
+   (the task ID that triggers real dispatch) vs. 1268 on pure bookkeeping
+   (`refresh-approval-gate`/`run-bounded-turn`/`record-reward`). On every
+   stall, the switch is as likely to bounce back to bookkeeping as to progress
+   toward the dispatch chain.
+
+## Intended change
+
+1. Add `_parse_backlog_task_from_goal_text(state_root)` — parses
+   `state_root/goals/goal_text.json`'s `"Current priority targets:"` section
+   (lines shaped `(A) Priority N — Title: instructions`) into the same shape
+   `_parse_backlog_task_from_memory` returns (`{"priority", "title",
+   "instructions"}`). Wire it into `_write_materialized_improvement_artifact`'s
+   existing fallback chain as a new tier, between MEMORY.md and todo.md:
+   `MEMORY.md → goal_text.json → todo.md → research feed`. This slots into an
+   existing, already-tested mechanism — no new dispatch code needed.
+2. In `_switch_off_stalled_lane`, sort the candidate `tasks` list before
+   calling `pick_alternative_task` so that backlog-progression task IDs
+   (`synthesize-next-improvement-candidate`, `materialize-pass-streak-improvement`,
+   `MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID`, `subagent-verify-materialized-improvement`)
+   sort ahead of pure bookkeeping (`refresh-approval-gate`, `run-bounded-turn`,
+   `record-reward`, etc.). `pick_alternative_task`'s signature/contract is
+   unchanged — only the order of the list passed to it changes.
+
+## Acceptance
+
+- [ ] `_parse_backlog_task_from_goal_text` correctly parses the current
+      on-host `goal_text.json` shape into `{"priority": 5, "title": "Write
+      scripts/cycle_logger.py", "instructions": "..."}` (unit test with the
+      real host format as fixture).
+- [ ] `_write_materialized_improvement_artifact`, given an exhausted
+      MEMORY.md and a populated `goal_text.json`, produces a
+      `next_bounded_candidate` sourced from `goal_text.json` rather than the
+      research feed (unit test).
+- [ ] `_switch_off_stalled_lane` prefers a backlog-progression task ID over a
+      bookkeeping task ID when both are present in the candidate list on
+      stall (unit test — regression guard: when only bookkeeping tasks
+      exist, behavior is unchanged).
+- [ ] Full test suite green; deployed to eeepc and verified (dev → test →
+      rollout) — at least one subsequent cycle selects/dispatches a
+      goal_text.json-sourced task rather than the research-feed fallback.
+
+## Out of scope
+
+- Redesigning `_derive_bounded_tasks_from_plan`'s selectable pool broadly (no
+  new task-pool architecture) — this only reorders an existing list and adds
+  one new fallback source.
+- Fixing `todo.md` staleness or MEMORY.md curriculum content — those are
+  pre-existing data-quality issues, not this change's concern.
+- Removing/deprioritizing bookkeeping lanes themselves — they remain the
+  correct fallback when the backlog (all sources) is genuinely empty (R5/R6).

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -73,6 +73,15 @@ CORE_TASK_IDS = {
 SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID = "synthesize-next-improvement-candidate"
 MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID = "materialize-synthesized-improvement"
 
+# Issue #568: task IDs that make real progress on the backlog-dispatch chain, preferred
+# over pure bookkeeping lanes (refresh-approval-gate/run-bounded-turn/record-reward) on lane-switch.
+_BACKLOG_PROGRESSION_IDS = {
+    SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID,
+    "materialize-pass-streak-improvement",
+    MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
+    "subagent-verify-materialized-improvement",
+}
+
 COMPLETED_TASK_STATUSES = {
     "blocked",
     "canceled",
@@ -437,6 +446,55 @@ def _next_open_goal_as_backlog_task(workspace: Path | None) -> dict[str, Any] | 
             "priority": int(priority) if priority and priority.isdigit() else None,
         }
     return None
+
+
+# Issue #568: route state/goals/goal_text.json's "Current priority targets:" into the backlog fallback chain.
+def _parse_backlog_task_from_goal_text(state_root: Path) -> dict[str, Any] | None:
+    """Read the lowest-numbered open priority from state/goals/goal_text.json.
+
+    goal_text.json is freshly seeded on every deploy with the operator's actual
+    current priorities (see deploy_release.sh), but was previously only used by
+    the bridge to build an LLM prompt string — never read by the coordinator.
+    Shape matches _parse_backlog_task_from_memory: {'priority', 'title', 'instructions'}.
+    Defensive — never raises; returns None if missing/unreadable/malformed.
+    """
+    goal_text_path = state_root / "goals" / "goal_text.json"
+    if not goal_text_path.exists():
+        return None
+    try:
+        raw = goal_text_path.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    text = data.get("text")
+    if not isinstance(text, str):
+        return None
+
+    import re as _re
+
+    marker = "Current priority targets:"
+    marker_idx = text.find(marker)
+    if marker_idx == -1:
+        return None
+    section = text[marker_idx + len(marker):]
+
+    matches = _re.findall(
+        r"\([A-Za-z]\)\s*Priority\s+(\d+)\s*[—-]\s*(.+?):\s*(.+?)(?=\n\([A-Za-z]\)|\Z)",
+        section,
+        _re.DOTALL,
+    )
+    if not matches:
+        return None
+
+    num, title, instructions = min(matches, key=lambda m: int(m[0]))
+    return {
+        "priority": int(num),
+        "title": title.strip(),
+        "instructions": instructions.strip()[:300],
+        "source": "goal_text",
+    }
 
 
 def _enrich_decision_lane_with_insight(
@@ -2605,13 +2663,20 @@ def _write_materialized_improvement_artifact(
     if _selfevo_root.is_dir():
         backlog_task = _parse_backlog_task_from_memory(_selfevo_root)
 
-    # Fallback 1: when the MEMORY backlog is empty (all Done), implement OUR top open
-    # goal from todo.md — a concrete, goal-aligned task the subagent can actually
-    # build & commit — before falling back to the (often stale) research feed.
+    # Fallback 1: when the MEMORY backlog is empty (all Done), route in the
+    # operator's actual current priorities from state/goals/goal_text.json — this
+    # is freshly seeded on every deploy and is more current than todo.md (#568).
+    if backlog_task is None:
+        backlog_task = _parse_backlog_task_from_goal_text(state_root)
+
+    # Fallback 2: when both MEMORY.md and goal_text.json are unavailable, implement
+    # OUR top open goal from todo.md — a concrete, goal-aligned task the subagent
+    # can actually build & commit — before falling back to the (often stale)
+    # research feed.
     if backlog_task is None:
         backlog_task = _next_open_goal_as_backlog_task(workspace)
 
-    # Fallback 2: last resort — top candidate from research/feed.json.
+    # Fallback 3: last resort — top candidate from research/feed.json.
     if backlog_task is None:
         backlog_task = _pick_candidate_from_research_feed(state_root)
 
@@ -4298,7 +4363,16 @@ def _switch_off_stalled_lane(
         current_id = feedback_decision.get("selected_task_id")
     current_id = current_id or task_plan.get("current_task_id") or task_plan.get("currentTaskId")
     tasks = task_plan.get("tasks") if isinstance(task_plan.get("tasks"), list) else []
-    alt = pick_alternative_task(current_id if isinstance(current_id, str) else None, tasks)
+    # Issue #568: prefer backlog-progression tasks over pure bookkeeping when switching
+    # off a stalled lane, so a stall is more likely to advance real dispatch than bounce
+    # back to bookkeeping. pick_alternative_task's contract is unchanged — only order.
+    sorted_tasks = sorted(
+        tasks,
+        key=lambda t: 0
+        if isinstance(t, dict) and (t.get("task_id") or t.get("taskId")) in _BACKLOG_PROGRESSION_IDS
+        else 1,
+    )
+    alt = pick_alternative_task(current_id if isinstance(current_id, str) else None, sorted_tasks)
     if alt is None:
         return feedback_decision
     alt_id = alt.get("task_id") or alt.get("taskId")

--- a/tests/test_goal_backlog_routing.py
+++ b/tests/test_goal_backlog_routing.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from nanobot.runtime.coordinator import (
     MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
     _next_open_goal_as_backlog_task,
+    _parse_backlog_task_from_goal_text,
     _write_materialized_improvement_artifact,
 )
 
@@ -27,6 +28,16 @@ TODO = """\
   - Acceptance:
     - UI says expired when expired
 - [ ] 2. Next goal
+"""
+
+# Real on-host goal_text.json shape (#568) — see docs/changes/backlog-routing-real-dispatch/proposal.md.
+GOAL_TEXT_JSON = """\
+{
+  "schema_version": "goal-text-v1",
+  "goal_id": "goal-bootstrap",
+  "updated_at_utc": "2026-06-21T15:30:00Z",
+  "text": "eeebot is a resource-aware, self-evolving autonomous agent on a weak eeepc host.\\n\\nCurrent priority targets:\\n(A) Priority 5 \\u2014 Write scripts/cycle_logger.py: helper function append_cycle_summary(repo_root, cycle_id, action, files_changed) that appends one line to memory/HISTORY.md without duplicates. Test with python3 scripts/cycle_logger.py --test. Commit.\\n(B) Priority 6 \\u2014 Write scripts/smoke_test_loop.py: quick sanity check that state/current_health.json, state/host_capabilities.json, memory/MEMORY.md, and state/goals/history/ are non-empty. Output PASS: N/N or list failures. Test with python3 scripts/smoke_test_loop.py. Commit."
+}
 """
 
 
@@ -69,3 +80,62 @@ def test_materialized_artifact_routes_goal_as_implement_and_commit(tmp_path: Pat
     assert "Implement and commit" in nbc["acceptance"]
     assert "recompute approval freshness" in (nbc["backlog_instructions"] or "")
     assert "Implement Priority 1" in artifact["recommended_next_action"]
+
+
+def test_parse_backlog_task_from_goal_text_real_host_format(tmp_path: Path):
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
+
+    task = _parse_backlog_task_from_goal_text(tmp_path)
+    assert task is not None
+    assert task["priority"] == 5
+    assert "cycle_logger.py" in task["title"]
+    assert "append_cycle_summary" in task["instructions"]
+    assert task["source"] == "goal_text"
+
+
+def test_parse_backlog_task_from_goal_text_missing_file_returns_none(tmp_path: Path):
+    assert _parse_backlog_task_from_goal_text(tmp_path) is None
+
+
+def test_parse_backlog_task_from_goal_text_no_priority_section_returns_none(tmp_path: Path):
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "goal_text.json").write_text(
+        json.dumps({"text": "just a plain goal description, no priority targets here."}),
+        encoding="utf-8",
+    )
+    assert _parse_backlog_task_from_goal_text(tmp_path) is None
+
+
+def test_materialized_artifact_routes_goal_text_over_research_feed(tmp_path: Path):
+    state_root = tmp_path / "state"
+    goals_dir = state_root / "goals"
+    goals_dir.mkdir(parents=True)
+    (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
+
+    research_dir = state_root / "research"
+    research_dir.mkdir(parents=True)
+    (research_dir / "feed.json").write_text(
+        json.dumps({"entries": [{"title": "stale research candidate", "action": "do something vague"}]}),
+        encoding="utf-8",
+    )
+
+    # No todo.md / no eeebot-self-evolving MEMORY.md — MEMORY.md exhausted.
+    path = _write_materialized_improvement_artifact(
+        state_root=state_root,
+        cycle_id="cycle-goal-text",
+        goal_id="goal-bootstrap",
+        current_task_id=MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
+        summary="s",
+        reward_signal={"value": 0.8},
+        feedback_decision={"mode": "synthesize_next_candidate"},
+        workspace=tmp_path,
+    )
+    assert path is not None
+    artifact = json.loads(Path(path).read_text(encoding="utf-8"))
+    nbc = artifact["next_bounded_candidate"]
+    assert "cycle_logger.py" in nbc["title"]
+    assert nbc["backlog_priority"] == 5
+    assert "stale research candidate" not in json.dumps(artifact)

--- a/tests/test_stop_guards_enforcement.py
+++ b/tests/test_stop_guards_enforcement.py
@@ -42,3 +42,36 @@ def test_no_switch_when_no_alternative_task():
 def test_no_switch_without_previous_experiment():
     decision = {"selected_task_id": "t1"}
     assert _switch_off_stalled_lane(decision, _plan(), None) is decision
+
+
+def test_switch_prefers_backlog_progression_over_bookkeeping():
+    # #568: on stall, prefer real dispatch progress over bookkeeping lanes, even
+    # when the bookkeeping task appears earlier in the candidate list.
+    decision = {"selected_task_id": "t1"}
+    plan = {
+        "current_task_id": "t1",
+        "tasks": [
+            {"task_id": "t1", "title": "Stalled lane"},
+            {"task_id": "refresh-approval-gate", "title": "Bookkeeping"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Real dispatch"},
+        ],
+    }
+    prev = {"stall": {"stop": True}}
+    out = _switch_off_stalled_lane(decision, plan, prev)
+    assert out["selected_task_id"] == "materialize-synthesized-improvement"
+
+
+def test_switch_unchanged_behavior_when_only_bookkeeping_present():
+    # regression guard: bookkeeping-only candidate list behaves as before (first distinct task).
+    decision = {"selected_task_id": "t1"}
+    plan = {
+        "current_task_id": "t1",
+        "tasks": [
+            {"task_id": "t1", "title": "Stalled lane"},
+            {"task_id": "refresh-approval-gate", "title": "Bookkeeping A"},
+            {"task_id": "record-reward", "title": "Bookkeeping B"},
+        ],
+    }
+    prev = {"stall": {"stop": True}}
+    out = _switch_off_stalled_lane(decision, plan, prev)
+    assert out["selected_task_id"] == "refresh-approval-gate"


### PR DESCRIPTION
Closes #568.

## Summary

Investigation found the coordinator already has a working dispatch mechanism (`_write_materialized_improvement_artifact` → `_write_subagent_request_artifact` writes real "implement and commit" requests into `state/subagents/requests/`) — it just never gets fed real work:

- On the host, `memory/MEMORY.md`'s backlog is exhausted (`Priority 12 [Done]`, nothing after), and `todo.md` is stale (references already-closed GitHub issues #549-554). Every materialize cycle fell through to the vague, self-invented research-feed fallback ("Priority 99: exploit and expand..." — exactly the pattern #565/#566 stopped from being rewarded).
- Meanwhile `state/goals/goal_text.json` — freshly seeded on every deploy with the operator's actual current priorities ("Priority 5 — write scripts/cycle_logger.py", "Priority 6 — write scripts/smoke_test_loop.py") — was **never read by the coordinator at all**, only used by the bridge to build an LLM prompt string.
- Separately, lane-switch (`pick_alternative_task`) has no backlog-priority awareness — across 1841 sampled host cycles, only 231 ever reached the dispatch-triggering task ID vs. 1268 on pure bookkeeping. A stall was as likely to bounce back to bookkeeping as to progress toward real dispatch.

## Changes

1. New `_parse_backlog_task_from_goal_text(state_root)` parses `goal_text.json`'s `"Current priority targets:"` section into the same shape `_parse_backlog_task_from_memory` returns. Wired into `_write_materialized_improvement_artifact`'s existing fallback chain: `MEMORY.md → goal_text.json → todo.md → research feed`.
2. `_switch_off_stalled_lane` now sorts candidate tasks so backlog-progression IDs (`synthesize-next-improvement-candidate`, `materialize-*`, `subagent-verify-materialized-improvement`) are preferred over pure bookkeeping when picking an alternative on stall. `pick_alternative_task`'s signature/contract is unchanged — only task order.

Design doc: `docs/changes/backlog-routing-real-dispatch/proposal.md`.

Explicitly out of scope: redesigning the task-pool architecture broadly, fixing `todo.md` staleness or MEMORY.md curriculum content, removing bookkeeping lanes (they remain the correct fallback per R5/R6 when the backlog is genuinely empty).

## Test plan
- [x] `python -m pytest tests/ -q` — 1061 passed
- [x] `ruff check nanobot/runtime/coordinator.py` — no new issues (pre-existing findings untouched)
- [ ] Deploy to eeepc host via `deploy_release.sh` after merge and verify a subsequent cycle dispatches a `goal_text.json`-sourced task rather than the research-feed fallback, and produces a real executor commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)