### PR TITLE
fix: tool-harness reports LLM errors as failures, not gate_clean (#643)

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -148,7 +148,17 @@ executor run does not stop early or hand off instead of acting:
   `nanobot.runtime.stop_guards` (`gate_clean` when the model stops calling
   tools on its own, `max_iterations`, or `budget_tool_calls`) using the caps
   `SubagentToolConfig.harness_max_iterations` (default 8) and
-  `harness_max_tool_calls` (default 24).
+  `harness_max_tool_calls` (default 24). Exception: an LLM-call failure is not
+  a cycle-stall concern `stop_guards` models, so it is the one harness-local
+  stop reason, `llm_error` (`nanobot.runtime.tool_harness.STOP_REASON_LLM_ERROR`)
+  — set when `chat_with_retry` exhausts retries and returns
+  `finish_reason="error"` instead of raising. The loop SHALL break
+  immediately in that case (`run_tool_harness_request` returns `ok=False`,
+  and `subagent_materializer._run_tool_harness` maps it to
+  `failure_reason="tool_harness_llm_error"`, distinct from
+  `tool_harness_incomplete`) rather than reporting the failed run as
+  `gate_clean`/`completed` (found live during #643 phase-1 verification: an
+  `un/qwen` model-group outage was silently recorded as a completed run).
 - R24. Every tool call (request, allow/veto decision, result byte size,
   truncation flag) SHALL be appended to a per-request JSONL sidecar at
   `state/subagents/tool_calls/<request_id>.jsonl`. The result JSON SHALL

--- a/nanobot/runtime/subagent_materializer.py
+++ b/nanobot/runtime/subagent_materializer.py
@@ -223,11 +223,22 @@ def _run_tool_harness(request: dict[str, Any], *, state_root: Path) -> tuple[boo
         }
 
     ok = bool(harness_result.get("ok"))
+    from nanobot.runtime.tool_harness import STOP_REASON_LLM_ERROR
+    is_llm_error = harness_result.get("stop_reason") == STOP_REASON_LLM_ERROR
+    if ok:
+        failure_reason = None
+    elif is_llm_error:
+        # Distinct from tool_harness_incomplete (#643 live-verification
+        # follow-up): an LLM outage/error is not "the model ran out of
+        # budget without finishing" — it never got a usable turn at all.
+        failure_reason = "tool_harness_llm_error"
+    else:
+        failure_reason = "tool_harness_incomplete"
     return ok, {
         "returncode": 0 if ok else 1,
         "stdout": _redact_secret_text(harness_result.get("stdout") or ""),
         "stderr": "",
-        "failure_reason": None if ok else "tool_harness_incomplete",
+        "failure_reason": failure_reason,
         "tool_calls_count": harness_result.get("tool_calls_count"),
         "tool_call_journal": harness_result.get("tool_call_journal"),
         "stop_reason": harness_result.get("stop_reason"),

--- a/nanobot/runtime/tool_harness.py
+++ b/nanobot/runtime/tool_harness.py
@@ -31,6 +31,15 @@ from nanobot.runtime._io import utc_iso as _utc_iso
 from nanobot.runtime.stop_guards import STOP_REASON_GATE_CLEAN
 from nanobot.runtime.stop_guards import derive_stop_reason as _derive_stop_reason
 
+# The R11-R13 stop-reason vocabulary in stop_guards.py is cycle-stall-shaped
+# (gate_clean/max_iterations/no_progress/budget_<name>) and has no entry for
+# "the LLM call itself failed" — that is a harness-loop concern, not a
+# cycle-level one, so it stays harness-local rather than growing the shared
+# enum (found live: un/qwen model group down was silently reported as
+# gate_clean/completed because chat_with_retry degrades to an error-content
+# LLMResponse instead of raising; see #643 live-verification follow-up).
+STOP_REASON_LLM_ERROR = "llm_error"
+
 # ---------------------------------------------------------------------------
 # Shared truncation (design.md "Shared truncation module")
 # ---------------------------------------------------------------------------
@@ -468,6 +477,18 @@ async def run_harness_loop(
             temperature=temperature,
         )
         budget.iterations_used += 1
+
+        if getattr(response, "finish_reason", "") == "error":
+            # chat_with_retry never raises: after exhausting retries it
+            # returns an LLMResponse(finish_reason="error", content=<error
+            # text>) instead. Left unchecked, that response looks like a
+            # normal no-tool-call turn and the loop below would break with
+            # gate_clean — reporting an LLM outage as a completed run. Break
+            # immediately instead, keeping the error text as the final
+            # message content so it still reaches the journal/result.
+            messages.append({"role": "assistant", "content": response.content or "LLM call failed"})
+            stop_reason = STOP_REASON_LLM_ERROR
+            break
 
         if not getattr(response, "has_tool_calls", False):
             messages.append({"role": "assistant", "content": response.content or ""})

--- a/tests/test_tool_harness.py
+++ b/tests/test_tool_harness.py
@@ -17,6 +17,7 @@ from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.runtime.stop_guards import STOP_REASON_GATE_CLEAN, STOP_REASON_MAX_ITERATIONS
 from nanobot.runtime.subagent_materializer import materialize_subagent_requests
 from nanobot.runtime.tool_harness import (
+    STOP_REASON_LLM_ERROR,
     HarnessBudget,
     PathEscapeError,
     WorkspaceOperations,
@@ -368,6 +369,64 @@ async def test_loop_veto_is_journaled_and_loop_continues(tmp_path):
     assert "vetoed" in tool_msgs[0]["content"]
 
 
+@pytest.mark.asyncio
+async def test_loop_llm_error_breaks_immediately_without_raising(tmp_path):
+    """A degraded LLMResponse(finish_reason="error") must not look like gate_clean.
+
+    Live-found bug (#643 phase-1 verification): chat_with_retry never raises —
+    after exhausting retries it returns an error-content LLMResponse. Before
+    this fix the loop treated that as an ordinary no-tool-call turn and broke
+    with stop_reason="gate_clean", so an LLM outage was recorded as completed.
+    """
+    ops = WorkspaceOperations(tmp_path)
+    budget = HarnessBudget(max_iterations=8, max_tool_calls=24)
+    journal_path = tmp_path / "journal.jsonl"
+
+    # Non-transient wording (no "connection"/"timeout"/etc marker) so
+    # chat_with_retry's own transient-error retry does not also kick in —
+    # this test is only about the harness loop's finish_reason check.
+    provider = ScriptedProvider([
+        LLMResponse(content="Error calling LLM: invalid api key", tool_calls=[], finish_reason="error"),
+    ])
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "inspect something"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == STOP_REASON_LLM_ERROR
+    assert provider.calls == 1
+    assert "Error calling LLM" in result["messages"][-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_loop_normal_run_unaffected_by_error_check(tmp_path):
+    """finish_reason defaults to "stop" — the new check must not alter normal runs."""
+    ops = WorkspaceOperations(tmp_path)
+    budget = HarnessBudget(max_iterations=8, max_tool_calls=24)
+    journal_path = tmp_path / "journal.jsonl"
+
+    provider = ScriptedProvider([
+        LLMResponse(content="all clear, nothing to report", tool_calls=[]),
+    ])
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "inspect something"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
+    assert provider.calls == 1
+
+
 # ---------------------------------------------------------------------------
 # Sync entrypoint: run_tool_harness_request
 # ---------------------------------------------------------------------------
@@ -399,6 +458,28 @@ def test_run_tool_harness_request_end_to_end(tmp_path):
     journal_path = Path(result["tool_call_journal"])
     assert journal_path.exists()
     assert journal_path.parent == state_root / "subagents" / "tool_calls"
+
+
+def test_run_tool_harness_request_llm_error_is_ok_false_not_an_exception(tmp_path):
+    workspace = tmp_path / "eeebot-self-evolving"
+    workspace.mkdir()
+    state_root = tmp_path / "state"
+
+    provider = ScriptedProvider([
+        LLMResponse(content="Error calling LLM: model group down", tool_calls=[], finish_reason="error"),
+    ])
+
+    result = run_tool_harness_request(
+        {"request_id": "req-err", "task_title": "find target"},
+        state_root=state_root,
+        workspace_root=workspace,
+        provider=provider,
+        model="test-model",
+    )
+
+    assert result["ok"] is False
+    assert result["stop_reason"] == STOP_REASON_LLM_ERROR
+    assert "Error calling LLM" in result["stdout"]
 
 
 # ---------------------------------------------------------------------------
@@ -451,6 +532,42 @@ def test_materialize_tool_harness_profile_runs_the_harness(tmp_path, monkeypatch
     assert result["tool_calls_count"] == 1
     assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
     assert Path(result["tool_call_journal"]).exists()
+
+
+def test_materialize_tool_harness_profile_llm_error_is_blocked_with_distinct_reason(tmp_path, monkeypatch):
+    """Live-found bug (#643): an LLM outage must not materialize as completed/gate_clean."""
+    state_root = tmp_path / "state"
+    workspace = tmp_path / "eeebot-self-evolving"
+    workspace.mkdir()
+
+    _write_request(state_root / "subagents" / "requests", "request-1.json", {
+        "request_id": "req-1",
+        "profile": "tool_harness",
+        "status": "queued",
+        "task_title": "inspect target.py",
+    })
+
+    provider = ScriptedProvider([
+        LLMResponse(content="Error calling LLM: model group down", tool_calls=[], finish_reason="error"),
+    ])
+
+    real_run_tool_harness_request = run_tool_harness_request
+
+    def _fake_run_tool_harness_request(request, *, state_root, **kwargs):
+        return real_run_tool_harness_request(request, state_root=state_root, workspace_root=workspace, provider=provider, model="test-model")
+
+    monkeypatch.setattr(
+        "nanobot.runtime.tool_harness.run_tool_harness_request",
+        _fake_run_tool_harness_request,
+    )
+
+    summary = materialize_subagent_requests(state_root=state_root)
+    assert summary["terminalized_count"] == 1
+    result = summary["results"][0]
+
+    assert result["result_status"] == "blocked"
+    assert result["terminal_reason"] == "tool_harness_llm_error"
+    assert result["stop_reason"] == STOP_REASON_LLM_ERROR
 
 
 def test_materialize_research_only_profile_is_byte_identical_to_before(tmp_path):


### PR DESCRIPTION
## Summary
- Live-found during #643 phase-1 verification on the eeepc host: when the LLM call fails (observed cause: `un/qwen` model group down), `nanobot/providers/base.py::chat_with_retry` never raises — after retries it returns `LLMResponse(content=f"Error calling LLM: {exc}", finish_reason="error")`.
- `run_harness_loop` didn't check `finish_reason`, so that response looked like a normal no-tool-call assistant turn: the loop broke with `stop_reason="gate_clean"` and the materializer wrote `result_status="completed"` with the error text as the findings — an outage silently reported as success.
- `run_harness_loop` now detects `finish_reason == "error"` and breaks immediately with a new harness-local stop reason `llm_error` (`nanobot.runtime.stop_guards`'s vocabulary is cycle-stall-shaped — `gate_clean`/`max_iterations`/`no_progress`/`budget_<name>` — with no fitting entry for an LLM-call failure, so this stays harness-local rather than growing the shared enum). `run_tool_harness_request` now returns `ok=False` in that case, with the error text still available via `stdout`.
- `subagent_materializer._run_tool_harness` maps that case to `failure_reason="tool_harness_llm_error"`, distinct from the existing `tool_harness_incomplete`, so the two failure modes stay distinguishable in result artifacts.
- Updated `docs/specs/subagent-bridge/spec.md` R23 to enumerate the new `llm_error` stop reason and its mapping.

## Test plan
- [x] Added tests in `tests/test_tool_harness.py`: fake provider returning `finish_reason="error"` → harness `ok=False`, `stop_reason="llm_error"`, no exception raised; materializer maps it to `result_status="blocked"` / `terminal_reason="tool_harness_llm_error"`; existing normal-run and gate_clean/max_iterations/budget tests confirmed unaffected.
- [x] `python -m pytest tests/ -q` — 1026 passed.
- [x] `ruff check` on changed files — no new issues (15 pre-existing `W293` findings in `subagent_materializer.py`, unrelated to this change, confirmed present on `origin/main` via `git stash` diff).

Part of #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)