### PR TITLE
fix(runtime): stop-guard lane switch must not override decisions already leaving the stalled lane (#586)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -4487,15 +4487,30 @@ def _switch_off_stalled_lane(
     feedback decision at a different available task so the next cycle does not
     re-run the stalled lane. If there is no distinct alternative, the decision is
     left unchanged (the stall is still recorded in durable state).
+
+    The stalled lane is the *previous* experiment's lane
+    (``previous_experiment["current_task_id"]``), not whatever the incoming
+    feedback decision selected. If the decision already selects a different,
+    truthy task (e.g. a forward move synthesized by the state machine that is
+    not present in the persisted task list), it has already escaped the
+    stalled lane — return it unchanged instead of re-trapping the coordinator
+    on stale bookkeeping (#586).
     """
     if not should_switch_lane(previous_experiment):
         return feedback_decision
     if not isinstance(task_plan, dict):
         return feedback_decision
-    current_id = None
+    stalled_lane_id = None
+    if isinstance(previous_experiment, dict):
+        stalled_lane_id = previous_experiment.get("current_task_id") or previous_experiment.get("currentTaskId")
+    if not stalled_lane_id:
+        stalled_lane_id = task_plan.get("current_task_id") or task_plan.get("currentTaskId")
     if isinstance(feedback_decision, dict):
-        current_id = feedback_decision.get("selected_task_id")
-    current_id = current_id or task_plan.get("current_task_id") or task_plan.get("currentTaskId")
+        decision_selected_id = feedback_decision.get("selected_task_id")
+        if decision_selected_id and decision_selected_id != stalled_lane_id:
+            # Decision already moves off the stalled lane — leave it alone.
+            return feedback_decision
+    current_id = stalled_lane_id
     tasks = task_plan.get("tasks") if isinstance(task_plan.get("tasks"), list) else []
     # Issue #580 follow-up: pick_alternative_task has no status/orphan awareness —
     # it returns the first task with a different id, even if that task is already

--- a/tests/test_stop_guards_enforcement.py
+++ b/tests/test_stop_guards_enforcement.py
@@ -78,3 +78,77 @@ def test_switch_unchanged_behavior_when_only_bookkeeping_present():
     prev = {"stall": {"stop": True}}
     out = _switch_off_stalled_lane(decision, plan, prev)
     assert out["selected_task_id"] == "refresh-approval-gate"
+
+
+def test_decision_already_off_stalled_lane_is_returned_unchanged():
+    # #586: the stalled lane is the PREVIOUS experiment's lane
+    # (record-reward), not whatever the incoming decision selects. A decision
+    # that already selects a different task is the escape from the stall —
+    # overriding it re-traps the coordinator.
+    decision = {
+        "mode": "synthesize_next_candidate",
+        "selected_task_id": "synthesize-next-improvement-candidate",
+    }
+    prev = {"current_task_id": "record-reward", "stall": {"stop": True}}
+    out = _switch_off_stalled_lane(decision, _plan(), prev)
+    assert out is decision
+    assert out["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert out["mode"] == "synthesize_next_candidate"
+
+
+def test_decision_still_on_stalled_lane_is_overridden():
+    # Decision selects the same lane the previous experiment stalled on ->
+    # existing override behavior (alt selection, backlog-progression
+    # preference, _task_is_selectable filtering) still applies.
+    decision = {"selected_task_id": "record-reward"}
+    plan = {
+        "current_task_id": "record-reward",
+        "tasks": [
+            {"task_id": "record-reward", "title": "Stalled lane"},
+            {"task_id": "refresh-approval-gate", "title": "Bookkeeping"},
+            {"task_id": "materialize-synthesized-improvement", "title": "Real dispatch"},
+        ],
+    }
+    prev = {"current_task_id": "record-reward", "stall": {"stop": True}}
+    out = _switch_off_stalled_lane(decision, plan, prev)
+    assert out["selected_task_id"] == "materialize-synthesized-improvement"
+    assert out["selected_task_id"] != "record-reward"
+    assert out["mode"] == "switch_stalled_lane"
+
+
+def test_decision_none_with_stalled_prev_lane_still_switches():
+    # Regression for the fallback path: no incoming decision at all.
+    prev = {"current_task_id": "run-bounded-turn", "stall": {"stop": True}}
+    out = _switch_off_stalled_lane(None, _plan(), prev)
+    assert out is not None
+    assert out["selected_task_id"] == "record-reward"
+    assert out["mode"] == "switch_stalled_lane"
+
+
+def test_live_replay_record_reward_stall_synthesize_next_candidate_unchanged():
+    # Live replay (2026-07-04 host incident, #586): previous_experiment lane
+    # is record-reward and stalled; the state machine already produced a
+    # forward move to synthesize_next_candidate. That decision must survive
+    # untouched so synthesis actually runs instead of bouncing back to
+    # refresh-approval-gate.
+    decision = {
+        "mode": "synthesize_next_candidate",
+        "selected_task_id": "synthesize-next-improvement-candidate",
+    }
+    prev = {"current_task_id": "record-reward", "stall": {"stop": True}}
+    plan = {
+        "current_task_id": "record-reward",
+        "tasks": [
+            {"task_id": "materialize-synthesized-improvement", "status": "done"},
+            {"task_id": "synthesize-next-improvement-candidate", "status": "done"},
+            {"task_id": "inspect-pass-streak", "status": "done"},
+            {"task_id": "refresh-approval-gate", "status": "pending"},
+            {"task_id": "run-bounded-turn", "status": "pending"},
+            {"task_id": "record-reward", "status": "active"},
+            {"task_id": "subagent-verify-materialized-improvement", "status": "pending"},
+            {"task_id": "exploit-successful-improvement-path", "status": "pending"},
+        ],
+    }
+    out = _switch_off_stalled_lane(decision, plan, prev)
+    assert out["selected_task_id"] == "synthesize-next-improvement-candidate"
+    assert out["mode"] == "synthesize_next_candidate"


### PR DESCRIPTION
Closes #586.

## Bug (live-verified 15:19–15:50)

`_switch_off_stalled_lane` fired on `stall.stop` and unconditionally replaced the decision's selection — treating the NEWLY selected task as the lane to move off, instead of the previous experiment's stalled lane. It thereby overrode the designed arc-restart (`synthesize_next_candidate` after record-reward) three cycles in a row, trapping the coordinator in a record-reward → refresh-approval-gate → verify loop. Synthesized candidates are new task dicts absent from the persisted list, so `pick_alternative_task` could never re-pick them.

## Fix

- Stalled lane = `previous_experiment.current_task_id` (fallback: task_plan's current_task_id — preserves prior behavior for records without it).
- A decision already selecting a different task than the stalled lane is returned unchanged — it IS the escape R11 wants.
- The override path (decision missing or still on the stalled lane) is unchanged, now keyed off the stalled lane id.

`stop_guards.py` untouched.

## Tests

+4 in `tests/test_stop_guards_enforcement.py`, including a replay of the live incident (record-reward stalled + `synthesize_next_candidate` decision survives). All pre-existing tests pass without modification.

## Verification

- `pytest tests/`: **1090 passed** (1086 + 4).
- `ruff check`: 203 → 203, zero new.

Rollout: deploy to eeepc; expect the next stalled retire to reach `synthesize_next_candidate` and the first fresh materialize artifact since 2026-06-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)