### PR TITLE
docs: variant-2 subagent tool-harness proposal + design (#643)

### DIFF
--- a/docs/changes/643-subagent-tool-harness/design.md
+++ b/docs/changes/643-subagent-tool-harness/design.md
@@ -1,0 +1,263 @@
+# 643 — design: minimal Python tool-harness for bounded subagents
+
+## Tool set (minimal)
+
+The subagent's actual job (per `docs/specs/subagent-bridge/spec.md` and the
+autonomous subagent operating directive in
+`docs/specs/self-evolving-runtime/spec.md`) is: implement or verify one
+bounded improvement, produce a diff, and report evidence. That bounds the
+tool set tightly — this is not a general coding-agent tool belt.
+
+| Tool | Phase | Justification |
+|---|---|---|
+| `read` | 1 | Needed to inspect the file(s) named in the source artifact before editing or reporting findings. Lowest risk: no mutation. |
+| `grep` | 1 | Needed to locate the change site when the source artifact names a symbol/behavior rather than a line number. Read-only. |
+| `ls` | 1 | Needed to confirm workspace layout before editing (avoid guessing paths). Read-only. |
+| `edit` | 2 | The actual implementation step — string-replace against a known-good original, not a truncated diff format the model has to invent. |
+| `write` | 2 | Needed only for new files (rare — most bounded tasks touch existing modules). Gated with `edit` since both mutate the confined workspace under the same policy seam. |
+| `bash` (command-runner) | 3 | Needed to run the import-smoke check or a narrow test the subagent itself, rather than the bridge, drives — but command execution is the hardest surface to bound (arbitrary subprocess) and stays last. |
+
+Phase 1 alone is already useful today: it lets the bounded "verify" role
+(`profile` ∈ `research_only`/`review_only`/`bounded_review`, see
+`nanobot/runtime/subagent_materializer.py::_run_local_executor`) read the
+actual changed files instead of reasoning only from the ~4000-char inlined
+`source_artifact` (`docs/specs/subagent-bridge/spec.md` R6), without any
+autonomy-surface expansion (no mutation, no execution).
+
+## Contracts (ported from pi, adapted to Python)
+
+### Edit tool
+
+Request shape: `{path, edits: [{oldText, newText}]}` (pi ref:
+`packages/coding-agent/src/core/tools/edit.ts`). Each `edits[i].oldText` must
+be an exact, unique, non-overlapping substring of the *current* file content
+at apply time — validated against the file as read, not a cached copy, so a
+concurrent modification is caught rather than silently overwritten. Multiple
+edits in one call are validated as a batch against the original text (not
+progressively against intermediate states) so overlapping ranges are rejected
+up front, matching pi's `edit-diff.ts` validation order.
+
+Validation failures (oldText not found, found more than once, edits overlap)
+are **not exceptions** — they come back to the model as normal tool-result
+text (e.g. `"oldText appears 3 times in file; must be unique"`), so the model
+gets a turn to retry with a larger, disambiguating context window. This is
+the same shape pi uses in `agent-loop.ts` (see below) and is deliberately
+loop-friendly: a bounded subagent with a small context budget cannot afford a
+crashed turn.
+
+A unified diff is produced as an audit byproduct on successful apply — not
+returned to the model as the primary result (the model only needs
+success/failure + the new relevant excerpt), but written alongside the tool
+call's journal entry (see Safety model) so a human reviewing a promoted
+change can read a real patch, not just "edit applied."
+
+### Pluggable Operations interface
+
+Each tool's logic (validate edits, run a command, list a directory) is
+written against a small `Operations` interface (pi ref: `BashOperations.exec`,
+`EditOperations.readFile/writeFile` in `tools/bash.ts` / `tools/edit.ts`), not
+directly against `open()`/`subprocess.run()`. The concrete implementation used
+in eeebot resolves and enforces the workspace boundary (see Safety model)
+before ever touching the filesystem or spawning a process. This keeps "what a
+tool does" separate from "what a tool is allowed to touch" — the same
+decoupling pi uses to run tools against local/SSH backends, repurposed here
+so the *only* backend eeebot ships is the confined-workspace one.
+
+### Shared truncation module
+
+One deterministic truncation function, applied uniformly by `read`, `grep`,
+and `bash` output — 2000 lines / 50KB head-tail with `truncated` and
+`totalLines` (or `total_bytes`) metadata told to the model explicitly (pi
+ref: `tools/truncate.ts`). This is not a nice-to-have here: the eeepc host is
+resource-constrained and the executor model
+(`un/qwen3.6-27b-mtp`) has a bounded context; an unbounded `read` or `bash`
+result is a real failure mode (context blowout, OOM-adjacent behavior on a
+weak host), not just an inconvenience.
+
+### Errors as tool-result content
+
+No tool call raises an exception that reaches the turn loop. Every failure —
+bad path, validation failure, timeout, veto (below) — becomes a tool result
+the model sees as a normal turn, exactly as `agent-loop.ts`'s
+`prepareToolCall`/`executePreparedToolCall` split does (prepare validates and
+can already produce an error result; execute only runs if prepare succeeded).
+This matters more for eeebot than for pi: pi's loop is human-supervised and
+can afford a rare TUI-visible crash; ours runs unattended, and an unhandled
+exception in a bounded subagent turn should never propagate up into the
+bridge process (`nanobot/runtime/bridge.py`) or the coordinator.
+
+### Single veto hook as the only policy seam
+
+Exactly one `before_tool_call(call) -> allow | veto(reason)` hook sits
+between "model asked for a tool call" and "tool call executes" (pi ref: the
+same `agent-loop.ts` prepare/execute split). Tools themselves stay
+policy-free — they do not know about stop-guards, promotion gating, or
+allowlists. All of eeebot's policy plugs in at this one seam:
+
+- stop-guard budget checks (max tool calls/iterations for the run, R2/R13);
+- path-confinement checks (is the resolved path inside the workspace root);
+- command allowlist/deny-by-default checks (phase 3 only);
+- a veto is itself a tool-result, not a crash — the model sees "this call was
+  not permitted: <reason>" and can adjust, same as a validation failure.
+
+## What we deliberately do NOT port
+
+- **pi's "no sandbox by design" posture.** pi assumes an attended CLI session
+  where a human can Ctrl-C a runaway command; eeebot runs unattended on a
+  host with no one watching. Every tool in our port assumes the opposite:
+  confinement is mandatory, not optional configuration.
+- **No loop-level turn/token budgets.** pi's agent loop runs until the model
+  stops on its own. Our loop enforces `max_iterations` and a token budget
+  *inside* the loop as a hard stop, independent of what the model wants — R2
+  and R11-R13 in `docs/specs/self-evolving-runtime/spec.md` remain the
+  authoritative budget/stop-reason contract; the harness adds tool calls to
+  what a stop-guard counts, it does not add a second budget system.
+- **The ~3,175-LOC `agent-session.ts` framework layer** (session persistence,
+  resumption, multi-turn conversation management beyond one bounded run) —
+  each bounded subagent run is already a single isolated invocation
+  (`docs/specs/subagent-bridge/spec.md` cycle-branch isolation), so there is
+  no cross-run session state to manage.
+- **The Node/TUI extension system and per-tool rendering** — there is no
+  interactive terminal on the other end; tool results are consumed by the
+  next model turn and by the result-artifact writer, not displayed live.
+
+## Safety model (eeebot-specific)
+
+This is the part with no pi precedent — pi does not need it because it is
+supervised.
+
+- **Workspace confinement.** Every tool that takes a path resolves it
+  (`Path.resolve()`) and verifies the resolved path is a descendant of the
+  subagent's workspace root (the cycle's isolated worktree/branch checkout,
+  `docs/specs/subagent-bridge/spec.md` R8) before any I/O. A path that
+  escapes the root (symlink, `..`, absolute path outside root) is a veto, not
+  a warning.
+- **Command execution policy (phase 3).** Deny-by-default: a command is only
+  runnable if its argv head matches a small allowlist (the same shape
+  `NANOBOT_SUBAGENT_EXECUTOR_COMMAND` already uses for the executor argv
+  itself, `nanobot/runtime/subagent_materializer.py::_executor_argv`).
+  Every invocation has a mandatory timeout with a conservative default (no
+  unbounded run, unlike pi which has no default timeout) — mirroring the
+  existing `executor_timeout_seconds` parameter on
+  `materialize_subagent_requests`.
+- **Journaling.** Every tool call (request, veto/allow decision, result,
+  truncation metadata) is appended to the same per-cycle evidence trail the
+  bridge already writes to `state/subagents/results/` — extending, not
+  replacing, the `bridge_llm_execution` result shape
+  (`docs/specs/subagent-bridge/spec.md` R16) with a `tool_calls` list.
+- **Stop-guards as the loop budget authority.** The harness loop does not
+  invent its own budget model; it decrements the same `max_tool_calls`/
+  `max_iterations` counters the coordinator's stop-guard tracking uses (R2,
+  R11-R13), so a harness run and a plain LLM-only run are comparable under
+  one accounting scheme.
+- **Promotion gating.** Harness-produced edits land only inside the existing
+  cycle-isolation branch (`selfevo/cycle-<id>`,
+  `docs/specs/subagent-bridge/spec.md` R8-R9) and are promoted to `main` only
+  through the existing smoke gate and integration path (R10-R15) — the
+  harness never merges or pushes on its own. A subagent using the harness is
+  not a new promotion authority; it is a richer producer of the same diff the
+  bridge already gates.
+
+## Loop shape
+
+A small turn loop, not a session framework:
+
+```
+loop:
+    if stop_guard.should_stop(): break with recorded stop_reason
+    response = litellm_client.call(model, messages, tools=tool_schemas)
+    if response has no tool calls: break with stop_reason="gate_clean"
+    for call in response.tool_calls:
+        result = before_tool_call(call)          # veto hook
+        if not result.allowed:
+            tool_result = error_result(result.reason)
+        else:
+            tool_result = execute(call)          # never raises
+        messages.append(tool_result)
+    stop_guard.record_iteration()
+```
+
+`max_iterations` and a token budget are enforced *in* this loop (stricter
+than pi, which has neither as a hard stop) — consistent with R13's
+requirement that termination never rely on budget exhaustion alone: the loop
+records one of the enumerated stop reasons (`gate_clean`, `max_iterations`,
+`no_progress`, `budget_<name>`) into the result artifact exactly like the
+bridge already does for cycle-level termination.
+
+## Integration point
+
+The harness is a new **executor profile**, not a replacement of any existing
+path. Today `nanobot/runtime/subagent_materializer.py::materialize_subagent_requests`
+picks one of: no configured executor (blocked stub), a configured
+`NANOBOT_SUBAGENT_EXECUTOR_COMMAND` (arbitrary external argv,
+`_run_local_executor`), or the bridge's own direct LiteLLM call
+(`nanobot/runtime/bridge.py::build_task` + `main`). The harness would be a
+new in-process option selectable the same way the bridge model is configured
+(`config.tools.subagent`, `docs/specs/subagent-bridge/spec.md` R4) — e.g. a
+`tool_harness` profile value — so:
+
+- the no-tools direct LiteLLM call remains the default, unaffected;
+- opting a request into the harness is explicit per-request (`profile` field
+  on the request artifact), not a global runtime-wide switch;
+- the bridge's branch isolation, smoke gate, and integration steps
+  (`_setup_cycle_branch`, `_run_smoke_tests`, `_integrate_cycle_to_main` in
+  `nanobot/runtime/bridge.py`) are unchanged — the harness only changes what
+  happens *inside* one subagent invocation, between branch setup and commit.
+
+Config surface stays minimal: model/timeout/max_iterations reuse existing
+`SubagentToolConfig` fields where possible; only genuinely new knobs (tool
+allowlist for phase 3, workspace-root override for tests) get new fields.
+
+## Phasing
+
+### Phase 1 — read-only tools (`read`, `grep`, `ls`)
+Lowest risk: no mutation, no command execution, path-confinement is the only
+new policy surface. Immediately useful for richer verification in the
+`research_only`/`review_only`/`bounded_review` profiles.
+
+Acceptance: tool calls are confined to the workspace root; every call is
+journaled; truncation module bounds all output; a veto (path escape) never
+crashes the loop; stop-guard counters include harness tool calls.
+
+### Phase 2 — edit + write in confined workspace
+Adds mutation. Requires the edit contract's uniqueness/overlap validation to
+be verified against adversarial inputs (empty oldText, non-existent path,
+concurrent external modification) before sign-off.
+
+Acceptance: all phase 1 criteria; edits land only on the cycle's isolation
+branch; a rejected edit call returns a validation-failure tool result (never
+an exception); an audit unified-diff is produced for every successful edit
+and journaled; the bridge's existing smoke gate and integration path require
+no changes to accept harness-produced commits.
+
+### Phase 3 — command execution (bash/command-runner)
+Hardest to bound — explicit sign-off required (per the autonomy-surface
+precondition in the (superseded) idea-backlog entry and #641's non-goals).
+
+Acceptance: all phase 1-2 criteria; command execution deny-by-default against
+an explicit allowlist; every invocation has a mandatory timeout with a
+conservative default; command stdout/stderr pass through the shared
+truncation module; a denied command returns a veto tool result, never a
+crash or silent skip.
+
+## Open questions
+
+- Should the harness share one LiteLLM client instance with the bridge's
+  direct-call path, or run in a fully separate process the bridge shells out
+  to (closer isolation, but reintroduces a subprocess boundary the #641
+  removal just simplified away)?
+- Where exactly does the tool-call journal live — a new
+  `state/subagents/tool_calls/<request_id>.jsonl` file, or inlined into the
+  existing result JSON under `executor_result`? Inlining is simpler but risks
+  growing the result artifact unboundedly on a long tool-call run.
+- Does phase 3's command allowlist need to be per-request (declared in the
+  source artifact) or a fixed runtime-wide list? Per-request is more bounded
+  but adds a new field to the request schema.
+- Should `write` (new files) really wait for phase 2, or is it low-risk
+  enough (still confined, still no execution) to ship alongside phase 1's
+  read-only tools? Left as phase 2 here per the prompt's grouping, but worth
+  revisiting once phase 1 ships and we see real usage.
+- Token-budget accounting: does the harness loop need its own token counter,
+  or can it reuse whatever the coordinator already tracks for R2's
+  `max_tool_calls`/budget caps? Assumed reusable above; needs confirmation
+  against the actual budget-tracking code once implementation starts.

