### PR TITLE
fix: tarfile extractall filter fallback for Python <3.11.4 (#658)

### DIFF
--- a/nanobot/runtime/autoevolve.py
+++ b/nanobot/runtime/autoevolve.py
@@ -535,7 +535,10 @@ def apply_candidate_release(workspace: Path, candidate_record: dict[str, Any]) -
         shutil.rmtree(release_dir)
     release_dir.mkdir(parents=True, exist_ok=True)
     with tarfile.open(candidate_record['archive_path'], 'r:gz') as tar:
-        tar.extractall(release_dir, filter='data')
+        try:
+            tar.extractall(release_dir, filter='data')
+        except TypeError:  # Python < 3.11.4: no filter= kwarg
+            tar.extractall(release_dir)
     previous_release_dir = None
     if current_link.exists() or current_link.is_symlink():
         try:

--- a/tests/test_autoevolve.py
+++ b/tests/test_autoevolve.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import tarfile
 from pathlib import Path
 
 from nanobot.runtime.autoevolve import (
@@ -69,6 +70,48 @@ def test_apply_candidate_release_switches_current_symlink_and_preserves_previous
     apply2 = apply_candidate_release(workspace=workspace, candidate_record=record2)
     assert Path(apply2["previous_release_dir"]).resolve() == Path(apply1["release_dir"]).resolve()
     assert current_link.resolve() == Path(apply2["release_dir"]).resolve()
+
+
+def test_apply_candidate_release_falls_back_when_extractall_rejects_filter_kwarg(tmp_path: Path, monkeypatch):
+    """Simulate Python < 3.11.4, where TarFile.extractall has no filter= kwarg (#658)."""
+    repo = tmp_path / "repo"
+    workspace = tmp_path / "workspace"
+    _init_repo(repo)
+    record = create_candidate_release(repo_root=repo, workspace=workspace)
+
+    real_extractall = tarfile.TarFile.extractall
+
+    def _rejecting_extractall(self, path=".", members=None, *, numeric_owner=False, filter=None):
+        if filter is not None:
+            raise TypeError("extractall() got an unexpected keyword argument 'filter'")
+        return real_extractall(self, path, members, numeric_owner=numeric_owner)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractall", _rejecting_extractall)
+
+    apply_result = apply_candidate_release(workspace=workspace, candidate_record=record)
+    release_dir = Path(apply_result["release_dir"])
+    assert release_dir.exists()
+    assert any(release_dir.iterdir())
+
+
+def test_apply_candidate_release_passes_filter_when_supported(tmp_path: Path, monkeypatch):
+    """When filter= is supported, extractall must be called with the safe 'data' filter."""
+    repo = tmp_path / "repo"
+    workspace = tmp_path / "workspace"
+    _init_repo(repo)
+    record = create_candidate_release(repo_root=repo, workspace=workspace)
+
+    real_extractall = tarfile.TarFile.extractall
+    calls: list[str | None] = []
+
+    def _spy_extractall(self, path=".", members=None, *, numeric_owner=False, filter=None):
+        calls.append(filter)
+        return real_extractall(self, path, members, numeric_owner=numeric_owner, filter=filter)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractall", _spy_extractall)
+
+    apply_candidate_release(workspace=workspace, candidate_record=record)
+    assert calls == ["data"]
 
 
 def test_health_check_release_reports_fail_for_stale_report_and_pass_for_fresh_state(tmp_path: Path):


### PR DESCRIPTION
## Summary

- `apply_candidate_release()` in `nanobot/runtime/autoevolve.py` called `tar.extractall(release_dir, filter='data')` unguarded. The `filter=` kwarg on `TarFile.extractall` was only added in Python 3.11.4; the eeepc production host runs Python 3.11.2 (Debian bookworm), so every call raised `TypeError`, breaking the self-evolving loop's release-apply path. This was reproduced live on the host (per issue #658) — the runtime workspace never actually created a runnable release until now.
- Grepped the whole repo for other `extractall(..., filter=` call sites (`git grep -n "extractall("`) — this was the only one, so no other guard was needed.
- Fix: wrap the call in `try/except TypeError`, falling back to plain `extractall()` on interpreters that reject the `filter=` kwarg, while keeping the safe `'data'` filter on interpreters that support it (3.11.4+).

## Test plan

- [x] Added `test_apply_candidate_release_falls_back_when_extractall_rejects_filter_kwarg` in `tests/test_autoevolve.py`: monkeypatches `tarfile.TarFile.extractall` to raise `TypeError` whenever `filter` is passed (simulating Python 3.11.2), and asserts the release still extracts successfully. Independent of the CI runner's actual Python patch version.
- [x] Added `test_apply_candidate_release_passes_filter_when_supported`: spies on `extractall` and asserts it is called with `filter='data'` on interpreters where the kwarg is supported.
- [x] `python -m pytest tests/ -q` — 1043 passed.
- [x] `ruff check nanobot/runtime/autoevolve.py tests/test_autoevolve.py` — no new issues (3 pre-existing import-order/unused-import warnings on `origin/main`, verified unchanged by this diff via `git stash` comparison).

Part of #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)