### PR TITLE
feat: subagent tool-harness phase 1 — read-only tools (#643)

### DIFF
--- a/docs/changes/643-subagent-tool-harness/design.md
+++ b/docs/changes/643-subagent-tool-harness/design.md
@@ -240,7 +240,7 @@ conservative default; command stdout/stderr pass through the shared
 truncation module; a denied command returns a veto tool result, never a
 crash or silent skip.
 
-## Open questions
+## Open questions (context — see resolutions below)
 
 - Should the harness share one LiteLLM client instance with the bridge's
   direct-call path, or run in a fully separate process the bridge shells out
@@ -261,3 +261,65 @@ crash or silent skip.
   or can it reuse whatever the coordinator already tracks for R2's
   `max_tool_calls`/budget caps? Assumed reusable above; needs confirmation
   against the actual budget-tracking code once implementation starts.
+
+## Resolved questions (2026-07-05)
+
+Decided by the operator in the #643 issue thread immediately before phase 1
+implementation started; binding for phase 1 and the default assumption for
+phases 2-3 unless a later task overturns them.
+
+1. **LLM client**: in-process, reusing the bridge's existing LiteLLM call
+   path — concretely, `nanobot.providers.base.LLMProvider.chat_with_retry`
+   via the same `_make_provider(config)` bridge.py already uses. A separate
+   subprocess would reintroduce the boundary #641 just removed. Implemented
+   as `nanobot.runtime.tool_harness.run_tool_harness_request`, which builds a
+   provider the same way `bridge.py::main` does (`config.tools.subagent.model`
+   / `SUBAGENT_BRIDGE_MODEL`, `_make_provider`) unless a provider is injected
+   (tests inject a fake `LLMProvider`).
+2. **Tool-call journal**: sidecar `state/subagents/tool_calls/<request_id>.jsonl`
+   (append-only, one JSON line per tool call), and the result JSON carries
+   only `{tool_calls_count, tool_call_journal, stop_reason}` — the result
+   artifact stays bounded regardless of how many tool calls a run makes.
+3. **Phase-3 command allowlist**: runtime-wide fixed list in config (no new
+   request-schema field). Still a design note only — phase 3 remains gated
+   and unimplemented.
+4. **`write` placement**: stays in phase 2 — phase 1 remains strictly
+   zero-mutation (cleanest autonomy story; no promotion-gating review needed
+   for phase 1 sign-off).
+5. **Token budget — implementer verification finding**: confirmed against
+   `nanobot/runtime/stop_guards.py`. The harness does **not** invent a second
+   budget system: `derive_stop_reason()` / the `budget_<name>` stop-reason
+   vocabulary (R13) are reused verbatim for the harness's own stop reason
+   string. The one deviation from stop_guards' existing
+   `budget_exceeded()` helper: that helper compares strictly `used > cap`
+   (an after-the-fact "did we exceed" check, appropriate for cycle-level
+   accounting sampled between cycles). The harness instead vetoes a tool
+   call the moment `tool_calls_used >= max_tool_calls` — a hard ceiling
+   enforced *before* the call executes, not after — because the loop can
+   observe its own counter mid-turn and a bounded subagent should never be
+   allowed to run one call over budget just because the check is
+   after-the-fact. The stop-reason *name* (`"tool_calls"` →
+   `stop_reason = "budget_tool_calls"`) is unchanged, so harness runs remain
+   comparable to any other stop-guard-tracked run. New config fields:
+   `SubagentToolConfig.harness_max_iterations` (default 8) and
+   `harness_max_tool_calls` (default 24) — both genuinely new knobs, not
+   duplicates of an existing field.
+
+Integration point (resolved by implementation, not a standing open
+question): the harness is wired into
+`nanobot/runtime/subagent_materializer.py::materialize_subagent_requests`,
+not into `nanobot/runtime/bridge.py`. The bridge's own `SubagentManager` path
+already runs a full nanobot agent tool-loop (`read_file`/`write_file`/
+`edit_file`/`list_dir`/`exec`, see `bridge.py::build_task`'s
+"Use your tools" instructions) — a materially richer surface than this
+phase-1 harness, and out of scope to touch. The materializer, by contrast,
+had no tool-execution path at all for `research_only`/`review_only`/
+`bounded_review`-style requests without a configured
+`NANOBOT_SUBAGENT_EXECUTOR_COMMAND` — those degraded straight to a blocked
+stub. `tool_harness` is a new, explicit, per-request `profile` value
+alongside those; every other profile's behavior in
+`materialize_subagent_requests` is unchanged byte-for-byte (see
+`tests/test_tool_harness.py::test_materialize_research_only_profile_is_byte_identical_to_before`).
+`_setup_cycle_branch`/the smoke gate/`_integrate_cycle_to_main` in
+`bridge.py` are untouched — this is a separate execution surface, not a
+change to promotion.

--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -115,6 +115,53 @@ executor run does not stop early or hand off instead of acting:
   `backlog_title`, `result_status`) so the coordinator can observe that a real
   subagent ran rather than only a blocked stub.
 
