### PR TITLE
feat(runtime): thread agents.defaults.maxToolIterations into subagent turns

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -92,6 +92,7 @@ class AgentLoop:
             web_proxy=web_proxy,
             exec_config=self.exec_config,
             restrict_to_workspace=restrict_to_workspace,
+            max_iterations=self.max_iterations,
         )
 
         self._running = False

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -36,6 +36,7 @@ class SubagentManager:
         subagent_config: Any | None = None,
         restrict_to_workspace: bool = False,
         max_running: int | None = None,
+        max_iterations: int | None = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -49,6 +50,11 @@ class SubagentManager:
         self.subagent_config = subagent_config
         configured_max_running = getattr(subagent_config, "max_running", None)
         self.max_running = int(max_running or configured_max_running or 1)
+        # Issue #578: previously hardcoded to 15 inside _run_subagent's loop, decoupled
+        # from agents.defaults.maxToolIterations (the main agent's own cap). Callers
+        # should now pass the same value through so subagents aren't cut off earlier
+        # than the coordinator's budget allows.
+        self.max_iterations = int(max_iterations) if max_iterations else 15
         self.restrict_to_workspace = restrict_to_workspace
         self._running_tasks: dict[str, asyncio.Task[None]] = {}
         self._session_tasks: dict[str, set[str]] = {}  # session_key -> {task_id, ...}
@@ -154,7 +160,7 @@ class SubagentManager:
             ]
 
             # Run agent loop (limited iterations)
-            max_iterations = 15
+            max_iterations = self.max_iterations
             iteration = 0
             final_result: str | None = None
 

--- a/scripts/eeepc_self_evolving_subagent_bridge.py
+++ b/scripts/eeepc_self_evolving_subagent_bridge.py
@@ -613,6 +613,9 @@ async def main():
         subagent_config=config.tools.subagent,
         restrict_to_workspace=False,
         max_running=config.tools.subagent.max_running,
+        # Issue #578: reuse the same cap as the main agent (agents.defaults.maxToolIterations)
+        # instead of the SubagentManager default of 15 — one consistent value end-to-end.
+        max_iterations=config.agents.defaults.max_tool_iterations,
     )
 
     # Capture HEAD SHA before spawn so we can count subagent commits correctly,
@@ -743,6 +746,7 @@ async def main():
                 subagent_config=_repair_cfg.tools.subagent,
                 restrict_to_workspace=False,
                 max_running=_repair_cfg.tools.subagent.max_running,
+                max_iterations=_repair_cfg.agents.defaults.max_tool_iterations,
             )
             await _repair_mgr.spawn(
                 task=_repair_prompt,

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -19,3 +19,35 @@ def test_subagent_manager_accepts_deployed_bridge_compat_kwargs(tmp_path):
         max_running=2,
     )
     assert manager.max_running == 2
+
+
+def test_subagent_manager_default_max_iterations_is_15(tmp_path):
+    """Issue #578: omitting max_iterations preserves the historical default."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    class Provider:
+        def get_default_model(self):
+            return 'test-model'
+
+    manager = SubagentManager(provider=Provider(), workspace=tmp_path, bus=MessageBus())
+    assert manager.max_iterations == 15
+
+
+def test_subagent_manager_honors_configured_max_iterations(tmp_path):
+    """Issue #578: callers can thread agents.defaults.maxToolIterations through,
+    so a subagent turn isn't cut off earlier than the coordinator's own budget."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    class Provider:
+        def get_default_model(self):
+            return 'test-model'
+
+    manager = SubagentManager(
+        provider=Provider(),
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_iterations=100,
+    )
+    assert manager.max_iterations == 100


### PR DESCRIPTION
Closes #578.

## Summary

`SubagentManager` hardcoded `max_iterations = 15` for every subagent turn (the ones that call the qwen 3.6 27b executor model to edit code), completely decoupled from `agents.defaults.maxToolIterations` (the main coordinator agent's own cap — 40 default, **100** on the deployed eeepc host) and from the coordinator's own experiment budget tiers (up to 32-40 tool calls). Every individual subagent spawn force-stopped at 15 round-trips regardless of how much budget/compute was actually available — leaving qwen 27b capacity underused (operator observation: minimal model utilization despite available headroom).

## Changes

- `SubagentManager.__init__` gains an optional `max_iterations` param (default 15 — unchanged behavior for any caller that omits it).
- `_run_subagent`'s loop now uses `self.max_iterations` instead of the hardcoded literal.
- Threaded the SAME `agents.defaults.max_tool_iterations` value through both places that matter, rather than introducing a new/separate config knob:
  - `nanobot/agent/loop.py`'s `AgentLoop` now passes its own already-configured `self.max_iterations` to the `SubagentManager` it constructs.
  - `scripts/eeepc_self_evolving_subagent_bridge.py`'s primary and repair-turn subagent spawns pass `config.agents.defaults.max_tool_iterations`.

One consistent, single-source-of-truth value end-to-end (main agent and subagents both driven by `agents.defaults.maxToolIterations`), instead of a second, lower, hardcoded cap nobody could tune.

Explicitly out of scope: changing the numeric value itself (already 100 on host); `host/eeepc/libexec/eeepc-self-evolving-subagent-bridge.py` (stub, always overwritten by deploy, not live code); the coordinator's own experiment budget tiers (separate, unaffected).

## Test plan
- [x] New unit tests: default `max_iterations=15` preserved when omitted; configured value (100) honored.
- [x] `python -m pytest tests/ -q` — 1072 passed
- [x] `ruff check` — no new issues (14 pre-existing findings, unchanged)
- [ ] Deploy to eeepc and verify subagent turns can now run up to 100 iterations instead of stopping at 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)