### PR TITLE
fix(agent): scrub runtime-state env vars from exec children so subagent test runs can't write into live state (#594)

### DIFF
--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -8,6 +8,20 @@ from typing import Any
 
 from nanobot.agent.tools.base import Tool
 
+# Runtime-state location env vars that must never leak into child processes
+# spawned by this tool. Incident #594: a qwen subagent ran `pytest` via exec,
+# and the inherited STATE_DIR caused test cycles (run_self_evolving_cycle) to
+# write fixture data into the LIVE durable state root instead of the test's
+# tmp_path workspace. The coordinator itself never goes through this tool —
+# it reads/writes state via direct in-process Python calls — so scrubbing
+# here only affects subagent-spawned children, not the coordinator's own
+# state access.
+SCRUBBED_STATE_ENV_VARS = (
+    "STATE_DIR",
+    "NANOBOT_RUNTIME_STATE_ROOT",
+    "NANOBOT_RUNTIME_STATE_SOURCE",
+)
+
 
 class ExecTool(Tool):
     """Tool to execute shell commands."""
@@ -87,6 +101,8 @@ class ExecTool(Tool):
         effective_timeout = min(timeout or self.timeout, self._MAX_TIMEOUT)
 
         env = os.environ.copy()
+        for var in SCRUBBED_STATE_ENV_VARS:
+            env.pop(var, None)
         if self.path_append:
             env["PATH"] = env.get("PATH", "") + os.pathsep + self.path_append
 

--- a/tests/test_exec_security.py
+++ b/tests/test_exec_security.py
@@ -67,3 +67,23 @@ async def test_exec_blocks_chained_internal_url():
             command="echo start && curl http://169.254.169.254/latest/meta-data/ && echo done"
         )
     assert "Error" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_scrubs_runtime_state_env_vars(monkeypatch):
+    """Regression for #594: STATE_DIR/NANOBOT_RUNTIME_STATE_ROOT/SOURCE must
+    never leak into exec children, so a subagent running e.g. `pytest` inside
+    a self-evolving-cycle test can't have its test writes redirected into the
+    live durable state root. An unrelated env var must still be inherited."""
+    monkeypatch.setenv("STATE_DIR", "/var/lib/eeepc-agent/self-evolving-agent/state")
+    monkeypatch.setenv("NANOBOT_RUNTIME_STATE_ROOT", "/var/lib/eeepc-agent/self-evolving-agent/state")
+    monkeypatch.setenv("NANOBOT_RUNTIME_STATE_SOURCE", "live")
+    monkeypatch.setenv("EXEC_TEST_MARKER", "present")
+
+    tool = ExecTool(timeout=5)
+    result = await tool.execute(command="env")
+
+    assert "STATE_DIR=" not in result
+    assert "NANOBOT_RUNTIME_STATE_ROOT=" not in result
+    assert "NANOBOT_RUNTIME_STATE_SOURCE=" not in result
+    assert "EXEC_TEST_MARKER=present" in result


### PR DESCRIPTION
Closes #594.

## Incident

The bridge's qwen subagent ran `pytest` via the exec tool; the inherited `STATE_DIR` made `resolve_runtime_state_location` route every test's `run_self_evolving_cycle` into the **live canonical state root** — 79 fixture files (reports, goals/history, experiments, promotion candidates, queue requests) leaked into durable state (cleaned by hand with operator authorization, 2026-07-04).

## Fix

`ExecTool.execute` (nanobot/agent/tools/shell.py) now scrubs `STATE_DIR`, `NANOBOT_RUNTIME_STATE_ROOT`, `NANOBOT_RUNTIME_STATE_SOURCE` from child environments (`SCRUBBED_STATE_ENV_VARS` constant with incident comment). Placement rationale: `SubagentManager` registers `ExecTool` directly and the bridge uses the same `SubagentManager` — single shared exec path; the coordinator itself accesses state via in-process Python and never routes through this tool, so its own state access is unaffected. `resolve_runtime_state_location` untouched.

## Tests

`tests/test_exec_security.py::test_exec_scrubs_runtime_state_env_vars` — three vars absent in child, unrelated marker inherited.

## Verification

- `pytest tests/`: **1102 passed** (1101 + 1).
- `ruff check nanobot/ scripts/ tests/`: 390 → 390, zero new.

Rollout: deploy to eeepc, then verify subsequent bridge turns produce no fixture-dated files in live state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)