### PR TITLE
refactor: unify internal imports on nanobot.* (#598)

### DIFF
--- a/eeebot/__init__.py
+++ b/eeebot/__init__.py
@@ -34,6 +34,7 @@ for _alias, _target in {
     'eeebot.config': 'nanobot.config',
     'eeebot.config.loader': 'nanobot.config.loader',
     'eeebot.config.paths': 'nanobot.config.paths',
+    'eeebot.config.schema': 'nanobot.config.schema',
     'eeebot.cron': 'nanobot.cron',
     'eeebot.cron.service': 'nanobot.cron.service',
     'eeebot.cron.types': 'nanobot.cron.types',

--- a/nanobot/__main__.py
+++ b/nanobot/__main__.py
@@ -1,6 +1,6 @@
 """Main entry point for running nanobot as a module."""
 
-from eeebot.cli.commands import app
+from nanobot.cli.commands import app
 
 if __name__ == "__main__":
     app()

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -15,7 +15,7 @@ from nanobot.utils.helpers import ensure_dir, estimate_message_tokens, estimate_
 
 if TYPE_CHECKING:
     from nanobot.providers.base import LLMProvider
-    from eeebot.session.manager import Session, SessionManager
+    from nanobot.session.manager import Session, SessionManager
 
 
 _SAVE_MEMORY_TOOL = [

--- a/nanobot/bus/__init__.py
+++ b/nanobot/bus/__init__.py
@@ -1,6 +1,6 @@
 """Message bus module for decoupled channel-agent communication."""
 
-from eeebot.bus.events import InboundMessage, OutboundMessage
-from eeebot.bus.queue import MessageBus
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
 
 __all__ = ["MessageBus", "InboundMessage", "OutboundMessage"]

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from eeebot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.events import InboundMessage, OutboundMessage
 
 
 class MessageBus:

--- a/nanobot/channels/__init__.py
+++ b/nanobot/channels/__init__.py
@@ -1,6 +1,6 @@
 """Chat channels module with plugin architecture."""
 
-from eeebot.channels.base import BaseChannel
-from eeebot.channels.manager import ChannelManager
+from nanobot.channels.base import BaseChannel
+from nanobot.channels.manager import ChannelManager
 
 __all__ = ["BaseChannel", "ChannelManager"]

--- a/nanobot/channels/base.py
+++ b/nanobot/channels/base.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from loguru import logger
 
-from eeebot.bus.events import InboundMessage, OutboundMessage
-from eeebot.bus.queue import MessageBus
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot.bus.queue import MessageBus
 
 
 class BaseChannel(ABC):
@@ -41,7 +41,7 @@ class BaseChannel(ABC):
         if not self.transcription_api_key:
             return ""
         try:
-            from eeebot.providers.transcription import GroqTranscriptionProvider
+            from nanobot.providers.transcription import GroqTranscriptionProvider
 
             provider = GroqTranscriptionProvider(api_key=self.transcription_api_key)
             return await provider.transcribe(file_path)

--- a/nanobot/channels/dingtalk.py
+++ b/nanobot/channels/dingtalk.py
@@ -13,10 +13,10 @@ import httpx
 from loguru import logger
 from pydantic import Field
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
 
 try:
     from dingtalk_stream import (
@@ -539,7 +539,7 @@ class DingTalkChannel(BaseChannel):
         sender_id: str,
     ) -> str | None:
         """Download a DingTalk file to the media directory, return local path."""
-        from eeebot.config.paths import get_media_dir
+        from nanobot.config.paths import get_media_dir
 
         try:
             token = await self._get_access_token()

--- a/nanobot/channels/discord.py
+++ b/nanobot/channels/discord.py
@@ -10,12 +10,12 @@ from pydantic import Field
 import websockets
 from loguru import logger
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.paths import get_media_dir
-from eeebot.config.schema import Base
-from eeebot.utils.helpers import split_message
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
+from nanobot.config.schema import Base
+from nanobot.utils.helpers import split_message
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
 MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024  # 20MB

--- a/nanobot/channels/email.py
+++ b/nanobot/channels/email.py
@@ -17,10 +17,10 @@ from typing import Any
 from loguru import logger
 from pydantic import Field
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
 
 
 class EmailConfig(Base):

--- a/nanobot/channels/feishu.py
+++ b/nanobot/channels/feishu.py
@@ -11,11 +11,11 @@ from typing import Any, Literal
 
 from loguru import logger
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.paths import get_media_dir
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
+from nanobot.config.schema import Base
 from pydantic import Field
 
 import importlib.util

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -7,9 +7,9 @@ from typing import Any
 
 from loguru import logger
 
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.schema import Config
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Config
 
 
 class ChannelManager:
@@ -32,7 +32,7 @@ class ChannelManager:
 
     def _init_channels(self) -> None:
         """Initialize channels discovered via pkgutil scan + entry_points plugins."""
-        from eeebot.channels.registry import discover_all
+        from nanobot.channels.registry import discover_all
 
         groq_key = self.config.providers.groq.api_key
 

--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -37,12 +37,12 @@ except ImportError as e:
         "Matrix dependencies not installed. Run: pip install eeebot-ai[matrix]"
     ) from e
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.paths import get_data_dir, get_media_dir
-from eeebot.config.schema import Base
-from eeebot.utils.helpers import safe_filename
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_data_dir, get_media_dir
+from nanobot.config.schema import Base
+from nanobot.utils.helpers import safe_filename
 
 TYPING_NOTICE_TIMEOUT_MS = 30_000
 # Must stay below TYPING_NOTICE_TIMEOUT_MS so the indicator doesn't expire mid-processing.

--- a/nanobot/channels/mochat.py
+++ b/nanobot/channels/mochat.py
@@ -12,11 +12,11 @@ from typing import Any
 import httpx
 from loguru import logger
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.paths import get_runtime_subdir
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_runtime_subdir
+from nanobot.config.schema import Base
 from pydantic import Field
 
 try:

--- a/nanobot/channels/qq.py
+++ b/nanobot/channels/qq.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from loguru import logger
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
 from pydantic import Field
 
 try:

--- a/nanobot/channels/registry.py
+++ b/nanobot/channels/registry.py
@@ -9,14 +9,14 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 if TYPE_CHECKING:
-    from eeebot.channels.base import BaseChannel
+    from nanobot.channels.base import BaseChannel
 
 _INTERNAL = frozenset({"base", "manager", "registry"})
 
 
 def discover_channel_names() -> list[str]:
     """Return all built-in channel module names by scanning the package (zero imports)."""
-    import eeebot.channels as pkg
+    import nanobot.channels as pkg
 
     return [
         name
@@ -27,9 +27,9 @@ def discover_channel_names() -> list[str]:
 
 def load_channel_class(module_name: str) -> type[BaseChannel]:
     """Import *module_name* and return the first BaseChannel subclass found."""
-    from eeebot.channels.base import BaseChannel as _Base
+    from nanobot.channels.base import BaseChannel as _Base
 
-    mod = importlib.import_module(f"eeebot.channels.{module_name}")
+    mod = importlib.import_module(f"nanobot.channels.{module_name}")
     for attr in dir(mod):
         obj = getattr(mod, attr)
         if isinstance(obj, type) and issubclass(obj, _Base) and obj is not _Base:

--- a/nanobot/channels/slack.py
+++ b/nanobot/channels/slack.py
@@ -11,12 +11,12 @@ from slack_sdk.socket_mode.websockets import SocketModeClient
 from slack_sdk.web.async_client import AsyncWebClient
 from slackify_markdown import slackify_markdown
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
 from pydantic import Field
 
-from eeebot.channels.base import BaseChannel
-from eeebot.config.schema import Base
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
 
 
 class SlackDMConfig(Base):

--- a/nanobot/channels/telegram.py
+++ b/nanobot/channels/telegram.py
@@ -16,13 +16,13 @@ from telegram.error import TimedOut
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 from telegram.request import HTTPXRequest
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.paths import get_media_dir
-from eeebot.config.schema import Base
-from eeebot.security.network import validate_url_target
-from eeebot.utils.helpers import split_message
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
+from nanobot.config.schema import Base
+from nanobot.security.network import validate_url_target
+from nanobot.utils.helpers import split_message
 from nanobot.runtime.state import format_runtime_state, load_runtime_state_for_workspace
 from nanobot.config.loader import load_config
 

--- a/nanobot/channels/wecom.py
+++ b/nanobot/channels/wecom.py
@@ -8,11 +8,11 @@ from typing import Any
 
 from loguru import logger
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.paths import get_media_dir
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.paths import get_media_dir
+from nanobot.config.schema import Base
 from pydantic import Field
 
 WECOM_AVAILABLE = importlib.util.find_spec("wecom_aibot_sdk") is not None

--- a/nanobot/channels/whatsapp.py
+++ b/nanobot/channels/whatsapp.py
@@ -10,10 +10,10 @@ from loguru import logger
 
 from pydantic import Field
 
-from eeebot.bus.events import OutboundMessage
-from eeebot.bus.queue import MessageBus
-from eeebot.channels.base import BaseChannel
-from eeebot.config.schema import Base
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.base import BaseChannel
+from nanobot.config.schema import Base
 
 
 class WhatsAppConfig(Base):

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -31,11 +31,11 @@ from rich.markdown import Markdown
 from rich.table import Table
 from rich.text import Text
 
-from eeebot import __logo__, __version__
-from eeebot.config.paths import get_workspace_path
-from eeebot.config.schema import Config
-from eeebot.runtime.state import format_runtime_state, load_runtime_state_for_workspace, load_runtime_state_from_root
-from eeebot.utils.helpers import sync_workspace_templates
+from nanobot import __logo__, __version__
+from nanobot.config.paths import get_workspace_path
+from nanobot.config.schema import Config
+from nanobot.runtime.state import format_runtime_state, load_runtime_state_for_workspace, load_runtime_state_from_root
+from nanobot.utils.helpers import sync_workspace_templates
 app = typer.Typer(
     add_completion=False,
     rich_markup_mode="markdown",
@@ -104,7 +104,7 @@ def _init_prompt_session() -> None:
     except Exception:
         pass
 
-    from eeebot.config.paths import get_cli_history_path
+    from nanobot.config.paths import get_cli_history_path
 
     history_file = get_cli_history_path()
     history_file.parent.mkdir(parents=True, exist_ok=True)
@@ -370,7 +370,7 @@ def _onboard_plugins(config_path: Path) -> None:
     """Inject default config for all discovered channels (built-in + plugins)."""
     import json
 
-    from eeebot.channels.registry import discover_all
+    from nanobot.channels.registry import discover_all
 
     all_channels = discover_all()
     if not all_channels:

--- a/nanobot/cli/eeebot.py
+++ b/nanobot/cli/eeebot.py
@@ -1,8 +1,7 @@
 """Compatibility CLI alias for the eeebot public project name."""
 
-from eeebot import __logo__
-from eeebot.cli.commands import app
-
+from nanobot import __logo__
+from nanobot.cli.commands import app
 
 app.info.name = "eeebot"
 app.info.help = f"{__logo__} eeebot - eeepc self-improving runtime"

--- a/nanobot/config/__init__.py
+++ b/nanobot/config/__init__.py
@@ -1,7 +1,7 @@
 """Configuration module for nanobot."""
 
-from eeebot.config.loader import get_config_path, load_config
-from eeebot.config.paths import (
+from nanobot.config.loader import get_config_path, load_config
+from nanobot.config.paths import (
     get_bridge_install_dir,
     get_cli_history_path,
     get_cron_dir,
@@ -12,7 +12,7 @@ from eeebot.config.paths import (
     get_runtime_subdir,
     get_workspace_path,
 )
-from eeebot.config.schema import Config
+from nanobot.config.schema import Config
 
 __all__ = [
     "Config",

--- a/nanobot/config/loader.py
+++ b/nanobot/config/loader.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pydantic
 from loguru import logger
 
-from eeebot.config.schema import Config
+from nanobot.config.schema import Config
 
 # Global variable to store current config path (for multi-instance support)
 _current_config_path: Path | None = None

--- a/nanobot/config/paths.py
+++ b/nanobot/config/paths.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from eeebot.config.loader import get_config_path
-from eeebot.utils.helpers import ensure_dir
+from nanobot.config.loader import get_config_path
+from nanobot.utils.helpers import ensure_dir
 
 
 def _compat_home_dir() -> Path:

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -186,7 +186,7 @@ class Config(BaseSettings):
         self, model: str | None = None
     ) -> tuple["ProviderConfig | None", str | None]:
         """Match provider config and its registry name. Returns (config, spec_name)."""
-        from eeebot.providers.registry import PROVIDERS
+        from nanobot.providers.registry import PROVIDERS
 
         forced = self.agents.defaults.provider
         if forced != "auto":
@@ -261,7 +261,7 @@ class Config(BaseSettings):
 
     def get_api_base(self, model: str | None = None) -> str | None:
         """Get API base URL for the given model. Applies default URLs for gateway/local providers."""
-        from eeebot.providers.registry import find_by_name
+        from nanobot.providers.registry import find_by_name
 
         p, name = self._match_provider(model)
         if p and p.api_base:

--- a/nanobot/cron/__init__.py
+++ b/nanobot/cron/__init__.py
@@ -1,6 +1,6 @@
 """Cron service for scheduled agent tasks."""
 
-from eeebot.cron.service import CronService
-from eeebot.cron.types import CronJob, CronSchedule
+from nanobot.cron.service import CronService
+from nanobot.cron.types import CronJob, CronSchedule
 
 __all__ = ["CronService", "CronJob", "CronSchedule"]

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Coroutine
 
 from loguru import logger
 
-from eeebot.cron.types import CronJob, CronJobState, CronPayload, CronRunRecord, CronSchedule, CronStore
+from nanobot.cron.types import CronJob, CronJobState, CronPayload, CronRunRecord, CronSchedule, CronStore
 
 
 def _now_ms() -> int:

--- a/nanobot/heartbeat/__init__.py
+++ b/nanobot/heartbeat/__init__.py
@@ -1,5 +1,5 @@
 """Heartbeat service for periodic agent wake-ups."""
 
-from eeebot.heartbeat.service import HeartbeatService
+from nanobot.heartbeat.service import HeartbeatService
 
 __all__ = ["HeartbeatService"]

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine
 from loguru import logger
 
 if TYPE_CHECKING:
-    from eeebot.providers.base import LLMProvider
+    from nanobot.providers.base import LLMProvider
 
 _HEARTBEAT_TOOL = [
     {
@@ -87,7 +87,7 @@ class HeartbeatService:
 
         Returns (action, tasks) where action is 'skip' or 'run'.
         """
-        from eeebot.utils.helpers import current_time_str
+        from nanobot.utils.helpers import current_time_str
 
         response = await self.provider.chat_with_retry(
             messages=[
@@ -142,7 +142,7 @@ class HeartbeatService:
 
     async def _tick(self) -> None:
         """Execute a single heartbeat tick."""
-        from eeebot.utils.evaluator import evaluate_response
+        from nanobot.utils.evaluator import evaluate_response
 
         content = self._read_heartbeat_file()
         if not content:

--- a/nanobot/providers/custom_provider.py
+++ b/nanobot/providers/custom_provider.py
@@ -8,7 +8,7 @@ from typing import Any
 import json_repair
 from openai import AsyncOpenAI
 
-from eeebot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 
 class CustomProvider(LLMProvider):

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -11,7 +11,7 @@ import httpx
 from loguru import logger
 from oauth_cli_kit import get_token as get_codex_token
 
-from eeebot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "nanobot"

--- a/nanobot/session/__init__.py
+++ b/nanobot/session/__init__.py
@@ -1,5 +1,5 @@
 """Session management module."""
 
-from eeebot.session.manager import Session, SessionManager
+from nanobot.session.manager import Session, SessionManager
 
 __all__ = ["SessionManager", "Session"]

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -10,8 +10,8 @@ from typing import Any
 
 from loguru import logger
 
-from eeebot.config.paths import get_legacy_sessions_dir
-from eeebot.utils.helpers import ensure_dir, safe_filename
+from nanobot.config.paths import get_legacy_sessions_dir
+from nanobot.utils.helpers import ensure_dir, safe_filename
 
 
 @dataclass

--- a/tests/test_dingtalk_channel.py
+++ b/tests/test_dingtalk_channel.py
@@ -3,10 +3,9 @@ from types import SimpleNamespace
 
 import pytest
 
-from nanobot.bus.queue import MessageBus
 import nanobot.channels.dingtalk as dingtalk_module
-from nanobot.channels.dingtalk import DingTalkChannel, NanobotDingTalkHandler
-from nanobot.channels.dingtalk import DingTalkConfig
+from nanobot.bus.queue import MessageBus
+from nanobot.channels.dingtalk import DingTalkChannel, DingTalkConfig, NanobotDingTalkHandler
 
 
 class _FakeResponse:
@@ -196,7 +195,7 @@ async def test_download_dingtalk_file(tmp_path, monkeypatch) -> None:
 
     # Redirect media dir to tmp_path
     monkeypatch.setattr(
-        "eeebot.config.paths.get_media_dir",
+        "nanobot.config.paths.get_media_dir",
         lambda channel_name=None: tmp_path / channel_name if channel_name else tmp_path,
     )
 

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -1,0 +1,45 @@
+"""Regression guard: nanobot/ and app/ must import nanobot.*, never eeebot.*.
+
+The eeebot/ package is preserved as an external compatibility shim (both CLI
+entrypoints, ~/.eeebot fallback paths), but internal code must be unified on
+the nanobot.* import name to avoid dual-name drift (see issue #598).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCAN_DIRS = ("nanobot", "app")
+
+
+def _iter_python_files():
+    for dirname in SCAN_DIRS:
+        base = REPO_ROOT / dirname
+        if base.exists():
+            yield from base.rglob("*.py")
+
+
+def _eeebot_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "eeebot" or alias.name.startswith("eeebot."):
+                    offenders.append(f"{path}:{node.lineno}: import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "eeebot" or module.startswith("eeebot."):
+                offenders.append(f"{path}:{node.lineno}: from {module} import ...")
+    return offenders
+
+
+def test_no_internal_eeebot_imports():
+    """nanobot/ and app/ must not import the eeebot compatibility shim."""
+    offenders: list[str] = []
+    for path in _iter_python_files():
+        offenders.extend(_eeebot_imports(path))
+
+    assert not offenders, "Found internal imports of the eeebot shim:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary

Unifies internal imports on `nanobot.*` so every module inside `nanobot/`, `app/`, and `scripts/` is reachable under exactly one name, while the `eeebot/` package continues to work as an external compatibility shim (both `nanobot` and `eeebot` CLI entrypoints, `~/.eeebot` fallback paths, `EEEBOT_*` env aliases all still work).

### Before / after

- **Before:** ~102 `from eeebot.X import ...` / `import eeebot.X` statements across 34 files inside `nanobot/` (all channels, `config/{loader,paths,schema}.py`, `bus/{queue,__init__}.py`, `cli/{commands,eeebot}.py`, `cron/`, `heartbeat/`, `providers/`, `session/`, `__main__.py`), plus one dynamic `importlib.import_module(f"eeebot.channels.{name}")` in `nanobot/channels/registry.py` and one incidental monkeypatch target string in `tests/test_dingtalk_channel.py`.
- **After:** 0 — `grep -rn "from eeebot\.\|from eeebot \|^import eeebot\|import eeebot\." nanobot/ app/ scripts/ --include='*.py'` returns nothing.

### What was NOT touched (external compat preserved)

- The `eeebot/` shim package itself is untouched except for **one line**: `eeebot/__init__.py` gained an explicit `'eeebot.config.schema': 'nanobot.config.schema'` alias entry (mirroring the existing pattern for `config.loader`/`config.paths`). This was required because `nanobot/config/__init__.py` used to import schema via `from eeebot.config.schema import Config` as an (undocumented) side channel that forced `eeebot.config.schema` to canonicalize through the real shim file before the top-level alias hijack ran. Switching that import to `nanobot.*` (as this task requires) removed that side channel, which made `eeebot.config.schema` re-execute `schema.py` under a second identity and broke the shim-parity tests. The added alias entry fixes this robustly, independent of import order.
- Shim-verification tests left importing `eeebot.*` on purpose (unchanged): `tests/test_eeebot_imports.py`, `tests/test_eeebot_cli.py`, `tests/test_eeebot_env_aliases.py`, `tests/test_config_paths.py`, `tests/test_lightweight_imports.py`.
- Both CLI entrypoints in `pyproject.toml` (`nanobot = "nanobot.cli.commands:app"`, `eeebot = "nanobot.cli.eeebot:main"`) unchanged.

### Regression guard

Added `tests/test_import_hygiene.py`: an ast-based test that walks `nanobot/` and `app/` and fails if any `Import`/`ImportFrom` references a module starting with `eeebot`.

## Test plan

- [x] `.venv/bin/python -m pytest tests/ -q` — 1103 passed
- [x] `.venv/bin/ruff check nanobot/ app/ scripts/ tests/` — no new errors introduced (390 pre-existing errors on main → 386 after; the only I001 import-sort issues our rename touched, in `nanobot/cli/eeebot.py` and `tests/test_dingtalk_channel.py`, were fixed)
- [x] `grep -rn "from eeebot\.\|from eeebot \|^import eeebot\|import eeebot\." nanobot/ app/ scripts/ --include='*.py'` — zero lines
- [x] `python -c "import nanobot, eeebot; import eeebot.bus.queue; import nanobot.cli.commands"` — resolves cleanly, shim still works

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)