### PR TITLE
feat(observability): surface autonomous_commits_24h and subagent_queue_depth in cycle-health (#590)

### DIFF
--- a/nanobot/runtime/health.py
+++ b/nanobot/runtime/health.py
@@ -7,10 +7,11 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
-from nanobot.runtime.state import load_runtime_state_from_root
+from nanobot.runtime.state import _json_files_sorted_by_mtime, load_runtime_state_from_root
 from nanobot.runtime.schemas import CycleHealth
 
 _DEFAULT_BRIDGE_SERVICE = "eeepc-self-evolving-subagent-bridge.service"
+_SELFEVO_REPO_DIRNAME = "eeebot-self-evolving"
 
 CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 
@@ -139,6 +140,42 @@ def _calculate_severity(
     return "ok", 0
 
 
+def read_autonomous_commits_24h(
+    state_root: Path,
+    *,
+    runner: CommandRunner | None = None,
+) -> int | None:
+    """Count commits in the last 24h in the selfevo executor repo.
+
+    The selfevo repo lives alongside the state root at
+    ``state_root.parent / "eeebot-self-evolving"`` (same sibling-layout
+    convention used by ``coordinator._has_concrete_changes`` and
+    ``coordinator._parse_backlog_task_from_memory``). Fails soft: returns
+    None when the repo is absent or git errors, never raises.
+    """
+    selfevo_repo = state_root.parent / _SELFEVO_REPO_DIRNAME
+    if not selfevo_repo.is_dir():
+        return None
+    run = runner or _default_runner
+    try:
+        proc = run([
+            "git", "-c", f"safe.directory={selfevo_repo}",
+            "-C", str(selfevo_repo),
+            "log", "--oneline", "--since=24 hours ago",
+        ])
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return len([line for line in proc.stdout.splitlines() if line.strip()])
+
+
+def read_subagent_queue_depth(state_root: Path) -> int:
+    """Count pending subagent request files under state/subagents/requests/."""
+    requests_dir = state_root / "subagents" / "requests"
+    return len(list(_json_files_sorted_by_mtime(False, requests_dir)))
+
+
 def build_cycle_health_summary(
     state_root: Path,
     *,
@@ -151,6 +188,8 @@ def build_cycle_health_summary(
     service_status = read_service_status(service_name, runner=runner)
     failed_units_count = read_failed_units_count(runner=runner)
     promotion_readiness = _promotion_readiness(runtime)
+    autonomous_commits_24h = read_autonomous_commits_24h(state_root, runner=runner)
+    subagent_queue_depth = read_subagent_queue_depth(state_root)
     summary = {
         "schema_version": "cycle-health-summary-v2",
         "runtime_state_source": runtime.get("runtime_state_source"),
@@ -162,6 +201,10 @@ def build_cycle_health_summary(
         "service_status": service_status,
         "failed_units_count": failed_units_count,
         "promotion_readiness": promotion_readiness,
+        "success_signals": {
+            "autonomous_commits_24h": autonomous_commits_24h,
+            "subagent_queue_depth": subagent_queue_depth,
+        },
     }
 
     severity, exit_code = _calculate_severity(
@@ -187,6 +230,7 @@ def format_cycle_health_summary(summary: CycleHealth) -> list[str]:
     """Format cycle health summary as stable text lines."""
     service = summary.get("service_status") if isinstance(summary.get("service_status"), dict) else {}
     promotion = summary.get("promotion_readiness") if isinstance(summary.get("promotion_readiness"), dict) else {}
+    success_signals = summary.get("success_signals") if isinstance(summary.get("success_signals"), dict) else {}
     return [
         "Cycle health summary:",
         f"  Severity: {summary.get('severity') or 'unknown'} (exit_code={summary.get('exit_code')})",
@@ -206,6 +250,9 @@ def format_cycle_health_summary(summary: CycleHealth) -> list[str]:
         f"state={promotion.get('state') or 'unknown'} "
         f"reason={promotion.get('reason') or 'none'}",
         f"  Next recommended action: {summary.get('next_recommended_action') or 'unknown'}",
+        "  Success signals: "
+        f"autonomous_commits_24h={success_signals.get('autonomous_commits_24h') if success_signals.get('autonomous_commits_24h') is not None else 'unavailable'} "
+        f"subagent_queue_depth={success_signals.get('subagent_queue_depth') if success_signals.get('subagent_queue_depth') is not None else 'unknown'}",
     ]
 
 

--- a/nanobot/runtime/schemas.py
+++ b/nanobot/runtime/schemas.py
@@ -52,3 +52,4 @@ class CycleHealth(TypedDict, total=False):
     severity: str
     exit_code: int
     next_recommended_action: str
+    success_signals: dict[str, Any]

--- a/tests/test_cycle_health_summary.py
+++ b/tests/test_cycle_health_summary.py
@@ -5,7 +5,12 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from nanobot.cli.commands import app
-from nanobot.runtime.health import build_cycle_health_summary, format_cycle_health_summary
+from nanobot.runtime.health import (
+    build_cycle_health_summary,
+    format_cycle_health_summary,
+    read_autonomous_commits_24h,
+    read_subagent_queue_depth,
+)
 
 
 def _write_json(path: Path, payload: dict):
@@ -75,3 +80,77 @@ def test_cycle_health_cli_json(tmp_path: Path, monkeypatch):
     payload = json.loads(result.stdout)
     assert payload["latest_cycle_id"] == "cycle-cli"
     assert payload["failed_units_count"] == 0
+    assert "success_signals" in payload
+    assert "autonomous_commits_24h" in payload["success_signals"]
+    assert "subagent_queue_depth" in payload["success_signals"]
+
+
+def _init_git_repo_with_commit(repo_dir: Path) -> None:
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    env_cmds = [
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "test@example.com"],
+        ["git", "config", "user.name", "Test"],
+    ]
+    for cmd in env_cmds:
+        subprocess.run(cmd, cwd=repo_dir, check=True, capture_output=True, text=True)
+    (repo_dir / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_dir, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial commit"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_read_autonomous_commits_24h_counts_recent_commit(tmp_path: Path):
+    state = tmp_path / "state"
+    state.mkdir()
+    selfevo_repo = tmp_path / "eeebot-self-evolving"
+    _init_git_repo_with_commit(selfevo_repo)
+
+    assert read_autonomous_commits_24h(state) == 1
+
+
+def test_read_autonomous_commits_24h_missing_repo_returns_none(tmp_path: Path):
+    state = tmp_path / "state"
+    state.mkdir()
+
+    assert read_autonomous_commits_24h(state) is None
+
+
+def test_read_subagent_queue_depth_counts_json_files(tmp_path: Path):
+    state = tmp_path / "state"
+    requests_dir = state / "subagents" / "requests"
+    requests_dir.mkdir(parents=True)
+    for i in range(3):
+        (requests_dir / f"req-{i}.json").write_text("{}", encoding="utf-8")
+    (requests_dir / "not-json.txt").write_text("ignore me", encoding="utf-8")
+
+    assert read_subagent_queue_depth(state) == 3
+
+
+def test_read_subagent_queue_depth_missing_dir_returns_zero(tmp_path: Path):
+    state = tmp_path / "state"
+    state.mkdir()
+
+    assert read_subagent_queue_depth(state) == 0
+
+
+def test_build_cycle_health_summary_includes_success_signals(tmp_path: Path):
+    state = tmp_path / "state"
+    _write_json(state / "reports" / "evolution-001.json", {"cycle_id": "cycle-001"})
+    _write_json(state / "outbox" / "latest.json", {"approval_gate": {"state": "fresh"}})
+    requests_dir = state / "subagents" / "requests"
+    requests_dir.mkdir(parents=True)
+    (requests_dir / "req-0.json").write_text("{}", encoding="utf-8")
+
+    summary = build_cycle_health_summary(state, runner=_fake_runner)
+
+    assert summary["success_signals"]["autonomous_commits_24h"] is None
+    assert summary["success_signals"]["subagent_queue_depth"] == 1
+
+    lines = format_cycle_health_summary(summary)
+    assert any("Success signals:" in line for line in lines)


### PR DESCRIPTION
Closes #590.

## What

Two read-only success-signal fields from docs/ACTIVE_GOAL.md, surfaced in `eeebot cycle-health` (both `--json` and text output) under a `success_signals` key:

- `autonomous_commits_24h` — `git log --since="24 hours ago"` count in the sibling `eeebot-self-evolving/` repo (same path convention as `_has_concrete_changes`); fails soft to `null` when the repo is absent.
- `subagent_queue_depth` — count of `*.json` in `state/subagents/requests/`, reusing the existing `_json_files_sorted_by_mtime` helper.

No config, no thresholds, no writes — pure aggregation (R7). Both signals were verified by hand over SSH throughout today's debugging; now they're one command away.

## Tests

+5 in `tests/test_cycle_health_summary.py` (tmp git repo, missing repo, json filtering, missing dir, CLI payload shape).

## Verification

- `pytest tests/`: **1095 passed** (1090 + 5).
- `ruff check nanobot/ tests/`: 301 → 301, zero new.

Rollout: deploy to eeepc, then `eeebot cycle-health` on host should show live values (expected: commits ≥4 today, queue ≈11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)