### PR TITLE
fix(runtime): give bridge-destined requests a grace period before health-cycle blocking

### DIFF
--- a/docs/changes/subagent-request-consumer-race/proposal.md
+++ b/docs/changes/subagent-request-consumer-race/proposal.md
@@ -1,0 +1,84 @@
+# Change: stop the health cycle from prematurely blocking bridge-destined requests
+
+- **change-id:** subagent-request-consumer-race
+- **issue:** #570
+- **capability:** `docs/specs/subagent-bridge`
+- **role / workstream:** role:developer / workstream:runtime
+
+## Problem
+
+`materialize_subagent_requests` (`nanobot/runtime/subagent_materializer.py:266`) is
+called unconditionally on **every** self-evolving cycle, immediately after
+`_write_subagent_request_artifact` writes a fresh `bounded_execution` request
+(`coordinator.py:4811` → `4821`) — in the same cycle, before the independently
+scheduled subagent-bridge systemd timer has any chance to claim it.
+
+The health-cycle process has no local executor configured
+(`NANOBOT_SUBAGENT_EXECUTOR`/`NANOBOT_SUBAGENT_EXECUTOR_COMMAND` are set for the
+bridge's systemd unit, not this process), so `configured_executor` is falsy
+(`subagent_materializer.py:301-302`), and the request is immediately
+terminalized as `result_status: "blocked"` / `terminal_reason:
+"local_executor_unavailable"` (`:344-393`). The `profile` field on the request
+(`"bounded_execution"`, set at `coordinator.py:2902`) is read only for cosmetic
+echoing into the result/blocker — never used to decide "this belongs to a
+different consumer, leave it alone."
+
+The bridge script already anticipates this: `_is_real_result` in both bridge
+copies treats a `materialized_from: "queued_request_terminalizer"` /
+`local_executor_unavailable` result as **not a real handling** and will still
+process the request on its own next tick — but only if the request file
+itself is still present and `queued` in `state/subagents/requests/`, which it
+is (the materializer never mutates/moves/deletes the request file itself,
+confirmed by reading the code — only `archive_stale_requests`, a separate
+4-hour-cutoff step, physically moves files). So today's behavior is not fatal
+data loss, but it does: (a) produce a confusing/noisy permanent `blocked`
+result artifact for a request the bridge later handles fine, and (b) risks a
+race where a *slow* bridge tick could still leave a stale-looking "blocked"
+result as the only signal an operator sees for a while.
+
+## Intended change
+
+In `materialize_subagent_requests`'s request-processing loop
+(`subagent_materializer.py:325-343`), before falling through to the
+executor/blocking logic: if a request's `profile` is `"bounded_execution"`
+(the bridge's own dispatch profile) AND the request is younger than a short
+grace period, skip it (`skipped += 1; continue`) — leave it untouched in
+`requests/` for the bridge to claim via its own polling. If the request is
+**older** than the grace period (meaning the bridge has had several ticks and
+still hasn't claimed it — e.g. the bridge service is down or broken), fall
+through to the existing termination logic unchanged, so a genuinely stuck
+request still gets a legitimate `blocked` fallback rather than sitting
+invisible forever.
+
+Grace period: `BOUNDED_EXECUTION_GRACE_SECONDS = 1800` (30 minutes — roughly 3
+bridge timer ticks at the current ~10-minute cadence), a module-level
+constant next to the existing `archive_stale_requests` 4-hour cutoff. Age is
+computed from the request file's mtime (same source `archive_stale_requests`
+already uses), no new field needed on the request schema.
+
+## Acceptance
+
+- [ ] A fresh (< 30 min old) `bounded_execution`-profile request is skipped
+      by `materialize_subagent_requests` (not terminalized to `blocked`),
+      leaving it queued for the bridge (test).
+- [ ] A `bounded_execution`-profile request older than the grace period is
+      still terminalized to `blocked`/`local_executor_unavailable` exactly as
+      today (regression/fallback guard — test).
+- [ ] Non-`bounded_execution` profiles (`research_only`, `review_only`,
+      `bounded_review`) are completely unaffected — existing tests in
+      `tests/test_runtime_coordinator.py` (`test_subagent_materializer_*`)
+      continue to pass unmodified.
+- [ ] Full test suite green; deployed to eeepc and verified (dev → test →
+      rollout) — a fresh materialize-lane dispatch request is no longer
+      immediately blocked by the health cycle.
+
+## Out of scope
+
+- Rewriting the bridge's own `_is_real_result`/pickup logic — it already
+  correctly treats `queued_request_terminalizer` blocks as non-terminal; this
+  change just avoids producing that noisy artifact in the common case.
+- Reconciling the diverged `scripts/eeepc_self_evolving_subagent_bridge.py`
+  vs. `host/eeepc/libexec/eeepc-self-evolving-subagent-bridge.py` copies —
+  separate pre-existing drift, not this issue's concern.
+- Adding a new `consumer`/`owner` field to the request schema — reusing the
+  existing `profile` field is sufficient and additive.

--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -30,6 +30,12 @@ PI_DEV_COMMAND_ARGV = [
 ]
 PI_DEV_COMMAND = " ".join(shlex.quote(part) for part in PI_DEV_COMMAND_ARGV)
 
+# Issue #570: grace period before the health cycle terminalizes a bridge-destined
+# (bounded_execution) request as blocked — gives the subagent bridge (which has the
+# real local executor) several timer ticks to claim it first, before assuming it's
+# genuinely stuck (e.g. bridge service down).
+BOUNDED_EXECUTION_GRACE_SECONDS = 1800
+
 # Precompiled patterns for subagent request matching
 _REQUEST_ID_RE = re.compile(r"^(subagent-|request-)?([a-f0-9]{8,32})(?:-[\w-]+)?$")
 _TASK_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
@@ -341,6 +347,11 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 existing_by_request.add(str(request_path))
                 skipped += 1
                 continue
+            if str(request.get("profile") or "").lower() == "bounded_execution":
+                age_seconds = (now - datetime.fromtimestamp(request_path.stat().st_mtime, tz=timezone.utc)).total_seconds()
+                if age_seconds < BOUNDED_EXECUTION_GRACE_SECONDS:
+                    skipped += 1
+                    continue
             executor_result: dict[str, Any] | None = None
             executor_ok = False
             if configured_executor and str(request.get("profile") or "").lower() in {"research_only", "review_only", "bounded_review", "bounded_execution"}:

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -966,17 +966,13 @@ def test_cycle_materializes_synthesized_execution_lane_artifact_and_completes(tm
     assert request["schema_version"] == "subagent-request-v1"
     assert request["task_id"] == "subagent-verify-materialized-improvement"
     assert request["source_artifact"] == artifact_path
-    materialization_summary = current.get("subagent_materialization_summary")
-    assert materialization_summary["schema_version"] == "subagent-materializer-summary-v1"
-    assert materialization_summary["terminalized_count"] == 1
-    assert materialization_summary["blocked_result_count"] == 1
-    result_path = Path(materialization_summary["results"][0]["path"])
-    result = _read_json(result_path)
-    assert result["schema_version"] == "subagent-result-v1"
-    assert result["status"] == "blocked"
-    assert result["request_path"] == request_path
+    assert request["profile"] == "bounded_execution"
+    # Issue #570: a freshly written bounded_execution request is left queued for the
+    # subagent bridge to claim (grace period), so the health cycle does not
+    # terminalize/block it in the same cycle it was created.
+    assert "subagent_materialization_summary" not in current
     latest_report = _read_json(tmp_path / "state" / "outbox" / "report.index.json")
-    assert latest_report["subagent_materialization_summary"]["terminalized_count"] == 1
+    assert latest_report.get("subagent_materialization_summary") is None
     assert current["budget_used"]["subagents"] >= 1
     assert current["budget"]["max_subagents"] == 5
     assert current["budget"]["max_tool_calls"] > 12
@@ -1028,14 +1024,33 @@ def test_cycle_executes_configured_subagent_executor_and_consumes_completed_resu
 
     assert "PASS" in summary
     current = _read_json(tmp_path / "state" / "goals" / "current.json")
-    materialization = current["subagent_materialization_summary"]
+    # Issue #570: the freshly written bounded_execution request is left queued for
+    # the subagent bridge (grace period) rather than being consumed by this same
+    # cycle's health-cycle materializer pass, even though a local executor happens
+    # to be configured in this test process.
+    assert "subagent_materialization_summary" not in current
+    assert "subagent_consumption" not in current
+    request_path = Path(current["subagent_request_path"])
+    assert request_path.exists()
+
+    # Once the grace period has elapsed (e.g. the bridge never claimed it), the
+    # materializer's existing fallback logic still runs the configured executor
+    # and terminalizes the request, exactly as before this change.
+    import os as _os
+
+    from nanobot.runtime.subagent_materializer import (
+        BOUNDED_EXECUTION_GRACE_SECONDS,
+        materialize_subagent_requests,
+    )
+
+    later = expires_at - timedelta(minutes=30) + timedelta(seconds=BOUNDED_EXECUTION_GRACE_SECONDS + 60)
+    _os.utime(request_path, ((later - timedelta(seconds=BOUNDED_EXECUTION_GRACE_SECONDS + 60)).timestamp(),) * 2)
+    materialization = materialize_subagent_requests(state_root=tmp_path / "state", now=later)
     assert materialization["terminalized_count"] == 1
     assert materialization["executed_count"] == 1
     result = _read_json(materialization["results"][0]["path"])
     assert result["status"] == "completed"
     assert "FAKE EXECUTOR COMPLETE" in result["summary"]
-    assert current["subagent_consumption"]["consumed_count"] == 1
-    assert current["subagent_consumption"]["result_paths"] == [materialization["results"][0]["path"]]
 
 
 
@@ -2600,6 +2615,96 @@ def test_subagent_materializer_terminalizes_queued_request_and_rollup_correlates
     assert rollup["blocked_result_count"] == 1
     assert rollup["stale_request_count"] == 0
     assert rollup["latest_request"]["materialized_result_path"] == str(result_path)
+
+
+def test_subagent_materializer_skips_fresh_bounded_execution_request_for_bridge(tmp_path):
+    from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "request-cycle-fresh.json"
+    request_path.write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "subagent-verify-materialized-improvement",
+        "cycle_id": "cycle-fresh",
+        "profile": "bounded_execution",
+        "source_artifact": "workspace/state/improvements/materialized-cycle-fresh.json",
+    }), encoding="utf-8")
+    now = datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc)
+    fresh = now - timedelta(seconds=60)
+    import os
+    os.utime(request_path, (fresh.timestamp(), fresh.timestamp()))
+
+    summary = materialize_subagent_requests(state_root=state_root, now=now)
+
+    assert summary["terminalized_count"] == 0
+    assert summary["blocked_result_count"] == 0
+    assert summary["skipped_count"] == 1
+    assert summary["results"] == []
+    result_dir = state_root / "subagents" / "results"
+    assert not any(result_dir.glob("*.json"))
+
+
+def test_subagent_materializer_terminalizes_stale_bounded_execution_request_as_fallback(tmp_path):
+    from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "request-cycle-stuck.json"
+    request_path.write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "subagent-verify-materialized-improvement",
+        "cycle_id": "cycle-stuck",
+        "profile": "bounded_execution",
+        "source_artifact": "workspace/state/improvements/materialized-cycle-stuck.json",
+    }), encoding="utf-8")
+    now = datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc)
+    stuck = now - timedelta(seconds=2000)
+    import os
+    os.utime(request_path, (stuck.timestamp(), stuck.timestamp()))
+
+    summary = materialize_subagent_requests(state_root=state_root, now=now)
+
+    assert summary["terminalized_count"] == 1
+    assert summary["blocked_result_count"] == 1
+    result_path = Path(summary["results"][0]["path"])
+    result = _read_json(result_path)
+    assert result["status"] == "blocked"
+    assert result["terminal_reason"] == "local_executor_unavailable"
+
+
+def test_subagent_materializer_terminalizes_fresh_research_only_request_regardless_of_grace_period(tmp_path):
+    from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True)
+    request_path = request_dir / "request-cycle-fresh-research.json"
+    request_path.write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "request_status": "queued",
+        "task_id": "subagent-verify-materialized-improvement",
+        "cycle_id": "cycle-fresh-research",
+        "profile": "research_only",
+        "source_artifact": "workspace/state/improvements/materialized-cycle-fresh-research.json",
+    }), encoding="utf-8")
+    now = datetime(2026, 4, 25, 12, 10, tzinfo=timezone.utc)
+    fresh = now - timedelta(seconds=60)
+    import os
+    os.utime(request_path, (fresh.timestamp(), fresh.timestamp()))
+
+    summary = materialize_subagent_requests(state_root=state_root, now=now)
+
+    assert summary["terminalized_count"] == 1
+    assert summary["blocked_result_count"] == 1
+    result_path = Path(summary["results"][0]["path"])
+    result = _read_json(result_path)
+    assert result["status"] == "blocked"
+    assert result["terminal_reason"] == "local_executor_unavailable"
 
 
 def test_material_progress_rejects_stale_historic_proofs_for_discarded_current_cycle():


