### PR TITLE
test(config): validate host config template against pydantic schema

### DIFF
--- a/host/eeepc/etc/nanobot-config.template.json
+++ b/host/eeepc/etc/nanobot-config.template.json
@@ -8,49 +8,7 @@
       "contextWindowTokens": 65536,
       "temperature": 0.1,
       "maxToolIterations": 100,
-      "reasoningEffort": null,
-      "modelRouting": {
-        "enabled": true,
-        "taskModels": {
-          "general": [
-            "cl/gemini-3.5-flash",
-            "cl/gemini-3.1-pro-preview"
-          ],
-          "code": [
-            "cl/gemini-3.1-pro-preview",
-            "cl/gemini-3.5-flash"
-          ],
-          "vision": [
-            "cl/gemini-3.5-flash",
-            "cl/gemini-3.1-pro-preview"
-          ]
-        },
-        "fallbackOn": [
-          "key not allowed",
-          "model not found",
-          "unsupported model",
-          "access denied",
-          "does not exist"
-        ],
-        "codeIntentMarkers": [
-          "```",
-          "pytest",
-          "npm",
-          "pip ",
-          "git ",
-          ".py",
-          ".js",
-          ".ts",
-          ".json",
-          ".yaml",
-          ".yml"
-        ],
-        "executorModels": {
-          "general": "cl/gemini-3.5-flash",
-          "code": "cl/gemini-3.1-pro-preview",
-          "vision": "cl/gemini-3.5-flash"
-        }
-      }
+      "reasoningEffort": null
     }
   },
   "channels": {
@@ -282,38 +240,7 @@
     "exec": {
       "enable": true,
       "timeout": 60,
-      "pathAppend": "",
-      "allowPatterns": [
-        "^pwd$",
-        "^ls(?:\\s+-[A-Za-z]+)*(?:\\s+[^;&|<>`$]+)?$",
-        "^find\\s+[^;&|<>`$]+$",
-        "^(?:rg|grep)(?:\\s+[^;&|<>`$]+)+$",
-        "^(?:fd|fdfind|tree)(?:\\s+[^;&|<>`$]+)*$",
-        "^cat\\s+[^;&|<>`$]+$",
-        "^head(?:\\s+-\\d+)?\\s+[^;&|<>`$]+$",
-        "^tail(?:\\s+-\\d+)?\\s+[^;&|<>`$]+$",
-        "^wc(?:\\s+-[lw])*\\s+[^;&|<>`$]+$",
-        "^git\\s+(?:status|diff|log(?:\\s+--oneline)?(?:\\s+-n\\s+\\d+)?|show\\s+[A-Za-z0-9._:/-]+|branch(?:\\s+[^;&|<>`$]+)?|add\\s+[^;&|<>`$]+|commit\\s+[^;&|<>`$]+|push(?:\\s+[^;&|<>`$]+)?|stash(?:\\s+[^;&|<>`$]+)?|checkout\\s+[^;&|<>`$]+|diff\\s+[^;&|<>`$]+)$",
-        "^python3?\\s+[^;&|<>`$]+$",
-        "^(?:python|python3|git|node|npm|pytest|ruff|uv|jq|sqlite3)\\s+(?:-V|--version|-v)$",
-        "^pytest(?:\\s+[^;&|<>`$]+)?$",
-        "^ruff(?:\\s+[^;&|<>`$]+)?$",
-        "^mkdir(?:\\s+-p)?\\s+[^;&|<>`$]+$",
-        "^cp(?:\\s+-[a-z]+)*\\s+[^;&|<>`$]+$",
-        "^touch\\s+[^;&|<>`$]+$",
-        "^mv\\s+[^;&|<>`$]+$",
-        "^ps(?:\\s+aux)?$",
-        "^ss\\s+-lntp$",
-        "^df\\s+-h$",
-        "^du\\s+-sh(?:\\s+[^;&|<>`$]+)?$",
-        "^free\\s+-m$",
-        "^uptime$",
-        "^lsof(?:\\s+[^;&|<>`$]+)*$"
-      ],
-      "denyPatterns": [
-        "[;&|><`]",
-        "\\$\\("
-      ]
+      "pathAppend": ""
     },
     "restrictToWorkspace": true,
     "mcpServers": {
@@ -325,32 +252,6 @@
           "*"
         ]
       }
