### PR TITLE
fix(runtime): never continue or switch onto orphaned task_ids (#580 follow-up)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -208,7 +208,13 @@ def _task_status(task: dict[str, Any] | None) -> str:
 
 def _task_is_selectable(task: dict[str, Any] | None) -> bool:
     status = _task_status(task)
-    return status not in COMPLETED_TASK_STATUSES
+    if status in COMPLETED_TASK_STATUSES:
+        return False
+    if isinstance(task, dict):
+        task_id = task.get("task_id") or task.get("taskId")
+        if task_id and str(task_id) not in KNOWN_TASK_IDS:
+            return False
+    return True
 
 
 def _retire_orphaned_task_ids(task_records: list[dict[str, Any]]) -> int:
@@ -1177,6 +1183,52 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
         if strong_pass_signature is not None
         else None
     )
+
+    # Issue #580 follow-up: current_task_id itself can be an orphan left behind
+    # by removed code (e.g. a live cycle already made it "active" before the
+    # repair pass ran). Never let a continue/streak branch below keep it
+    # selected — switch off it here, before any other branch gets a chance.
+    if isinstance(current_task_id, str) and current_task_id and current_task_id not in KNOWN_TASK_IDS:
+        _orphan_sorted_candidates = sorted(
+            task_records,
+            key=lambda t: 0
+            if isinstance(t, dict) and (t.get("task_id") or t.get("taskId")) in _BACKLOG_PROGRESSION_IDS
+            else 1,
+        )
+        orphan_alternative: dict[str, Any] | None = None
+        for _candidate in _orphan_sorted_candidates:
+            if not isinstance(_candidate, dict):
+                continue
+            _candidate_id = _candidate.get("task_id") or _candidate.get("taskId")
+            if not _candidate_id or _candidate_id == current_task_id:
+                continue
+            if _task_is_selectable(_candidate):
+                orphan_alternative = _candidate
+                break
+        if orphan_alternative is not None:
+            _alt_id = orphan_alternative.get("task_id") or orphan_alternative.get("taskId")
+            return {
+                "mode": "switch_stalled_lane",
+                "reason": f"current_task_id {current_task_id!r} is not a known/producible task_id (orphaned); switched to {_alt_id}",
+                "reward_value": reward_value,
+                "current_task_id": current_task_id,
+                "current_task_class": current_task_class,
+                "repeat_block_count": repeat_block_count,
+                "repeat_block_failure_class": repeat_block_failure_class,
+                "goal_artifact_signature": strong_pass_signature_list,
+                "strong_pass_count": strong_pass_count,
+                "retire_goal_artifact_pair": False,
+                "selected_task_id": _alt_id,
+                "selected_task_class": _task_action_class(_alt_id),
+                "selection_source": "orphaned_current_task_retired",
+                "selected_task_title": orphan_alternative.get("title") or orphan_alternative.get("summary") or _alt_id,
+                "selected_task_label": _render_task_selection(orphan_alternative),
+            }
+        # No selectable alternative exists — fall through to the existing
+        # logic below rather than crash; the generic branches will still see
+        # _task_by_id.get(current_task_id) resolve to the (now-retired)
+        # orphan record, but _task_is_selectable's KNOWN_TASK_IDS check keeps
+        # any downstream selection logic from treating it as selectable.
 
     selected_task: dict[str, Any] | None = None
     selection_source = "recorded_current_task"
