### PR TITLE
feat: lazy provider imports — defer litellm/oauth_cli_kit to first use (#657)

### DIFF
--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -7,12 +7,47 @@ import string
 from typing import Any
 
 import json_repair
-import litellm
-from litellm import acompletion
 from loguru import logger
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from nanobot.providers.registry import find_by_model, find_gateway
+
+# `litellm` (and, transitively, `tiktoken`) is imported lazily on first use
+# (see `_ensure_litellm` below) rather than at module load time, so that
+# importing this module — and collecting tests that reference it — stays
+# cheap and doesn't require the full litellm/tiktoken dependency chain to be
+# installed (tiktoken needs a Rust toolchain to build on some hosts, e.g. the
+# i386 eeepc host; see #657).
+#
+# `acompletion` is kept as a module-level attribute (initially None) so tests
+# can `mock.patch("nanobot.providers.litellm_provider.acompletion", ...)`
+# before any real import has happened; `_ensure_litellm` fills it in and
+# subsequent calls patch the already-bound name.
+acompletion = None
+
+
+def _ensure_litellm() -> None:
+    """Import litellm on first use and apply process-global settings once.
+
+    Race-safety note: this module runs in a single asyncio event loop plus
+    occasional worker threads spawned by tool_harness._run_async. The
+    check-and-import below is not atomic, but CPython's GIL makes the worst
+    case a harmless double-import (idempotent) rather than a data race, so a
+    plain module-level flag is sufficient here — no lock needed.
+    """
+    global acompletion
+    if acompletion is not None:
+        return
+    import litellm as _litellm
+    from litellm import acompletion as _acompletion
+
+    acompletion = _acompletion
+    # Disable LiteLLM logging noise. Process-global by nature (litellm has no
+    # per-instance equivalent), so applying it once at first import is correct.
+    _litellm.suppress_debug_info = True
+    # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params).
+    _litellm.drop_params = True
+
 
 # Standard chat-completion message keys.
 _ALLOWED_MSG_KEYS = frozenset({"role", "content", "tool_calls", "tool_call_id", "name", "reasoning_content"})
@@ -54,14 +89,14 @@ class LiteLLMProvider(LLMProvider):
         if api_key:
             self._setup_env(api_key, api_base, default_model)
 
-        if api_base:
-            litellm.api_base = api_base
-
-        # Disable LiteLLM logging noise
-        litellm.suppress_debug_info = True
-        # Drop unsupported parameters for providers (e.g., gpt-5 rejects some params)
-        litellm.drop_params = True
-
+        # NOTE: we deliberately do *not* set `litellm.api_base` here (the
+        # stranded/reworked version of this lazy-import patch used to do
+        # that once per process on first chat() call anywhere, which meant
+        # every instance's requests silently picked up whichever instance
+        # happened to initialize litellm first). It is unnecessary: `chat()`
+        # already passes `api_base` per-request via `kwargs["api_base"]`
+        # (see below), which takes precedence over any module-level litellm
+        # default and is correctly scoped to this instance's config.
         self._langsmith_enabled = bool(os.getenv("LANGSMITH_API_KEY"))
 
     def _setup_env(self, api_key: str, api_base: str | None, model: str) -> None:
@@ -280,6 +315,7 @@ class LiteLLMProvider(LLMProvider):
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice or "auto"
 
+        _ensure_litellm()
         try:
             response = await acompletion(**kwargs)
             return self._parse_response(response)

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -9,9 +9,12 @@ from typing import Any, AsyncGenerator
 
 import httpx
 from loguru import logger
-from oauth_cli_kit import get_token as get_codex_token
 
 from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+
+# `oauth_cli_kit` is imported lazily in chat() below so this module can be
+# imported (and its pure-Python helpers like `_strip_model_prefix` tested)
+# even in environments where oauth_cli_kit isn't installed (see #657).
 
 DEFAULT_CODEX_URL = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_ORIGINATOR = "nanobot"
@@ -36,6 +39,8 @@ class OpenAICodexProvider(LLMProvider):
     ) -> LLMResponse:
         model = model or self.default_model
         system_prompt, input_items = _convert_messages(messages)
+
+        from oauth_cli_kit import get_token as get_codex_token  # lazy import (see module docstring)
 
         token = await asyncio.to_thread(get_codex_token)
         headers = _build_headers(token.account_id, token.access)

