### PR TITLE
chore(providers): trim ProviderSpec registry to the supported set

### DIFF
--- a/host/eeepc/etc/nanobot-config.template.json
+++ b/host/eeepc/etc/nanobot-config.template.json
@@ -143,22 +143,7 @@
       "apiBase": null,
       "extraHeaders": null
     },
-    "deepseek": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
     "groq": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "zhipu": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "dashscope": {
       "apiKey": "",
       "apiBase": null,
       "extraHeaders": null
@@ -178,42 +163,7 @@
       "apiBase": null,
       "extraHeaders": null
     },
-    "moonshot": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "minimax": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
     "aihubmix": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "siliconflow": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "volcengine": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "volcengineCodingPlan": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "byteplus": {
-      "apiKey": "",
-      "apiBase": null,
-      "extraHeaders": null
-    },
-    "byteplusCodingPlan": {
       "apiKey": "",
       "apiBase": null,
       "extraHeaders": null

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -72,21 +72,11 @@ class ProvidersConfig(Base):
     anthropic: ProviderConfig = Field(default_factory=ProviderConfig)
     openai: ProviderConfig = Field(default_factory=ProviderConfig)
     openrouter: ProviderConfig = Field(default_factory=ProviderConfig)
-    deepseek: ProviderConfig = Field(default_factory=ProviderConfig)
     groq: ProviderConfig = Field(default_factory=ProviderConfig)
-    zhipu: ProviderConfig = Field(default_factory=ProviderConfig)
-    dashscope: ProviderConfig = Field(default_factory=ProviderConfig)
     vllm: ProviderConfig = Field(default_factory=ProviderConfig)
     ollama: ProviderConfig = Field(default_factory=ProviderConfig)  # Ollama local models
     gemini: ProviderConfig = Field(default_factory=ProviderConfig)
-    moonshot: ProviderConfig = Field(default_factory=ProviderConfig)
-    minimax: ProviderConfig = Field(default_factory=ProviderConfig)
     aihubmix: ProviderConfig = Field(default_factory=ProviderConfig)  # AiHubMix API gateway
-    siliconflow: ProviderConfig = Field(default_factory=ProviderConfig)  # SiliconFlow (硅基流动)
-    volcengine: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine (火山引擎)
-    volcengine_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # VolcEngine Coding Plan
-    byteplus: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus (VolcEngine international)
-    byteplus_coding_plan: ProviderConfig = Field(default_factory=ProviderConfig)  # BytePlus Coding Plan
     openai_codex: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # OpenAI Codex (OAuth)
     github_copilot: ProviderConfig = Field(default_factory=ProviderConfig, exclude=True)  # Github Copilot (OAuth)
 

--- a/nanobot/providers/registry.py
+++ b/nanobot/providers/registry.py
@@ -129,97 +129,6 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         strip_model_prefix=True,  # anthropic/claude-3 → claude-3 → openai/claude-3
         model_overrides=(),
     ),
-    # SiliconFlow (硅基流动): OpenAI-compatible gateway, model names keep org prefix
-    ProviderSpec(
-        name="siliconflow",
-        keywords=("siliconflow",),
-        env_key="OPENAI_API_KEY",
-        display_name="SiliconFlow",
-        litellm_prefix="openai",
-        skip_prefixes=(),
-        env_extras=(),
-        is_gateway=True,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="siliconflow",
-        default_api_base="https://api.siliconflow.cn/v1",
-        strip_model_prefix=False,
-        model_overrides=(),
-    ),
-
-    # VolcEngine (火山引擎): OpenAI-compatible gateway, pay-per-use models
-    ProviderSpec(
-        name="volcengine",
-        keywords=("volcengine", "volces", "ark"),
-        env_key="OPENAI_API_KEY",
-        display_name="VolcEngine",
-        litellm_prefix="volcengine",
-        skip_prefixes=(),
-        env_extras=(),
-        is_gateway=True,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="volces",
-        default_api_base="https://ark.cn-beijing.volces.com/api/v3",
-        strip_model_prefix=False,
-        model_overrides=(),
-    ),
-
-    # VolcEngine Coding Plan (火山引擎 Coding Plan): same key as volcengine
-    ProviderSpec(
-        name="volcengine_coding_plan",
-        keywords=("volcengine-plan",),
-        env_key="OPENAI_API_KEY",
-        display_name="VolcEngine Coding Plan",
-        litellm_prefix="volcengine",
-        skip_prefixes=(),
-        env_extras=(),
-        is_gateway=True,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="https://ark.cn-beijing.volces.com/api/coding/v3",
-        strip_model_prefix=True,
-        model_overrides=(),
-    ),
-
-    # BytePlus: VolcEngine international, pay-per-use models
-    ProviderSpec(
-        name="byteplus",
-        keywords=("byteplus",),
-        env_key="OPENAI_API_KEY",
-        display_name="BytePlus",
-        litellm_prefix="volcengine",
-        skip_prefixes=(),
-        env_extras=(),
-        is_gateway=True,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="bytepluses",
-        default_api_base="https://ark.ap-southeast.bytepluses.com/api/v3",
-        strip_model_prefix=True,
-        model_overrides=(),
-    ),
-
-    # BytePlus Coding Plan: same key as byteplus
-    ProviderSpec(
-        name="byteplus_coding_plan",
-        keywords=("byteplus-plan",),
-        env_key="OPENAI_API_KEY",
-        display_name="BytePlus Coding Plan",
-        litellm_prefix="volcengine",
-        skip_prefixes=(),
-        env_extras=(),
-        is_gateway=True,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="https://ark.ap-southeast.bytepluses.com/api/coding/v3",
-        strip_model_prefix=True,
-        model_overrides=(),
-    ),
-
-
     # === Standard providers (matched by model-name keywords) ===============
     # Anthropic: LiteLLM recognizes "claude-*" natively, no prefix needed.
     ProviderSpec(
@@ -292,23 +201,6 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         model_overrides=(),
         is_oauth=True,  # OAuth-based authentication
     ),