### PR DESCRIPTION
Closes #570.

## Summary

`materialize_subagent_requests` runs on every self-evolving cycle, immediately after `_write_subagent_request_artifact` writes a fresh `bounded_execution` request — in the same cycle, before the independently-scheduled subagent bridge (which has the real local executor) gets any chance to claim it. The health-cycle process has no executor configured, so the request was instantly terminalized as `blocked`/`local_executor_unavailable` — a noisy, misleading permanent artifact for work the bridge often handles fine moments later (confirmed on host during #568/#569 verification).

## Changes

- New constant `BOUNDED_EXECUTION_GRACE_SECONDS = 1800` (30 min ≈ 3 bridge timer ticks).
- In `materialize_subagent_requests`'s request loop: a `bounded_execution`-profile request younger than the grace period is skipped (left queued for the bridge) instead of terminalized. Once older than the grace period — bridge genuinely stuck/down — it still falls through to the existing blocked-fallback logic unchanged.
- Other profiles (`research_only`, `review_only`, `bounded_review`) are completely unaffected.
- Two existing coordinator integration tests updated to reflect the new same-cycle-skip behavior (one adds a follow-up call with an aged mtime to still cover the old fallback-execution path). Three new materializer-level tests: fresh `bounded_execution` skipped, stale `bounded_execution` still blocked as fallback, fresh `research_only` unaffected.

Design doc: `docs/changes/subagent-request-consumer-race/proposal.md`.

Explicitly out of scope: rewriting the bridge's own pickup logic (already correct), reconciling the diverged bridge script copies, adding a new request-schema field (reusing existing `profile` is sufficient).

## Test plan
- [x] `python -m pytest tests/ -q` — 1064 passed
- [x] `ruff check` — no new issues (27 pre-existing findings, unchanged)
- [ ] Deploy to eeepc host after merge and verify a fresh `bounded_execution` request is left queued for the bridge instead of being immediately blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)