@@ -4453,11 +4505,16 @@ def _switch_off_stalled_lane(
         current_id = feedback_decision.get("selected_task_id")
     current_id = current_id or task_plan.get("current_task_id") or task_plan.get("currentTaskId")
     tasks = task_plan.get("tasks") if isinstance(task_plan.get("tasks"), list) else []
+    # Issue #580 follow-up: pick_alternative_task has no status/orphan awareness —
+    # it returns the first task with a different id, even if that task is already
+    # done or is an orphaned task_id left behind by removed code. Filter to
+    # selectable tasks first so the stall-switch can never land on a dead lane.
+    selectable_tasks = [t for t in tasks if isinstance(t, dict) and _task_is_selectable(t)]
     # Issue #568: prefer backlog-progression tasks over pure bookkeeping when switching
     # off a stalled lane, so a stall is more likely to advance real dispatch than bounce
     # back to bookkeeping. pick_alternative_task's contract is unchanged — only order.
     sorted_tasks = sorted(
-        tasks,
+        selectable_tasks,
         key=lambda t: 0
         if isinstance(t, dict) and (t.get("task_id") or t.get("taskId")) in _BACKLOG_PROGRESSION_IDS
         else 1,

--- a/tests/test_coordinator_orphaned_task_ids.py
+++ b/tests/test_coordinator_orphaned_task_ids.py
@@ -13,6 +13,7 @@ from nanobot.runtime.coordinator import (
     TASK_ACTION_CLASS_BY_ID,
     _derive_feedback_decision,
     _retire_orphaned_task_ids,
+    _switch_off_stalled_lane,
     _task_is_selectable,
 )
 
@@ -124,6 +125,91 @@ def test_derive_feedback_decision_repairs_orphan_from_persisted_goal_state(tmp_p
     orphan = next(t for t in tasks if t["task_id"] == "exploit-successful-improvement-path")
     assert _task_is_selectable(orphan) is False
     assert orphan["terminal_reason"] == "orphaned_unrecognized_task_id"
+
+
+def test_task_is_selectable_rejects_unknown_task_id():
+    """Follow-up to #580: selection paths that don't run after the repair pass
+
+    (e.g. _switch_off_stalled_lane's raw task list) must independently reject
+    orphaned task_ids, not rely solely on _retire_orphaned_task_ids having
+    already flipped the status.
+    """
+    unknown_pending = {"task_id": "exploit-successful-improvement-path", "status": "pending"}
+    assert _task_is_selectable(unknown_pending) is False
+
+    known_pending = {"task_id": "run-bounded-turn", "status": "pending"}
+    assert _task_is_selectable(known_pending) is True
+
+
+def test_derive_feedback_decision_switches_off_orphan_made_current_before_repair(tmp_path):
+    """Regression for the escape that #580's first fix missed (verified live on
+
+    the host): a pre-deploy cycle had already made the orphan
+    exploit-successful-improvement-path the current_task_id (status=active).
+    The generic "stable" continue-lane branch in _derive_feedback_decision
+    only checked `active_task is not None`, so it kept running the orphan lane
+    even after _retire_orphaned_task_ids canceled the record in place. This
+    mirrors the exact live snapshot: orphan active as current_task_id,
+    subagent-verify-materialized-improvement pending with a terminal_reason,
+    four backlog-progression tasks already done, and the three core
+    bookkeeping tasks pending.
+    """
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "history").mkdir()
+
+    tasks = [
+        {"task_id": "materialize-synthesized-improvement", "status": "done"},
+        {"task_id": "synthesize-next-improvement-candidate", "status": "done"},
+        {"task_id": "inspect-pass-streak", "status": "done"},
+        {"task_id": "materialize-pass-streak-improvement", "status": "done"},
+        {
+            "task_id": "subagent-verify-materialized-improvement",
+            "status": "pending",
+            "terminal_reason": "terminal_noop_or_no_material_change",
+        },
+        {"task_id": "exploit-successful-improvement-path", "status": "active"},
+        {"task_id": "refresh-approval-gate", "status": "pending"},
+        {"task_id": "run-bounded-turn", "status": "pending"},
+        {"task_id": "record-reward", "status": "pending"},
+    ]
+    task_plan = {
+        "current_task_id": "exploit-successful-improvement-path",
+        "tasks": tasks,
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals_dir)
+
+    assert decision is not None
+    assert decision["selected_task_id"] != "exploit-successful-improvement-path"
+    assert decision["selected_task_id"] in KNOWN_TASK_IDS
+    assert decision["mode"] != "continue_active_lane"
+
+
+def test_switch_off_stalled_lane_never_lands_on_done_or_orphaned_task():
+    """The R11 stop-guard passes the RAW task list to pick_alternative_task,
+
+    which has no status/orphan awareness — it just returns the first task
+    with a different id. Verify the coordinator-side filter added in the
+    #580 follow-up keeps the stall-switch off both a `done` task and an
+    orphaned task_id, landing on the next pending known task instead.
+    """
+    decision = {"selected_task_id": "run-bounded-turn"}
+    plan = {
+        "current_task_id": "run-bounded-turn",
+        "tasks": [
+            {"task_id": "run-bounded-turn", "title": "Stalled lane"},
+            {"task_id": "exploit-successful-improvement-path", "title": "Orphan", "status": "active"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Already done", "status": "done"},
+            {"task_id": "record-reward", "title": "Next known pending task", "status": "pending"},
+        ],
+    }
+    prev = {"stall": {"stop": True}}
+
+    out = _switch_off_stalled_lane(decision, plan, prev)
+
+    assert out["selected_task_id"] == "record-reward"
+    assert out["mode"] == "switch_stalled_lane"
 
 
 def test_known_task_ids_is_a_superset_of_the_core_constants():

--- a/tests/test_stop_guards_enforcement.py
+++ b/tests/test_stop_guards_enforcement.py
@@ -6,23 +6,26 @@ from nanobot.runtime.coordinator import _switch_off_stalled_lane
 
 
 def _plan():
+    # run-bounded-turn / record-reward are real known task_ids (KNOWN_TASK_IDS);
+    # placeholder ids like "t1"/"t2" are now rejected as orphaned by
+    # _task_is_selectable (#580 follow-up), so fixtures must use real ids.
     return {
-        "current_task_id": "t1",
+        "current_task_id": "run-bounded-turn",
         "tasks": [
-            {"task_id": "t1", "title": "Stalled lane"},
-            {"task_id": "t2", "title": "Fresh lane"},
+            {"task_id": "run-bounded-turn", "title": "Stalled lane"},
+            {"task_id": "record-reward", "title": "Fresh lane"},
         ],
     }
 
 
 def test_switch_off_stalled_lane_repoints_to_alternative():
-    decision = {"selected_task_id": "t1", "selected_task_label": "Stalled lane [task_id=t1]"}
+    decision = {"selected_task_id": "run-bounded-turn", "selected_task_label": "Stalled lane [task_id=run-bounded-turn]"}
     prev = {"stall": {"stop": True}}
     out = _switch_off_stalled_lane(decision, _plan(), prev)
-    assert out["selected_task_id"] == "t2"
+    assert out["selected_task_id"] == "record-reward"
     assert out["mode"] == "switch_stalled_lane"
     assert out["selection_source"] == "switch_stalled_lane"
-    assert "t2" in out["selected_task_label"]
+    assert "record-reward" in out["selected_task_label"]
 
 
 def test_no_switch_when_not_stalled():


### PR DESCRIPTION
Follow-up to #582; closes #580.

## Why the first fix escaped

Live verification after deploying `f491fa1` showed the first post-deploy cycle continued the orphan lane: a pre-deploy cycle had already made `exploit-successful-improvement-path` the `current_task_id`, and `continue_active_lane` continues the current lane without consulting task-record status. Full analysis: https://github.com/ozand/eeebot/issues/580#issuecomment-4882203168

## Three targeted changes (all in existing choke points)

1. `_task_is_selectable` also rejects task_ids outside `KNOWN_TASK_IDS` — protects every selection scan, not just ones downstream of the repair pass.
2. `_derive_feedback_decision`: if `current_task_id` itself is orphaned, return an immediate `switch_stalled_lane` decision (`selection_source="orphaned_current_task_retired"`) to the first selectable task, backlog-progression preferred (same ordering as #568). Mode string reused — grep of all `feedback_decision.get("mode")` consumers confirmed no special-casing.
3. `_switch_off_stalled_lane` (R11 stop-guard) filters to selectable records before `pick_alternative_task` — the stall-switch can no longer land on a `done` task or an orphan. `stop_guards.pick_alternative_task` contract unchanged.

## Tests

+3 in `tests/test_coordinator_orphaned_task_ids.py`, including a replay of the exact live post-deploy snapshot that escaped (orphan as active current task → decision must select a known task). One fixture in `tests/test_stop_guards_enforcement.py` swapped placeholder ids (`t1`/`t2`) for real known ids; no test intent weakened.

## Verification

- `pytest tests/`: **1080 passed** (1077 baseline + 3 new).
- `ruff check`: 203 → 203, zero new findings.

Rollout: deploy to eeepc, then verify the next cycle's `feedback_decision` switches off the orphan lane (`selection_source=orphaned_current_task_retired`) and subsequent cycles re-enter synthesize/materialize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)