--- a/tests/test_provider_lazy_imports.py
+++ b/tests/test_provider_lazy_imports.py
@@ -1,0 +1,66 @@
+"""Regression guard: heavy provider deps must not load at module-import time.
+
+`nanobot.providers.litellm_provider` used to `import litellm` (which pulls in
+`tiktoken`, requiring a Rust toolchain to build on some hosts, e.g. the i386
+eeepc host) at module scope, and `nanobot.providers.openai_codex_provider`
+used to `import oauth_cli_kit` at module scope. Both are now deferred to
+first use (see #657) so importing the modules — and collecting tests that
+reference them — stays cheap and doesn't require those packages to be
+installed at all. This test runs the import in a subprocess so it reflects a
+clean interpreter state, independent of import order elsewhere in the suite.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_litellm_provider_import_does_not_load_litellm():
+    """Importing the module alone must not pull in litellm/tiktoken."""
+    code = (
+        "import sys\n"
+        "import nanobot.providers.litellm_provider\n"
+        "assert 'litellm' not in sys.modules, "
+        "'litellm_provider module import must not eagerly import litellm'\n"
+        "assert 'tiktoken' not in sys.modules, "
+        "'litellm_provider module import must not eagerly import tiktoken'\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_openai_codex_provider_import_does_not_load_oauth_cli_kit():
+    """Importing the module alone must not pull in oauth_cli_kit."""
+    code = (
+        "import sys\n"
+        "import nanobot.providers.openai_codex_provider\n"
+        "assert 'oauth_cli_kit' not in sys.modules, "
+        "'openai_codex_provider module import must not eagerly import oauth_cli_kit'\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_litellm_provider_acompletion_is_module_level_and_patchable():
+    """`acompletion` must remain a module attribute so tests can mock.patch it
+    before any real litellm import happens (see tests/test_litellm_kwargs.py)."""
+    import nanobot.providers.litellm_provider as mod
+
+    assert hasattr(mod, "acompletion")


### PR DESCRIPTION
## Origin story

This ports the "lazy provider imports" portion of #657, recovered from a stranded subagent branch. The evaluation comment on #657 verdict for this hunk was **PORT (rework)**: real value is cheap pytest collection without pulling in the litellm/tiktoken chain (tiktoken needs a Rust toolchain to build on some hosts, e.g. the i386 eeepc host), but the stranded patch had a known api_base regression that needed fixing before landing, and the recovered diff was used as reference only, not applied verbatim.

## What changed

- `nanobot/providers/litellm_provider.py`: removed the module-level `import litellm` / `from litellm import acompletion`. `litellm` is now imported lazily via `_ensure_litellm()`, called at the top of `chat()`. `acompletion` remains a module-level attribute (`None` until first real use) so existing tests can `mock.patch("nanobot.providers.litellm_provider.acompletion", ...)` before any real litellm import happens.
- `nanobot/providers/openai_codex_provider.py`: `from oauth_cli_kit import get_token` moved from module scope into `chat()`, so the module (and its pure-Python helpers like `_strip_model_prefix`) can be imported/tested without `oauth_cli_kit` installed.
- `tests/test_provider_lazy_imports.py` (new): subprocess-based regression guard mirroring `tests/test_import_hygiene.py`'s style — asserts importing `litellm_provider`/`openai_codex_provider` does not pull `litellm`, `tiktoken`, or `oauth_cli_kit` into `sys.modules`, and that `acompletion` stays patchable.

## The api_base decision

The stranded patch applied `litellm.api_base = api_base` once per process, inside the lazy-init block that ran on whichever `LiteLLMProvider` instance's `chat()` happened to fire first — so every other instance's requests would silently pick up that first instance's `api_base`, a real regression versus current `main` (which sets it per-instance in `__init__`, before it's overwritten by the next instance's `__init__`... which was itself already racy across instances, just less visibly so).

Fix: **removed the global `litellm.api_base` assignment entirely.** `chat()` already threads `api_base` through per-request via `kwargs["api_base"]` (see the existing `if self.api_base: kwargs["api_base"] = self.api_base` block), which is correctly scoped to the instance making the call and takes precedence over any module-level litellm default anyway. The global assignment was redundant even before this change; removing it eliminates the whole class of cross-instance leakage instead of just relocating it.

`suppress_debug_info` and `drop_params` are still applied, but now once at first real litellm import (in `_ensure_litellm()`) rather than in every `__init__` — they're process-global by nature (no per-instance equivalent in litellm), so applying them once is correct and cheaper.

## Thread-safety note

`_ensure_litellm()`'s check-and-import is not atomic, but this runs under a single asyncio event loop plus occasional worker threads from `tool_harness._run_async`; CPython's GIL means the worst case is a harmless duplicate import (idempotent), not a data race. Documented inline; no lock added.

## Test evidence

- Full suite: `python -m pytest tests/ -q` → **1044 passed** (in a fresh venv built from `pip install -e ".[dev]"`).
- Demonstrated the actual win: uninstalled `litellm`, `tiktoken`, and `oauth_cli_kit` from that venv entirely and reran the full suite → **still 1044 passed**, confirming none of the existing tests (`tests/test_commands.py`, `tests/test_gemini_thought_signature.py`, `tests/test_litellm_kwargs.py`) actually require those packages to be installed for collection or execution, since they all either avoid calling `chat()` or mock `acompletion`.
- Deliberately did **not** port the stranded patch's `pytest.importorskip("tiktoken")` / deferred-import-in-test-body edits to those three test files — they're unnecessary now. In the stranded patch, laziness lived only in the test files (deferring `from nanobot.providers.litellm_provider import LiteLLMProvider` inside each test function); here it lives in the provider module itself, so even a plain top-of-file `from nanobot.providers.litellm_provider import LiteLLMProvider` import is already cheap and doesn't need litellm/tiktoken installed. Added `tests/test_provider_lazy_imports.py` instead as the single source of truth for this guarantee, verified via subprocess with a clean interpreter state.
- `ruff check` on touched files: no new issues (4 pre-existing `W293`/`E741` findings confirmed present on `main` before this change; the one new import-order finding my edit introduced was fixed by shortening an inline comment).

Part of #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)