### PR TITLE
docs(lessons): record ERR-2026-07-04-001 + HISTORY entries for goal_text/done-detector/telemetry/env-scrub work

### DIFF
--- a/lessons/errors/ERR-2026-07-04-001.md
+++ b/lessons/errors/ERR-2026-07-04-001.md
@@ -1,0 +1,55 @@
+# ERR-2026-07-04-001: Subagent pytest runs wrote fixture data into the live state root (STATE_DIR env leak)
+
+## Metadata
+- **ID**: ERR-2026-07-04-001
+- **Date**: 2026-07-04
+- **Category**: state-integrity
+- **Status**: Fixed
+
+## Description
+The bridge's qwen subagent legitimately ran `pytest` inside the selfevo repo via
+the shared exec tool. Fixture-dated artifacts (fixed timestamp `2026-04-15T12:30Z`)
+started appearing in the canonical live state root: two waves totalling **111
+files** — cycle reports, `goals/history` entries (inputs to the PASS-streak
+logic), experiment records, promotion candidates, subagent queue requests — plus
+29 fixture lines appended to `experiments/history.jsonl`.
+
+## Root Cause
+The bridge service exports `STATE_DIR` / `NANOBOT_RUNTIME_STATE_ROOT` pointing at
+the live control-plane state. Child processes spawned by the subagent's exec tool
+inherited that environment. The repo's tests call
+`run_self_evolving_cycle(workspace=tmp_path)`, but
+`resolve_runtime_state_location` (nanobot/runtime/state.py) prefers the inherited
+env override over the workspace — so every test cycle wrote durable artifacts
+into the live root instead of the test's tmp directory.
+
+## Impact
+Fixture reports polluted the durable evidence trail (R7): fake PASS history could
+skew PASS-streak/strong-signature computations, and 29 fixture **promotion
+candidates** entered the promotion queue. Also broke `ls -t`-based monitoring
+(fixture files kept winning by mtime).
+
+## Fix Applied
+1. `ExecTool.execute` now scrubs `STATE_DIR`, `NANOBOT_RUNTIME_STATE_ROOT`,
+   `NANOBOT_RUNTIME_STATE_SOURCE` from child environments
+   (`SCRUBBED_STATE_ENV_VARS` in `nanobot/agent/tools/shell.py`, #594/#595,
+   deployed as `dbec76a`). The coordinator itself never routes state access
+   through this tool, so only subagent-spawned children are affected.
+2. Both contamination waves cleaned with operator authorization, keyed strictly
+   off the fixture cycle-id set (79 + 32 files, plus history.jsonl filtering);
+   verified zero `*20260415*` files remain.
+3. Live-verified on the bridge's real `PYTHONPATH`: exec child sees empty
+   `STATE_DIR`/`NANOBOT_RUNTIME_STATE_ROOT` while inheriting unrelated env.
+
+## Prevention
+1. Never let control-plane env vars reach subagent-spawned child processes —
+   the scrub list lives in `nanobot/agent/tools/shell.py`; extend it if new
+   state-location vars are introduced.
+2. Deliberately avoided "am I under pytest?" heuristics inside
+   `resolve_runtime_state_location` — the env contract stays simple; isolation
+   is enforced at the process boundary that spawns untrusted children.
+3. When monitoring live state, key on filename timestamps rather than mtime
+   ordering; fixture-dated filenames (`2026-04-15T12:30Z` is the repo's test
+   fixture epoch) in live dirs are a contamination signal worth an immediate
+   audit of `reports/`, `goals/history/`, `experiments/`, `promotions/`, and
+   `subagents/requests/`.

--- a/memory/HISTORY.md
+++ b/memory/HISTORY.md
@@ -238,3 +238,10 @@
 [2026-07-04 20:30] Fixed stop-guard override semantics (#586/#587): _switch_off_stalled_lane no longer overrides
   decisions already leaving the stalled lane (was killing synthesize_next_candidate arc-restarts).
   Live-verified on eeepc 17:20Z: first verifier_unchanged/no_progress ever recorded + synthesize lane reached.
+[2026-07-04 22:30] Phase-2/3 follow-through: refreshed goal_text seed with real ACTIVE_GOAL gaps (#589);
+  fixed done-detector word-pooling false positives with per-line proportional match (#592/#593);
+  added success_signals (autonomous_commits_24h, subagent_queue_depth) to cycle-health (#590/#591).
+  Bot autonomously implemented seeded P5 target (host_metrics_sampler.py, 31 self-tests, commit 196fe6a).
+[2026-07-04 22:30] Incident ERR-2026-07-04-001: subagent pytest runs contaminated live state root via
+  STATE_DIR env leak (111 fixture files, 2 waves) — ExecTool now scrubs runtime-state env vars (#594/#595);
+  both waves cleaned with operator authorization, live-verified on the bridge PYTHONPATH.


### PR DESCRIPTION
Lessons entry for the state-root contamination incident (fixed in #595) following the ERR-* convention (added with -f per precedent — every existing ERR-*.md is tracked past the gitignore rule), plus memory/HISTORY.md lines for #589/#590/#591/#592/#593/#594 per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)