-    },
-    "autonomy": {
-      "enabled": true,
-      "dryRunDefault": false,
-      "enabledActions": [
-        "workspace.inventory",
-        "policy.snapshot",
-        "capability.truth-check",
-        "runtime.diagnostics_snapshot",
-        "workspace.runtime.probe",
-        "workspace.venv.ensure",
-        "workspace.python.run",
-        "workspace.pip.install_local",
-        "workspace.experiment.tiny_runtime_check",
-        "workspace.repo_status",
-        "autonomy.cycle.run_once"
-      ],
-      "safetyClassAllowlist": [
-        "class_a_read_only",
-        "class_b_bounded_mutation"
-      ],
-      "targetAllowlist": [
-        "/home/opencode/.nanobot-eeepc/workspace"
-      ],
-      "sourceRepoPath": "/home/opencode/servers_team/repo_research/nanobot",
-      "source_repo_path": "/home/opencode/servers_team/repo_research/nanobot"
     }
   }
 }

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -1,0 +1,138 @@
+"""Drift-guard: the host config template must validate against the real Config schema.
+
+`host/eeepc/etc/nanobot-config.template.json` hand-mirrors the structure defined
+by `nanobot/config/schema.py`. Nothing enforced the two stay in sync, so the
+template could silently drift from the schema it's meant to model. These tests
+load the template through the exact same code path `nanobot.config.loader`
+uses for a real config file (`Config.model_validate`), then fail on unknown
+fields, missing required fields, or load-bearing values not surviving the
+round-trip.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from nanobot.config.schema import Config
+
+TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "host"
+    / "eeepc"
+    / "etc"
+    / "nanobot-config.template.json"
+)
+
+
+def _load_template_data() -> dict[str, Any]:
+    with open(TEMPLATE_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _find_dropped_keys(original: Any, dumped: Any, path: str = "") -> list[str]:
+    """Recursively collect keys present in `original` but absent from `dumped`.
+
+    `Config`'s default pydantic extra policy is "ignore": unknown keys parse
+    without error but vanish silently on `model_dump` -- convenient for a
+    schema that wants to stay lenient toward user config files, but it means
+    drift between the template and the schema would never surface on its
+    own. A model with `extra="allow"` (e.g. `ChannelsConfig`, which stores
+    per-channel plugin config as extra fields by design) round-trips its
+    extra keys losslessly, so this diff only flags fields the schema
+    actually discards -- i.e. real unknown/dead fields -- without requiring
+    the production schema to switch to `extra="forbid"`.
+    """
+    dropped: list[str] = []
+    if isinstance(original, dict):
+        if not isinstance(dumped, dict):
+            return [path or "<root>"]
+        for key, value in original.items():
+            sub_path = f"{path}.{key}" if path else key
+            if key not in dumped:
+                dropped.append(sub_path)
+                continue
+            dropped.extend(_find_dropped_keys(value, dumped[key], sub_path))
+    elif isinstance(original, list):
+        if not isinstance(dumped, list):
+            return [path]
+        for i, item in enumerate(original):
+            if i < len(dumped):
+                dropped.extend(_find_dropped_keys(item, dumped[i], f"{path}[{i}]"))
+    return dropped
+
+
+def _required_schema_paths(
+    node: dict[str, Any], defs: dict[str, Any], path: str = ""
+) -> list[str]:
+    """Recursively resolve every field the JSON schema marks required, as dotted paths."""
+    paths: list[str] = []
+    for req in node.get("required", []):
+        paths.append(f"{path}.{req}" if path else req)
+    for prop_name, prop_schema in node.get("properties", {}).items():
+        ref = prop_schema.get("$ref")
+        if ref is None and "allOf" in prop_schema:
+            ref = prop_schema["allOf"][0].get("$ref")
+        if ref:
+            def_name = ref.rsplit("/", 1)[-1]
+            sub_node = defs.get(def_name, {})
+            sub_path = f"{path}.{prop_name}" if path else prop_name
+            paths.extend(_required_schema_paths(sub_node, defs, sub_path))
+    return paths
+
+
+def _get_nested(data: dict[str, Any], dotted_path: str) -> tuple[bool, Any]:
+    """Return (present, value) for a dotted path into a nested dict."""
+    current: Any = data
+    for part in dotted_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False, None
+        current = current[part]
+    return True, current
+
+
+def test_template_loads_through_real_config_schema() -> None:
+    """The template must parse cleanly through the exact call `load_config` uses."""
+    data = _load_template_data()
+    config = Config.model_validate(data)  # same call as nanobot.config.loader.load_config
+    assert isinstance(config, Config)
+
+
+def test_template_has_no_unknown_or_dropped_fields() -> None:
+    """Fail if the template carries fields the schema doesn't know about (drift)."""
+    data = _load_template_data()
+    config = Config.model_validate(data)
+    dumped = config.model_dump(mode="json", by_alias=True)
+
+    dropped = _find_dropped_keys(data, dumped)
+    assert not dropped, (
+        "Template fields not recognized by nanobot/config/schema.py (silently "
+        f"dropped by pydantic's default extra='ignore' policy): {dropped}"
+    )
+
+
+def test_template_declares_all_schema_required_fields() -> None:
+    """Fail if the template is missing any field the schema marks required."""
+    schema = Config.model_json_schema()
+    defs = schema.get("$defs", {})
+    data = _load_template_data()
+
+    required_paths = _required_schema_paths(schema, defs)
+    missing = [p for p in required_paths if not _get_nested(data, p)[0]]
+    assert not missing, f"Template is missing schema-required fields: {missing}"
+
+
+def test_template_round_trips_load_bearing_values() -> None:
+    """Load-bearing provider/model fields must survive the real load path unchanged."""
+    data = _load_template_data()
+    config = Config.model_validate(data)
+
+    assert config.agents.defaults.model == data["agents"]["defaults"]["model"]
+    assert config.agents.defaults.provider == data["agents"]["defaults"]["provider"]
+    assert (
+        config.providers.custom.api_base
+        == data["providers"]["custom"]["apiBase"]
+    )
+    assert (
+        config.tools.mcp_servers["openspace"].url
+        == data["tools"]["mcpServers"]["openspace"]["url"]
+    )


