### PR TITLE
fix(runtime,dashboard): cross-cycle subagent_consumption matching + grace-aware dashboard stagnant check

### DIFF
--- a/docs/changes/dashboard-and-consumption-grace-period-regressions/proposal.md
+++ b/docs/changes/dashboard-and-consumption-grace-period-regressions/proposal.md
@@ -1,0 +1,98 @@
+# Change: fix dashboard false-stagnant and cross-cycle subagent_consumption gaps from the #571 grace period
+
+- **change-id:** dashboard-and-consumption-grace-period-regressions
+- **issue:** #572
+- **capability:** `docs/specs/subagent-bridge`
+- **role / workstream:** role:developer / workstream:runtime
+
+## Problem
+
+#571 added `BOUNDED_EXECUTION_GRACE_SECONDS = 1800` so a fresh `bounded_execution`
+request is left queued (no result) for up to 30 minutes instead of being
+terminalized immediately. Two consumers weren't updated for this and are
+confirmed broken by code review + reading the logic:
+
+1. `ops/dashboard/src/nanobot_ops_dashboard/app.py`'s `_discover_subagent_requests`
+   already computes per-request `age_seconds` (mtime-based, line ~1426), but
+   `queued_subagent_request_count` (line ~1528) counts every queued request with
+   no age filter, and `unresolved_subagent_request` (lines ~2122-2127) — which
+   forces `autonomy_verdict.status = "stagnant"` — trips whenever
+   `queued_count > 0` regardless of age. Every normal `bounded_execution` cycle
+   now falsely reports "stagnant" for up to 30 minutes.
+2. `nanobot/runtime/coordinator.py`'s `_subagent_consumption_snapshot`
+   (~line 2104) only accepts a materializer result as a match when
+   `"cycle_id" in match_reasons or "report_path" in match_reasons`. The
+   materializer stamps the request's *original* `cycle_id` into the result,
+   never a `report_path`. When a request is terminalized in a later cycle than
+   the one that created it (now routine), the terminalizing cycle's own
+   `cycle_id` won't equal the request's original one, so the match fails and
+   `subagent_consumption` silently never populates for that request.
+
+## Intended change
+
+### 1. Dashboard: age-aware unresolved check
+
+Import `BOUNDED_EXECUTION_GRACE_SECONDS` from `nanobot.runtime.subagent_materializer`
+into `app.py`. In `_discover_subagent_requests`'s result (or the call site that
+derives `unresolved_subagent_request`), compute a grace-aware count — e.g.
+`queued_beyond_grace_count`: the number of queued requests that are either not
+`profile: bounded_execution`, or are `bounded_execution` AND
+`age_seconds >= BOUNDED_EXECUTION_GRACE_SECONDS`. Use this new count (not the
+raw `queued_subagent_request_count`) to gate `unresolved_subagent_request`.
+`queued_subagent_request_count` itself (the raw display figure) is unchanged —
+this only narrows the "stagnant" trigger, so a genuinely stuck request (past
+the grace period, still no result) still correctly trips stagnant.
+
+### 2. Coordinator: cross-cycle `subagent_consumption` matching
+
+`_write_subagent_request_artifact`'s path is only recorded onto `current_plan`
+in the cycle that creates it (`coordinator.py:4818-4819`). Carry it forward
+across cycles when no new request is written this cycle:
+```python
+current_plan["subagent_request_path"] = subagent_request_path or (
+    recorded_task_plan.get("subagent_request_path")
+    if isinstance(recorded_task_plan, dict) else None
+)
+```
+Pass this persisted path into `_subagent_consumption_snapshot` as a new
+parameter (e.g. `tracked_request_path`). Inside the function, add a new
+`match_reasons` entry when `payload.get("request_path") == tracked_request_path`
+(the materializer result's `request_path` field is the original request
+file's path — stable and always populated), and include this reason in the
+acceptance gate alongside the existing `cycle_id`/`report_path` checks. This
+lets a result terminalized in a later cycle still be attributed correctly, as
+long as the request path is still being tracked (i.e. hasn't been superseded
+by a newer request).
+
+## Acceptance
+
+- [ ] A queued `bounded_execution` request younger than the grace period does
+      not cause `unresolved_subagent_request`/`autonomy_verdict.status` to be
+      `"stagnant"` (test).
+- [ ] Regression guard: a request queued well past the grace period with still
+      no result correctly still trips `stagnant` (test — the existing test
+      `test_autonomy_verdict_blocks_healthy_progress_when_subagent_request_is_queued_without_result`
+      must keep passing unmodified since it constructs the "genuinely stuck"
+      case directly).
+- [ ] A subagent result terminalized in a cycle later than the one that
+      created its request still populates `current["subagent_consumption"]`
+      (test).
+- [ ] Regression guard: the existing same-cycle grace-period test
+      (`test_cycle_executes_configured_subagent_executor_and_consumes_completed_result`)
+      keeps asserting no consumption happens in the SAME cycle a fresh request
+      is written (grace period still applies) — this change only fixes
+      *later*-cycle attribution, it does not shrink the grace period.
+- [ ] Full test suite green; deployed to eeepc and verified (dev → test →
+      rollout).
+
+## Out of scope
+
+- Re-litigating the grace-period mechanism itself (#571).
+- The broader altitude concerns from #571's review (hardcoded profile
+  special-case instead of a general consumer/ownership field; grace period
+  constant not linked to the bridge's timer cadence) — a future design pass,
+  not this bugfix.
+- Any change to `_subagent_rollup_snapshot`/`state.py`'s separate disk-rescan
+  path unless it turns out to feed the same `unresolved_subagent_request`
+  computation (verify during implementation; only touch if actually in the
+  path).

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2054,6 +2054,7 @@ def _subagent_consumption_snapshot(
     cycle_id: str,
     report_path: Path,
     current_task_id: str | None,
+    tracked_request_path: str | None = None,
     max_results: int = 8,
 ) -> dict[str, Any]:
     """Return bridge subagent results that should be consumed by this cycle.
@@ -2101,7 +2102,9 @@ def _subagent_consumption_snapshot(
             payload_task_id = payload.get("current_task_id") or payload.get("task_id")
             if current_task_id and payload_task_id == current_task_id:
                 match_reasons.append("current_task_id")
-            if not ("cycle_id" in match_reasons or "report_path" in match_reasons):
+            if tracked_request_path and payload.get("request_path") == tracked_request_path:
+                match_reasons.append("request_path")
+            if not ("cycle_id" in match_reasons or "report_path" in match_reasons or "request_path" in match_reasons):
                 continue
             # Reuse the stat cached by os.scandir to avoid a second stat() syscall.
             # This cuts syscalls in half for each candidate directory (e.g. 143 files
@@ -4815,8 +4818,11 @@ async def run_self_evolving_cycle(
         current_plan=current_plan,
         workspace=workspace,
     )
+    current_plan["subagent_request_path"] = subagent_request_path or (
+        recorded_task_plan.get("subagent_request_path")
+        if isinstance(recorded_task_plan, dict) else None
+    )
     if subagent_request_path:
-        current_plan["subagent_request_path"] = subagent_request_path
         experiment["budget_used"]["subagents"] = max(int(experiment["budget_used"].get("subagents") or 0), 1)
     subagent_materialization_summary = materialize_subagent_requests(
         state_root=state_root,
@@ -4843,6 +4849,7 @@ async def run_self_evolving_cycle(
         cycle_id=cycle_id,
         report_path=report_path,
         current_task_id=current_plan.get("current_task_id"),
+        tracked_request_path=current_plan.get("subagent_request_path"),
     )
     if subagent_consumption.get("consumed_count"):
         experiment["subagent_consumption"] = subagent_consumption

--- a/ops/dashboard/src/nanobot_ops_dashboard/app.py
+++ b/ops/dashboard/src/nanobot_ops_dashboard/app.py
@@ -17,6 +17,7 @@ from .collector import collect_once, _build_ssh_command
 from .config import DashboardConfig
 from .storage import count_collections, count_events, fetch_events, fetch_latest_collections
 from nanobot.runtime.state import _subagent_rollup_snapshot
+from nanobot.runtime.subagent_materializer import BOUNDED_EXECUTION_GRACE_SECONDS
 
 
 MSK = timezone(timedelta(hours=3), name='MSK')
@@ -1526,6 +1527,16 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
             request['effective_status'] = 'stale'
     stale_count = sum(1 for item in requests if item.get('request_status') in {'queued', 'pending'} and not item.get('materialized_result_path') and item.get('age_seconds', 0) >= stale_after_seconds)
     queued_count = sum(1 for item in requests if item.get('request_status') in {'queued', 'pending'} and not item.get('materialized_result_path'))
+
+    def _within_bounded_execution_grace(item: dict) -> bool:
+        return item.get('profile') == 'bounded_execution' and item.get('age_seconds', 0) < BOUNDED_EXECUTION_GRACE_SECONDS
+
+    queued_beyond_grace_count = sum(
+        1 for item in requests
+        if item.get('request_status') in {'queued', 'pending'}
+        and not item.get('materialized_result_path')
+        and not _within_bounded_execution_grace(item)
+    )
     blocked_count = sum(1 for item in results if str(item.get('status') or '').lower() in {'blocked', 'terminal_blocked'})
     result_count = len(results)
     rollup = None if canonical_remote else _subagent_rollup_snapshot(state_root=state_root)
@@ -1554,6 +1565,7 @@ def _discover_subagent_requests(cfg: DashboardConfig, stale_after_seconds: int =
         'total_requests': len(requests),
         'stale_request_count': stale_count,
         'queued_request_count': queued_count,
+        'queued_beyond_grace_count': queued_beyond_grace_count,
         'result_count': result_count,
         'blocked_result_count': blocked_count,
         'stale_result_count': stale_result_count,
@@ -2113,6 +2125,10 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     subagent_result_count = int(subagent_summary.get('result_count') or 0) if subagent_summary else 0
     stale_subagent_result_count = int(subagent_summary.get('stale_result_count') or 0) if subagent_summary else 0
     queued_subagent_request_count = int(subagent_summary.get('queued_request_count') or 0) if subagent_summary else 0
+    queued_subagent_request_beyond_grace_count = (
+        int(subagent_summary.get('queued_beyond_grace_count') if subagent_summary.get('queued_beyond_grace_count') is not None else queued_subagent_request_count)
+        if subagent_summary else 0
+    )
     blocked_subagent_result_count = int(subagent_summary.get('blocked_result_count') or 0) if subagent_summary else 0
     no_fresh_subagent_result = bool(
         subagent_summary
@@ -2121,7 +2137,7 @@ def _autonomy_verdict(*, analytics: dict, plan_latest: dict | None, experiment_v
     )
     unresolved_subagent_request = bool(
         subagent_summary
-        and queued_subagent_request_count > 0
+        and queued_subagent_request_beyond_grace_count > 0
         and fresh_subagent_result_count == 0
         and blocked_subagent_result_count == 0
     )

--- a/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
+++ b/ops/dashboard/tests/test_dashboard_truth_audit_gaps.py
@@ -3009,6 +3009,92 @@ def test_autonomy_verdict_blocks_healthy_progress_when_subagent_request_is_queue
     assert 'subagent_request_unresolved' in verdict['reasons']
 
 
+def test_discover_subagent_requests_does_not_count_fresh_bounded_execution_request_as_beyond_grace(tmp_path: Path) -> None:
+    repo = tmp_path / 'repo'
+    requests_dir = repo / 'workspace' / 'state' / 'subagents' / 'requests'
+    requests_dir.mkdir(parents=True)
+    request_path = requests_dir / 'request-fresh.json'
+    request_path.write_text(json.dumps({
+        'schema_version': 'subagent-request-v1',
+        'request_status': 'queued',
+        'task_id': 'materialize-synthesized-improvement',
+        'cycle_id': 'cycle-fresh',
+        'profile': 'bounded_execution',
+    }), encoding='utf-8')
+    # Freshly written: age well under BOUNDED_EXECUTION_GRACE_SECONDS (1800s).
+    now = time.time()
+    os.utime(request_path, (now - 60, now - 60))
+    cfg = DashboardConfig(
+        project_root=tmp_path,
+        db_path=tmp_path / 'dashboard.sqlite3',
+        nanobot_repo_root=repo,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root=str(tmp_path / 'nonexistent-canonical-state'),
+    )
+
+    visibility = _discover_subagent_requests(cfg)
+
+    assert visibility['summary']['queued_request_count'] == 1
+    assert visibility['summary']['queued_beyond_grace_count'] == 0
+
+    verdict = _autonomy_verdict(
+        analytics={'recent_status_sequence': [], 'current_streak': {'status': 'PASS', 'length': 3}},
+        plan_latest={'current_task_id': 'materialize-synthesized-improvement'},
+        experiment_visibility={'current_experiment': {'outcome': 'accept'}},
+        credits_visibility={'current': {}},
+        cfg=cfg,
+        material_progress={'schema_version': 'material-progress-v1', 'state': 'proven', 'healthy_autonomy_allowed': True},
+        subagent_visibility=visibility,
+    )
+
+    assert verdict['state'] != 'stagnant'
+    assert 'subagent_request_unresolved' not in verdict['reasons']
+
+
+def test_discover_subagent_requests_still_flags_bounded_execution_request_stagnant_past_grace(tmp_path: Path) -> None:
+    repo = tmp_path / 'repo'
+    requests_dir = repo / 'workspace' / 'state' / 'subagents' / 'requests'
+    requests_dir.mkdir(parents=True)
+    request_path = requests_dir / 'request-stale.json'
+    request_path.write_text(json.dumps({
+        'schema_version': 'subagent-request-v1',
+        'request_status': 'queued',
+        'task_id': 'materialize-synthesized-improvement',
+        'cycle_id': 'cycle-stale',
+        'profile': 'bounded_execution',
+    }), encoding='utf-8')
+    # Well past BOUNDED_EXECUTION_GRACE_SECONDS (1800s) with no result: still stuck.
+    now = time.time()
+    os.utime(request_path, (now - 7200, now - 7200))
+    cfg = DashboardConfig(
+        project_root=tmp_path,
+        db_path=tmp_path / 'dashboard.sqlite3',
+        nanobot_repo_root=repo,
+        eeepc_ssh_host='eeepc',
+        eeepc_ssh_key=tmp_path / 'missing-key',
+        eeepc_state_root=str(tmp_path / 'nonexistent-canonical-state'),
+    )
+
+    visibility = _discover_subagent_requests(cfg)
+
+    assert visibility['summary']['queued_request_count'] == 1
+    assert visibility['summary']['queued_beyond_grace_count'] == 1
+
+    verdict = _autonomy_verdict(
+        analytics={'recent_status_sequence': [], 'current_streak': {'status': 'PASS', 'length': 3}},
+        plan_latest={'current_task_id': 'materialize-synthesized-improvement'},
+        experiment_visibility={'current_experiment': {'outcome': 'accept'}},
+        credits_visibility={'current': {}},
+        cfg=cfg,
+        material_progress={'schema_version': 'material-progress-v1', 'state': 'proven', 'healthy_autonomy_allowed': True},
+        subagent_visibility=visibility,
+    )
+
+    assert verdict['state'] == 'stagnant'
+    assert 'subagent_request_unresolved' in verdict['reasons']
+
+
 def test_ambition_utilization_escalates_rotating_synthesis_reward_window_when_subagents_and_tools_underused() -> None:
     analytics = {
         'recent_status_sequence': [

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from nanobot.runtime.state import _material_progress_snapshot, _subagent_rollup_snapshot, format_runtime_state, load_runtime_state, load_runtime_state_from_root, resolve_runtime_state_location
-from nanobot.runtime.coordinator import _build_task_plan_snapshot, _derive_feedback_decision, _has_concrete_changes, _runtime_source_fingerprint, _write_subagent_request_artifact, run_self_evolving_cycle
+from nanobot.runtime.coordinator import _build_task_plan_snapshot, _derive_feedback_decision, _has_concrete_changes, _runtime_source_fingerprint, _subagent_consumption_snapshot, _write_subagent_request_artifact, run_self_evolving_cycle
 
 
 def _read_json(path):
@@ -518,6 +518,61 @@ def test_cycle_consumes_correlated_subagent_bridge_result_into_canonical_budget(
     assert consumed_path in report_index["goal"]["follow_through"]["artifact_paths"]
     assert outbox["subagent_consumption"] == consumption
     assert credits["subagent_consumption"] == consumption
+
+
+def test_subagent_consumption_snapshot_attributes_result_terminalized_in_a_later_cycle_via_tracked_request_path(tmp_path):
+    """Issue #572: a request created in an earlier cycle (cycle-origin) may only be
+    terminalized by the bridge in a *later* cycle (cycle-later). The terminalizing
+    cycle's own cycle_id/report_path won't match the request's original cycle_id, so
+    the only stable correlation is the persisted request_path carried forward on
+    current_plan['subagent_request_path'] across cycles."""
+    state_root = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    subagents_dir = state_root / "subagents"
+    subagents_dir.mkdir(parents=True)
+    original_request_path = state_root / "subagents" / "requests" / "request-cycle-origin.json"
+    original_request_path.parent.mkdir(parents=True, exist_ok=True)
+    original_request_path.write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "cycle_id": "cycle-origin",
+        "task_id": "subagent-verify-materialized-improvement",
+        "profile": "bounded_execution",
+    }), encoding="utf-8")
+    bridge_result_path = subagents_dir / "result-late.json"
+    bridge_result_path.write_text(json.dumps({
+        "subagent_id": "bridge-late-1",
+        "status": "ok",
+        "summary": "Verified bounded runtime change (terminalized late)",
+        # The materializer stamps the request's *original* cycle_id into the
+        # result, never the terminalizing cycle's own cycle_id/report_path.
+        "cycle_id": "cycle-origin",
+        "report_path": str(tmp_path / "state" / "reports" / "does-not-match.json"),
+        "request_path": str(original_request_path),
+    }), encoding="utf-8")
+
+    # Without tracking, neither cycle_id nor report_path match => no consumption.
+    unmatched = _subagent_consumption_snapshot(
+        state_root=state_root,
+        workspace=workspace,
+        cycle_id="cycle-later",
+        report_path=tmp_path / "state" / "reports" / "current-cycle-report.json",
+        current_task_id=None,
+    )
+    assert unmatched["consumed_count"] == 0
+
+    # With the persisted request_path tracked forward, the later cycle correctly
+    # attributes the result via the new "request_path" match reason.
+    tracked = _subagent_consumption_snapshot(
+        state_root=state_root,
+        workspace=workspace,
+        cycle_id="cycle-later",
+        report_path=tmp_path / "state" / "reports" / "current-cycle-report.json",
+        current_task_id=None,
+        tracked_request_path=str(original_request_path),
+    )
+    assert tracked["consumed_count"] == 1
+    assert tracked["results"][0]["subagent_id"] == "bridge-late-1"
+    assert tracked["results"][0]["match_reasons"] == ["request_path"]
 
 
 def test_cycle_writes_discard_revert_record_when_metric_regresses(tmp_path):


### PR DESCRIPTION
Closes #572.

## Summary

A \`/code-review\` of #571 (the bounded_execution grace-period fix) found two confirmed regressions the grace period introduced in downstream consumers that weren't updated for it:

1. **Dashboard false "stagnant" status**: \`ops/dashboard\`'s \`unresolved_subagent_request\` check counted every queued request with no age filter, so a normal bounded_execution cycle now falsely trips \`autonomy_verdict.status = "stagnant"\` for up to 30 minutes.
2. **\`subagent_consumption\` silently stops populating**: \`_subagent_consumption_snapshot\` only matched a materializer result to the current cycle via \`cycle_id\`/\`report_path\`, both of which reflect the request's *original* cycle — a result terminalized in a later cycle (now routine given the grace period) was silently dropped.

## Changes

1. Dashboard: new \`queued_beyond_grace_count\` (excludes fresh \`bounded_execution\` requests inside \`BOUNDED_EXECUTION_GRACE_SECONDS\`) gates the stagnant check instead of the raw queued count. The existing hand-built-fixture regression test (\`test_autonomy_verdict_blocks_healthy_progress_when_subagent_request_is_queued_without_result\`) keeps passing unmodified via a fallback to the raw count when the new field is absent.
2. Coordinator: \`subagent_request_path\` is now carried forward on \`current_plan\` across cycles when no new request is written; \`_subagent_consumption_snapshot\` accepts a new \`tracked_request_path\` param and adds a \`"request_path"\` match reason, so a result terminalized in a later cycle than its origin still correctly populates \`subagent_consumption\`.
3. New tests: dashboard fresh-vs-stale bounded_execution grace behavior, and cross-cycle \`request_path\` matching in \`_subagent_consumption_snapshot\`.

Design doc: \`docs/changes/dashboard-and-consumption-grace-period-regressions/proposal.md\`.

Explicitly out of scope: re-litigating #571's grace-period mechanism itself; the broader altitude concerns from that review (hardcoded profile special-case, grace period not linked to bridge timer cadence) — a future design pass.

## Test plan
- [x] \`python -m pytest tests/ -q\` — 1065 passed
- [x] \`cd ops/dashboard && python -m pytest tests/ -q\` — 150 passed, 21 failed (pre-existing, unrelated: stale hardcoded template path from an old editable install, confirmed identical before/after this change)
- [x] \`ruff check\` — no new issues (29 pre-existing findings, unchanged)
- [ ] Deploy to eeepc host after merge and verify the dashboard no longer shows false "stagnant" during a normal bounded_execution grace window

🤖 Generated with [Claude Code](https://claude.com/claude-code)