### PR TITLE
chore(deploy): drop legacy pinned/current transition block (#615)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -79,15 +79,7 @@ echo "[remote] updating current symlink"
 sudo ln -sfn "$RELEASE_DIR" /opt/eeepc-agent/runtimes/self-evolving-agent/current
 
 # Since #601 the bridge unit uses the same `current` symlink as everything else
-# (PYTHONPATH from the unit; ExecStart runs `-m nanobot.runtime.bridge`). The old
-# separate pinned/current runtime path (ERR-2026-06-28-001) is retired: keep it
-# pointing at the release only as a transition alias until the old drop-in is
-# confirmed gone everywhere, then this block can be deleted.
-PINNED_DIR=/var/lib/eeepc-agent/.nanobot-eeepc/runtime/pinned
-if [ -L "$PINNED_DIR/current" ]; then
-  sudo ln -sfn "$RELEASE_DIR" "$PINNED_DIR/current"
-  echo "[remote] pinned/current (legacy alias) -> $(readlink "$PINNED_DIR/current")"
-fi
+# (PYTHONPATH from the unit; ExecStart runs `-m nanobot.runtime.bridge`).
 
 echo "[remote] seeding goal_text.json into state/goals/"
 STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state


### PR DESCRIPTION
## Why inert

Follow-up to #601. The pinned/current runtime path was retired and the directory deleted from the host (2026-07-05); `deploy_release.sh` still carried a conditional legacy-alias block (`PINNED_DIR=...` + `if [ -L "$PINNED_DIR/current" ] ...`) kept only for the transition. With the pinned directory gone from the host, the `[ -L ... ]` check always fails and the block is dead code. Also drops the now-moot `ERR-2026-06-28-001` comment reference (the lesson file itself is untouched).

## Verification

- `bash -n host/eeepc/scripts/deploy_release.sh` — syntax OK
- `grep -n pinned host/eeepc/scripts/deploy_release.sh` — no matches
- `git diff origin/main...HEAD --stat` — touches only `host/eeepc/scripts/deploy_release.sh`
- `grep -rl deploy_release tests/` found `tests/test_bridge_wrapper.py`, but its only reference is a docstring comment noting the wrapper path is unchanged — it does not assert anything about the pinned block. Ran it locally; one unrelated test fails due to a missing `loguru` dependency in this environment (no project venv installed), unrelated to this diff.

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)