--- a/docs/changes/643-subagent-tool-harness/proposal.md
+++ b/docs/changes/643-subagent-tool-harness/proposal.md
@@ -1,0 +1,68 @@
+# 643 — Variant 2: minimal Python tool-harness for bounded subagents
+
+## Context
+
+#641 removed the `pi_dev` subagent executor profile: shelling out to the
+external `pi` binary with `--no-tools` disabled its entire agentic harness, so
+the call was functionally equivalent to one direct LiteLLM request through the
+same proxy nanobot already uses — a dependency (external binary, self-compiled
+Node runtime on an unsupported i386 host) paid for with no harness benefit.
+#641 explicitly scoped out "variant 2": giving bounded subagents a real
+code-editing harness (read/edit/run tools, not just a single LLM completion).
+
+That idea backlog entry (superseded by this change folder) already did the
+research: the open-source core of pi (https://github.com/earendil-works/pi,
+`packages/coding-agent` + `packages/agent`) has small, well-tested tool
+contracts worth reusing. This proposal turns that research into a design.
+
+## Decision (operator, 2026-07-05)
+
+If/when we build variant 2, it is a **small Python port of proven patterns**
+from pi's open-source core — not a re-adoption of the `pi` binary. There is no
+Node runtime dependency, no external product dependency, no `--no-tools`
+degradation. The harness lives entirely inside `nanobot/runtime/`, calling the
+same LiteLLM client the rest of the runtime already uses.
+
+## Goals
+
+- Bounded subagents can read, edit, and (later) run commands inside a
+  confined workspace, under the existing stop-guards (R11-R13,
+  `docs/specs/self-evolving-runtime/spec.md`) and promotion gating
+  (`docs/specs/subagent-bridge/spec.md`) — not as a parallel authority.
+- Core stays small: ~1.0-1.5k LOC target for loop + tools + shared
+  truncation/veto plumbing (pi's comparable core is ~2.3k LOC across 7 tools
+  plus 450 LOC shared; we need fewer tools and no rendering/session layers).
+- Zero new external dependencies: Python stdlib + the existing LiteLLM
+  client. No Node, no new pip packages, no new host services.
+- Every tool call is policy-gated and journaled the same way bridge results
+  are today (`state/subagents/results/`).
+
+## Non-goals
+
+- No TUI, no extension system, no general-purpose agent framework — this is
+  a bounded tool-call loop for one subagent role, not a product surface.
+- No sandbox-free execution. pi assumes a supervised human CLI session and
+  deliberately has no path confinement or command allowlist; eeebot runs
+  unattended on a host with no operator watching in real time, so isolation
+  is a hard requirement, not an option.
+- No replacement of the coordinator loop, the bridge's branch-isolation/smoke
+  gate/integration path, or the R11-R13 stop-guards — the harness runs
+  *inside* the existing bounded-subagent-execution boundary, it does not
+  introduce a second one.
+- No expansion of the executor model contract (`un/qwen3.6-27b-mtp`,
+  `docs/specs/subagent-bridge/spec.md` R4) — the harness changes what tools
+  the executor can call, not which model runs it.
+
+## Sequencing
+
+- Starts only after the #641 rollout is verified closed (single built-in
+  executor path stable in production).
+- Implementation is gated on explicit autonomy-surface sign-off: promotion
+  gating and stop-guard coverage for file mutation and command execution must
+  be reviewed and approved before phase 2 (edit/write) or phase 3 (command
+  execution) code is written. Phase 1 (read-only tools) carries no autonomy
+  expansion and can proceed once scoped as its own Issue.
+- This change folder covers **design only**; implementation is separate
+  work, tracked as follow-up Issues linked from #643.
+
+story_id: docs/specs/subagent-bridge/spec.md