### PR DESCRIPTION
## Summary
- Adds `tests/test_config_template.py`, a drift-guard test that loads `host/eeepc/etc/nanobot-config.template.json` through the exact same code path `nanobot.config.loader.load_config` uses (`Config.model_validate`), then fails on unknown/dropped fields, missing schema-required fields, and load-bearing provider/model values not surviving the round-trip.
- The template's default pydantic behavior (`extra="ignore"`) meant unknown keys parsed silently without error — so a simple `Config.model_validate(data)` call alone would not have caught drift. The test instead re-dumps the validated config (`model_dump(mode="json", by_alias=True)`) and recursively diffs it against the raw template, flagging any key the schema silently discarded. `ChannelsConfig`'s intentional `extra="allow"` (per-channel plugin config) round-trips losslessly, so it isn't falsely flagged. Production schema leniency (`extra="ignore"` everywhere else) is unchanged.
- Fixed the template — it had drifted from the schema: removed three field groups that are silently dropped today because nothing in the current schema/runtime consumes them (confirmed via repo-wide grep — no `.py` file reads any of them, through the schema or via raw dict access):
  - `agents.defaults.modelRouting` (task-model tables, fallback rules, etc.) — model routing is a fixed hardcoded rule set per `docs/specs/model-routing/spec.md`, not schema-configurable.
  - `tools.exec.allowPatterns` / `tools.exec.denyPatterns` — `ExecToolConfig` only has `enable`/`timeout`/`path_append`; the runtime's `ExecTool` (`nanobot/agent/loop.py`) never receives allow/deny patterns from config.
  - `tools.autonomy` (`enabled`, `dryRunDefault`, `enabledActions`, `safetyClassAllowlist`, `targetAllowlist`, `sourceRepoPath`/`source_repo_path`) — `ToolsConfig` has no `autonomy` field at all; no runtime code reads any of its sub-keys.
- Did not rename the template file (issue lists renaming as optional; `install.sh`/host still reference the current `nanobot-config.template.json` name).

## Test plan
- [x] `.venv/bin/python -m pytest tests/test_config_template.py -v` — 4/4 passed
- [x] `.venv/bin/python -m pytest tests/ -q` — 999/999 passed
- [x] `.venv/bin/python -m ruff check tests/test_config_template.py` — clean

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)