### PR TITLE
fix(host): single-authority deploy & model routing (#601)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,13 +14,19 @@ DEFAULT_RUNTIME_STATE_ROOT = Path("/var/lib/eeepc-agent/self-evolving-agent/stat
 DEFAULT_WORKSPACE = Path.cwd()
 DEFAULT_TASKS = "Run one bounded self-evolving cycle and persist canonical runtime state."
 
-# LiteLLM proxy env vars — set by /etc/eeepc-agent/litellm.env via systemd drop-in
-_LITELLM_BASE_URL = os.environ.get("LITELLM_BASE_URL", "https://litellm.ayga.tech:9443/v1")
-_LITELLM_API_KEY = os.environ.get("LITELLM_API_KEY", "")
-# Prefixed models route via openai-compatible client pointed at the proxy.
-# Default to an/gemini-3.5-flash-low; the old cl/gemini-2.5-flash Cliproxy route
-# now returns "unknown provider for model gemini-2.5-flash" (BadGateway).
-_LITELLM_MODEL = os.environ.get("LITELLM_MODEL", "an/gemini-3.5-flash-low")
+# LiteLLM proxy env vars — the ONLY source is /etc/eeepc-agent/litellm.env plus the
+# systemd drop-ins (AGENTS.md "LiteLLM config — single source of truth"). No inline
+# fallbacks: a missing value must fail loudly, not silently route elsewhere.
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(
+            f"{name} is not set — expected from /etc/eeepc-agent/litellm.env "
+            "or a systemd drop-in; refusing to start with a hardcoded fallback"
+        )
+    return value
+
+
 _LITELLM_TIMEOUT = int(os.environ.get("LITELLM_TIMEOUT_S", "45"))
 
 _SYSTEM_PROMPT = """\
@@ -61,12 +67,12 @@ async def _call_llm(prompt: str) -> str:
         import openai  # available in the venv
 
         client = openai.AsyncOpenAI(
-            api_key=_LITELLM_API_KEY,
-            base_url=_LITELLM_BASE_URL,
+            api_key=_require_env("LITELLM_API_KEY"),
+            base_url=_require_env("LITELLM_BASE_URL"),
             timeout=_LITELLM_TIMEOUT,
         )
         response = await client.chat.completions.create(
-            model=_LITELLM_MODEL,
+            model=_require_env("LITELLM_MODEL"),
             messages=[
                 {"role": "system", "content": _SYSTEM_PROMPT},
                 {"role": "user", "content": prompt},

--- a/docs/specs/host-runtime/spec.md
+++ b/docs/specs/host-runtime/spec.md
@@ -82,9 +82,11 @@ weak hardware without unbounded or non-recoverable behavior.
 
 ### Deploy / verify / rollback
 - R14. Releases SHALL be unpacked side-by-side under
-  `/home/opencode/.nanobot-eeepc/runtime/pinned/<release-id>` and verified via
-  `PYTHONPATH` against live host truth BEFORE the active `current` symlink is
-  switched. Proof SHALL precede activation.
+  `/opt/eeepc-agent/runtimes/self-evolving-agent/releases/<release-id>` and
+  verified via `PYTHONPATH` against live host truth BEFORE the active `current`
+  symlink is switched. Proof SHALL precede activation. The `current` symlink is
+  the SINGLE runtime code authority — the legacy separate
+  `runtime/pinned/current` path is retired (#601).
 - R15. Activation SHALL switch `current` only when activation is actually
   required; rollback SHALL restore `current` to the last known-good release and
   restart the affected service FIRST, then debug. A failed release directory
@@ -138,7 +140,7 @@ weak hardware without unbounded or non-recoverable behavior.
   active goal, approval state, and report path from the same tree.
 
 ### Scenario: verify before activate
-- Given a new release unpacked side-by-side under `runtime/pinned/<release-id>`
+- Given a new release unpacked side-by-side under `releases/<release-id>`
 - When it is verified read-only via `PYTHONPATH` against live host truth and the
   output is coherent
 - Then `current` may be switched; if startup later fails, `current` is restored to

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -78,15 +78,16 @@ sudo ln -sfn "/opt/eeepc-agent/venv" "$RELEASE_DIR/.venv"
 echo "[remote] updating current symlink"
 sudo ln -sfn "$RELEASE_DIR" /opt/eeepc-agent/runtimes/self-evolving-agent/current
 
-# The subagent bridge runs with PYTHONPATH=.../pinned/current, a SEPARATE runtime
-# path the current-symlink step above does NOT cover. If it dangles, the bridge
-# (which imports nanobot.runtime.stop_guards) crashes on import. Repoint it at the
-# freshly deployed release so the bridge always loads the same code as the loop.
-# See lessons/errors/ERR-2026-06-28-001.
+# Since #601 the bridge unit uses the same `current` symlink as everything else
+# (PYTHONPATH from the unit; ExecStart runs `-m nanobot.runtime.bridge`). The old
+# separate pinned/current runtime path (ERR-2026-06-28-001) is retired: keep it
+# pointing at the release only as a transition alias until the old drop-in is
+# confirmed gone everywhere, then this block can be deleted.
 PINNED_DIR=/var/lib/eeepc-agent/.nanobot-eeepc/runtime/pinned
-sudo mkdir -p "$PINNED_DIR"
-sudo ln -sfn "$RELEASE_DIR" "$PINNED_DIR/current"
-echo "[remote] pinned/current -> $(readlink "$PINNED_DIR/current")"
+if [ -L "$PINNED_DIR/current" ]; then
+  sudo ln -sfn "$RELEASE_DIR" "$PINNED_DIR/current"
+  echo "[remote] pinned/current (legacy alias) -> $(readlink "$PINNED_DIR/current")"
+fi
 
 echo "[remote] seeding goal_text.json into state/goals/"
 STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
@@ -99,12 +100,11 @@ echo "[remote] fixing ownership"
 sudo chown -R eeepc-agent:eeepc-agent "$RELEASE_DIR" "$VENV_BASE" 2>/dev/null || true
 
 echo "[remote] syncing libexec scripts from release"
-# Copy OTHER libexec scripts first (health check, etc.)
+# Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`
+# straight from the release; only auxiliary libexec scripts are synced.
 sudo cp "$RELEASE_DIR/host/eeepc/libexec/"*.py /usr/local/libexec/ 2>/dev/null || true
-# Copy canonical bridge script LAST (authoritative — overwrites the stub in libexec/)
-sudo cp "$RELEASE_DIR/scripts/eeepc_self_evolving_subagent_bridge.py" \
-        /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py 2>/dev/null || true
-sudo chmod +x /usr/local/libexec/eeepc-self-evolving-*.py
+sudo rm -f /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
+sudo chmod +x /usr/local/libexec/eeepc-self-evolving-*.py 2>/dev/null || true
 echo "[remote] reloading systemd + restarting agent"
 sudo systemctl daemon-reload
 sudo systemctl restart eeepc-self-evolving-agent.service || true

--- a/host/eeepc/scripts/install.sh
+++ b/host/eeepc/scripts/install.sh
@@ -158,14 +158,10 @@ install_libexec() {
     log "  ✓ $name"
   done
 
-  # Subagent bridge: no libexec stub exists anymore (#599) — the canonical
-  # implementation lives in nanobot/runtime/bridge.py and this thin wrapper
-  # at scripts/eeepc_self_evolving_subagent_bridge.py is what deploy_release.sh
-  # also installs, so a fresh install and a later deploy always agree.
-  run cp "$REPO_ROOT/scripts/eeepc_self_evolving_subagent_bridge.py" \
-         /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
-  run chmod +x /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
-  log "  ✓ eeepc-self-evolving-subagent-bridge.py (from scripts/, wrapper)"
+  # Subagent bridge: nothing to copy since #601 — the unit's ExecStart runs
+  # `python -m nanobot.runtime.bridge` directly from the release on PYTHONPATH,
+  # so libexec holds no bridge file at all (single code authority: the release).
+  run rm -f /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
 }
 
 # ---------------------------------------------------------------------------

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/91-runtime-state-root.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/91-runtime-state-root.conf
@@ -1,3 +1,0 @@
-[Service]
-Environment=NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state
-Environment=NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/95-issue57-timeout.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/95-issue57-timeout.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment=LITELLM_TIMEOUT_S=25

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/litellm-env.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/litellm-env.conf
@@ -1,2 +1,0 @@
-[Service]
-EnvironmentFile=/etc/eeepc-agent/litellm.env

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent-health.service.d/override.conf
@@ -1,5 +1,11 @@
+# Single consolidated drop-in for the health (coordinator driver) service.
+# Replaces the former 91-runtime-state-root / 95-issue57-timeout / litellm-env
+# accretion (#601). Note: the old 95-issue57-timeout.conf (25s) was INERT — it
+# sorted before this file, so 45s below was already the effective value.
+# Credentials/routing come only from /etc/eeepc-agent/litellm.env.
 [Service]
 WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=/etc/eeepc-agent/litellm.env
 Environment=POLICY_FILE=/opt/eeepc-agent/runtimes/self-evolving-agent/current/config/policy.yaml
 Environment=LITELLM_MODEL=an/gemini-3.5-flash-low
 Environment=LITELLM_TIMEOUT_S=45
@@ -8,5 +14,7 @@ Environment=LITELLM_RETRY_MAX_ATTEMPTS=3
 Environment=DRY_RUN=false
 Environment=ALLOW_CODE_EDITS=false
 Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state
+Environment=NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane
 ExecStart=
 ExecStart=/opt/eeepc-agent/venv/bin/python3 -m app.main

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/litellm-env.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/litellm-env.conf
@@ -1,2 +1,0 @@
-[Service]
-EnvironmentFile=/etc/eeepc-agent/litellm.env

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-agent.service.d/override.conf
@@ -1,12 +1,19 @@
+# Single consolidated drop-in for the post-deploy one-shot kick service.
+# Replaces the former litellm-env / override / zz-working-venv accretion (#601).
+# Values match the host-effective state (running behavior is the tie-breaker):
+# the old repo copy said 35s/45000ms and the release .venv, but the host's
+# zz-working-venv.conf (shared /opt venv) and override (90s/120000ms) won.
+# Credentials/routing only from /etc/eeepc-agent/litellm.env.
 [Service]
 WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=/etc/eeepc-agent/litellm.env
 Environment=POLICY_FILE=
 Environment=LITELLM_MODEL=cl/gemini-3.5-flash-low
 Environment=LITELLM_FALLBACK_MODELS=
-Environment=LITELLM_TIMEOUT_S=35
-Environment=LITELLM_TOTAL_BUDGET_MS=45000
+Environment=LITELLM_TIMEOUT_S=90
+Environment=LITELLM_TOTAL_BUDGET_MS=120000
 Environment=LITELLM_RETRY_MAX_ATTEMPTS=2
 Environment=DRY_RUN=false
 Environment=ALLOW_CODE_EDITS=false
 ExecStart=
-ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main
+ExecStart=/opt/eeepc-agent/venv/bin/python -m app.main

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/90-runtime-pinned-pythonpath.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/90-runtime-pinned-pythonpath.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment=PYTHONPATH=/var/lib/eeepc-agent/.nanobot-eeepc/runtime/pinned/current

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/91-runtime-state-root.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/91-runtime-state-root.conf
@@ -1,3 +1,0 @@
-[Service]
-Environment=NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state
-Environment=NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/92-canonical-workspace.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/92-canonical-workspace.conf
@@ -1,6 +1,0 @@
-# Managed by servers_team HOST-015 on 2026-06-05.
-# Subagent workspace = live release dir so agent can read/write real code.
-[Service]
-WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
-EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-subagent-bridge-workspace.env
-Environment=TARGET_WORKSPACE=/opt/eeepc-agent/runtimes/self-evolving-agent/current

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/95-runtime-timeout.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/95-runtime-timeout.conf
@@ -1,4 +1,0 @@
-[Service]
-# Hard kill subagent bridge execution if it exceeds 55 minutes
-# to prevent resource leaks and desync with coordinator stale timeout (60 minutes).
-RuntimeMaxSec=3300

--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/override.conf
@@ -1,0 +1,22 @@
+# Single consolidated drop-in for the subagent bridge (executor) service.
+# Replaces the former 90-pinned-pythonpath / 91-state-root / 92-canonical-workspace /
+# 93-self-evolving-repo / 94-git-auth / 95-runtime-timeout / litellm-env accretion (#601).
+#
+# Deliberate changes vs the old set:
+# - NO PYTHONPATH override: the unit's own PYTHONPATH (the `current` release symlink)
+#   applies — the separate pinned/current runtime path is retired (bridge lives in
+#   the package since #599).
+# - TimeoutStartSec replaces RuntimeMaxSec: with Type=oneshot systemd IGNORED
+#   RuntimeMaxSec ("no effect" journal warning), so the intended 55-min cap was
+#   never enforced. TimeoutStartSec is the oneshot-correct directive.
+[Service]
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=/etc/eeepc-agent/litellm.env
+EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-subagent-bridge-workspace.env
+Environment=TARGET_WORKSPACE=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=NANOBOT_RUNTIME_STATE_ROOT=/var/lib/eeepc-agent/self-evolving-agent/state
+Environment=NANOBOT_RUNTIME_STATE_SOURCE=host_control_plane
+Environment=HOME=/opt/eeepc-agent
+Environment=GIT_TERMINAL_PROMPT=0
+ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving
+TimeoutStartSec=3300

--- a/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
@@ -7,4 +7,6 @@ Type=oneshot
 WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
 Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
-ExecStart=/opt/eeepc-agent/venv/bin/python /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
+# Bridge is a package module since #599 — no file-copy to libexec, the release
+# on PYTHONPATH (current symlink) is the single code authority.
+ExecStart=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.bridge

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -153,7 +153,9 @@ class SubagentToolConfig(Base):
     max_running: int = 1
     provider: str = "hermes_pi_qwen"
     model: str = "un/qwen3.6-27b-mtp"
-    api_base: str = "https://litellm.ayga.tech:9443/v1"
+    # Routing lives in /etc/eeepc-agent/litellm.env (LITELLM_BASE_URL); empty
+    # default means "resolve from env", never a hardcoded endpoint.
+    api_base: str = ""
     bin_path: str = "~/.hermes/node/bin/pi"
 
 

--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -17,7 +17,6 @@ from nanobot.runtime._io import utc_now as _utc_now
 
 PI_DEV_PROVIDER = "hermes_pi_qwen"
 PI_DEV_MODEL = "un/qwen3.6-27b-mtp"
-PI_DEV_PUBLIC_BASE_URL = "https://litellm.ayga.tech:9443/v1"
 PI_DEV_BIN = os.path.expanduser("~/.hermes/node/bin/pi")
 PI_DEV_COMMAND_ARGV = [
     PI_DEV_BIN if Path(PI_DEV_BIN).exists() else "pi",
@@ -146,11 +145,11 @@ def _executor_metadata() -> dict[str, Any]:
         subagent_cfg = config.tools.subagent
         provider = subagent_cfg.provider
         model = subagent_cfg.model
-        api_base = subagent_cfg.api_base
+        api_base = subagent_cfg.api_base or os.environ.get("LITELLM_BASE_URL", "")
     except Exception:
         provider = PI_DEV_PROVIDER
         model = PI_DEV_MODEL
-        api_base = PI_DEV_PUBLIC_BASE_URL
+        api_base = os.environ.get("LITELLM_BASE_URL", "")
 
     return {
         "provider": provider,

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -2458,7 +2458,8 @@ def test_subagent_request_artifact_uses_generation_scoped_identity(tmp_path):
 
 
 
-def test_subagent_materializer_executes_research_only_request_with_local_executor(tmp_path):
+def test_subagent_materializer_executes_research_only_request_with_local_executor(tmp_path, monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm.ayga.tech:9443/v1")
     from nanobot.runtime.subagent_materializer import materialize_subagent_requests
 
     state_root = tmp_path / "state"
@@ -2511,7 +2512,8 @@ def test_subagent_materializer_executes_research_only_request_with_local_executo
     assert rollup["latest_result"]["key_learnings"] == result["key_learnings"]
 
 
-def test_subagent_materializer_records_executor_failure_without_leaking_command_secrets(tmp_path):
+def test_subagent_materializer_records_executor_failure_without_leaking_command_secrets(tmp_path, monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm.ayga.tech:9443/v1")
     from nanobot.runtime.subagent_materializer import materialize_subagent_requests
 
     state_root = tmp_path / "state"
@@ -2581,6 +2583,7 @@ def test_subagent_materializer_runs_executor_without_shell(tmp_path, monkeypatch
 
 
 def test_subagent_materializer_pi_dev_executor_uses_public_json_argv(tmp_path, monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm.ayga.tech:9443/v1")
     import subprocess
     from nanobot.runtime import subagent_materializer
 

--- a/tests/test_service_entrypoint.py
+++ b/tests/test_service_entrypoint.py
@@ -31,6 +31,11 @@ def test_service_entrypoint_routes_through_writer_lane(tmp_path, monkeypatch):
     monkeypatch.setenv("NANOBOT_RUNTIME_STATE_ROOT", str(state_root))
     monkeypatch.delenv("NANOBOT_RUNTIME_STATE_SOURCE", raising=False)
     monkeypatch.setenv("NANOBOT_SELF_EVOLVING_TASKS", "Verify the writer lane path.")
+    # app.main now refuses to run without the litellm.env contract (#601);
+    # dummy values keep the graceful LLM-error fallback path exercised.
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-test-dummy")
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://127.0.0.1:1/v1")
+    monkeypatch.setenv("LITELLM_MODEL", "cl/test-model")
 
     exit_code = service_main()
 


### PR DESCRIPTION
Implements #601 — the last item of the simplification roadmap. Behavior-preserving except two deliberate fixes, both of which restore *intended* behavior:

**Code (routing single-source):**
- `app/main.py` — removes the hardcoded `LITELLM_BASE_URL`/`LITELLM_MODEL`/empty-key fallbacks; the three vars are now required at the point of the LLM call and missing values raise `SystemExit` with a message pointing at `/etc/eeepc-agent/litellm.env` (AGENTS.md "single source of truth" rule; also docs/specs/host-runtime/spec.md:50).
- `nanobot/runtime/subagent_materializer.py` + `nanobot/config/schema.py` — the last two hardcoded `litellm.ayga.tech` endpoints now resolve from `LITELLM_BASE_URL`. `grep -rn "litellm.ayga" app/ nanobot/` is empty.

**Systemd (drop-in consolidation, 12 → 3):** one `override.conf` per service, values copied from the HOST-effective state (running behavior wins over the drifted repo copies — the repo agent override said 35s/45000ms but the host ran 90s/120000ms via `zz-working-venv.conf`):
- health: 4 files → 1. The old `95-issue57-timeout.conf` (25s) was **inert** (lexically shadowed by `override.conf`'s 45s) — resolved to the effective 45s.
- agent (post-deploy kick): 3 files → 1.
- bridge: 7 files → 1. Two deliberate changes: **(a)** no `PYTHONPATH` override — the unit's own `current`-symlink path applies, retiring the separate `pinned/current` runtime path (bridge is a package module since #599); **(b)** `TimeoutStartSec=3300` replaces `RuntimeMaxSec=3300`, which systemd **ignores** for `Type=oneshot` (live journal warning) — the intended 55-min cap was never actually enforced until now.

**Deploy contract:**
- bridge unit `ExecStart` → `/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.bridge` (single code authority: the release).
- `deploy_release.sh` — no bridge libexec copy (removes the stale file), `pinned/current` repoint only while the legacy symlink still exists (transition alias).
- `install.sh` — no bridge file installation.
- specs: R14/scenario in host-runtime spec updated to the real `releases/<release-id>` path.

**Rollout plan (after merge, one step at a time):** apply consolidated drop-ins + new unit on host, `daemon-reload`, deploy release, verify health+bridge timer runs, then delete the legacy pinned symlink and stale drop-in files.

Tests: 995 passed (3 materializer tests + 1 entrypoint test updated to provide the env contract). Ruff: no new findings (28 pre-existing before and after on touched paths).

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)