### PR DESCRIPTION
## Summary
- Add `docs/changes/643-subagent-tool-harness/proposal.md`: context (counterpart
  of #641), the operator decision to port pi's open-source tool patterns
  instead of re-adopting the `pi` binary, goals/non-goals, and sequencing
  (gated on #641 rollout + autonomy-surface sign-off).
- Add `docs/changes/643-subagent-tool-harness/design.md`: minimal tool set
  (read/grep/ls/edit/write/bash) justified against the subagent's actual job,
  ported contracts (edit string-replace validation, pluggable Operations
  interface, shared truncation module, errors-as-tool-results, single
  before-tool-call veto hook), what is deliberately not ported (no-sandbox
  posture, unbounded loop budgets, session framework, TUI/extension system),
  an eeebot-specific safety model (workspace confinement, command allowlist +
  mandatory timeout, journaling, stop-guards as budget authority, promotion
  gating), loop shape, integration point (new executor profile, no existing
  path replaced), 3-phase rollout with acceptance criteria, and open
  questions.

Docs only — no runtime code changes. Grounded in
`docs/specs/subagent-bridge/spec.md`, `docs/specs/self-evolving-runtime/spec.md`
(R2, R11-R13), `nanobot/runtime/bridge.py`, and
`nanobot/runtime/subagent_materializer.py`.

Part of #643

## Test plan
- [x] N/A — documentation only, no runtime code touched.
- [x] Confirmed `docs/changes/README.md` layout conventions followed
      (proposal.md + design.md, story_id linking to subagent-bridge spec).
- [x] Confirmed no edits to `docs/specs/*`, `memory/HISTORY.md`, or other
      change folders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)