### PR TITLE
fix: restart improvement generation when chain completes — planner leaves maintenance rotation (#656)

### DIFF
--- a/nanobot/runtime/cycle_feedback.py
+++ b/nanobot/runtime/cycle_feedback.py
@@ -22,6 +22,7 @@ from nanobot.runtime._io import utc_iso as _utc_iso
 from nanobot.runtime._io import utc_now as _utc_now
 from nanobot.runtime.cycle_observe import (
     _BACKLOG_PROGRESSION_IDS,
+    _TERMINAL_SUBAGENT_RESULT_STATUSES,
     AMBITION_UNDERUTILIZATION_STREAK_LIMIT,
     COMPLETED_TASK_STATUSES,
     CORE_TASK_IDS,
@@ -58,6 +59,51 @@ from nanobot.runtime.stop_guards import (
     evaluate_stall,
     lane_iteration,
 )
+from nanobot.runtime.subagent_materializer import _result_path_for
+
+# Task ids that make up one improvement generation's synthesize->materialize->
+# verify chain (issue #656). When all three are terminal (COMPLETED_TASK_STATUSES)
+# and no verify request is still in flight, nothing in the existing branch chain
+# below re-opens the chain for a new generation: the fast-path in the
+# SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID branch only fires while that task is
+# *current*, but a "done" task is never re-selected as current — a catch-22 that
+# leaves the planner rotating CORE_TASK_IDS (refresh-approval-gate /
+# run-bounded-turn / record-reward) forever. See _derive_feedback_decision's
+# "start_next_improvement_generation" fallback for the restart.
+_IMPROVEMENT_GENERATION_CHAIN_IDS = (
+    SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID,
+    MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
+    "subagent-verify-materialized-improvement",
+)
+
+
+def _has_live_verify_request_queue(state_root: Path | None) -> bool:
+    """True when a subagent-verify request is queued/pending with no terminal result yet.
+
+    Guards the improvement-generation restart (issue #656) so it never fires
+    while genuine in-flight verify work exists for the prior generation — that
+    would orphan the live request instead of just moving on to the next one.
+    """
+    if state_root is None:
+        return False
+    request_dir = state_root / "subagents" / "requests"
+    result_dir = state_root / "subagents" / "results"
+    if not request_dir.exists():
+        return False
+    for path, _mtime in list(_json_files_sorted_by_mtime(True, request_dir))[:100]:
+        payload = _safe_read_json(path)
+        if not payload or payload.get("task_id") != "subagent-verify-materialized-improvement":
+            continue
+        status = payload.get("request_status") or payload.get("status") or "queued"
+        if status not in {"queued", "pending"}:
+            continue
+        result_path = _result_path_for(result_dir, path, payload)
+        result_payload = _safe_read_json(result_path) if result_path.exists() else None
+        result_status = result_payload.get("result_status") if isinstance(result_payload, dict) else None
+        if result_status in _TERMINAL_SUBAGENT_RESULT_STATUSES:
+            continue
+        return True
+    return False
 
 
 def _enrich_decision_lane_with_insight(
@@ -556,7 +602,7 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
 
     if (
         isinstance(recorded_feedback_decision, dict)
-        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane", "retire_completed_subagent_lane"}
+        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane", "retire_completed_subagent_lane", "start_next_improvement_generation"}
         and recorded_feedback_decision.get("current_task_id") == current_task_id
         and recorded_feedback_decision.get("selected_task_id")
         and recorded_feedback_decision.get("selected_task_id") != current_task_id
@@ -1119,6 +1165,37 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
                     status="active",
                 )
                 selection_source = "feedback_no_selectable_retired_lane_synthesis"
+
+    if mode == "stable" and not reason:
+        # Issue #656 (third-layer finding): none of the branches above matched —
+        # this is exactly the state the planner falls into once a full
+        # synthesize->materialize->verify generation completes while
+        # current_task_id sits on a CORE bookkeeping task (refresh-approval-gate /
+        # run-bounded-turn / record-reward). Those tasks have no branch of their
+        # own above, so mode stayed "stable" and the function would otherwise
+        # return None — leaving nothing to ever re-select the (now "done")
+        # synthesize task and R11's stall-switch to round-robin the CORE tasks
+        # forever. Re-open the chain here as a last resort, once per cycle, and
+        # only when no verify work is still in flight for the prior generation.
+        _generation_chain_tasks = [_task_by_id.get(_gid) for _gid in _IMPROVEMENT_GENERATION_CHAIN_IDS]
+        _generation_chain_complete = all(
+            _gt is not None and _task_status(_gt) in COMPLETED_TASK_STATUSES
+            for _gt in _generation_chain_tasks
+        )
+        if _generation_chain_complete and not _has_live_verify_request_queue(state_root):
+            selected_task = _synthesized_next_improvement_candidate(
+                current_task_id=current_task_id,
+                strong_pass_count=strong_pass_count,
+                goal_artifact_signature=strong_pass_signature_list,
+                status="active",
+            )
+            mode = "start_next_improvement_generation"
+            reason = (
+                "synthesize/materialize/verify chain for the prior generation is fully "
+                "complete and no verify work is in flight; reopen the chain instead of "
+                "leaving the planner rotating CORE bookkeeping tasks forever"
+            )
+            selection_source = "feedback_start_next_improvement_generation"
 
     decision = {
         "mode": mode,

--- a/nanobot/runtime/cycle_observe.py
+++ b/nanobot/runtime/cycle_observe.py
@@ -85,6 +85,13 @@ COMPLETED_TASK_STATUSES = {
     "terminal_noop",
 }
 
+# Terminal subagent result_status values that mean a subagent request genuinely
+# finished (issue #656/#661): a request in this state is no longer "live" work,
+# regardless of whether the owning task's own status has been flipped yet.
+# Shared by cycle_planning._subagent_lane_health and
+# cycle_feedback._has_live_verify_request_queue (the generation-restart guard).
+_TERMINAL_SUBAGENT_RESULT_STATUSES = {"already_done", "completed", "no_commit", "blocked"}
+
 
 TASK_ACTION_CLASS_BY_ID = {
     "refresh-approval-gate": "remediation",

--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -28,6 +28,7 @@ from nanobot.runtime.cycle_feedback import (
     _task_readiness_gate,
 )
 from nanobot.runtime.cycle_observe import (
+    _TERMINAL_SUBAGENT_RESULT_STATUSES,
     CORE_TASK_IDS,
     MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
     SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID,
@@ -581,12 +582,10 @@ def _write_materialized_improvement_artifact(
     return str(path)
 
 
-# Terminal bridge/materializer result_status values that mean the subagent
-# verify lane genuinely finished — including a clean "already_done" verdict
-# (issue #656: an unscoped completed_count previously left the lane "pending"
-# forever because it counted ANY result file ever written, not the one
-# correlated to the request actually issued this cycle).
-_TERMINAL_SUBAGENT_RESULT_STATUSES = {"already_done", "completed", "no_commit", "blocked"}
+# _TERMINAL_SUBAGENT_RESULT_STATUSES (terminal bridge/materializer
+# result_status values meaning the subagent verify lane genuinely finished —
+# including a clean "already_done" verdict, issue #656/#661) now lives in
+# cycle_observe.py, shared with cycle_feedback's generation-restart guard.
 
 
 def _subagent_lane_health(*, state_root: Path, current_task_id: str | None, stale_after_seconds: int = 3600) -> dict[str, Any]:

--- a/nanobot/runtime/scorer.py
+++ b/nanobot/runtime/scorer.py
@@ -42,6 +42,7 @@ _MODE_SCORES: dict[str, float] = {
     "continue_active_lane":                  1.0,
     "synthesize_next_candidate":             1.0,
     "handoff_to_subagent_verification":      1.0,
+    "start_next_improvement_generation":     1.0,
     "record_reward_after_synthesized_materialization": 0.8,
     "record_reward_after_synth":             0.8,
     "retire_stale_subagent_lane":            0.7,

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from nanobot.runtime import autoevolve
 from nanobot.runtime.coordinator import (
     _build_task_plan_snapshot,
+    _derive_feedback_decision,
     _subagent_lane_health,
 )
 
@@ -1160,3 +1161,128 @@ def test_coordinator_retires_analyze_last_failed_candidate_when_terminal_issue_e
     assert plan['feedback_decision']['selected_task_id'] == 'record-reward'
     assert plan['feedback_decision']['terminal_selfevo_issue']['selfevo_issue']['number'] == 261
     assert all(task.get('task_id') != 'analyze-last-failed-candidate' or task.get('status') == 'done' for task in plan['tasks'])
+
+
+def _live_host_maintenance_rotation_snapshot(*, current_task_id: str = 'refresh-approval-gate') -> dict:
+    """Mirrors the live host state/goals/current.json snapshot from issue #656's
+
+    third-layer finding: synthesize->materialize->verify are all 'done' for the
+    prior generation, but current_task_id sits on a CORE bookkeeping task with
+    no branch of its own in `_derive_feedback_decision` — the catch-22 that
+    left the planner rotating refresh-approval-gate / run-bounded-turn /
+    record-reward forever.
+    """
+    return {
+        'current_task_id': current_task_id,
+        'tasks': [
+            {'task_id': 'materialize-synthesized-improvement', 'status': 'done'},
+            {'task_id': 'synthesize-next-improvement-candidate', 'status': 'done'},
+            {'task_id': 'inspect-pass-streak', 'status': 'done'},
+            {'task_id': 'materialize-pass-streak-improvement', 'status': 'done'},
+            {'task_id': 'subagent-verify-materialized-improvement', 'status': 'done'},
+            {'task_id': 'exploit-successful-improvement-path', 'status': 'pending'},
+            {'task_id': 'refresh-approval-gate', 'status': 'active' if current_task_id == 'refresh-approval-gate' else 'pending'},
+            {'task_id': 'run-bounded-turn', 'status': 'active' if current_task_id == 'run-bounded-turn' else 'pending'},
+            {'task_id': 'record-reward', 'status': 'active' if current_task_id == 'record-reward' else 'pending'},
+        ],
+    }
+
+
+def test_generation_restart_fires_when_chain_complete_and_verify_queue_empty(tmp_path: Path) -> None:
+    # Issue #656 (third layer): with the whole synthesize->materialize->verify
+    # chain done and no live verify request, the planner must re-open the
+    # chain instead of returning no decision (which previously left
+    # current_task_id stuck on CORE bookkeeping forever).
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+
+    task_plan = _live_host_maintenance_rotation_snapshot(current_task_id='refresh-approval-gate')
+
+    decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+    assert decision is not None
+    assert decision['mode'] == 'start_next_improvement_generation'
+    assert decision['selection_source'] == 'feedback_start_next_improvement_generation'
+    assert decision['selected_task_id'] == 'synthesize-next-improvement-candidate'
+
+
+def test_generation_restart_does_not_fire_with_live_queued_verify_work(tmp_path: Path) -> None:
+    # Guard: a still-queued verify request for the current generation must
+    # block the restart — otherwise it would orphan live in-flight work.
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+    _write_subagent_request(state_root / 'subagents' / 'requests', name='request-cycle-live.json', request_id='req-live', request_status='queued')
+
+    task_plan = _live_host_maintenance_rotation_snapshot(current_task_id='refresh-approval-gate')
+
+    decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+    assert decision is None
+
+
+def test_generation_restart_does_not_fire_when_chain_incomplete() -> None:
+    import tempfile
+    from pathlib import Path as _Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = _Path(tmp)
+        goals_dir = tmp_path / 'state' / 'goals'
+        goals_dir.mkdir(parents=True)
+        (goals_dir / 'history').mkdir()
+        state_root = tmp_path / 'state'
+
+        task_plan = _live_host_maintenance_rotation_snapshot(current_task_id='refresh-approval-gate')
+        # materialize still pending -> chain not complete, no restart should fire.
+        for task in task_plan['tasks']:
+            if task['task_id'] == 'materialize-synthesized-improvement':
+                task['status'] = 'pending'
+
+        decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+        assert decision is None
+
+
+def test_generation_restart_mode_is_idempotent_across_a_repeated_cycle(tmp_path: Path) -> None:
+    # Once the restart has fired and been recorded, a follow-up cycle whose
+    # persisted current_task_id has not yet advanced (e.g. a rapid re-read)
+    # must not recompute a fresh decision from scratch — it returns the
+    # already-recorded one unchanged (same idempotency pattern as #661's
+    # retire_* modes at the top of _derive_feedback_decision).
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+
+    task_plan = _live_host_maintenance_rotation_snapshot(current_task_id='refresh-approval-gate')
+    first_decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+    assert first_decision['mode'] == 'start_next_improvement_generation'
+
+    task_plan['feedback_decision'] = first_decision
+    second_decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+    assert second_decision == first_decision
+
+
+def test_maintenance_rotation_converges_to_synthesize_instead_of_rotating_forever(tmp_path: Path) -> None:
+    # Regression for the live symptom: simulate several cycles of the R11
+    # stall-switch round-robining refresh-approval-gate -> run-bounded-turn ->
+    # record-reward (the only selectable tasks once the whole backlog chain
+    # is done) and confirm each of those CORE current_task_id values now
+    # converges on reopening the chain instead of returning no decision.
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+
+    for rotating_task_id in ('refresh-approval-gate', 'run-bounded-turn', 'record-reward'):
+        task_plan = _live_host_maintenance_rotation_snapshot(current_task_id=rotating_task_id)
+
+        decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+        assert decision is not None, f'no restart decision while stuck on {rotating_task_id}'
+        assert decision['mode'] == 'start_next_improvement_generation'
+        assert decision['selected_task_id'] == 'synthesize-next-improvement-candidate'


### PR DESCRIPTION
## Catch-22 confirmed

`_derive_feedback_decision` (`nanobot/runtime/cycle_feedback.py`) has **no
branch keyed on `CORE_TASK_IDS`** (`refresh-approval-gate`, `run-bounded-turn`,
`record-reward` — `cycle_observe.py:55-59`). Every `elif current_task_id == …`
clause in the function targets an improvement-chain id (`record-reward`'s two
standalone early-`if` blocks at `cycle_feedback.py:654/700/731` also require
`materialized_improvement_artifact_path` to be set — see below). None of them
match `refresh-approval-gate`/`run-bounded-turn`, so once
`synthesize-next-improvement-candidate` / `materialize-synthesized-improvement`
/ `subagent-verify-materialized-improvement` are all `"done"` for a
generation, the function falls through with `mode="stable"`, `reason=""` and
returns `None` (`cycle_feedback.py:1196-1198`, pre-fix).

With no decision, `current_task_id` never advances on its own
(`cycle_planning._build_task_plan_snapshot` only changes it via
`feedback_decision.selected_task_id`). The only thing that *does* move it is
R11's `_switch_off_stalled_lane` (`cycle_persist.py:635`), which — once the
stall stop-guard trips — round-robins `pick_alternative_task` over
`selectable_tasks`. Since the whole backlog-progression set
(`_BACKLOG_PROGRESSION_IDS`) is `"done"` (hence unselectable), the only
tasks left to round-robin are the three CORE ones. That's the observed
"planner rotates maintenance lanes forever" symptom.

The existing `record_reward_after_synthesized_materialization ->
synthesize_next_candidate` restart path (`cycle_feedback.py:731-755`,
`988-1121`) *can* reopen the chain, but only if `current_task_id` lands on
`record-reward` for **two consecutive cycles** with
`materialized_improvement_artifact_path` set — a fragile precondition the R11
round-robin routinely breaks by moving off `record-reward` before the second
cycle.

Reproduced directly against the live host's 9-task snapshot shape
(`refresh-approval-gate=active`, backlog chain all `done`): before this fix,
`_derive_feedback_decision` returns `None`; after, it returns
`mode="start_next_improvement_generation"`, `selected_task_id="synthesize-next-improvement-candidate"`.

## `exploit-successful-improvement-path` finding

It is **not** the intended next-generation gateway — it's a dead orphan
task_id left behind by code removed between `c4aea9c` and `e345ca1` (issue
#580). `_retire_orphaned_task_ids` (`cycle_persist.py`) already retires it to
a terminal status every cycle (`tests/test_coordinator_orphaned_task_ids.py`,
`tests/test_retire_lane_arc_completion.py`). It plays no role in this fix.

## Restart condition

Added as a **last-resort fallback** inside `_derive_feedback_decision`, right
before the final `if mode == "stable" and not reason: return None` — so it
only fires once nothing else in the (large, priority-ordered) branch chain
above it already produced a decision (ambition escalation, revert handling,
terminal-selfevo repair, the existing synthesize/record-reward paths, etc. all
keep priority unchanged):

- `synthesize-next-improvement-candidate`, `materialize-synthesized-improvement`,
  and `subagent-verify-materialized-improvement` are all in
  `COMPLETED_TASK_STATUSES`, **and**
- no subagent-verify request is still queued/pending without a terminal
  result (new `_has_live_verify_request_queue`, scanning
  `state/subagents/requests` + `results`, correlated via
  `_result_path_for` — same correlation convention #661 established) —
  guards against orphaning in-flight verify work.

On fire: mints a fresh `synthesize-next-improvement-candidate` task (reusing
the existing `_synthesized_next_improvement_candidate` factory — same one the
existing `synthesize_next_candidate` mode already used) with mode
`start_next_improvement_generation` / selection_source
`feedback_start_next_improvement_generation`. Re-arms naturally: once
synthesize becomes current, the existing
`SYNTHESIZE_NEXT_IMPROVEMENT_CANDIDATE_ID` fast-path
(`cycle_feedback.py:907-946`, since materialize/verify from the *prior*
generation are still `done`) immediately advances to a fresh materialize
task — the same steady-state transition that already existed at every
generation boundary. `R11`'s stall-switch leaves the decision alone once it
selects a task different from the stalled lane
(`cycle_persist.py:664-668`), so it can't re-trap this.

Idempotency: added `start_next_improvement_generation` to the existing
recorded-decision idempotent-return guard at `cycle_feedback.py:~605` (same
pattern #661 used for its `retire_*` modes) and to the mode→score table in
`scorer.py` (1.0 — genuine forward progress, same tier as
`synthesize_next_candidate`). Moved the shared
`_TERMINAL_SUBAGENT_RESULT_STATUSES` constant to `cycle_observe.py` so both
`cycle_planning._subagent_lane_health` and the new
`cycle_feedback._has_live_verify_request_queue` use one definition (no
behavior change to `_subagent_lane_health`).

## Tests

Added to `tests/test_autonomy_stagnation_followthrough.py` (mirrors #661's
style), against `_derive_feedback_decision` directly with a fixture matching
the live host's 9-task snapshot shape:

- `test_generation_restart_fires_when_chain_complete_and_verify_queue_empty`
- `test_generation_restart_does_not_fire_with_live_queued_verify_work`
- `test_generation_restart_does_not_fire_when_chain_incomplete`
- `test_generation_restart_mode_is_idempotent_across_a_repeated_cycle`
- `test_maintenance_rotation_converges_to_synthesize_instead_of_rotating_forever`
  (regression for the live symptom: all three CORE task ids as
  `current_task_id` now converge on the restart instead of returning `None`)

Full suite: `python -m pytest tests/ -q` → **1058 passed**.
`ruff check` on all touched files → only the same 2 pre-existing, unrelated
`F821` errors in `cycle_planning.py` remain (confirmed present on
`origin/main` before this change, same as #661 noted); no new issues.

## Docs

Checked `docs/specs/self-evolving-runtime/spec.md` — no text describes the
synthesize/materialize/verify generation lifecycle (grep for
"generation"/"synthesize.*materialize.*verify" is empty), so no spec update
needed, consistent with #661's finding.

Part of #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)