-    # DeepSeek: needs "deepseek/" prefix for LiteLLM routing.
-    ProviderSpec(
-        name="deepseek",
-        keywords=("deepseek",),
-        env_key="DEEPSEEK_API_KEY",
-        display_name="DeepSeek",
-        litellm_prefix="deepseek",  # deepseek-chat → deepseek/deepseek-chat
-        skip_prefixes=("deepseek/",),  # avoid double-prefix
-        env_extras=(),
-        is_gateway=False,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="",
-        strip_model_prefix=False,
-        model_overrides=(),
-    ),
     # Gemini: needs "gemini/" prefix for LiteLLM.
     ProviderSpec(
         name="gemini",
@@ -323,79 +215,6 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         detect_by_key_prefix="",
         detect_by_base_keyword="",
         default_api_base="",
-        strip_model_prefix=False,
-        model_overrides=(),
-    ),
-    # Zhipu: LiteLLM uses "zai/" prefix.
-    # Also mirrors key to ZHIPUAI_API_KEY (some LiteLLM paths check that).
-    # skip_prefixes: don't add "zai/" when already routed via gateway.
-    ProviderSpec(
-        name="zhipu",
-        keywords=("zhipu", "glm", "zai"),
-        env_key="ZAI_API_KEY",
-        display_name="Zhipu AI",
-        litellm_prefix="zai",  # glm-4 → zai/glm-4
-        skip_prefixes=("zhipu/", "zai/", "openrouter/", "hosted_vllm/"),
-        env_extras=(("ZHIPUAI_API_KEY", "{api_key}"),),
-        is_gateway=False,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="",
-        strip_model_prefix=False,
-        model_overrides=(),
-    ),
-    # DashScope: Qwen models, needs "dashscope/" prefix.
-    ProviderSpec(
-        name="dashscope",
-        keywords=("qwen", "dashscope"),
-        env_key="DASHSCOPE_API_KEY",
-        display_name="DashScope",
-        litellm_prefix="dashscope",  # qwen-max → dashscope/qwen-max
-        skip_prefixes=("dashscope/", "openrouter/"),
-        env_extras=(),
-        is_gateway=False,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="",
-        strip_model_prefix=False,
-        model_overrides=(),
-    ),
-    # Moonshot: Kimi models, needs "moonshot/" prefix.
-    # LiteLLM requires MOONSHOT_API_BASE env var to find the endpoint.
-    # Kimi K2.5 API enforces temperature >= 1.0.
-    ProviderSpec(
-        name="moonshot",
-        keywords=("moonshot", "kimi"),
-        env_key="MOONSHOT_API_KEY",
-        display_name="Moonshot",
-        litellm_prefix="moonshot",  # kimi-k2.5 → moonshot/kimi-k2.5
-        skip_prefixes=("moonshot/", "openrouter/"),
-        env_extras=(("MOONSHOT_API_BASE", "{api_base}"),),
-        is_gateway=False,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="https://api.moonshot.ai/v1",  # intl; use api.moonshot.cn for China
-        strip_model_prefix=False,
-        model_overrides=(("kimi-k2.5", {"temperature": 1.0}),),
-    ),
-    # MiniMax: needs "minimax/" prefix for LiteLLM routing.
-    # Uses OpenAI-compatible API at api.minimax.io/v1.
-    ProviderSpec(
-        name="minimax",
-        keywords=("minimax",),
-        env_key="MINIMAX_API_KEY",
-        display_name="MiniMax",
-        litellm_prefix="minimax",  # MiniMax-M2.1 → minimax/MiniMax-M2.1
-        skip_prefixes=("minimax/", "openrouter/"),
-        env_extras=(),
-        is_gateway=False,
-        is_local=False,
-        detect_by_key_prefix="",
-        detect_by_base_keyword="",
-        default_api_base="https://api.minimax.io/v1",
         strip_model_prefix=False,
         model_overrides=(),
     ),


### PR DESCRIPTION
## Summary

