### PR TITLE
fix(runtime): line-buffer bridge output so journald timestamps are trustworthy

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -87,6 +87,14 @@ passes — so a broken or unverified cycle never reaches `main`.
   `backlog_title`, `result_status`) so the coordinator can observe that a real
   subagent ran rather than only a blocked stub.
 
+> **Journald timestamp gotcha (#620):** under systemd, stdout/stderr are a pipe
+> to the journal, and Python fully-buffers a piped stream by default. During a
+> 2026-07-04 token-rotation incident, a stale `auto-push` print line was
+> journaled minutes after the event it described, which sent the investigation
+> down a wrong path. The bridge now calls
+> `sys.stdout.reconfigure(line_buffering=True)` / same for stderr at process
+> start (`cli_main`), so journal timestamps are trustworthy going forward.
+
 ## Scenarios
 
 ### Scenario: blocked stub does not suppress a real run

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -1489,8 +1490,27 @@ def _write_bridge_completed_result(
         print(f'bridge-result: failed to write result: {exc}')
 
 
+def _ensure_line_buffered_streams() -> None:
+    """Force line-buffered stdout/stderr so journald timestamps reflect real event time.
+
+    Under systemd, this process's stdout/stderr are a pipe to the journal, which
+    Python (and libc) will fully-buffer by default. That delays flush of
+    ``print()`` output — sometimes by minutes — so journal timestamps drift from
+    the actual event, which previously misled an incident investigation (see
+    docs/specs/subagent-bridge/spec.md). ``reconfigure`` is Python 3.7+; guard
+    against streams that don't support it (e.g. when stdout/stderr are replaced
+    by a non-reconfigurable object in tests).
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except (AttributeError, ValueError):
+            pass
+
+
 def cli_main() -> int:
     """Synchronous entry point used by the ``scripts/`` wrapper and console script."""
+    _ensure_line_buffered_streams()
     return asyncio.run(main())
 
 

--- a/tests/test_bridge_line_buffering.py
+++ b/tests/test_bridge_line_buffering.py
@@ -1,0 +1,34 @@
+"""Regression test for #620: bridge stdout/stderr must be line-buffered.
+
+Under systemd, the bridge's stdout/stderr are a pipe to the journal, which
+Python fully-buffers by default — delaying flush of `print()` output by
+minutes and making journal timestamps untrustworthy (see incident note in
+docs/specs/subagent-bridge/spec.md). `_ensure_line_buffered_streams` in
+nanobot/runtime/bridge.py forces line buffering via `reconfigure`.
+
+Run in a subprocess rather than in-process so the test never mutates the
+test runner's own stdout/stderr streams.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_ensure_line_buffered_streams_sets_line_buffering():
+    code = (
+        "import sys\n"
+        "from nanobot.runtime.bridge import _ensure_line_buffered_streams\n"
+        "_ensure_line_buffered_streams()\n"
+        "assert sys.stdout.line_buffering is True\n"
+        "assert sys.stderr.line_buffering is True\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Force line-buffered stdout/stderr in `nanobot/runtime/bridge.py::cli_main` via a small `_ensure_line_buffered_streams()` helper that calls `sys.stdout.reconfigure(line_buffering=True)` / same for stderr (guarded against non-reconfigurable streams).
- This is the single code-level fix requested in #620: under systemd, stdout/stderr are a pipe to the journal, and Python fully-buffers a piped stream by default, so `print()` output (e.g. "auto-push: N new commit(s)") could reach the journal minutes late — which misled a 2026-07-04 incident investigation.
- No churn: prints were left untouched (no `flush=True` added at call sites, no logging-framework rewrite).
- Added a short incident note to `docs/specs/subagent-bridge/spec.md` documenting the gotcha and the fix.

## Test plan
- [x] New test `tests/test_bridge_line_buffering.py`: subprocess-based, imports `nanobot.runtime.bridge`, calls `_ensure_line_buffered_streams()`, asserts `sys.stdout.line_buffering is True` and `sys.stderr.line_buffering is True` (subprocess isolation so the test runner's own streams are never mutated).
- [x] `.venv/bin/python -m pytest tests/ -q` — 996 passed.
- [x] `ruff check nanobot/runtime/bridge.py tests/test_bridge_line_buffering.py` — confirmed the 11 reported errors are pre-existing (identical count/locations on `origin/main` before this change); no new issues introduced by this diff.

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)