### PR TITLE
fix(runtime): skip already-done goal_text.json priorities via shared git-log heuristic

### DIFF
--- a/docs/changes/goal-text-done-detection/proposal.md
+++ b/docs/changes/goal-text-done-detection/proposal.md
@@ -1,0 +1,75 @@
+# Change: skip already-done goal_text.json priorities using the existing git-log heuristic
+
+- **change-id:** goal-text-done-detection
+- **issue:** #575
+- **capability:** `docs/specs/self-evolving-runtime`
+- **role / workstream:** role:developer / workstream:runtime
+
+## Problem
+
+`_parse_backlog_task_from_goal_text` (`coordinator.py:452-497`, added in #568/#569)
+parses `state/goals/goal_text.json`'s `"Current priority targets:"` section
+with **no done-detection** — it always returns the lowest-numbered priority
+found, regardless of whether it was already completed. Meanwhile
+`_parse_backlog_task_from_memory`/`_curriculum_level`
+(`coordinator.py:2502-2554`) already has exactly this heuristic for the
+MEMORY.md backlog: search `eeebot-self-evolving`'s `git log --oneline
+--since=14 days ago`, extract 4+ char words from the priority title, and
+treat it as done if ≥2 of those words appear in the log.
+
+On host: `goal_text.json`'s "Priority 5 — Write scripts/cycle_logger.py" was
+completed 2026-06-22 and re-confirmed as already-done at least 5 times since
+(bridge commits like `chore: confirm Priority 5 (cycle_logger.py) verified
+for cycle-...`). The keyword-match heuristic would already catch this: title
+words `write/scripts/cycle/logger` match `cycle`/`logger` substrings in the
+confirmation commit messages, satisfying the existing `matches >= 2` rule —
+but `_parse_backlog_task_from_goal_text` never runs this check, so the same
+priority keeps getting re-derived as a fresh dispatchable task every cycle,
+producing duplicate `bounded_execution` requests (10 of 13 queued requests
+observed to be exact duplicates).
+
+## Intended change
+
+Extract the git-log keyword-match heuristic currently embedded in
+`_curriculum_level`'s loop body (lines 2544-2552) into a standalone helper,
+e.g. `_title_already_done_in_git_log(title: str, repo_root: Path) -> bool`.
+`_curriculum_level` calls this helper instead of inlining the logic (pure
+refactor, no behavior change — existing MEMORY.md/curriculum tests must keep
+passing unmodified).
+
+Give `_parse_backlog_task_from_goal_text` an optional
+`selfevo_repo_root: Path | None = None` parameter. When iterating candidate
+priorities (currently just taking the lowest-numbered match), skip any whose
+title the new helper reports as already-done, and return the lowest-numbered
+**not-done** priority, or `None` if all found priorities are done.
+
+Update the call site in `_write_materialized_improvement_artifact`
+(`coordinator.py:2673`) to pass the already-in-scope `_selfevo_root`
+(computed at line 2665, before this call) into
+`_parse_backlog_task_from_goal_text(state_root, selfevo_repo_root=_selfevo_root)`.
+
+## Acceptance
+
+- [ ] A `goal_text.json` priority whose title keywords (≥2 matches, 4+ chars)
+      appear in `eeebot-self-evolving`'s recent git log is skipped, not
+      re-derived as a fresh task (test).
+- [ ] When all found `goal_text.json` priorities are already done, the
+      function returns `None` (falls through to the next fallback tier —
+      `todo.md`/research feed — unchanged existing behavior).
+- [ ] Regression guard: `_curriculum_level`'s existing behavior (MEMORY.md
+      `[Done]`-marker + keyword-match gating) is unchanged after the
+      refactor — all existing curriculum/backlog tests pass unmodified.
+- [ ] Regression guard: a genuinely open (not-yet-done) `goal_text.json`
+      priority is still correctly routed — existing #568/#569 tests
+      (`test_parse_backlog_task_from_goal_text_real_host_format`, etc.) pass
+      unmodified.
+- [ ] Full test suite green; deployed to eeepc and verified — the duplicate
+      "Priority 5" request churn stops.
+
+## Out of scope
+
+- Redesigning `goal_text.json`'s schema, adding a `[Done]`-marker convention
+  to it, or making the deploy-time seeding mechanism smarter — this only
+  wires in the existing done-detection heuristic, it doesn't change how
+  `goal_text.json` itself is authored/seeded.
+- The bridge crash bug (#574) — unrelated root cause, fixed separately.

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -449,14 +449,23 @@ def _next_open_goal_as_backlog_task(workspace: Path | None) -> dict[str, Any] | 
 
 
 # Issue #568: route state/goals/goal_text.json's "Current priority targets:" into the backlog fallback chain.
-def _parse_backlog_task_from_goal_text(state_root: Path) -> dict[str, Any] | None:
-    """Read the lowest-numbered open priority from state/goals/goal_text.json.
+def _parse_backlog_task_from_goal_text(
+    state_root: Path, selfevo_repo_root: Path | None = None
+) -> dict[str, Any] | None:
+    """Read the lowest-numbered open (not-already-done) priority from state/goals/goal_text.json.
 
     goal_text.json is freshly seeded on every deploy with the operator's actual
     current priorities (see deploy_release.sh), but was previously only used by
     the bridge to build an LLM prompt string — never read by the coordinator.
     Shape matches _parse_backlog_task_from_memory: {'priority', 'title', 'instructions'}.
     Defensive — never raises; returns None if missing/unreadable/malformed.
+
+    Issue #575: a priority is skipped (treated as already done) when its title's
+    keywords match recent commits in selfevo_repo_root's git log, via the same
+    heuristic used for the MEMORY.md backlog (_title_already_done_in_git_log).
+    If selfevo_repo_root is None or not a valid git directory, every priority is
+    treated as not-done (fail-open, matching the MEMORY.md path's behavior when
+    git access fails).
     """
     goal_text_path = state_root / "goals" / "goal_text.json"
     if not goal_text_path.exists():
@@ -488,13 +497,21 @@ def _parse_backlog_task_from_goal_text(state_root: Path) -> dict[str, Any] | Non
     if not matches:
         return None
 
-    num, title, instructions = min(matches, key=lambda m: int(m[0]))
-    return {
-        "priority": int(num),
-        "title": title.strip(),
-        "instructions": instructions.strip()[:300],
-        "source": "goal_text",
-    }
+    git_log = ""
+    if selfevo_repo_root is not None and selfevo_repo_root.is_dir():
+        git_log = _recent_git_log(selfevo_repo_root)
+
+    for num, title, instructions in sorted(matches, key=lambda m: int(m[0])):
+        title = title.strip()
+        if git_log and _title_already_done_in_git_log(title, git_log):
+            continue  # treat as done — skip to next lowest-numbered priority
+        return {
+            "priority": int(num),
+            "title": title,
+            "instructions": instructions.strip()[:300],
+            "source": "goal_text",
+        }
+    return None  # all found priorities already done
 
 
 def _enrich_decision_lane_with_insight(
@@ -2499,6 +2516,45 @@ def _inferred_generated_candidates_from_tasks(tasks: list[dict[str, Any]]) -> li
     return inferred
 
 
+def _recent_git_log(repo_root: Path, since: str = "14 days ago") -> str:
+    """Return `git log --oneline --since=<since>` output for repo_root, or "" on any failure.
+
+    Shared helper: both `_curriculum_level` (MEMORY.md backlog) and
+    `_parse_backlog_task_from_goal_text` (goal_text.json priorities) need
+    "recent git log text for a repo" to feed the done-detection heuristic (#575).
+    """
+    import subprocess as _sp
+
+    git_cmd = [
+        "git", "-c", f"safe.directory={repo_root}",
+        "-C", str(repo_root),
+        "log", "--oneline", f"--since={since}",
+    ]
+    try:
+        return _sp.check_output(git_cmd, stderr=_sp.DEVNULL, timeout=10).decode(errors="replace")
+    except Exception:
+        return ""
+
+
+def _title_already_done_in_git_log(title: str, git_log: str) -> bool:
+    """Return True if >=2 words (4+ chars) from title appear in the given git log text.
+
+    Shared heuristic: a priority/backlog title is treated as already completed
+    when its distinctive words show up in recent commit messages, even if the
+    priority itself carries no explicit [Done] marker (used for both the
+    MEMORY.md backlog curriculum and goal_text.json priority parsing — #575).
+    """
+    import re as _re
+
+    if not git_log:
+        return False
+    words = [w.lower() for w in _re.findall(r'[A-Za-z]{4,}', title)]
+    if len(words) < 2:
+        return False
+    matches = sum(1 for w in words if w in git_log.lower())
+    return matches >= 2
+
+
 def _curriculum_level(selfevo_repo_root: Path) -> int:
     """Return the curriculum level: the priority number of the first non-Done backlog item.
 
@@ -2515,7 +2571,6 @@ def _curriculum_level(selfevo_repo_root: Path) -> int:
         return 9
 
     import re as _re
-    import subprocess as _sp
 
     backlog_match = _re.search(r"## (?:Concrete backlog|Active backlog).*?(?=\n## |\Z)", text, _re.DOTALL)
     if not backlog_match:
@@ -2528,15 +2583,7 @@ def _curriculum_level(selfevo_repo_root: Path) -> int:
         _re.DOTALL,
     )
 
-    git_cmd = [
-        "git", "-c", f"safe.directory={selfevo_repo_root}",
-        "-C", str(selfevo_repo_root),
-        "log", "--oneline", "--since=14 days ago",
-    ]
-    try:
-        git_log = _sp.check_output(git_cmd, stderr=_sp.DEVNULL, timeout=10).decode(errors="replace")
-    except Exception:
-        git_log = ""
+    git_log = _recent_git_log(selfevo_repo_root)
 
     for num, title, _body in priority_blocks:
         title = title.strip()
@@ -2544,12 +2591,8 @@ def _curriculum_level(selfevo_repo_root: Path) -> int:
         if _re.search(r"\[Done\]", title, _re.IGNORECASE):
             continue
         # Done by git log: ≥2 keywords (4+ chars) found in recent commits
-        if git_log:
-            words = [w.lower() for w in _re.findall(r'[A-Za-z]{4,}', title)]
-            if len(words) >= 2:
-                matches = sum(1 for w in words if w in git_log.lower())
-                if matches >= 2:
-                    continue  # treat as done
+        if _title_already_done_in_git_log(title, git_log):
+            continue
         return int(num)
     return 9999  # all done
 
@@ -2670,7 +2713,7 @@ def _write_materialized_improvement_artifact(
     # operator's actual current priorities from state/goals/goal_text.json — this
     # is freshly seeded on every deploy and is more current than todo.md (#568).
     if backlog_task is None:
-        backlog_task = _parse_backlog_task_from_goal_text(state_root)
+        backlog_task = _parse_backlog_task_from_goal_text(state_root, selfevo_repo_root=_selfevo_root)
 
     # Fallback 2: when both MEMORY.md and goal_text.json are unavailable, implement
     # OUR top open goal from todo.md — a concrete, goal-aligned task the subagent

--- a/tests/test_goal_backlog_routing.py
+++ b/tests/test_goal_backlog_routing.py
@@ -9,6 +9,7 @@ top open goal in as a concrete implement-and-commit task.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from nanobot.runtime.coordinator import (
@@ -107,6 +108,66 @@ def test_parse_backlog_task_from_goal_text_no_priority_section_returns_none(tmp_
         encoding="utf-8",
     )
     assert _parse_backlog_task_from_goal_text(tmp_path) is None
+
+
+# ─── #575: skip already-done goal_text.json priorities via shared git-log heuristic ───
+
+def _make_git_repo_with_commit(tmp_path: Path, commit_message: str) -> Path:
+    """Create a tmp git repo (playing the role of eeebot-self-evolving) with one commit."""
+    repo = tmp_path / "eeebot-self-evolving"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+    (repo / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", commit_message], cwd=repo, check=True)
+    return repo
+
+
+def test_parse_backlog_task_from_goal_text_skips_done_priority_via_git_log(tmp_path: Path):
+    """Priority 5's title keywords ('cycle', 'logger') match a recent commit → skipped, P6 returned."""
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
+
+    repo = _make_git_repo_with_commit(
+        tmp_path, "chore: confirm Priority 5 (cycle_logger.py) verified for cycle-999"
+    )
+
+    task = _parse_backlog_task_from_goal_text(tmp_path, selfevo_repo_root=repo)
+    assert task is not None
+    assert task["priority"] == 6
+    assert "smoke_test_loop.py" in task["title"]
+
+
+def test_parse_backlog_task_from_goal_text_all_done_returns_none(tmp_path: Path):
+    """When every found priority matches the git log, the function returns None."""
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
+
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        "chore: confirm cycle logger and smoke test loop both verified",
+    )
+
+    task = _parse_backlog_task_from_goal_text(tmp_path, selfevo_repo_root=repo)
+    assert task is None
+
+
+def test_parse_backlog_task_from_goal_text_open_priority_regression(tmp_path: Path):
+    """An open priority with no matching commits is still returned correctly."""
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
+
+    repo = _make_git_repo_with_commit(tmp_path, "chore: unrelated housekeeping commit")
+
+    task = _parse_backlog_task_from_goal_text(tmp_path, selfevo_repo_root=repo)
+    assert task is not None
+    assert task["priority"] == 5
+    assert "cycle_logger.py" in task["title"]
 
 
 def test_materialized_artifact_routes_goal_text_over_research_feed(tmp_path: Path):


### PR DESCRIPTION
Closes #575.

## Summary

`_parse_backlog_task_from_goal_text` (#568/#569) had no done-detection — it always returned the lowest-numbered priority in `goal_text.json` regardless of whether it was already completed. Meanwhile `_curriculum_level` (used for the MEMORY.md backlog) already has exactly this heuristic: search `eeebot-self-evolving`'s recent git log, treat a title as done if ≥2 of its 4+-char words appear in commit messages. On host, "Priority 5 — Write scripts/cycle_logger.py" was completed 2026-06-22 and re-confirmed done 5+ times since, but kept being re-derived as a fresh dispatchable task every materialize cycle — 10 of 13 queued subagent requests observed to be exact duplicates.

## Changes

- Extracted the git-log fetch (`_recent_git_log`) and keyword-match check (`_title_already_done_in_git_log`) out of `_curriculum_level` into standalone, reusable helpers — `_curriculum_level` itself is refactored to call them, behavior unchanged.
- `_parse_backlog_task_from_goal_text` gained an optional `selfevo_repo_root` param; it now skips any priority whose title matches the git-log heuristic and returns the next lowest-numbered not-done one, or `None` if all are done.
- Wired the already-in-scope `_selfevo_root` into the call site in `_write_materialized_improvement_artifact`.

Design doc: `docs/changes/goal-text-done-detection/proposal.md`.

Explicitly out of scope: redesigning `goal_text.json`'s schema/seeding; #574 (bridge crash, unrelated root cause).

## Test plan
- [x] `python -m pytest tests/ -q` — 1068 passed
- [x] `ruff check` — no new issues (10 pre-existing findings, unchanged)
- [ ] Deploy to eeepc and verify the duplicate "Priority 5" request churn stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)