### PR TITLE
fix: retire verify lane on clean bridge completion — unblock planner (#656)

### DIFF
--- a/nanobot/runtime/cycle_feedback.py
+++ b/nanobot/runtime/cycle_feedback.py
@@ -556,7 +556,7 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
 
     if (
         isinstance(recorded_feedback_decision, dict)
-        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane"}
+        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane", "retire_completed_subagent_lane"}
         and recorded_feedback_decision.get("current_task_id") == current_task_id
         and recorded_feedback_decision.get("selected_task_id")
         and recorded_feedback_decision.get("selected_task_id") != current_task_id

--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -44,6 +44,7 @@ from nanobot.runtime.cycle_observe import (
     _task_is_terminal_selfevo_retired,
     _task_title_for_id,
 )
+from nanobot.runtime.subagent_materializer import _result_path_for
 
 
 def _parse_backlog_task_from_goal_text(
@@ -580,6 +581,14 @@ def _write_materialized_improvement_artifact(
     return str(path)
 
 
+# Terminal bridge/materializer result_status values that mean the subagent
+# verify lane genuinely finished — including a clean "already_done" verdict
+# (issue #656: an unscoped completed_count previously left the lane "pending"
+# forever because it counted ANY result file ever written, not the one
+# correlated to the request actually issued this cycle).
+_TERMINAL_SUBAGENT_RESULT_STATUSES = {"already_done", "completed", "no_commit", "blocked"}
+
+
 def _subagent_lane_health(*, state_root: Path, current_task_id: str | None, stale_after_seconds: int = 3600) -> dict[str, Any]:
     if current_task_id != "subagent-verify-materialized-improvement":
         return {"state": "not_applicable", "stale_request_count": 0, "queued_request_count": 0, "recommended_action": None}
@@ -588,25 +597,41 @@ def _subagent_lane_health(*, state_root: Path, current_task_id: str | None, stal
     now = time.time()
     queued: list[dict[str, Any]] = []
     stale: list[dict[str, Any]] = []
-    completed_count = 0
-    if result_dir.exists():
-        # Only the count and truthiness of completed results are used downstream
-        # (lines 2066, 2074). Avoid O(n log n) full sort — just count files.
-        completed_count = sum(1 for _ in result_dir.glob("*.json"))
+    completed: list[dict[str, Any]] = []
     if request_dir.exists():
         # Use os.scandir-based helper to avoid double-stat penalty of glob()+stat().
         for path, mtime in list(_json_files_sorted_by_mtime(True, request_dir))[:100]:
             payload = _safe_read_json(path)
-            if payload.get("task_id") != current_task_id:
+            if not payload or payload.get("task_id") != current_task_id:
                 continue
             status = payload.get("request_status") or payload.get("status") or "queued"
             age = max(0, int(now - mtime))
             item = {"path": str(path), "status": status, "age_seconds": age, "task_id": current_task_id}
+
+            # Scope completion detection to the result file actually produced
+            # for THIS request — correlated via the same request_id (== the
+            # _generation_scoped_verification_id materialized when the
+            # request was written) that _write_bridge_completed_result and
+            # the coordinator materializer use to name result-<request_id>.json.
+            # An unscoped `len(glob("*.json"))` would (and previously did)
+            # match a stale/prior-cycle result and hide real stagnation.
+            result_path = _result_path_for(result_dir, path, payload)
+            result_payload = _safe_read_json(result_path) if result_path.exists() else None
+            result_status = result_payload.get("result_status") if isinstance(result_payload, dict) else None
+            if result_status in _TERMINAL_SUBAGENT_RESULT_STATUSES:
+                completed.append({
+                    **item,
+                    "status": "completed",
+                    "result_status": result_status,
+                    "result_path": str(result_path),
+                })
+                continue
+
             if status in {"queued", "pending"}:
                 queued.append(item)
                 if age >= stale_after_seconds:
                     stale.append({**item, "status": "stale"})
-    state = "completed" if completed_count else ("stale" if stale else ("queued" if queued else "missing_request"))
+    state = "completed" if completed else ("stale" if stale else ("queued" if queued else "missing_request"))
     return {
         "schema_version": "subagent-lane-health-v1",
         "state": state,
@@ -614,7 +639,8 @@ def _subagent_lane_health(*, state_root: Path, current_task_id: str | None, stal
         "stale_request_count": len(stale),
         "latest_stale_request": stale[0] if stale else None,
         "latest_request": queued[0] if queued else None,
-        "completed_result_count": completed_count,
+        "completed_result_count": len(completed),
+        "latest_completed_result": completed[0] if completed else None,
         "recommended_action": "retire_or_block_stale_subagent_lane" if state in {"stale", "missing_request"} else None,
     }
 
@@ -1429,14 +1455,19 @@ def _build_task_plan_snapshot(
         and not (isinstance(feedback_decision, dict) and feedback_decision.get("mode") in {"execute_queued_revert", "handoff_to_subagent_verification"})
         and (
             latest_noop.get("status") == "terminal_noop"
-            or subagent_lane_health.get("state") == "stale"
+            or subagent_lane_health.get("state") in {"stale", "completed"}
             or (experiment.get("outcome") == "discard" and experiment.get("revert_status") == "skipped_no_material_change")
         )
     )
     if should_retire_subagent_lane:
         subagent_retirement_target_id = "record-reward"
         subagent_retirement_target_title = "Record cycle reward"
-        subagent_retirement_selection_source = "feedback_terminal_noop_retire" if latest_noop.get("status") == "terminal_noop" else "feedback_stale_subagent_retire"
+        if latest_noop.get("status") == "terminal_noop":
+            subagent_retirement_selection_source = "feedback_terminal_noop_retire"
+        elif subagent_lane_health.get("state") == "completed":
+            subagent_retirement_selection_source = "feedback_completed_subagent_retire"
+        else:
+            subagent_retirement_selection_source = "feedback_stale_subagent_retire"
         if failure_learning_is_fresh and isinstance(latest_failure_learning, dict):
             subagent_retirement_target_id = "analyze-last-failed-candidate"
             subagent_retirement_target_title = "Analyze the last failed self-evolution candidate before retrying mutation"
@@ -1467,9 +1498,15 @@ def _build_task_plan_snapshot(
                 })
             tasks.append(task_payload)
         current_task_id = subagent_retirement_target_id
+        if latest_noop.get("status") == "terminal_noop":
+            _retirement_mode = "retire_terminal_noop_lane"
+        elif subagent_lane_health.get("state") == "completed":
+            _retirement_mode = "retire_completed_subagent_lane"
+        else:
+            _retirement_mode = "retire_stale_subagent_lane"
         feedback_decision = {
-            "mode": "retire_terminal_noop_lane" if latest_noop.get("status") == "terminal_noop" else "retire_stale_subagent_lane",
-            "reason": "subagent verification lane reached a terminal no-op/discard/stale state and must not keep producing PASS-only telemetry",
+            "mode": _retirement_mode,
+            "reason": "subagent verification lane reached a terminal no-op/discard/stale/completed state and must not keep producing PASS-only telemetry",
             "current_task_id": "subagent-verify-materialized-improvement",
             "current_task_class": _task_action_class("subagent-verify-materialized-improvement"),
             "selected_task_id": subagent_retirement_target_id,

--- a/nanobot/runtime/scorer.py
+++ b/nanobot/runtime/scorer.py
@@ -45,6 +45,7 @@ _MODE_SCORES: dict[str, float] = {
     "record_reward_after_synthesized_materialization": 0.8,
     "record_reward_after_synth":             0.8,
     "retire_stale_subagent_lane":            0.7,
+    "retire_completed_subagent_lane":        0.8,
     "record_reward":                         0.6,
     "discard":                               0.3,
 }

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -207,6 +207,140 @@ def test_subagent_lane_health_marks_stale_queued_request(tmp_path: Path) -> None
     assert health['recommended_action'] == 'retire_or_block_stale_subagent_lane'
 
 
+def _write_subagent_request(req_dir: Path, *, name: str, request_id: str, request_status: str = 'pending') -> None:
+    req_dir.mkdir(parents=True, exist_ok=True)
+    (req_dir / name).write_text(json.dumps({
+        'request_id': request_id,
+        'request_status': request_status,
+        'task_id': 'subagent-verify-materialized-improvement',
+    }), encoding='utf-8')
+
+
+def _write_subagent_result(result_dir: Path, *, request_id: str, result_status: str) -> None:
+    result_dir.mkdir(parents=True, exist_ok=True)
+    (result_dir / f'result-{request_id}.json').write_text(json.dumps({
+        'schema_version': 'subagent-result-v1',
+        'request_id': request_id,
+        'result_status': result_status,
+    }), encoding='utf-8')
+
+
+def test_subagent_lane_health_completed_when_current_request_has_terminal_result(tmp_path: Path) -> None:
+    # Issue #656 regression: a clean bridge completion (already_done) for the
+    # request actually issued this cycle must be recognized as "completed",
+    # not left dangling as "queued"/"pending" forever.
+    state_root = tmp_path / 'state'
+    _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-current.json', request_id='req-current')
+    _write_subagent_result(state_root / 'subagents' / 'results', request_id='req-current', result_status='already_done')
+
+    health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+    assert health['state'] == 'completed'
+    assert health['completed_result_count'] == 1
+    assert health['latest_completed_result']['result_status'] == 'already_done'
+
+
+def test_subagent_lane_health_ignores_result_belonging_to_a_different_request(tmp_path: Path) -> None:
+    # A stray/older result file for a DIFFERENT request must not be treated
+    # as completion for the current request — this is the unscoped-glob bug.
+    state_root = tmp_path / 'state'
+    _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-current.json', request_id='req-current')
+    _write_subagent_result(state_root / 'subagents' / 'results', request_id='req-old-stale', result_status='completed')
+
+    health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+    assert health['state'] == 'queued'
+    assert health['completed_result_count'] == 0
+
+
+def test_subagent_lane_health_stale_detection_still_works_with_scoped_completion(tmp_path: Path) -> None:
+    state_root = tmp_path / 'state'
+    req_dir = state_root / 'subagents' / 'requests'
+    _write_subagent_request(req_dir, name='request-cycle-old.json', request_id='req-old')
+    old = time.time() - 3 * 3600
+    os.utime(req_dir / 'request-cycle-old.json', (old, old))
+
+    health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+    assert health['state'] == 'stale'
+    assert health['stale_request_count'] == 1
+
+
+def test_subagent_lane_health_each_terminal_result_status_counts_as_completed(tmp_path: Path) -> None:
+    for status in ('already_done', 'completed', 'no_commit', 'blocked'):
+        state_root = tmp_path / f'state-{status}'
+        _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-current.json', request_id='req-current')
+        _write_subagent_result(state_root / 'subagents' / 'results', request_id='req-current', result_status=status)
+
+        health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+        assert health['state'] == 'completed', f'expected completed for result_status={status}'
+
+
+def test_subagent_lane_health_non_terminal_result_does_not_count_as_completed(tmp_path: Path) -> None:
+    state_root = tmp_path / 'state'
+    _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-current.json', request_id='req-current')
+    _write_subagent_result(state_root / 'subagents' / 'results', request_id='req-current', result_status='in_progress')
+
+    health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+    assert health['state'] == 'queued'
+    assert health['completed_result_count'] == 0
+
+
+def test_subagent_lane_health_absent_result_does_not_count_as_completed(tmp_path: Path) -> None:
+    state_root = tmp_path / 'state'
+    _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-current.json', request_id='req-current')
+
+    health = _subagent_lane_health(state_root=state_root, current_task_id='subagent-verify-materialized-improvement', stale_after_seconds=3600)
+
+    assert health['state'] == 'queued'
+    assert health['completed_result_count'] == 0
+
+
+def test_clean_bridge_completion_retires_verify_lane_and_unblocks_reward(tmp_path: Path) -> None:
+    # End-to-end regression for issue #656: a genuinely-completed verify
+    # request (already_done, scoped to the current request) must retire the
+    # verify lane so the coordinator's synthesize->materialize->verify
+    # fast-path (cycle_feedback.py) can produce a new materialized candidate
+    # on a subsequent cycle instead of stalling forever on "pending".
+    workspace = tmp_path / 'workspace'
+    state_root = workspace / 'state'
+    goals = state_root / 'goals'
+    goals.mkdir(parents=True)
+    (state_root / 'self_evolution' / 'runtime').mkdir(parents=True)
+    _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-current.json', request_id='req-current')
+    _write_subagent_result(state_root / 'subagents' / 'results', request_id='req-current', result_status='already_done')
+    (goals / 'current.json').write_text(json.dumps({
+        'current_task_id': 'subagent-verify-materialized-improvement',
+        'tasks': [
+            {'task_id': 'subagent-verify-materialized-improvement', 'title': 'Verify materialized improvement', 'status': 'active'},
+            {'task_id': 'record-reward', 'title': 'Record cycle reward', 'status': 'pending'},
+        ],
+        'feedback_decision': {'mode': 'handoff_to_next_candidate', 'selected_task_id': 'subagent-verify-materialized-improvement'},
+    }), encoding='utf-8')
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id='cycle-current',
+        goal_id='goal-bootstrap',
+        result_status='PASS',
+        approval_gate_state='fresh',
+        next_hint='continue',
+        experiment={'reward_signal': {'value': 1.0}, 'budget': {}, 'budget_used': {}, 'outcome': 'keep', 'revert_status': None},
+        report_path=tmp_path / 'report.json',
+        history_path=tmp_path / 'history.json',
+        improvement_score=1.0,
+        feedback_decision={'mode': 'handoff_to_next_candidate', 'selected_task_id': 'subagent-verify-materialized-improvement'},
+        goals_dir=goals,
+    )
+
+    assert plan['current_task_id'] != 'subagent-verify-materialized-improvement'
+    assert plan['feedback_decision']['mode'] == 'retire_completed_subagent_lane'
+    assert plan['feedback_decision']['selection_source'] == 'feedback_completed_subagent_retire'
+    verify_task = next(t for t in plan['tasks'] if t.get('task_id') == 'subagent-verify-materialized-improvement')
+    assert verify_task['status'] == 'done'
+
 
 def test_hadi_dor_dod_gate_blocks_weak_synthesized_materialization_candidate(tmp_path: Path) -> None:
     workspace = tmp_path / 'workspace'


### PR DESCRIPTION
## Root cause

`subagent-verify-materialized-improvement` never left `"pending"` even after
the bridge correctly reported `already_done` for the pinned candidate (the
task was genuinely implemented days earlier in commits `2118c1b..5877e23`).
`_subagent_lane_health` did compute a `"completed"` state, but (a) that state
was never checked by `should_retire_subagent_lane` — only `"stale"` was — and
(b) `completed_count` was an unscoped `len(glob("*.json"))` over ALL result
files ever written, so it was unreliable even when checked. Because the verify
lane stayed "pending" forever, the coordinator's synthesize→materialize→verify
fast-path (`cycle_feedback.py:907-946`) never fired (its precondition — verify
task status in `COMPLETED_TASK_STATUSES` — was never true), so R11 kept
ping-pong stall-switching between verify and refresh-approval-gate every 10
minutes: the stall detector was working correctly, the upstream planner state
was wrong.

## Correlation key

Result files are named `result-<request_id>.json` (see
`subagent_materializer._result_path_for` / `bridge._write_bridge_completed_result`),
where `request_id` is the same `_generation_scoped_verification_id` value
materialized into the request when it was written
(`cycle_planning.py:_write_subagent_request_artifact`). `_subagent_lane_health`
now, for each request matching the current task_id, computes that request's
own result path via `_result_path_for(result_dir, request_path, payload)` and
only counts a match if that specific file exists with a terminal
`result_status` (`already_done`, `completed`, `no_commit`, `blocked`) — a
result belonging to a different/older request no longer counts.

(Minor deviation from the issue text: it described the convention as
`result-<task_id>.json`; the actual convention, confirmed in both
`subagent_materializer.py` and `bridge.py`, is `result-<request_id>.json`. The
fix follows the real convention.)

## End-to-end unblock trace

1. `_subagent_lane_health` returns `state="completed"` when the current
   cycle's request has a terminal result.
2. `should_retire_subagent_lane` now also fires on `state == "completed"`
   (previously only `"stale"`), with a new distinct mode
   `retire_completed_subagent_lane` / selection_source
   `feedback_completed_subagent_retire` (kept separate from the stale path so
   telemetry doesn't conflate a clean completion with an actual stall).
3. Retirement sets the verify task's status to `"done"` (existing branch at
   `cycle_planning.py:1446`, unchanged) and routes `current_task_id` to
   `record-reward`.
4. `"done"` is in `COMPLETED_TASK_STATUSES` (`cycle_observe.py`), so once the
   plan cycles back through `synthesize-next-improvement-candidate`, the
   fast-path condition in `cycle_feedback.py:907-946`
   (`_materialize_task_completed and verify_task status in
   COMPLETED_TASK_STATUSES`) is now satisfiable, and `mode:
   materialize_synthesized_improvement` fires, producing a new
   `materialized-cycle-*.json` instead of reusing the Jul 5 artifact forever.
5. Added `retire_completed_subagent_lane` to the idempotent-retirement guard
   in `cycle_feedback.py:559` and to the mode→score table in `scorer.py` (0.8,
   between the 0.7 stale-retire and 0.8 record-reward-after-synth scores)
   since it's a new terminal mode string that those tables previously didn't
   recognize.

## Tests

Added to `tests/test_autonomy_stagnation_followthrough.py`:
- `test_subagent_lane_health_completed_when_current_request_has_terminal_result`
- `test_subagent_lane_health_ignores_result_belonging_to_a_different_request`
  (the scoping regression)
- `test_subagent_lane_health_stale_detection_still_works_with_scoped_completion`
- `test_subagent_lane_health_each_terminal_result_status_counts_as_completed`
  (already_done/completed/no_commit/blocked)
- `test_subagent_lane_health_non_terminal_result_does_not_count_as_completed`
- `test_subagent_lane_health_absent_result_does_not_count_as_completed`
- `test_clean_bridge_completion_retires_verify_lane_and_unblocks_reward`
  (end-to-end: `_build_task_plan_snapshot` retires the lane, verify task
  reaches `"done"`, feedback_decision mode is `retire_completed_subagent_lane`)

Full suite: `python -m pytest tests/ -q` → **1048 passed**.
`ruff check` on all touched files → only 2 pre-existing, unrelated `F821`
errors remain (confirmed present on `origin/main` before this change); no new
issues introduced.

## Docs

Checked `docs/specs/self-evolving-runtime/spec.md` R11-R13 — those cover
stall-threshold/no_progress detection and gate-revision/stop-reason
enumeration, not the subagent-verify-lane retirement mechanism itself (which
is coordinator/planner-internal state, not an enumerated spec requirement).
No spec text describes these retirement conditions, so no spec update was
needed.

Part of #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)