### PR TITLE
fix: tool-harness extracts findings from thinking-model output (#649)

### DIFF
--- a/nanobot/runtime/tool_harness.py
+++ b/nanobot/runtime/tool_harness.py
@@ -491,7 +491,18 @@ async def run_harness_loop(
             break
 
         if not getattr(response, "has_tool_calls", False):
-            messages.append({"role": "assistant", "content": response.content or ""})
+            # Keep reasoning_content alongside content: the production
+            # executor model (un/qwen3.6-27b-mtp) is a thinking model whose
+            # visible answer can land in LLMResponse.reasoning_content (the
+            # OpenAI-compatible provider mapping in litellm_provider.py
+            # already extracts it) instead of, or in addition to, `content`.
+            # _final_text() below needs it to avoid reporting empty findings
+            # on an otherwise-clean run (#649).
+            messages.append({
+                "role": "assistant",
+                "content": response.content or "",
+                "reasoning_content": getattr(response, "reasoning_content", None),
+            })
             stop_reason = STOP_REASON_GATE_CLEAN
             break
 
@@ -556,11 +567,47 @@ async def run_harness_loop(
     }
 
 
+# Same <think>...</think>-stripping shape as nanobot.agent.loop.Agent._strip_think
+# (that class already handles this exact model family in the operator-facing
+# path). Duplicated rather than imported: agent.loop pulls in the full agent
+# stack (tools, sessions, MCP...), which would be a heavyweight, policy-bearing
+# dependency for this policy-free, read-only harness module (#649).
+_THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>")
+
+
+def _strip_think(text: str | None) -> str | None:
+    if not text:
+        return None
+    return _THINK_TAG_RE.sub("", text).strip() or None
+
+
+_NO_FINDINGS_TEXT = "(no final findings text returned by model)"
+
+
 def _final_text(messages: list[dict[str, Any]]) -> str:
+    """Extract the model's final visible findings text.
+
+    Thinking models (the production executor is ``un/qwen3.6-27b-mtp``) can
+    put their answer in ``reasoning_content`` instead of ``content``, or
+    embed it after a ``<think>...</think>`` block inside ``content`` — found
+    live (2026-07-05) as an empty ``stdout`` on an otherwise gate_clean run
+    (#649). Fallback chain per assistant message, most recent first:
+    visible (think-tag-stripped) ``content`` -> ``reasoning_content`` -> a
+    fixed diagnostic placeholder so callers never see a silently-empty
+    string on a completed run.
+    """
     for msg in reversed(messages):
-        if msg.get("role") == "assistant" and msg.get("content"):
-            return str(msg["content"])
-    return ""
+        if msg.get("role") != "assistant":
+            continue
+        visible = _strip_think(msg.get("content"))
+        if visible:
+            return visible
+        reasoning = msg.get("reasoning_content")
+        if reasoning:
+            stripped_reasoning = _strip_think(str(reasoning))
+            return stripped_reasoning or str(reasoning)
+        return _NO_FINDINGS_TEXT
+    return _NO_FINDINGS_TEXT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_harness.py
+++ b/tests/test_tool_harness.py
@@ -21,6 +21,7 @@ from nanobot.runtime.tool_harness import (
     HarnessBudget,
     PathEscapeError,
     WorkspaceOperations,
+    _final_text,
     before_tool_call,
     run_harness_loop,
     run_tool_harness_request,
@@ -425,6 +426,76 @@ async def test_loop_normal_run_unaffected_by_error_check(tmp_path):
 
     assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
     assert provider.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# _final_text: thinking-model findings extraction (#649)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_empty_content_with_reasoning_content_is_carried_to_messages(tmp_path):
+    """A thinking model can answer entirely via reasoning_content, empty content.
+
+    Found live (2026-07-05) against un/qwen3.6-27b-mtp: a clean gate_clean run
+    (5 tool calls) produced an empty stdout because the loop only ever stored
+    response.content on the final message, dropping reasoning_content.
+    """
+    ops = WorkspaceOperations(tmp_path)
+    budget = HarnessBudget(max_iterations=8, max_tool_calls=24)
+    journal_path = tmp_path / "journal.jsonl"
+
+    provider = ScriptedProvider([
+        LLMResponse(content="", tool_calls=[], reasoning_content="Reviewed the file: all clear."),
+    ])
+
+    result = await run_harness_loop(
+        provider,
+        model="test-model",
+        messages=[{"role": "user", "content": "inspect something"}],
+        ops=ops,
+        budget=budget,
+        journal_path=journal_path,
+    )
+
+    assert result["stop_reason"] == STOP_REASON_GATE_CLEAN
+    assert result["messages"][-1]["reasoning_content"] == "Reviewed the file: all clear."
+    assert _final_text(result["messages"]) == "Reviewed the file: all clear."
+
+
+def test_final_text_content_empty_reasoning_content_present():
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "reasoning_content": "the actual findings"},
+    ]
+    assert _final_text(messages) == "the actual findings"
+
+
+def test_final_text_strips_think_tags_from_content():
+    messages = [
+        {"role": "user", "content": "task"},
+        {
+            "role": "assistant",
+            "content": "<think>let me check the file...</think>Findings: looks good.",
+        },
+    ]
+    assert _final_text(messages) == "Findings: looks good."
+
+
+def test_final_text_everything_empty_returns_diagnostic_placeholder():
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "reasoning_content": None},
+    ]
+    assert _final_text(messages) == "(no final findings text returned by model)"
+
+
+def test_final_text_normal_content_path_unchanged():
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "plain findings, no thinking involved"},
+    ]
+    assert _final_text(messages) == "plain findings, no thinking involved"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `run_harness_loop` in `nanobot/runtime/tool_harness.py` only ever stored `LLMResponse.content` on the final (no-tool-call) assistant message; `_final_text()` only read that field. The production executor model, `un/qwen3.6-27b-mtp`, is a thinking model — a clean run (stop_reason=gate_clean, 5 tool calls) was observed live (2026-07-05) producing an empty `stdout`.
- **Investigation result:** `LLMResponse` (`nanobot/providers/base.py`) already carries a `reasoning_content: str | None` field, and the OpenAI-compatible provider (`nanobot/providers/litellm_provider.py:344-345,352`) already extracts `message.reasoning_content` from the raw API response into it — no provider-side change needed. `nanobot/agent/loop.py` (the operator-facing agent loop, which already runs this model family daily) already has a `_strip_think()` regex helper (`<think>...</think>` stripping) for exactly this shape; I reused that same regex logic locally in `tool_harness.py` rather than importing `agent.loop` (which pulls in the full agent/tools/session stack — too heavy a dependency for this policy-free, read-only harness module).
- **Fix:** `run_harness_loop` now also stores `reasoning_content` on the final assistant message. `_final_text()` now uses a fallback chain per the issue's guidance: think-tag-stripped `content` -> `reasoning_content` -> a fixed diagnostic placeholder `"(no final findings text returned by model)"`. A completed (`gate_clean`) run with all-empty output stays `ok=True`/`gate_clean` (the issue's "probably not blocked" call) but the placeholder ensures no downstream consumer ever sees a silently-empty findings string.
- No spec changes: `docs/specs/subagent-bridge/spec.md` R17-R25 cover profile gating, tool set, confinement, truncation, budget/stop-reasons, and the journal sidecar, but none literally specify findings-text extraction semantics, so none needed updating per this task's scope-check.

## Test plan

- [x] `tests/test_tool_harness.py`: added `_final_text` import + 4 new unit tests (content-empty+reasoning_content present, think-tag-wrapped content stripped, everything-empty -> placeholder, normal content path unchanged) + 1 loop-level test that `reasoning_content` is carried onto the final message.
- [x] `python -m pytest tests/ -q` — 1031 passed.
- [x] `ruff check nanobot/runtime/tool_harness.py tests/test_tool_harness.py` — no issues.

Part of #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)