+### Tool harness — phase 1 (read-only tools, #643)
+- R17. `nanobot.runtime.subagent_materializer.materialize_subagent_requests`
+  SHALL run the in-process phase-1 tool harness
+  (`nanobot.runtime.tool_harness`) only when a request's `profile` field is
+  exactly `tool_harness`; every other profile SHALL take the pre-existing
+  path (configured external executor, or the blocked-stub
+  `queued_request_terminalizer` path) completely unaffected.
+- R18. The phase-1 tool set SHALL be exactly `read`, `grep`, `ls` —
+  read-only, no mutation, no command execution. `edit`/`write` (phase 2) and
+  command execution (phase 3) remain gated per
+  `docs/changes/643-subagent-tool-harness/design.md`.
+- R19. Every tool call SHALL resolve its path argument
+  (`Path.resolve()`, following symlinks) and verify the resolved path is a
+  descendant of the workspace root *before* any I/O. An escape (`..`,
+  absolute path outside root, symlink pointing outside) SHALL be vetoed —
+  the model SHALL see a tool-result string explaining the veto, and the loop
+  SHALL continue; the harness SHALL NOT crash or raise on an escape attempt.
+- R20. `read` and `grep` output SHALL be truncated by one shared,
+  deterministic head-tail truncation function (2000 lines / 50KB defaults)
+  whose `{truncated, total_lines, total_bytes}` metadata is surfaced to the
+  model in the tool result, never silently dropped.
+- R21. No tool call SHALL raise an exception into the turn loop. Bad paths,
+  invalid regexes, missing files, and vetoes SHALL all become normal
+  tool-result text the model sees on its next turn.
+- R22. Exactly one veto hook (`before_tool_call`) SHALL sit between "model
+  requested a tool call" and "tool call executes", checking (a) the harness's
+  own tool-call budget and (b) path confinement. Tools themselves SHALL stay
+  policy-free.
+- R23. The harness loop SHALL NOT invent a second budget/stop-reason system:
+  it SHALL record one of the stop reasons already enumerated by
+  `nanobot.runtime.stop_guards` (`gate_clean` when the model stops calling
+  tools on its own, `max_iterations`, or `budget_tool_calls`) using the caps
+  `SubagentToolConfig.harness_max_iterations` (default 8) and
+  `harness_max_tool_calls` (default 24).
+- R24. Every tool call (request, allow/veto decision, result byte size,
+  truncation flag) SHALL be appended to a per-request JSONL sidecar at
+  `state/subagents/tool_calls/<request_id>.jsonl`. The result JSON SHALL
+  carry only the bounded summary fields `tool_calls_count`,
+  `tool_call_journal` (path to the sidecar), and `stop_reason` — full detail
+  lives in the sidecar, not inlined into the result artifact.
+- R25. The harness workspace root SHALL be the cycle's existing isolated
+  checkout (`state_root.parent / "eeebot-self-evolving"`, the same
+  convention `nanobot/runtime/bridge.py` already uses), overridable
+  per-request via a `workspace_root` field for tests. The harness SHALL NOT
+  touch `_setup_cycle_branch`, the smoke gate, or `_integrate_cycle_to_main`
+  — those remain the bridge's exclusive authority.
+
 > **Journald timestamp gotcha (#620):** under systemd, stdout/stderr are a pipe
 > to the journal, and Python fully-buffers a piped stream by default. During a
 > 2026-07-04 token-rotation incident, a stale `auto-push` print line was

--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -145,6 +145,12 @@ class SubagentToolConfig(Base):
     # Routing lives in /etc/eeepc-agent/litellm.env (LITELLM_BASE_URL); empty
     # default means "resolve from env", never a hardcoded endpoint.
     api_base: str = ""
+    # Phase-1 tool-harness loop caps (#643). The harness does not invent a
+    # second budget system — these feed nanobot.runtime.stop_guards'
+    # existing budget_exceeded()/derive_stop_reason() vocabulary, they are
+    # not a parallel accounting scheme.
+    harness_max_iterations: int = 8
+    harness_max_tool_calls: int = 24
 
 
 class ToolsConfig(Base):

--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -200,6 +200,40 @@ def _bare_python_executor_reason(argv: list[str]) -> str | None:
     return None
 
 
+def _run_tool_harness(request: dict[str, Any], *, state_root: Path) -> tuple[bool, dict[str, Any]]:
+    """Run the phase-1 read-only tool-harness (#643) for a ``tool_harness``-profile request.
+
+    Explicit per-request opt-in only (``request["profile"] == "tool_harness"``)
+    — the default no-tools direct LiteLLM path used by every other profile is
+    unaffected. Errors never propagate: a harness failure degrades to a
+    ``blocked``-shaped executor_result, exactly like ``_run_local_executor``.
+    """
+    try:
+        from nanobot.runtime.tool_harness import run_tool_harness_request
+        harness_result = run_tool_harness_request(request, state_root=state_root)
+    except Exception as exc:
+        return False, {
+            "returncode": None,
+            "stdout": "",
+            "stderr": _redact_secret_text(str(exc)),
+            "failure_reason": "tool_harness_error",
+            "tool_calls_count": None,
+            "tool_call_journal": None,
+            "stop_reason": None,
+        }
+
+    ok = bool(harness_result.get("ok"))
+    return ok, {
+        "returncode": 0 if ok else 1,
+        "stdout": _redact_secret_text(harness_result.get("stdout") or ""),
+        "stderr": "",
+        "failure_reason": None if ok else "tool_harness_incomplete",
+        "tool_calls_count": harness_result.get("tool_calls_count"),
+        "tool_call_journal": harness_result.get("tool_call_journal"),
+        "stop_reason": harness_result.get("stop_reason"),
+    }
+
+
 def _run_local_executor(command: str | list[str] | tuple[str, ...], request: dict[str, Any], *, timeout_seconds: int) -> tuple[bool, dict[str, Any]]:
     argv = _executor_argv(command)
     misconfiguration_reason = _bare_python_executor_reason(argv)
@@ -320,7 +354,14 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                     continue
             executor_result: dict[str, Any] | None = None
             executor_ok = False
-            if configured_executor and str(request.get("profile") or "").lower() in {"research_only", "review_only", "bounded_review", "bounded_execution"}:
+            profile_lower = str(request.get("profile") or "").lower()
+            is_tool_harness = profile_lower == "tool_harness"
+            if is_tool_harness:
+                # #643 phase 1: explicit per-request opt-in, independent of
+                # NANOBOT_SUBAGENT_EXECUTOR_COMMAND — the harness is in-process,
+                # not an external argv executor.
+                executor_ok, executor_result = _run_tool_harness(request, state_root=state_root)
+            elif configured_executor and profile_lower in {"research_only", "review_only", "bounded_review", "bounded_execution"}:
                 executor_ok, executor_result = _run_local_executor(
                     configured_executor,
                     request,
@@ -345,7 +386,11 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 "status": status_value,
                 "result_status": status_value,
                 "terminal_reason": terminal_reason,
-                "materialized_from": "configured_local_executor" if executor_result else "queued_request_terminalizer",
+                "materialized_from": (
+                    "tool_harness" if is_tool_harness
+                    else "configured_local_executor" if executor_result
+                    else "queued_request_terminalizer"
+                ),
                 "created_at": now.isoformat().replace("+00:00", "Z"),
                 "request_path": str(request_path),
                 "request_status": status,
@@ -364,8 +409,18 @@ def materialize_subagent_requests(*, state_root: Path, now: datetime | None = No
                 "learning_classification": learning_classification,
                 "recommended_next_action": blocker.get("recommended_next_action") if blocker else None,
                 "blocker": blocker,
-                "executor": _executor_metadata() if (executor_result or configured_executor) else None,
+                "executor": (
+                    {**_executor_metadata(), "provider": "tool_harness_phase1"} if is_tool_harness
+                    else _executor_metadata() if (executor_result or configured_executor)
+                    else None
+                ),
                 "executor_result": executor_result,
+                # #643 phase-1: bounded extension of the result shape (resolved
+                # question 2) — full detail lives in the tool_call_journal
+                # sidecar, not inlined here. None for every non-harness profile.
+                "tool_calls_count": (executor_result or {}).get("tool_calls_count") if is_tool_harness else None,
+                "tool_call_journal": (executor_result or {}).get("tool_call_journal") if is_tool_harness else None,
+                "stop_reason": (executor_result or {}).get("stop_reason") if is_tool_harness else None,
             }
             result_path.write_text(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
             results.append({"path": str(result_path), **result})

--- a/nanobot/runtime/tool_harness.py
+++ b/nanobot/runtime/tool_harness.py
@@ -1,0 +1,678 @@
+"""Phase-1 subagent tool-harness: read-only tools + a small turn loop.
+
+Implements the read-only slice of ``docs/changes/643-subagent-tool-harness/design.md``:
+``read``/``grep``/``ls`` tools, workspace confinement, a single veto hook, and a
+turn loop that reuses the existing LiteLLM-backed :class:`LLMProvider` call
+mechanics (``nanobot.providers.base.LLMProvider.chat_with_retry``) rather than
+inventing a second LLM client (issue #643, resolved question 1).
+
+Everything here is policy-free except the single ``before_tool_call`` veto
+hook (design.md "Single veto hook as the only policy seam"): tools never
+raise into the loop, and the loop never invents its own budget/stop-reason
+model — it reuses ``nanobot.runtime.stop_guards`` so a harness run is
+comparable to any other stop-guard-tracked run (resolved question 5).
+
+Phase 1 is strictly read-only: no ``edit``/``write``/``bash`` tool exists
+here (those are gated to phase 2/3 per the design and issue #643's decision).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import threading
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+from nanobot.runtime._io import utc_iso as _utc_iso
+from nanobot.runtime.stop_guards import STOP_REASON_GATE_CLEAN
+from nanobot.runtime.stop_guards import derive_stop_reason as _derive_stop_reason
+
+# ---------------------------------------------------------------------------
+# Shared truncation (design.md "Shared truncation module")
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_LINES = 2000
+DEFAULT_MAX_BYTES = 50_000
+_HEAD_FRACTION = 0.6  # 60% of the kept budget is head, 40% is tail
+
+
+def truncate_text(
+    text: str,
+    *,
+    max_lines: int = DEFAULT_MAX_LINES,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> tuple[str, dict[str, Any]]:
+    """Deterministic head-tail truncation shared by ``read`` and ``grep`` output.
+
+    Returns ``(possibly_truncated_text, metadata)`` where metadata is
+    ``{"truncated": bool, "total_lines": int, "total_bytes": int}`` — told to
+    the model explicitly rather than silently dropped, per design.md.
+    """
+    total_bytes = len(text.encode("utf-8", errors="replace"))
+    lines = text.split("\n")
+    total_lines = len(lines)
+
+    over_lines = total_lines > max_lines
+    over_bytes = total_bytes > max_bytes
+    if not over_lines and not over_bytes:
+        return text, {"truncated": False, "total_lines": total_lines, "total_bytes": total_bytes}
+
+    if over_lines:
+        head_n = max(1, int(max_lines * _HEAD_FRACTION))
+        tail_n = max(0, max_lines - head_n)
+        head = lines[:head_n]
+        tail = lines[len(lines) - tail_n:] if tail_n else []
+        omitted = total_lines - head_n - tail_n
+        body = "\n".join(head) + f"\n... [{omitted} lines omitted] ...\n" + "\n".join(tail)
+    else:
+        body = text
+
+    encoded = body.encode("utf-8", errors="replace")
+    if len(encoded) > max_bytes:
+        head_bytes = max(1, int(max_bytes * _HEAD_FRACTION))
+        tail_bytes = max(0, max_bytes - head_bytes)
+        head_part = encoded[:head_bytes].decode("utf-8", errors="ignore")
+        tail_part = encoded[len(encoded) - tail_bytes:].decode("utf-8", errors="ignore") if tail_bytes else ""
+        body = head_part + "\n... [byte-truncated] ...\n" + tail_part
+
+    return body, {"truncated": True, "total_lines": total_lines, "total_bytes": total_bytes}
+
+
+# ---------------------------------------------------------------------------
+# Workspace confinement (design.md "Safety model")
+# ---------------------------------------------------------------------------
+
+
+class PathEscapeError(Exception):
+    """Raised when a resolved path is not a descendant of the workspace root.
+
+    Never propagates past :func:`before_tool_call` / the tool functions — it
+    is always converted to a veto tool-result string.
+    """
+
+    def __init__(self, reason: str):
+        self.reason = reason
+        super().__init__(reason)
+
+
+class WorkspaceOperations:
+    """The concrete Operations backend: every path is resolved and confined.
+
+    Tools are written against this small interface (design.md "Pluggable
+    Operations interface") rather than against ``open()``/``Path`` directly,
+    so "what a tool does" stays separate from "what a tool is allowed to
+    touch". This is the only backend eeebot ships.
+    """
+
+    def __init__(self, root: Path):
+        self.root = Path(root).resolve()
+
+    def resolve(self, rel_path: str) -> Path:
+        """Resolve *rel_path* against the workspace root; raise on escape.
+
+        Follows symlinks (``Path.resolve()``) and verifies the resolved path
+        is a descendant of ``self.root`` before any I/O happens.
+        """
+        candidate = Path(rel_path or ".")
+        base = candidate if candidate.is_absolute() else self.root / candidate
+        try:
+            resolved = base.resolve(strict=False)
+        except (OSError, RuntimeError) as exc:  # pragma: no cover - defensive
+            raise PathEscapeError(f"could not resolve path {rel_path!r}: {exc}") from exc
+        try:
+            resolved.relative_to(self.root)
+        except ValueError:
+            raise PathEscapeError(
+                f"path {rel_path!r} resolves outside the workspace root"
+            )
+        return resolved
+
+    def read_text(self, rel_path: str) -> str:
+        path = self.resolve(rel_path)
+        if not path.exists():
+            raise FileNotFoundError(f"no such file: {rel_path}")
+        if path.is_dir():
+            raise IsADirectoryError(f"is a directory, not a file: {rel_path}")
+        return path.read_text(encoding="utf-8", errors="replace")
+
+    def list_dir(self, rel_path: str) -> list[tuple[str, bool]]:
+        path = self.resolve(rel_path)
+        if not path.exists():
+            raise FileNotFoundError(f"no such directory: {rel_path}")
+        if not path.is_dir():
+            raise NotADirectoryError(f"not a directory: {rel_path}")
+        entries: list[tuple[str, bool]] = []
+        for child in path.iterdir():
+            entries.append((child.name, child.is_dir()))
+        entries.sort(key=lambda e: (not e[1], e[0].lower()))
+        return entries
+
+    def iter_files(self, rel_path: str | None, glob: str | None) -> Iterator[Path]:
+        """Yield confined files under *rel_path* (default: workspace root).
+
+        Files reached via a glob match that individually escape the root
+        (e.g. a symlink inside the workspace pointing outside it) are
+        skipped rather than aborting the whole search — the base path itself
+        is still confinement-checked via :meth:`resolve`.
+        """
+        base = self.resolve(rel_path) if rel_path else self.root
+        if base.is_file():
+            yield base
+            return
+        if not base.is_dir():
+            raise NotADirectoryError(f"not a directory: {rel_path}")
+        pattern = glob or "**/*"
+        for candidate in sorted(base.glob(pattern)):
+            if not candidate.is_file():
+                continue
+            try:
+                candidate.resolve().relative_to(self.root)
+            except ValueError:
+                continue  # symlink escape found via glob traversal — skip silently
+            yield candidate
+
+
+# ---------------------------------------------------------------------------
+# Tool contracts
+# ---------------------------------------------------------------------------
+
+TOOL_READ = "read"
+TOOL_GREP = "grep"
+TOOL_LS = "ls"
+
+# Which tools take a path-like argument the veto hook must confinement-check,
+# and the argument name to check.
+_PATH_ARG_BY_TOOL = {TOOL_READ: "path", TOOL_GREP: "path", TOOL_LS: "path"}
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": TOOL_READ,
+            "description": (
+                "Read a text file from the confined workspace, with 1-based "
+                "line numbers. Large files are truncated (head+tail) with "
+                "truncation metadata."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative file path."},
+                    "offset": {"type": "integer", "description": "1-based line number to start at (default 1)."},
+                    "limit": {"type": "integer", "description": "Maximum number of lines to return."},
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": TOOL_GREP,
+            "description": (
+                "Search workspace files for a Python regular expression. "
+                "Pure-Python search (no external binary required). Matches "
+                "are returned as path:line:text, truncated (head+tail)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Python regular expression to search for."},
+                    "path": {"type": "string", "description": "Workspace-relative directory or file to search (default: workspace root)."},
+                    "glob": {"type": "string", "description": "Glob pattern relative to path (default: '**/*')."},
+                },
+                "required": ["pattern"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": TOOL_LS,
+            "description": "List a workspace directory (sorted, directories marked).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Workspace-relative directory path (default: workspace root)."},
+                },
+                "required": [],
+            },
+        },
+    },
+]
+
+
+@dataclass
+class ToolOutcome:
+    ok: bool
+    text: str
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+def tool_read(ops: WorkspaceOperations, args: dict[str, Any]) -> ToolOutcome:
+    path = str(args.get("path") or "").strip()
+    if not path:
+        return ToolOutcome(ok=False, text="read: 'path' is required")
+    try:
+        offset = int(args["offset"]) if args.get("offset") is not None else 1
+        limit = int(args["limit"]) if args.get("limit") is not None else None
+    except (TypeError, ValueError):
+        return ToolOutcome(ok=False, text="read: 'offset'/'limit' must be integers")
+
+    try:
+        content = ops.read_text(path)
+    except PathEscapeError as exc:
+        # Defense in depth: before_tool_call should already have vetoed this.
+        return ToolOutcome(ok=False, text=f"read: {exc.reason}")
+    except (FileNotFoundError, IsADirectoryError) as exc:
+        return ToolOutcome(ok=False, text=f"read: {exc}")
+    except OSError as exc:
+        return ToolOutcome(ok=False, text=f"read: error reading file: {exc}")
+
+    lines = content.split("\n")
+    start = max(0, offset - 1)
+    end = (start + limit) if limit is not None else len(lines)
+    selected = lines[start:end]
+    numbered = "\n".join(f"{i + start + 1:>6}\t{line}" for i, line in enumerate(selected))
+    if not selected:
+        numbered = "(no lines in requested range)"
+    body, meta = truncate_text(numbered)
+    return ToolOutcome(ok=True, text=body, meta=meta)
+
+
+_GREP_MAX_LINE_LEN = 500
+_GREP_MAX_MATCHES = 500
+
+
+def tool_grep(ops: WorkspaceOperations, args: dict[str, Any]) -> ToolOutcome:
+    pattern = str(args.get("pattern") or "")
+    if not pattern:
+        return ToolOutcome(ok=False, text="grep: 'pattern' is required")
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        return ToolOutcome(ok=False, text=f"grep: invalid regex: {exc}")
+
+    rel_path = args.get("path")
+    glob = args.get("glob")
+    try:
+        files = list(ops.iter_files(rel_path, glob))
+    except PathEscapeError as exc:
+        return ToolOutcome(ok=False, text=f"grep: {exc.reason}")
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        return ToolOutcome(ok=False, text=f"grep: {exc}")
+
+    matches: list[str] = []
+    for file_path in files:
+        try:
+            rel = file_path.relative_to(ops.root)
+        except ValueError:
+            continue
+        try:
+            # Stream line-by-line rather than slurp — the i386 host is
+            # memory-constrained (design.md / task constraints).
+            with file_path.open("r", encoding="utf-8", errors="replace") as fh:
+                for lineno, line in enumerate(fh, start=1):
+                    line = line.rstrip("\n")
+                    if regex.search(line):
+                        if len(line) > _GREP_MAX_LINE_LEN:
+                            line = line[:_GREP_MAX_LINE_LEN] + "…"
+                        matches.append(f"{rel}:{lineno}:{line}")
+                        if len(matches) >= _GREP_MAX_MATCHES:
+                            break
+        except OSError:
+            continue
+        if len(matches) >= _GREP_MAX_MATCHES:
+            break
+
+    if not matches:
+        return ToolOutcome(ok=True, text="grep: no matches", meta={"truncated": False, "total_lines": 0, "total_bytes": 0})
+    body, meta = truncate_text("\n".join(matches))
+    return ToolOutcome(ok=True, text=body, meta=meta)
+
+
+def tool_ls(ops: WorkspaceOperations, args: dict[str, Any]) -> ToolOutcome:
+    rel_path = args.get("path") or "."
+    try:
+        entries = ops.list_dir(str(rel_path))
+    except PathEscapeError as exc:
+        return ToolOutcome(ok=False, text=f"ls: {exc.reason}")
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        return ToolOutcome(ok=False, text=f"ls: {exc}")
+
+    lines = [f"{'d' if is_dir else '-'} {name}" for name, is_dir in entries]
+    body_source = "\n".join(lines) if lines else "(empty directory)"
+    body, meta = truncate_text(body_source)
+    return ToolOutcome(ok=True, text=body, meta=meta)
+
+
+_TOOL_DISPATCH = {TOOL_READ: tool_read, TOOL_GREP: tool_grep, TOOL_LS: tool_ls}
+
+
+# ---------------------------------------------------------------------------
+# Single veto hook (design.md "Single veto hook as the only policy seam")
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HarnessBudget:
+    """Loop-local budget counters, reusing the R2/R11-R13 stop-reason vocabulary.
+
+    The harness does not invent a second budget system (issue #643 resolved
+    question 5): ``budget_exceeded``/``derive_stop_reason`` from
+    ``nanobot.runtime.stop_guards`` are reused verbatim, only the cap names
+    (``max_tool_calls``) and counters (``tool_calls_used``) are harness-local.
+    """
+
+    max_iterations: int = 8
+    max_tool_calls: int = 24
+    iterations_used: int = 0
+    tool_calls_used: int = 0
+
+    def tool_call_stop_reason(self) -> str | None:
+        # Checked BEFORE executing the next call (>=, not the after-the-fact
+        # "> cap" semantics stop_guards.budget_exceeded uses for cycle-level
+        # accounting) so the cap is a hard ceiling on calls actually executed.
+        # The stop-reason *name* ("tool_calls") still matches R2/R13's
+        # existing budget-cap vocabulary — see _BUDGET_CAP_TO_USAGE.
+        if self.tool_calls_used < self.max_tool_calls:
+            return None
+        return _derive_stop_reason(outcome="", stall=None, budget_exceeded="tool_calls", max_iterations_reached=False)
+
+    def max_iterations_stop_reason(self) -> str | None:
+        if self.iterations_used < self.max_iterations:
+            return None
+        return _derive_stop_reason(outcome="", stall=None, budget_exceeded=None, max_iterations_reached=True)
+
+
+def before_tool_call(
+    name: str,
+    args: dict[str, Any],
+    *,
+    ops: WorkspaceOperations,
+    budget: HarnessBudget,
+) -> tuple[bool, str | None]:
+    """The one policy seam between "model asked for a tool call" and execution.
+
+    Checks (a) the tool-call budget is not exhausted, (b) path confinement.
+    Tools themselves stay policy-free. A veto is a reason string, never an
+    exception — the caller turns it into a normal tool-result message.
+    """
+    stop_reason = budget.tool_call_stop_reason()
+    if stop_reason:
+        return False, f"tool-call budget exhausted ({stop_reason})"
+
+    path_key = _PATH_ARG_BY_TOOL.get(name)
+    if path_key:
+        raw_path = args.get(path_key)
+        if raw_path:
+            try:
+                ops.resolve(str(raw_path))
+            except PathEscapeError as exc:
+                return False, exc.reason
+    return True, None
+
+
+# ---------------------------------------------------------------------------
+# Journal (state/subagents/tool_calls/<request_id>.jsonl)
+# ---------------------------------------------------------------------------
+
+
+def _append_journal(journal_path: Path, entry: dict[str, Any]) -> None:
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    with journal_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Turn loop (design.md "Loop shape")
+# ---------------------------------------------------------------------------
+
+
+async def run_harness_loop(
+    provider: Any,
+    *,
+    model: str,
+    messages: list[dict[str, Any]],
+    ops: WorkspaceOperations,
+    budget: HarnessBudget,
+    journal_path: Path,
+    max_tokens: int = 4096,
+    temperature: float = 0.2,
+) -> dict[str, Any]:
+    """Drive the bounded tool-call loop. Never raises for tool/veto failures.
+
+    Returns ``{"stop_reason": str, "messages": [...], "tool_calls_count": int}``.
+    """
+    stop_reason = STOP_REASON_GATE_CLEAN
+
+    while True:
+        max_iter_reason = budget.max_iterations_stop_reason()
+        if max_iter_reason:
+            stop_reason = max_iter_reason
+            break
+        tool_budget_reason = budget.tool_call_stop_reason()
+        if tool_budget_reason:
+            stop_reason = tool_budget_reason
+            break
+
+        response = await provider.chat_with_retry(
+            messages=messages,
+            tools=TOOL_SCHEMAS,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        budget.iterations_used += 1
+
+        if not getattr(response, "has_tool_calls", False):
+            messages.append({"role": "assistant", "content": response.content or ""})
+            stop_reason = STOP_REASON_GATE_CLEAN
+            break
+
+        messages.append({
+            "role": "assistant",
+            "content": response.content,
+            "tool_calls": [tc.to_openai_tool_call() for tc in response.tool_calls],
+        })
+
+        budget_hit_mid_turn: str | None = None
+        for tool_call in response.tool_calls:
+            name = tool_call.name
+            args = tool_call.arguments if isinstance(tool_call.arguments, dict) else {}
+
+            allowed, veto_reason = before_tool_call(name, args, ops=ops, budget=budget)
+            if allowed:
+                budget.tool_calls_used += 1
+                fn = _TOOL_DISPATCH.get(name)
+                if fn is None:
+                    outcome = ToolOutcome(ok=False, text=f"unknown tool: {name}")
+                else:
+                    try:
+                        outcome = fn(ops, args)
+                    except Exception as exc:  # tools must never crash the loop
+                        outcome = ToolOutcome(ok=False, text=f"{name}: unexpected error: {exc}")
+                decision = "allow"
+                result_text = outcome.text
+                meta = outcome.meta
+            else:
+                decision = "veto"
+                result_text = f"tool call vetoed: {veto_reason}"
+                meta = {}
+
+            _append_journal(journal_path, {
+                "ts": _utc_iso(),
+                "tool": name,
+                "args": args,
+                "decision": decision,
+                "veto_reason": veto_reason if decision == "veto" else None,
+                "result_bytes": len(result_text.encode("utf-8", errors="replace")),
+                "truncated": bool(meta.get("truncated")) if meta else False,
+            })
+
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": result_text,
+            })
+
+            budget_hit_mid_turn = budget.tool_call_stop_reason()
+            if budget_hit_mid_turn:
+                break
+
+        if budget_hit_mid_turn:
+            stop_reason = budget_hit_mid_turn
+            break
+
+    return {
+        "stop_reason": stop_reason,
+        "messages": messages,
+        "tool_calls_count": budget.tool_calls_used,
+    }
+
+
+def _final_text(messages: list[dict[str, Any]]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant" and msg.get("content"):
+            return str(msg["content"])
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Sync entrypoint used by nanobot.runtime.subagent_materializer
+# ---------------------------------------------------------------------------
+
+
+def _run_async(coro: Any) -> Any:
+    """Run *coro* to completion, safe whether or not a loop is already running.
+
+    ``materialize_subagent_requests`` is called both from plain sync code
+    (``nanobot cli``) and from inside an already-running asyncio loop
+    (``coordinator.run_self_evolving_cycle``); ``asyncio.run()`` would raise
+    in the latter case, so a running loop pushes the harness loop onto its
+    own dedicated thread/event loop instead.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result_box: dict[str, Any] = {}
+    error_box: dict[str, BaseException] = {}
+
+    def _runner() -> None:
+        try:
+            result_box["result"] = asyncio.run(coro)
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the caller's thread
+            error_box["error"] = exc
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in error_box:
+        raise error_box["error"]
+    return result_box["result"]
+
+
+def _harness_system_prompt(workspace_root: Path) -> str:
+    return (
+        "You are a bounded verification subagent for the eeepc self-evolving "
+        "runtime, running with a read-only tool harness (phase 1 of #643). "
+        f"Your tools are confined to the workspace root: {workspace_root}. "
+        "Use `read`, `grep`, and `ls` to inspect the actual files named in the "
+        "task before answering. You cannot edit or execute anything in this "
+        "profile — report findings only. Stop calling tools once you have "
+        "enough information and answer with your findings as your final "
+        "message content."
+    )
+
+
+def _harness_task_prompt(request: dict[str, Any]) -> str:
+    title = request.get("task_title") or request.get("title") or request.get("task_id") or "subagent verification task"
+    source = request.get("source_artifact") or "source artifact unavailable"
+    return (
+        f"Task: {title}.\n"
+        f"Task id: {request.get('task_id') or request.get('taskId')}.\n"
+        f"Cycle id: {request.get('cycle_id') or request.get('cycleId')}.\n"
+        f"Source artifact: {source}.\n"
+        "Use your read-only tools to inspect the relevant files, then report "
+        "concise findings. Do not claim a mutation happened — this profile "
+        "cannot mutate files."
+    )
+
+
+def run_tool_harness_request(
+    request: dict[str, Any],
+    *,
+    state_root: Path,
+    workspace_root: Path | None = None,
+    provider: Any | None = None,
+    model: str | None = None,
+    config: Any | None = None,
+    max_iterations: int | None = None,
+    max_tool_calls: int | None = None,
+) -> dict[str, Any]:
+    """Run the phase-1 read-only harness for one materializer request.
+
+    Returns a dict with ``ok``, ``stdout`` (the model's final findings text),
+    ``tool_calls_count``, ``tool_call_journal`` (path), and ``stop_reason`` —
+    the fields ``subagent_materializer`` folds into the result artifact per
+    issue #643 resolved question 2 (bounded result JSON, full detail lives in
+    the journal sidecar).
+    """
+    request_id = str(request.get("request_id") or request.get("id") or uuid.uuid4().hex)
+    safe_id = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in request_id).strip("-") or "request"
+    journal_path = Path(state_root) / "subagents" / "tool_calls" / f"{safe_id}.jsonl"
+
+    if config is None:
+        from nanobot.config.loader import load_config
+        config = load_config()
+    subagent_cfg = config.tools.subagent
+    resolved_model = (
+        model
+        or os.environ.get("SUBAGENT_BRIDGE_MODEL", "").strip()
+        or getattr(subagent_cfg, "model", None)
+        or "un/qwen3.6-27b-mtp"
+    )
+
+    if provider is None:
+        from nanobot.cli.commands import _make_provider
+        config.agents.defaults.model = resolved_model
+        provider = _make_provider(config)
+
+    resolved_workspace = workspace_root
+    if resolved_workspace is None:
+        raw_workspace = request.get("workspace_root")
+        resolved_workspace = Path(str(raw_workspace)) if raw_workspace else Path(state_root).parent / "eeebot-self-evolving"
+    ops = WorkspaceOperations(resolved_workspace)
+
+    budget = HarnessBudget(
+        max_iterations=int(max_iterations or getattr(subagent_cfg, "harness_max_iterations", 8)),
+        max_tool_calls=int(max_tool_calls or getattr(subagent_cfg, "harness_max_tool_calls", 24)),
+    )
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": _harness_system_prompt(ops.root)},
+        {"role": "user", "content": _harness_task_prompt(request)},
+    ]
+
+    result = _run_async(run_harness_loop(
+        provider,
+        model=resolved_model,
+        messages=messages,
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    ))
+
+    return {
+        "ok": result["stop_reason"] == STOP_REASON_GATE_CLEAN,
+        "stdout": _final_text(result["messages"]),
+        "tool_calls_count": result["tool_calls_count"],
+        "tool_call_journal": str(journal_path),
+        "stop_reason": result["stop_reason"],
+    }

--- a/tests/test_tool_harness.py
+++ b/tests/test_tool_harness.py
@@ -1,0 +1,476 @@
+"""Tests for the phase-1 subagent tool-harness (#643).
+
+Covers: workspace confinement, shared truncation, errors-as-tool-results,
+the turn loop (tool-call -> result -> second turn -> stop; max_iterations;
+tool-call budget), the JSONL journal, and the ``tool_harness`` profile
+integration into ``subagent_materializer.materialize_subagent_requests``
+(default no-tools path stays byte-identical for other profiles).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+from nanobot.runtime.stop_guards import STOP_REASON_GATE_CLEAN, STOP_REASON_MAX_ITERATIONS
+from nanobot.runtime.subagent_materializer import materialize_subagent_requests
+from nanobot.runtime.tool_harness import (
+    HarnessBudget,
+    PathEscapeError,
+    WorkspaceOperations,
+    before_tool_call,
+    run_harness_loop,
+    run_tool_harness_request,
+    tool_grep,
+    tool_ls,
+    tool_read,
+    truncate_text,
+)
+
+
+class ScriptedProvider(LLMProvider):
+    """Fake LLM client driving the turn loop, same style as test_provider_retry.py."""
+
+    def __init__(self, responses: list[LLMResponse]):
+        super().__init__()
+        self._responses = list(responses)
+        self.calls = 0
+        self.seen_messages: list[list[dict]] = []
+
+    async def chat(self, messages=None, tools=None, model=None, max_tokens=4096, temperature=0.7, reasoning_effort=None, tool_choice=None) -> LLMResponse:
+        self.calls += 1
+        self.seen_messages.append(list(messages or []))
+        return self._responses.pop(0)
+
+    def get_default_model(self) -> str:
+        return "test-model"
+
+
+def _tc(call_id: str, name: str, arguments: dict) -> ToolCallRequest:
+    return ToolCallRequest(id=call_id, name=name, arguments=arguments)
+
+
+# ---------------------------------------------------------------------------
+# Truncation
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_text_under_limits_is_unchanged():
+    text = "line\n" * 10
+    body, meta = truncate_text(text, max_lines=2000, max_bytes=50_000)
+    assert body == text
+    assert meta == {"truncated": False, "total_lines": 11, "total_bytes": len(text.encode())}
+
+
+def test_truncate_text_over_line_limit_is_deterministic_head_tail():
+    lines = [f"line-{i}" for i in range(5000)]
+    text = "\n".join(lines)
+    body, meta = truncate_text(text, max_lines=100, max_bytes=1_000_000)
+    assert meta["truncated"] is True
+    assert meta["total_lines"] == 5000
+    assert meta["total_bytes"] == len(text.encode())
+    assert "line-0" in body
+    assert "line-4999" in body
+    assert "omitted" in body
+    # deterministic: running again gives the same output
+    body2, meta2 = truncate_text(text, max_lines=100, max_bytes=1_000_000)
+    assert body == body2
+    assert meta == meta2
+
+
+def test_truncate_text_over_byte_limit():
+    text = "x" * 200_000
+    body, meta = truncate_text(text, max_lines=1_000_000, max_bytes=1000)
+    assert meta["truncated"] is True
+    assert meta["total_bytes"] == 200_000
+    assert len(body.encode("utf-8")) < 200_000
+
+
+# ---------------------------------------------------------------------------
+# Confinement
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_operations_resolves_inside_root(tmp_path):
+    (tmp_path / "a.txt").write_text("hello", encoding="utf-8")
+    ops = WorkspaceOperations(tmp_path)
+    assert ops.resolve("a.txt") == (tmp_path / "a.txt").resolve()
+
+
+def test_workspace_operations_rejects_dotdot_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (tmp_path / "secret.txt").write_text("nope", encoding="utf-8")
+    ops = WorkspaceOperations(workspace)
+    with pytest.raises(PathEscapeError):
+        ops.resolve("../secret.txt")
+
+
+def test_workspace_operations_rejects_absolute_outside_path(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("nope", encoding="utf-8")
+    ops = WorkspaceOperations(workspace)
+    with pytest.raises(PathEscapeError):
+        ops.resolve(str(outside))
+
+
+def test_workspace_operations_rejects_symlink_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "leaked.txt").write_text("secret", encoding="utf-8")
+    link = workspace / "escape_link"
+    link.symlink_to(outside_dir)
+    ops = WorkspaceOperations(workspace)
+    with pytest.raises(PathEscapeError):
+        ops.resolve("escape_link/leaked.txt")
+
+
+def test_before_tool_call_vetoes_path_escape_and_never_touches_disk(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ops = WorkspaceOperations(workspace)
+    budget = HarnessBudget(max_iterations=8, max_tool_calls=24)
+    allowed, reason = before_tool_call("read", {"path": "../etc/passwd"}, ops=ops, budget=budget)
+    assert allowed is False
+    assert "outside the workspace root" in reason
+
+
+def test_before_tool_call_vetoes_symlink_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "leaked.txt").write_text("secret", encoding="utf-8")
+    link = workspace / "escape_link"
+    link.symlink_to(outside_dir)
+    ops = WorkspaceOperations(workspace)
+    budget = HarnessBudget()
+    allowed, reason = before_tool_call("read", {"path": "escape_link/leaked.txt"}, ops=ops, budget=budget)
+    assert allowed is False
+    assert "outside the workspace root" in reason
+
+
+def test_tool_read_confinement_veto_surfaces_as_tool_result_via_loop(tmp_path):
+    """A confinement escape never crashes the tool function itself either."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ops = WorkspaceOperations(workspace)
+    outcome = tool_read(ops, {"path": "../secret.txt"})
+    assert outcome.ok is False
+    assert "outside the workspace root" in outcome.text
+
+
+# ---------------------------------------------------------------------------
+# Errors-as-tool-results (no exceptions propagate)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_read_nonexistent_path_is_a_result_not_an_exception(tmp_path):
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_read(ops, {"path": "does_not_exist.txt"})
+    assert outcome.ok is False
+    assert "no such file" in outcome.text
+
+
+def test_tool_grep_invalid_regex_is_a_result_not_an_exception(tmp_path):
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_grep(ops, {"pattern": "("})
+    assert outcome.ok is False
+    assert "invalid regex" in outcome.text
+
+
+def test_tool_ls_nonexistent_dir_is_a_result_not_an_exception(tmp_path):
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_ls(ops, {"path": "no_such_dir"})
+    assert outcome.ok is False
+    assert "no such directory" in outcome.text
+
+
+# ---------------------------------------------------------------------------
+# Tool behavior
+# ---------------------------------------------------------------------------
+
+
+def test_tool_read_line_numbers_and_offset_limit(tmp_path):
+    (tmp_path / "f.py").write_text("a\nb\nc\nd\n", encoding="utf-8")
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_read(ops, {"path": "f.py", "offset": 2, "limit": 2})
+    assert outcome.ok is True
+    assert "2\tb" in outcome.text
+    assert "3\tc" in outcome.text
+    assert "1\ta" not in outcome.text
+
+
+def test_tool_grep_finds_matches_and_caps_line_length(tmp_path):
+    (tmp_path / "f.py").write_text("needle here\nno match\nx" + ("y" * 600) + " needle\n", encoding="utf-8")
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_grep(ops, {"pattern": "needle"})
+    assert outcome.ok is True
+    assert "f.py:1:" in outcome.text
+    assert "f.py:3:" in outcome.text
+    # long line is capped with an ellipsis
+    assert "…" in outcome.text
+
+
+def test_tool_grep_no_matches(tmp_path):
+    (tmp_path / "f.py").write_text("nothing here\n", encoding="utf-8")
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_grep(ops, {"pattern": "zzzznotfound"})
+    assert outcome.ok is True
+    assert "no matches" in outcome.text
+
+
+def test_tool_ls_sorted_dirs_marked(tmp_path):
+    (tmp_path / "b_file.txt").write_text("x", encoding="utf-8")
+    (tmp_path / "a_dir").mkdir()
+    ops = WorkspaceOperations(tmp_path)
+    outcome = tool_ls(ops, {})
+    lines = outcome.text.splitlines()
+    assert lines[0].startswith("d ") and "a_dir" in lines[0]
+    assert lines[1].startswith("- ") and "b_file.txt" in lines[1]
+
+
+# ---------------------------------------------------------------------------
+# Turn loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_tool_call_then_second_turn_then_stop(tmp_path):
+    (tmp_path / "f.py").write_text("hello world\n", encoding="utf-8")
+    ops = WorkspaceOperations(tmp_path)
+    budget = HarnessBudget(max_iterations=8, max_tool_calls=24)
+    journal_path = tmp_path / "journal.jsonl"
+
+    provider = ScriptedProvider([
+        LLMResponse(content=None, tool_calls=[_tc("call-1", "read", {"path": "f.py"})]),
+        LLMResponse(content="Found: hello world", tool_calls=[]),
+    ])
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "inspect f.py"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
+    assert result["tool_calls_count"] == 1
+    assert provider.calls == 2
+    tool_msgs = [m for m in result["messages"] if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    assert "hello world" in tool_msgs[0]["content"]
+
+    journal_lines = journal_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(journal_lines) == 1
+    entry = json.loads(journal_lines[0])
+    assert entry["tool"] == "read"
+    assert entry["decision"] == "allow"
+    assert entry["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_at_max_iterations(tmp_path):
+    ops = WorkspaceOperations(tmp_path)
+    budget = HarnessBudget(max_iterations=2, max_tool_calls=100)
+    journal_path = tmp_path / "journal.jsonl"
+
+    # Model keeps calling ls forever — the loop must cut it off at max_iterations.
+    responses = [
+        LLMResponse(content=None, tool_calls=[_tc(f"call-{i}", "ls", {})])
+        for i in range(10)
+    ]
+    provider = ScriptedProvider(responses)
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "loop forever"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == STOP_REASON_MAX_ITERATIONS
+    assert provider.calls == 2  # exactly max_iterations turns taken
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_at_tool_call_budget(tmp_path):
+    ops = WorkspaceOperations(tmp_path)
+    budget = HarnessBudget(max_iterations=100, max_tool_calls=2)
+    journal_path = tmp_path / "journal.jsonl"
+
+    # One turn asks for 3 tool calls at once — budget should cut it off mid-turn.
+    provider = ScriptedProvider([
+        LLMResponse(content=None, tool_calls=[
+            _tc("call-1", "ls", {}),
+            _tc("call-2", "ls", {}),
+            _tc("call-3", "ls", {}),
+        ]),
+    ])
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "ls three times"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == "budget_tool_calls"
+    assert result["tool_calls_count"] == 2
+
+    journal_lines = journal_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(journal_lines) == 2  # third call never got a journal entry — loop stopped first
+
+
+@pytest.mark.asyncio
+async def test_loop_veto_is_journaled_and_loop_continues(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    ops = WorkspaceOperations(workspace)
+    budget = HarnessBudget(max_iterations=8, max_tool_calls=24)
+    journal_path = tmp_path / "journal.jsonl"
+
+    provider = ScriptedProvider([
+        LLMResponse(content=None, tool_calls=[_tc("call-1", "read", {"path": "../secret.txt"})]),
+        LLMResponse(content="ok, giving up on that path", tool_calls=[]),
+    ])
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "read ../secret.txt"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
+    assert provider.calls == 2  # loop continued to a second turn after the veto
+
+    journal_lines = journal_path.read_text(encoding="utf-8").strip().splitlines()
+    entry = json.loads(journal_lines[0])
+    assert entry["decision"] == "veto"
+    assert "outside the workspace root" in entry["veto_reason"]
+
+    tool_msgs = [m for m in result["messages"] if m.get("role") == "tool"]
+    assert "vetoed" in tool_msgs[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Sync entrypoint: run_tool_harness_request
+# ---------------------------------------------------------------------------
+
+
+def test_run_tool_harness_request_end_to_end(tmp_path):
+    workspace = tmp_path / "eeebot-self-evolving"
+    workspace.mkdir()
+    (workspace / "notes.md").write_text("target content\n", encoding="utf-8")
+    state_root = tmp_path / "state"
+
+    provider = ScriptedProvider([
+        LLMResponse(content=None, tool_calls=[_tc("call-1", "grep", {"pattern": "target"})]),
+        LLMResponse(content="Found target content in notes.md", tool_calls=[]),
+    ])
+
+    result = run_tool_harness_request(
+        {"request_id": "req-abc123", "task_title": "find target"},
+        state_root=state_root,
+        workspace_root=workspace,
+        provider=provider,
+        model="test-model",
+    )
+
+    assert result["ok"] is True
+    assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
+    assert result["tool_calls_count"] == 1
+    assert "Found target content" in result["stdout"]
+    journal_path = Path(result["tool_call_journal"])
+    assert journal_path.exists()
+    assert journal_path.parent == state_root / "subagents" / "tool_calls"
+
+
+# ---------------------------------------------------------------------------
+# Integration: subagent_materializer profile == "tool_harness"
+# ---------------------------------------------------------------------------
+
+
+def _write_request(request_dir: Path, name: str, payload: dict) -> Path:
+    request_dir.mkdir(parents=True, exist_ok=True)
+    path = request_dir / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_materialize_tool_harness_profile_runs_the_harness(tmp_path, monkeypatch):
+    state_root = tmp_path / "state"
+    workspace = tmp_path / "eeebot-self-evolving"
+    workspace.mkdir()
+    (workspace / "target.py").write_text("def foo(): pass\n", encoding="utf-8")
+
+    _write_request(state_root / "subagents" / "requests", "request-1.json", {
+        "request_id": "req-1",
+        "profile": "tool_harness",
+        "status": "queued",
+        "task_title": "inspect target.py",
+    })
+
+    provider = ScriptedProvider([
+        LLMResponse(content=None, tool_calls=[_tc("call-1", "read", {"path": "target.py"})]),
+        LLMResponse(content="target.py defines foo()", tool_calls=[]),
+    ])
+
+    real_run_tool_harness_request = run_tool_harness_request
+
+    def _fake_run_tool_harness_request(request, *, state_root, **kwargs):
+        return real_run_tool_harness_request(request, state_root=state_root, workspace_root=workspace, provider=provider, model="test-model")
+
+    monkeypatch.setattr(
+        "nanobot.runtime.tool_harness.run_tool_harness_request",
+        _fake_run_tool_harness_request,
+    )
+
+    summary = materialize_subagent_requests(state_root=state_root)
+    assert summary["terminalized_count"] == 1
+    result = summary["results"][0]
+
+    assert result["materialized_from"] == "tool_harness"
+    assert result["result_status"] == "completed"
+    assert result["executor"]["provider"] == "tool_harness_phase1"
+    assert result["tool_calls_count"] == 1
+    assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
+    assert Path(result["tool_call_journal"]).exists()
+
+
+def test_materialize_research_only_profile_is_byte_identical_to_before(tmp_path):
+    """The default no-tools path (no configured executor) must be unaffected."""
+    state_root = tmp_path / "state"
+    _write_request(state_root / "subagents" / "requests", "request-1.json", {
+        "request_id": "req-1",
+        "profile": "research_only",
+        "status": "queued",
+        "task_title": "review something",
+    })
+
+    summary = materialize_subagent_requests(state_root=state_root)
+    result = summary["results"][0]
+
+    # Unaffected: same blocked-stub shape research_only always got when no
+    # executor is configured.
+    assert result["materialized_from"] == "queued_request_terminalizer"
+    assert result["executor"] is None
+    assert result["result_status"] == "blocked"
+    assert result["tool_calls_count"] is None
+    assert result["tool_call_journal"] is None
+    assert result["stop_reason"] is None


### PR DESCRIPTION
## Summary

Implements phase 1 of #643: a minimal Python tool-harness giving bounded
subagents `read`/`grep`/`ls` tools inside a confined workspace, per
`docs/changes/643-subagent-tool-harness/design.md` and the operator's
2026-07-05 open-question resolutions on the issue.

- **New module** `nanobot/runtime/tool_harness.py` (678 LOC, one flat file
  as scoped): shared head-tail truncation (2000 lines / 50KB, with
  `{truncated, total_lines, total_bytes}` metadata surfaced to the model);
  `WorkspaceOperations` — every path is `Path.resolve()`d (following
  symlinks) and confinement-checked against the workspace root *before* any
  I/O, escapes become a veto tool-result, never an exception; `read`/`grep`/
  `ls` tool functions with OpenAI-style JSON-schema definitions; a single
  `before_tool_call` veto hook (budget + confinement — the only policy seam,
  tools themselves stay policy-free); a turn loop
  (`run_harness_loop`/`run_tool_harness_request`) that reuses the bridge's
  existing `LLMProvider.chat_with_retry` call mechanics in-process
  (resolved question 1) instead of a new LiteLLM client; an append-only JSONL
  journal at `state/subagents/tool_calls/<request_id>.jsonl` (resolved
  question 2), with only `{tool_calls_count, tool_call_journal, stop_reason}`
  folded into the result JSON.
- **Config**: `SubagentToolConfig.harness_max_iterations` (default 8) and
  `harness_max_tool_calls` (default 24) — the only new fields, per resolved
  question 5.
- **Integration**: wired into
  `nanobot/runtime/subagent_materializer.py::materialize_subagent_requests`
  behind an explicit new `profile == "tool_harness"` value. Every other
  profile's behavior is byte-for-byte unchanged (see
  `test_materialize_research_only_profile_is_byte_identical_to_before`).
- **Docs**: `docs/specs/subagent-bridge/spec.md` gains R17-R25 for the
  phase-1 harness; `docs/changes/643-subagent-tool-harness/design.md`'s
  "Open questions" section gets a "Resolved questions (2026-07-05)" section
  recording the 5 decisions plus the integration-point rationale.

## Integration point: materializer, not bridge — and why

`nanobot/runtime/bridge.py`'s `SubagentManager` path already runs a full
nanobot agent tool-loop (`read_file`/`write_file`/`edit_file`/`list_dir`/
`exec` — see `build_task`'s "Use your tools" instructions) — a materially
richer surface than this phase-1 harness, and explicitly out of scope to
touch (`_setup_cycle_branch`/smoke gate/`_integrate_cycle_to_main` are
untouched). `subagent_materializer.materialize_subagent_requests`, by
contrast, had **no** tool-execution path at all for
`research_only`/`review_only`/`bounded_review`-style requests unless an
external `NANOBOT_SUBAGENT_EXECUTOR_COMMAND` was configured — those
degraded straight to a blocked stub. `tool_harness` is a new, explicit,
per-request profile value there, resolving workspace root as
`state_root.parent / "eeebot-self-evolving"` (the same convention
`bridge.py` already uses for the cycle's isolated checkout), overridable via
a `workspace_root` request field for tests.

## Budget-accounting finding (resolved question 5)

Confirmed against `nanobot/runtime/stop_guards.py`: the harness reuses
`derive_stop_reason()`'s `budget_<name>`/`max_iterations`/`gate_clean`
vocabulary verbatim rather than inventing a second budget system. One
deliberate deviation: `stop_guards.budget_exceeded()` uses strict
`used > cap` (an after-the-fact check appropriate for cycle-level
accounting sampled between cycles); the harness instead vetoes a tool call
the instant `tool_calls_used >= max_tool_calls`, since the loop can observe
its own counter mid-turn and a bounded subagent shouldn't get to run one
call past budget just because the check is retrospective. The stop-reason
*name* (`"budget_tool_calls"`) is unchanged, so harness runs stay
comparable to any other stop-guard-tracked run.

## Test plan

- [x] `python -m pytest tests/ -q` — 1022 passed (998 existing + 24 new in
  `tests/test_tool_harness.py`)
- [x] `ruff check nanobot/ tests/` on touched files — 15 pre-existing
  warnings in `subagent_materializer.py` (verified present before this PR
  via `git stash`), zero new
- [x] `python -m pytest tests/test_import_hygiene.py` — passes
      (`nanobot.*`-only imports preserved)
- New tests cover: confinement (`..`, absolute-outside, symlink escape →
  veto, loop continues, journal records veto), truncation determinism
  (lines and bytes), errors-as-tool-results (bad path, invalid regex, never
  an exception), the turn loop (tool-call → second turn → `gate_clean`;
  `max_iterations` stop; mid-turn `budget_tool_calls` stop), journal
  well-formedness, and the materializer integration (`tool_harness` profile
  runs the harness; `research_only` stays on the unchanged blocked-stub
  path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)