### PR TITLE
fix(runtime): per-line proportional match in title done-detection — stop false positives from commit-log word pooling (#592)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -2625,13 +2625,26 @@ def _recent_git_log(repo_root: Path, since: str = "14 days ago") -> str:
 
 
 def _title_already_done_in_git_log(title: str, git_log: str) -> bool:
-    """Return True if >=2 words (4+ chars) from title appear in the given git log text.
+    """Return True if some SINGLE commit line contains a proportional share of title words.
 
     Shared heuristic: a priority/backlog title is treated as already completed
-    when its distinctive words show up in recent commit messages, even if the
-    priority itself carries no explicit [Done] marker (used for both the
-    MEMORY.md backlog curriculum and goal_text.json priority parsing — #575).
+    when its distinctive words show up together in one recent commit message,
+    even if the priority itself carries no explicit [Done] marker (used for
+    both the MEMORY.md backlog curriculum and goal_text.json priority parsing
+    — #575).
+
+    #592: the original rule counted a title as done when >=2 of its words (4+
+    chars) appeared ANYWHERE in the whole multi-day git log, pooling matches
+    across unrelated commits. The autonomous bot commits ~70+ times/24h with a
+    narrow, repetitive commit vocabulary ("write", "scripts", "test", "subagent",
+    "queue", "dashboard", ...), so that pooled-anywhere check saturates and
+    produces false positives (a title's words each individually appear in some
+    commit, even though no single commit is actually about that title). The fix
+    requires a proportional share of the title's words to appear together on
+    ONE commit line: at least `max(2, ceil(0.6 * len(words)))` of them,
+    matching per-word substring containment as before.
     """
+    import math as _math
     import re as _re
 
     if not git_log:
@@ -2639,8 +2652,13 @@ def _title_already_done_in_git_log(title: str, git_log: str) -> bool:
     words = [w.lower() for w in _re.findall(r'[A-Za-z]{4,}', title)]
     if len(words) < 2:
         return False
-    matches = sum(1 for w in words if w in git_log.lower())
-    return matches >= 2
+    threshold = max(2, _math.ceil(0.6 * len(words)))
+    for line in git_log.splitlines():
+        line_lower = line.lower()
+        matches = sum(1 for w in words if w in line_lower)
+        if matches >= threshold:
+            return True
+    return False
 
 
 def _curriculum_level(selfevo_repo_root: Path) -> int:

--- a/tests/test_goal_backlog_routing.py
+++ b/tests/test_goal_backlog_routing.py
@@ -16,6 +16,7 @@ from nanobot.runtime.coordinator import (
     MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
     _next_open_goal_as_backlog_task,
     _parse_backlog_task_from_goal_text,
+    _title_already_done_in_git_log,
     _write_materialized_improvement_artifact,
 )
 
@@ -112,27 +113,29 @@ def test_parse_backlog_task_from_goal_text_no_priority_section_returns_none(tmp_
 
 # ─── #575: skip already-done goal_text.json priorities via shared git-log heuristic ───
 
-def _make_git_repo_with_commit(tmp_path: Path, commit_message: str) -> Path:
-    """Create a tmp git repo (playing the role of eeebot-self-evolving) with one commit."""
+def _make_git_repo_with_commit(tmp_path: Path, *commit_messages: str) -> Path:
+    """Create a tmp git repo (playing the role of eeebot-self-evolving) with one commit per message."""
     repo = tmp_path / "eeebot-self-evolving"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
-    (repo / "f.txt").write_text("x", encoding="utf-8")
-    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-q", "-m", commit_message], cwd=repo, check=True)
+    for i, commit_message in enumerate(commit_messages):
+        (repo / "f.txt").write_text(str(i), encoding="utf-8")
+        subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", commit_message], cwd=repo, check=True)
     return repo
 
 
 def test_parse_backlog_task_from_goal_text_skips_done_priority_via_git_log(tmp_path: Path):
-    """Priority 5's title keywords ('cycle', 'logger') match a recent commit → skipped, P6 returned."""
+    """Priority 5's title words ('write', 'scripts', 'cycle', 'logger') all match one
+    commit line (per-line proportional match, #592) → skipped, P6 returned."""
     goals_dir = tmp_path / "goals"
     goals_dir.mkdir()
     (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
 
     repo = _make_git_repo_with_commit(
-        tmp_path, "chore: confirm Priority 5 (cycle_logger.py) verified for cycle-999"
+        tmp_path, "feat: write scripts/cycle_logger.py — confirmed done for cycle-999"
     )
 
     task = _parse_backlog_task_from_goal_text(tmp_path, selfevo_repo_root=repo)
@@ -142,14 +145,16 @@ def test_parse_backlog_task_from_goal_text_skips_done_priority_via_git_log(tmp_p
 
 
 def test_parse_backlog_task_from_goal_text_all_done_returns_none(tmp_path: Path):
-    """When every found priority matches the git log, the function returns None."""
+    """When every found priority's title words all match on some single commit
+    line, the function returns None (each priority "done" via its own commit)."""
     goals_dir = tmp_path / "goals"
     goals_dir.mkdir()
     (goals_dir / "goal_text.json").write_text(GOAL_TEXT_JSON, encoding="utf-8")
 
     repo = _make_git_repo_with_commit(
         tmp_path,
-        "chore: confirm cycle logger and smoke test loop both verified",
+        "feat: write scripts/cycle_logger.py finished",
+        "feat: write scripts/smoke_test_loop.py finished with test",
     )
 
     task = _parse_backlog_task_from_goal_text(tmp_path, selfevo_repo_root=repo)
@@ -200,3 +205,87 @@ def test_materialized_artifact_routes_goal_text_over_research_feed(tmp_path: Pat
     assert "cycle_logger.py" in nbc["title"]
     assert nbc["backlog_priority"] == 5
     assert "stale research candidate" not in json.dumps(artifact)
+
+
+# ─── #592: per-line proportional match — stop false positives from commit-log word pooling ───
+
+# Realistic synthetic 14-day bot commit log: the autonomous bot commits ~74x/24h with a narrow,
+# repetitive vocabulary ("write", "scripts", "test", "subagent", "queue", "dashboard", ...). Under
+# the old "any 2 words anywhere in the whole log" rule, this noise alone flipped fresh, never-done
+# titles to "already done". None of these lines are actually about any of the three live titles.
+BOT_NOISE_GIT_LOG = "\n".join([
+    "a1b2c3d feat: add 18 self-tests to scripts/analyze_pass_streak.py with --test flag",
+    "b2c3d4e chore: record structured lesson for [cycle-xxxxxx]",
+    'c3d4e5f chore: move "Add self-tests to scripts/archive_subagent_requests.py" to Completed (bridge safety-net)',
+    "d4e5f6a feat: add 10 self-tests to scripts/report_summary.py with --test flag",
+    "e5f6a7b chore: log cycle-199d395d2f19 — analyze_pass_streak.py self-tests added",
+])
+
+
+def test_title_already_done_false_positive_host_metrics_sampler(tmp_path: Path):
+    """Live bug: 'Write scripts/host_metrics_sampler.py' was never written, but the old
+    anywhere-in-log rule pooled 'write'/'scripts' matches from unrelated commits → False now."""
+    assert _title_already_done_in_git_log(
+        "Write scripts/host_metrics_sampler.py", BOT_NOISE_GIT_LOG
+    ) is False
+
+
+def test_title_already_done_false_positive_subagent_queue(tmp_path: Path):
+    """Live bug: the stale subagent queue (11 items) was not actually reduced, but
+    'subagent'/'request' pooled from an unrelated commit about a different script → False now."""
+    assert _title_already_done_in_git_log(
+        "Reduce the stale subagent request queue below 10", BOT_NOISE_GIT_LOG
+    ) is False
+
+
+def test_title_already_done_false_positive_dashboard_wiring(tmp_path: Path):
+    """Live bug: host metrics were not wired into the dashboard; no commit mentions
+    either concept, so the old rule's incidental pooling must not fire here either."""
+    assert _title_already_done_in_git_log(
+        "Wire host metrics into the dashboard", BOT_NOISE_GIT_LOG
+    ) is False
+
+
+def test_title_already_done_true_positive_single_commit_line_preserved(tmp_path: Path):
+    """A title IS done when a single commit line actually names it — per-line proportional
+    matching must still detect this (regression guard against over-correcting #592)."""
+    title = "Write scripts/cycle_logger.py"
+    log = "\n".join([
+        "a1b2c3d feat: add scripts/cycle_logger.py with append_cycle_summary helper",
+        "b2c3d4e chore: unrelated housekeeping",
+    ])
+    assert _title_already_done_in_git_log(title, log) is True
+
+
+def test_title_already_done_still_false_when_fewer_than_2_words(tmp_path: Path):
+    """Unchanged edge case: fewer than 2 distinctive (4+ char) words → always False."""
+    assert _title_already_done_in_git_log("Fix bug", "fix bug fix bug fix bug") is False
+
+
+# Live goal_text.json shape from the #592 bug report: three fresh priorities, none ever
+# actually implemented, against a noisy autonomous-bot git log that must not falsely mark
+# any of them done.
+LIVE_GOAL_TEXT_JSON = """\
+{
+  "schema_version": "goal-text-v1",
+  "goal_id": "goal-bootstrap",
+  "updated_at_utc": "2026-07-03T12:00:00Z",
+  "text": "eeebot is a resource-aware, self-evolving autonomous agent on a weak eeepc host.\\n\\nCurrent priority targets:\\n(A) Priority 5 \\u2014 Write scripts/host_metrics_sampler.py: sample host CPU/mem/disk and write state/host_metrics.json. Test with python3 scripts/host_metrics_sampler.py --test. Commit.\\n(B) Priority 6 \\u2014 Reduce the stale subagent request queue below 10: archive or process stale entries in state/subagent_requests/. Commit.\\n(C) Priority 7 \\u2014 Wire host metrics into the dashboard: surface state/host_metrics.json fields on the operator dashboard. Commit."
+}
+"""
+
+
+def test_parse_backlog_task_from_goal_text_live_bug_regression(tmp_path: Path):
+    """End-to-end #592 regression: with a noisy bot-style git log, none of the three
+    live fresh priorities should be falsely marked done — the parser must return
+    Priority 5 (host_metrics_sampler), not None."""
+    goals_dir = tmp_path / "goals"
+    goals_dir.mkdir()
+    (goals_dir / "goal_text.json").write_text(LIVE_GOAL_TEXT_JSON, encoding="utf-8")
+
+    repo = _make_git_repo_with_commit(tmp_path, *BOT_NOISE_GIT_LOG.split("\n"))
+
+    task = _parse_backlog_task_from_goal_text(tmp_path, selfevo_repo_root=repo)
+    assert task is not None
+    assert task["priority"] == 5
+    assert "host_metrics_sampler.py" in task["title"]


### PR DESCRIPTION
Closes #592.

## Bug (live-verified)

`_title_already_done_in_git_log` marked a title done when any 2 words (4+ chars) appeared **anywhere** in the whole 14-day git log. With the bot committing 74×/24h, its commit vocabulary saturates the log and word matches pool across unrelated commits — all three fresh goal_text priorities (#589) were falsely "done", the parser returned None, and the materialize lane kept feeding on vague lesson insights.

## Fix

Per-commit-line matching with a proportional threshold: done only if some **single line** contains ≥ max(2, ceil(0.6 × title_words)) of the title's words. A commit that actually completed the work naturally repeats most title words in its one message. Same signature; both callers (`_parse_backlog_task_from_goal_text`, `_curriculum_level`) unchanged.

## Tests

+6: the three live false-positive titles vs the exact bot-noise commit styles → all False; true-positive guard; <2-words edge; end-to-end parser returns Priority 5 (host_metrics_sampler) against the noisy log. Two #575 fixtures updated from cross-log pooling (the bug) to single-line semantics — intent preserved.

## Verification

- `pytest tests/`: **1101 passed** (1095 + 6).
- `ruff check`: zero new findings.

Rollout: deploy; live check `_parse_backlog_task_from_goal_text` on host must return priority 5; the next materialize arc should carry the host_metrics_sampler target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)