### PR TITLE
docs: declare eeebot/nanobot naming split as final state (#619)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,15 +18,17 @@ cycles on a constrained host (`eeepc`), plus an operator-facing chat-agent
 framework forked from `HKUDS/nanobot`. See `docs/ARCHITECTURE.md` and
 `docs/specs/` for the full map.
 
-**Naming / compatibility (critical):** the repo/project is `eeebot`, but the
-implementation lives in the **`nanobot/` package**. `eeebot/` is a thin
-compatibility layer (path-extension + `sys.modules` aliases). Both import names
-are intentionally live during the migration window. Two CLI entrypoints ship and
-must both be preserved unless a task explicitly retires compatibility:
-`nanobot = "nanobot.cli.commands:app"` and `eeebot = "nanobot.cli.eeebot:main"`.
-Runtime paths still default to `~/.nanobot` (`~/.eeebot` is fallback); Docker/compose
-still use `nanobot` naming. Do **not** do broad mechanical renames — internal
-rename work is in progress on parallel branches.
+**Naming / compatibility (final state, decided in #619):** the repo/project is
+`eeebot`, the implementation lives in the **`nanobot/` package** — permanently.
+`eeebot/` is a thin external-compatibility layer (path-extension + `sys.modules`
+aliases); no further rename phases are planned. Internal code imports
+**`nanobot.*` only** (enforced by `tests/test_import_hygiene.py` since #598);
+`eeebot` naming is for public identity and user-facing surfaces. Two CLI
+entrypoints ship and must both be preserved unless a task explicitly retires
+compatibility: `nanobot = "nanobot.cli.commands:app"` and
+`eeebot = "nanobot.cli.eeebot:main"`. Runtime paths default to `~/.nanobot`
+(`~/.eeebot` is fallback); Docker/compose use `nanobot` naming. Do **not** do
+broad mechanical renames. See `docs/specs/migration/spec.md`.
 
 ## Source of truth
 

--- a/docs/specs/chat-agent-framework/spec.md
+++ b/docs/specs/chat-agent-framework/spec.md
@@ -22,8 +22,9 @@ single shared message bus; the agent loop is channel-agnostic.
 
 > Implementation note: the framework lives in the `nanobot/` package
 > (`nanobot.channels.*`), and `eeebot.channels.*` resolves to the same module
-> objects. New code prefers `eeebot` naming where practical, but the package name
-> is `nanobot` during the migration window — see the `migration` spec.
+> objects via the compatibility shim. The package name is `nanobot` — final
+> state, decided in #619; internal imports use `nanobot.*` (enforced by
+> `tests/test_import_hygiene.py`). See the `migration` spec.
 
 ## Requirements
 

--- a/docs/specs/migration/spec.md
+++ b/docs/specs/migration/spec.md
@@ -4,15 +4,16 @@ _Status: current. Last updated: 2026-06-25._
 
 ## Purpose
 
-The project/repo is **`eeebot`**, but the implementation still lives in the
-**`nanobot/` package**. The rename from `nanobot` to `eeebot` is a *staged
-compatibility migration*, not a cosmetic search/replace — its job is to move the
-public identity and the highest-value user-facing surfaces to `eeebot` while
-keeping the live 32-bit eeepc host runtime, dashboard collectors, systemd units,
-scripts, and durable state roots working unchanged. This spec describes what is
-**true now** about that in-progress migration and the guardrails new code must
-follow during the window. Public identity and the compatibility-alias layer are
-complete; hard internal/runtime renames are intentionally deferred.
+The project/repo is **`eeebot`**; the implementation lives in the
+**`nanobot/` package**. As of #619 (2026-07-05) this split is the **decided
+final state**, not a migration in flight: public identity and user-facing
+surfaces are `eeebot`, the package and all internal imports are `nanobot`
+(unified in #598 and enforced by `tests/test_import_hygiene.py`), and the
+`eeebot/` compatibility layer is a permanent external-facing shim. No further
+rename phases are planned; a full package rename would require a new
+`docs/changes/` proposal. The guardrails below remain binding as permanent
+rules for the live eeepc host runtime, systemd units, scripts, and durable
+state roots.
 
 ## Requirements
 
@@ -32,9 +33,10 @@ complete; hard internal/runtime renames are intentionally deferred.
   dashboard systemd unit names SHALL install and run.
 
 ### Rename guardrails (what new code must / must not do)
-- R5. New code SHOULD use `eeebot` naming where practical, but SHALL NOT perform
-  broad mechanical `nanobot`→`eeebot` renames; edits SHALL stay task-local
-  (internal rename is staged on parallel branches).
+- R5. Internal code SHALL import `nanobot.*` only (guard:
+  `tests/test_import_hygiene.py`); `eeebot` naming SHALL be used for public
+  identity and user-facing surfaces. New code SHALL NOT perform broad mechanical
+  `nanobot`→`eeebot` renames; edits SHALL stay task-local.
 - R6. New code SHALL NOT rename the `nanobot/` package directory, bulk-rewrite
   import paths to `eeebot.*`, or rename systemd units/scripts without alias shims.
 - R7. New code SHALL NOT rename or bulk-rewrite durable runtime-state paths,


### PR DESCRIPTION
Implements decision (a) from #619 (cheapest, matches running behavior): the dual naming is frozen as the deliberate end-state — package/internal imports = `nanobot` (guard test from #598), public identity/CLI/user-facing = `eeebot`, shim permanent. \"Migration window\" / \"parallel branches\" prose removed from AGENTS.md, docs/specs/migration/spec.md (status → final state, R5 aligned with the import guard), and the chat-agent-framework spec note. A future full rename would need a fresh docs/changes proposal.

Docs-only; no code or host impact.

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)