### PR TITLE
fix(bridge): correct SubagentManager kwargs in repair-turn spawn

### DIFF
--- a/scripts/eeepc_self_evolving_subagent_bridge.py
+++ b/scripts/eeepc_self_evolving_subagent_bridge.py
@@ -733,10 +733,16 @@ async def main():
             _repair_cfg = config
             _repair_provider = _make_provider(_repair_cfg)
             _repair_mgr = _SM2(
-                workspace=TARGET_WORKSPACE,
-                config=_repair_cfg,
                 provider=_repair_provider,
-                message_bus=bus,
+                workspace=TARGET_WORKSPACE,
+                bus=bus,
+                model=_repair_cfg.agents.defaults.model,
+                web_search_config=_repair_cfg.tools.web.search,
+                web_proxy=_repair_cfg.tools.web.proxy,
+                exec_config=_repair_cfg.tools.exec,
+                subagent_config=_repair_cfg.tools.subagent,
+                restrict_to_workspace=False,
+                max_running=_repair_cfg.tools.subagent.max_running,
             )
             await _repair_mgr.spawn(
                 task=_repair_prompt,

--- a/tests/test_bridge_repair_subagent_manager_kwargs.py
+++ b/tests/test_bridge_repair_subagent_manager_kwargs.py
@@ -1,0 +1,52 @@
+"""
+Regression test for issue #574: the bridge's repair-turn SubagentManager spawn
+used kwargs (`config`, `message_bus`) that don't exist on SubagentManager.__init__,
+causing every smoke-gate repair attempt to crash the bridge with:
+    TypeError: SubagentManager.__init__() got an unexpected keyword argument 'config'
+
+Statically verifies the repair-spawn call site's keyword arguments are a valid
+subset of SubagentManager.__init__'s real signature, without importing the
+heavy bridge script (which pulls in nanobot config/agent machinery not
+available in this test environment).
+"""
+import ast
+import inspect
+from pathlib import Path
+
+from nanobot.agent.subagent import SubagentManager
+
+BRIDGE_PATH = Path(__file__).parent.parent / "scripts" / "eeepc_self_evolving_subagent_bridge.py"
+
+
+def _find_repair_mgr_call_kwargs() -> set[str]:
+    tree = ast.parse(BRIDGE_PATH.read_text(encoding="utf-8"), filename=str(BRIDGE_PATH))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "_repair_mgr"
+            and isinstance(node.value, ast.Call)
+        ):
+            return {kw.arg for kw in node.value.keywords if kw.arg is not None}
+    raise AssertionError("could not find `_repair_mgr = ...(...)` assignment in bridge script")
+
+
+def test_repair_subagent_manager_call_uses_only_valid_kwargs():
+    valid_params = set(inspect.signature(SubagentManager.__init__).parameters) - {"self"}
+    used_kwargs = _find_repair_mgr_call_kwargs()
+
+    invalid = used_kwargs - valid_params
+    assert not invalid, (
+        f"repair-turn SubagentManager call passes kwargs not accepted by "
+        f"SubagentManager.__init__: {invalid} (valid: {valid_params})"
+    )
+
+
+def test_repair_subagent_manager_call_passes_required_bus_kwarg():
+    used_kwargs = _find_repair_mgr_call_kwargs()
+    # `bus` is a required positional-or-keyword param with no default; the
+    # original bug used `message_bus` (invalid) and omitted `bus` entirely.
+    assert "bus" in used_kwargs
+    assert "message_bus" not in used_kwargs
+    assert "config" not in used_kwargs


### PR DESCRIPTION
Closes #574.

## Summary

The bridge's smoke-gate repair-turn spawn (\`scripts/eeepc_self_evolving_subagent_bridge.py\`, ~line 735) constructed \`SubagentManager\` with \`config=\`/\`message_bus=\` kwargs that don't exist on its \`__init__\` (and never passed the required \`bus=\`), so **every** repair attempt crashed the entire bridge process with an unhandled \`TypeError\` instead of retrying. Observed on host: ~9 of 18 bridge runs crashed in a 3-hour window.

Fixed by mirroring the primary \`mgr\` construction a few lines above (same \`config\`, different provider for the repair turn).

## Test plan
- [x] New regression test statically verifies the repair-spawn call site's kwargs are a valid subset of \`SubagentManager.__init__\`'s real signature (confirmed it fails on the pre-fix code, passes on the fix).
- [x] \`python -m pytest tests/ -q\` — 1067 passed
- [x] \`ruff check\` — no new issues (11 pre-existing findings, unchanged)
- [ ] Deploy to eeepc and verify a smoke-gate failure no longer crashes the bridge service

🤖 Generated with [Claude Code](https://claude.com/claude-code)