Part B of #602 (deferred): reconciles `nanobot/providers/registry.py` with
reality. Only 4 concrete provider classes exist (`custom`, `azure_openai`,
`openai_codex`, plus the generic LiteLLM gateway path), and the product
routes production traffic through a single LiteLLM proxy (`custom` provider
pointed at `litellm.ayga.tech`, using `cl/`, `an/`, `un/` model prefixes —
see `host/eeepc/etc/models.yaml`, `host/eeepc/etc/litellm.env.example`).
The other 18 `ProviderSpec` entries were pure LiteLTM env-var metadata for
providers we may never route to.

Method: evidence-driven, not vibes. A spec was kept only if it satisfied at
least one of:
- (a) maps to a concrete, non-generic provider class (`is_direct`/`is_oauth`
  wiring in `nanobot/providers/`)
- (b) is a distinctly-wired product feature beyond generic LiteLLM routing
  (e.g. a dedicated OAuth login command, or a config field read directly by
  name elsewhere in the codebase)
- (c) has real regression-test coverage tied to provider-specific behavior
  (not just incidental use of the name as an arbitrary example value)

### Keep-set (12) — name → justification

| Provider | Justification |
|---|---|
| `custom` | (a) `CustomProvider`, `is_direct=True`; the actual default in `host/eeepc/etc/nanobot-config.template.json` (`provider: "custom"`, pointed at the LiteLLM gateway) |
| `azure_openai` | (a) `AzureOpenAIProvider`, `is_direct=True`; dedicated `tests/test_azure_openai_provider.py` |
| `openai_codex` | (a) `OpenAICodexProvider`, `is_oauth=True`; dedicated OAuth flow + tests |
| `github_copilot` | (b) `is_oauth=True`; dedicated `_login_github_copilot` CLI command in `nanobot/cli/commands.py`, pinned by name in `tests/test_commands.py` / `tests/test_onboard_logic.py` |
| `anthropic` | (b)/(c) hardcoded fallback `default_model="anthropic/claude-opus-4-5"` in `LiteLLMProvider.__init__`; `supports_prompt_caching=True`; used as the canonical "non-gateway" baseline in `tests/test_litellm_kwargs.py` |
| `openai` | (b) flagship standard OpenAI-compatible provider; `OPENAI_API_KEY` reused as the shared env key by other kept gateways (`aihubmix`) |
| `openrouter` | (c) extensive dedicated regression suite in `tests/test_litellm_kwargs.py` (double-prefix bug, PR #2026), plus auto-detect-by-key-prefix tests |
| `aihubmix` | (c) exercised in `tests/test_litellm_kwargs.py` as the `strip_model_prefix` gateway regression case |
| `gemini` | (c) dedicated `tests/test_gemini_thought_signature.py` regression test |
| `ollama` | (c) dedicated local-provider auto-detect/fallback-priority tests in `tests/test_commands.py` |
| `vllm` | (c) paired with `ollama` in the same fallback-priority regression tests — removing it would break that coverage |
| `groq` | (b) wired distinctly for voice transcription: `nanobot/channels/manager.py` reads `config.providers.groq.api_key` directly (not just generic LLM routing) |

### Removed (10) — zero test coverage, zero config/wizard-default references

`deepseek`, `zhipu`, `dashscope`, `moonshot`, `minimax`, `siliconflow`,
`volcengine`, `volcengine_coding_plan`, `byteplus`, `byteplus_coding_plan`

Each was pure LiteLLM env-var metadata (regional/vendor OpenAI-compatible
gateway clones) with no dedicated test, no reference in
`host/eeepc/etc/nanobot-config.template.json` beyond the generic empty
placeholder every `ProvidersConfig` field gets, and no wizard/CLI wiring
beyond the registry entry itself. Confirmed no references outside
`nanobot/providers/registry.py` / `nanobot/config/schema.py` /
`host/eeepc/etc/nanobot-config.template.json` (grepped `docs/`, `README.md`,
`tests/`, all `.py`/`.json`/`.md` files).

No test was deleted or repurposed to keep a dead spec — removal was clean
in all 10 cases.

### Changes
- `nanobot/providers/registry.py`: 22 → 12 `ProviderSpec` entries (523 → 342 LOC)
- `nanobot/config/schema.py`: matching `ProvidersConfig` fields removed 1:1
- `host/eeepc/etc/nanobot-config.template.json`: matching provider blocks removed to keep `tests/test_config_template.py` round-trip green

No changes to provider base classes, retry logic, `LiteLLMProvider`, or env-var naming for any kept provider.

## Test plan
- [x] `.venv/bin/python -m pytest tests/ -q` — 999 passed
- [x] `.venv/bin/python -m pytest tests/test_config_template.py -q` — 4 passed (schema/template round-trip)
- [x] `ruff check nanobot/providers/registry.py nanobot/config/schema.py` — all checks passed
- [x] `nanobot onboard --help` — works
- [x] Wizard smoke: `_get_provider_names()` / `_get_provider_info()` return the trimmed 10-provider menu (excludes OAuth-only `openai_codex`/`github_copilot` as before) with no errors

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)