### PR TITLE
fix: bridge auto-commits uncommitted subagent work before the gate (#666)

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -1,6 +1,7 @@
 # Subagent Bridge — spec
 
-_Status: current. Last updated: 2026-07-05 (#653: R8-R15 cycle-branch isolation
+_Status: current. Last updated: 2026-07-06 (#666: R11a auto-commit safety net
+for uncommitted subagent work added; #653: R8-R15 cycle-branch isolation
 implemented in code; R10/R11 corrected to describe the full-pytest gate that
 was already running)._
 
@@ -109,6 +110,20 @@ executor run does not stop early or hand off instead of acting:
     corrected the requirement text to match the running code (CLAUDE.md
     "executable truth wins") rather than implementing the cheaper import-only
     check, since the full suite is a strictly stronger gate.
+- R11a. If no commits landed on the cycle branch but the working tree is dirty
+  (`git status --porcelain` non-empty), the bridge SHALL commit those changes
+  itself (`_auto_commit_uncommitted_work`) before applying R11 — excluding any
+  file matching the same `_BLOCKED_FILE_PATTERNS` used by
+  `_validate_mutation_surfaces` (logged, never staged) — then recount commits
+  and proceed through the normal smoke gate / R12-R15 flow unchanged. Found
+  live during #656 verification (2026-07-06): a subagent implemented real
+  changes via `edit_file` but ended its turn without running `git commit`;
+  because `cycle_commit_count` stayed `0`, the gate was skipped and the
+  `finally`-block restore-to-main discarded the work outright, so every
+  following cycle re-did (and re-lost) the same task. This is a bridge-level
+  safety net, not a prompt-only fix — R7's branch-discipline prompt also
+  reinforces "commit is the final step" so the gap is rarer, but the bridge
+  no longer relies on the subagent remembering to commit (#666).
 
 ### Integration to main
 - R12. The bridge SHALL integrate the cycle branch into `main` (merge `--no-ff`
@@ -128,13 +143,15 @@ executor run does not stop early or hand off instead of acting:
   `backlog_title`, `result_status`) so the coordinator can observe that a real
   subagent ran rather than only a blocked stub. The result SHALL also carry a
   `rollback` record — `{"integrated": bool, "cycle_branch": str,
-  "main_sha_before": str, "main_sha_after": str, "reason": str | None}` — so
-  integration/non-integration is git-verifiable from the artifact alone:
-  `main_sha_before == main_sha_after` whenever `integrated` is `false`.
-  `commits_pushed` counts only commits that reached `origin/main` (i.e. it is
-  `0` whenever `integrated` is `false`, even if the subagent committed on the
-  cycle branch) — this is the one semantic change from the pre-#653 field,
-  which counted any subagent commit regardless of whether it survived the gate.
+  "main_sha_before": str, "main_sha_after": str, "reason": str | None,
+  "auto_committed": bool}` — so integration/non-integration is git-verifiable
+  from the artifact alone: `main_sha_before == main_sha_after` whenever
+  `integrated` is `false`. `auto_committed` is `true` when R11a fired for this
+  cycle (#666). `commits_pushed` counts only commits that reached
+  `origin/main` (i.e. it is `0` whenever `integrated` is `false`, even if the
+  subagent committed on the cycle branch) — this is the one semantic change
+  from the pre-#653 field, which counted any subagent commit regardless of
+  whether it survived the gate.
 
 ### Tool harness — phase 1 (read-only tools, #643)
 - R17. `nanobot.runtime.subagent_materializer.materialize_subagent_requests`
@@ -224,6 +241,16 @@ executor run does not stop early or hand off instead of acting:
   artifact records `rollback.integrated=false`, and the cycle branch is
   retained for inspection.
 
+### Scenario: uncommitted subagent work is auto-committed before the gate
+- Given a subagent edited files on `selfevo/cycle-<id>` via `edit_file`/`write_file`
+  but ended its turn without running `git commit` (dirty tree, `cycle_commit_count == 0`)
+- When the bridge checks for new commits after the subagent run
+- Then `_auto_commit_uncommitted_work` commits the dirty changes (excluding any
+  `_BLOCKED_FILE_PATTERNS` match) as `selfevo: auto-commit uncommitted subagent
+  work — <title>`, the commit count is re-derived, and the normal smoke
+  gate/integration flow (R10-R15) proceeds exactly as if the subagent had
+  committed itself.
+
 ### Scenario: idempotent re-run
 - Given a request already has a `handled_<id>.txt` marker
 - When the bridge runs again
@@ -241,7 +268,8 @@ executor run does not stop early or hand off instead of acting:
 - Code (authoritative): `nanobot/runtime/bridge.py`
   (`main`, `find_pending_request`, `_is_real_result`, `build_task`,
   `_setup_cycle_branch`, `_run_smoke_tests`, `_integrate_cycle_to_main`,
-  `_cleanup_cycle_branch`). `scripts/eeepc_self_evolving_subagent_bridge.py`
+  `_cleanup_cycle_branch`, `_auto_commit_uncommitted_work`).
+  `scripts/eeepc_self_evolving_subagent_bridge.py`
   is a thin wrapper that calls `nanobot.runtime.bridge.cli_main`.
 - Related specs: `docs/specs/self-evolving-runtime/spec.md`,
   `docs/specs/host-runtime/spec.md`, `promotion-and-release`, `model-routing`.

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -408,6 +408,101 @@ def _restore_to_main(repo_root: 'Path') -> bool:
         return False
 
 
+def _auto_commit_uncommitted_work(
+    repo_root: 'Path',
+    branch: str,
+    backlog_title: str = '',
+    task_snippet: str = '',
+) -> dict:
+    """Safety net (#666): commit uncommitted subagent work before the smoke gate runs.
+
+    Live-observed gap (#656 verification, 2026-07-06): a subagent implemented real
+    changes via edit_file but finished its turn without running ``git commit``. The
+    bridge saw ``cycle_commit_count == 0``, skipped the gate entirely, and the
+    ``finally``-block :func:`_restore_to_main` discarded the uncommitted work — every
+    following cycle re-did (and re-lost) the same task.
+
+    Only meaningful when the caller has already established ``cycle_commit_count == 0``
+    for this cycle. Checks ``git status --porcelain`` itself, so it is a no-op (and
+    returns ``committed: False``) on a clean tree.
+
+    Files matching ``_BLOCKED_FILE_PATTERNS`` (secret-shaped names, lockfiles, ``.git``
+    internals, ...) are excluded from the auto-commit and reported back — the smoke
+    gate remains the actual arbiter of whether the *included* changes are good; this
+    function only decides whether the subagent's uncommitted work gets a chance to be
+    judged by that gate at all.
+
+    Returns ``{"committed": bool, "excluded": list[str], "files_committed": int}``.
+    Never raises — degrades to ``committed: False`` on any git failure.
+    """
+    import re as _re_auto
+    import subprocess as _sp_auto
+
+    git = _git_cmd(repo_root)
+    try:
+        status = _sp_auto.run(git + ['status', '--porcelain'], capture_output=True, text=True)
+    except Exception:
+        return {'committed': False, 'excluded': [], 'files_committed': 0}
+    if status.returncode != 0 or not status.stdout.strip():
+        return {'committed': False, 'excluded': [], 'files_committed': 0}
+
+    changed_files: list[str] = []
+    for line in status.stdout.splitlines():
+        if not line.strip():
+            continue
+        # Porcelain format: "XY <path>" (or "XY <old> -> <new>" for renames).
+        path = line[3:].strip()
+        if ' -> ' in path:
+            path = path.split(' -> ', 1)[1]
+        path = path.strip('"')
+        if path:
+            changed_files.append(path)
+
+    # NOTE: intentionally a for-loop, not a comprehension assigned in one shot —
+    # tests/test_mutation_surfaces.py AST-extracts any module-level assignment
+    # whose source mentions _BLOCKED_FILE_PATTERNS as a "constant" to splice into
+    # its isolated exec() of _validate_mutation_surfaces(); a one-line comprehension
+    # here would get swept up by that (fragile, but out of scope to fix in #666).
+    excluded_set: set[str] = set()
+    for f in changed_files:
+        is_blocked = False
+        for pat in _BLOCKED_FILE_PATTERNS:
+            if pat in f.lower():
+                is_blocked = True
+                break
+        if is_blocked:
+            excluded_set.add(f)
+    excluded = sorted(excluded_set)
+    included = [f for f in changed_files if f not in excluded_set]
+
+    if not included:
+        return {'committed': False, 'excluded': excluded, 'files_committed': 0}
+
+    for f in included:
+        try:
+            _sp_auto.run(git + ['add', '--', f], capture_output=True, text=True)
+        except Exception:
+            pass
+
+    title = (backlog_title or task_snippet or 'subagent task').strip()
+    title = _re_auto.sub(r'\s+', ' ', title)[:80]
+    subject = f'selfevo: auto-commit uncommitted subagent work — {title}'
+    body = (
+        f'Subagent finished on {branch} without running git commit; the bridge\n'
+        'committed its working-tree changes so the smoke gate can evaluate them (#666).'
+    )
+    try:
+        commit = _sp_auto.run(
+            git + ['commit', '-m', subject, '-m', body],
+            capture_output=True, text=True,
+        )
+    except Exception:
+        return {'committed': False, 'excluded': excluded, 'files_committed': 0}
+    if commit.returncode != 0:
+        return {'committed': False, 'excluded': excluded, 'files_committed': 0}
+    return {'committed': True, 'excluded': excluded, 'files_committed': len(included)}
+
+
 def build_task(req: dict, goal_text: str, report_source: str,
                state_dir: 'Path | None' = None,
                repair_context: 'str | None' = None) -> str:
@@ -556,6 +651,8 @@ def build_task(req: dict, goal_text: str, report_source: str,
         'itself, only after your changes pass the test-suite gate. A stray push from',
         'this branch cannot reach main (it is not the checked-out branch), but it',
         'still wastes a turn, so just commit and let the bridge handle integration.',
+        'Work you do not commit is discarded when this turn ends — git commit MUST',
+        'be the final step of your session, not an afterthought.',
         '',
         '## Your instructions',
         'You MUST take a concrete action in this session. Do not return a review only.',
@@ -815,6 +912,7 @@ async def main():
     files_changed: list[str] = []
     cycle_commit_count = 0
     commits_pushed = 0
+    _auto_committed = False
     _integrated = False
     _rollback_reason: 'str | None' = None
     main_sha_after = main_sha_before
@@ -868,6 +966,30 @@ async def main():
         if _selfevo_repo.is_dir():
             _git_se = _git_cmd(_selfevo_repo)
             _new_commits = _count_commits_since(_selfevo_repo, _pre_spawn_sha)
+            if _new_commits == 0:
+                print(f'cycle-branch: no new commits on {cycle_branch}')
+                # Safety net (#666): the subagent may have implemented real changes via
+                # edit_file/write_file but finished the turn without running git commit.
+                # Without this, cycle_commit_count stays 0, the gate is skipped, and the
+                # finally-block _restore_to_main() below discards the work outright.
+                _auto = _auto_commit_uncommitted_work(
+                    _selfevo_repo,
+                    cycle_branch,
+                    backlog_title=backlog_title,
+                    task_snippet=req.get('task_title') or request_id,
+                )
+                if _auto['excluded']:
+                    print(
+                        f"auto-commit: excluded {len(_auto['excluded'])} blocked-pattern file(s): "
+                        f"{', '.join(_auto['excluded'][:5])}"
+                    )
+                if _auto['committed']:
+                    _auto_committed = True
+                    _new_commits = _count_commits_since(_selfevo_repo, _pre_spawn_sha)
+                    print(
+                        f"auto-commit: {_auto['files_committed']} file(s) committed on "
+                        f'{cycle_branch} (#666)'
+                    )
             if _new_commits > 0:
                 cycle_commit_count = _new_commits
                 # Get list of changed files across all new commits
@@ -885,8 +1007,6 @@ async def main():
                     else:
                         print(f'mutation surfaces: clean ({len(files_changed)} file(s) changed)')
                 print(f'cycle-branch: {cycle_commit_count} new commit(s) on {cycle_branch}')
-            else:
-                print(f'cycle-branch: no new commits on {cycle_branch}')
         else:
             print(f'cycle-branch: eeebot-self-evolving not found at {_selfevo_repo}')
 
@@ -1045,6 +1165,10 @@ async def main():
         'main_sha_before': main_sha_before,
         'main_sha_after': main_sha_after,
         'reason': _rollback_reason,
+        # #666: bridge committed uncommitted subagent work itself (see
+        # _auto_commit_uncommitted_work) because the subagent finished without
+        # a git commit despite having a dirty working tree.
+        'auto_committed': _auto_committed,
     }
     _write_bridge_completed_result(
         state_dir=STATE_DIR,
@@ -1612,10 +1736,12 @@ def _write_bridge_completed_result(
         revisions: smoke-gate repair-loop record from stop_guards.revision_outcome.
         rollback: cycle-branch integration record (R8-R15) —
             ``{"integrated": bool, "cycle_branch": str, "main_sha_before": str,
-            "main_sha_after": str, "reason": str | None}``. ``main_sha_before``
-            and ``main_sha_after`` are equal whenever ``integrated`` is False —
-            a git-verifiable guarantee that a non-integrated cycle never moved
-            ``origin/main``.
+            "main_sha_after": str, "reason": str | None, "auto_committed": bool}``.
+            ``main_sha_before`` and ``main_sha_after`` are equal whenever
+            ``integrated`` is False — a git-verifiable guarantee that a
+            non-integrated cycle never moved ``origin/main``. ``auto_committed``
+            is True when the bridge itself committed uncommitted subagent work
+            before the gate (#666); see :func:`_auto_commit_uncommitted_work`.
     """
     import datetime as _dt
     results_dir = state_dir / 'subagents' / 'results'

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -192,6 +192,167 @@ class TestSelfPushIsolation:
         assert setup["branch"] in remote_branches or True  # bare repo branch listing format varies
 
 
+class TestAutoCommitUncommittedWork:
+    """Tests for issue #666: the subagent implements real changes via edit_file but
+    finishes the turn without running git commit. Previously the bridge saw
+    cycle_commit_count == 0, skipped the gate, and _restore_to_main() silently
+    discarded the work. _auto_commit_uncommitted_work() is the safety net.
+    """
+
+    def test_dirty_tree_gets_committed(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-1")
+        assert setup["ok"]
+        # Subagent edits a file but never commits.
+        (work / "mod.py").write_text("def ok():\n    return 'edited-not-committed'\n")
+
+        result = bridge._auto_commit_uncommitted_work(
+            work, setup["branch"], backlog_title="Wire host_metrics into dashboard",
+        )
+
+        assert result["committed"] is True
+        assert result["files_committed"] == 1
+        assert result["excluded"] == []
+        status = _run(work, "status", "--porcelain").stdout
+        assert status.strip() == ""
+        log = _run(work, "log", "-1", "--pretty=%s").stdout
+        assert log.startswith("selfevo: auto-commit uncommitted subagent work")
+        assert "Wire host_metrics into dashboard" in log
+        body = _run(work, "log", "-1", "--pretty=%b").stdout
+        assert "#666" in body
+
+    def test_clean_tree_is_a_noop(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-clean")
+        assert setup["ok"]
+
+        result = bridge._auto_commit_uncommitted_work(work, setup["branch"])
+
+        assert result["committed"] is False
+        assert result["files_committed"] == 0
+        assert result["excluded"] == []
+        # No stray commit was created.
+        log = _run(work, "log", "-1", "--pretty=%s").stdout
+        assert log.strip() == "init"
+
+    def test_blocked_pattern_file_excluded(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-blocked")
+        assert setup["ok"]
+        (work / "mod.py").write_text("def ok():\n    return 'edited'\n")
+        (work / ".env").write_text("SECRET=abc123\n")
+
+        result = bridge._auto_commit_uncommitted_work(work, setup["branch"])
+
+        assert result["committed"] is True
+        assert result["files_committed"] == 1
+        assert result["excluded"] == [".env"]
+        # The blocked file is still untracked/dirty afterwards — never staged.
+        status = _run(work, "status", "--porcelain").stdout
+        assert ".env" in status
+        assert "mod.py" not in status
+        log_files = _run(work, "show", "--stat", "--pretty=", "HEAD").stdout
+        assert ".env" not in log_files
+
+    def test_only_blocked_pattern_files_commits_nothing(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-only-blocked")
+        assert setup["ok"]
+        (work / "credential.json").write_text('{"token": "x"}\n')
+
+        result = bridge._auto_commit_uncommitted_work(work, setup["branch"])
+
+        assert result["committed"] is False
+        assert result["files_committed"] == 0
+        assert result["excluded"] == ["credential.json"]
+
+
+class TestFullCycleFlowWithAutoCommit:
+    """Mirrors TestFullCycleFlow but for the #666 auto-commit safety net: a
+    subagent that edits files without committing must still get a shot at the
+    smoke gate, and a failing gate must leave the auto-commit on the forensic
+    branch (never on main).
+    """
+
+    def test_dirty_uncommitted_work_green_gate_integrates(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-flow-green")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+        # Subagent "implements" a change but forgets to commit.
+        (work / "feature.py").write_text("def feature():\n    return 42\n")
+
+        auto = bridge._auto_commit_uncommitted_work(work, setup["branch"])
+        assert auto["committed"] is True
+
+        passed, _ = bridge._run_smoke_tests(work)
+        assert passed is True
+
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], main_sha_before)
+        assert integ["ok"] is True
+        bridge._cleanup_cycle_branch(work, setup["branch"])
+
+        assert _origin_main_sha(origin) == integ["main_sha_after"]
+        assert integ["main_sha_after"] != main_sha_before
+        branches = _run(work, "branch", "--list", setup["branch"]).stdout
+        assert setup["branch"] not in branches
+
+    def test_dirty_uncommitted_work_failing_gate_keeps_forensic_branch(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-flow-fail")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+        # Subagent breaks the test suite and never commits.
+        (work / "tests" / "test_smoke.py").write_text("def test_ok():\n    assert False\n")
+
+        auto = bridge._auto_commit_uncommitted_work(work, setup["branch"])
+        assert auto["committed"] is True
+
+        passed, _ = bridge._run_smoke_tests(work)
+        assert passed is False
+
+        restored = bridge._restore_to_main(work)
+
+        assert restored is True
+        assert _origin_main_sha(origin) == main_sha_before
+        assert _local_main_sha(work) == main_sha_before
+        current_branch = _run(work, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        assert current_branch == "main"
+        # Forensic branch retained WITH the auto-commit on it.
+        branches = _run(work, "branch", "--list", setup["branch"]).stdout
+        assert setup["branch"] in branches
+        log = _run(work, "log", setup["branch"], "--oneline").stdout
+        assert "auto-commit uncommitted subagent work" in log
+
+    def test_clean_tree_no_commits_stays_a_noop(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-flow-clean")
+        assert setup["ok"]
+
+        auto = bridge._auto_commit_uncommitted_work(work, setup["branch"])
+        assert auto["committed"] is False
+
+        # No gate is meaningful to run — same no-op path as before #666.
+        new_commits = bridge._count_commits_since(work, setup["main_sha"])
+        assert new_commits == 0
+
+    def test_subagent_committed_normally_no_auto_commit(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "auto-flow-normal")
+        assert setup["ok"]
+        _commit_file(work, "feature3.py", "x = 1\n", "feat: subagent committed properly")
+        pre_auto_sha = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        # cycle_commit_count > 0 in main() means _auto_commit_uncommitted_work is
+        # never called; simulate that guard and confirm no extra commit appears.
+        new_commits = bridge._count_commits_since(work, setup["main_sha"])
+        assert new_commits == 1
+
+        assert _run(work, "rev-parse", "HEAD").stdout.strip() == pre_auto_sha
+        log = _run(work, "log", "-1", "--pretty=%s").stdout
+        assert log.strip() == "feat: subagent committed properly"
+
+
 class TestFullCycleFlow:
     """Integration-style tests combining setup → commit → gate → integrate/rollback,
     mirroring the shape of main()'s cycle-branch flow without spawning a real subagent.


### PR DESCRIPTION
## Summary

- **Live-observed loss scenario (#656 verification, 2026-07-06):** subagent `67b5c098` genuinely implemented Priority 7 (wiring `host_metrics` into `scripts/eeebot_dashboard.py` renderers via multiple precise `edit_file` calls, plus a passing import/format smoke check) and reported "completed successfully" — but never ran `git commit`. `nanobot/runtime/bridge.py`'s `main()` then saw `cycle_commit_count == 0`, skipped the smoke gate entirely, and the `finally`-block `_restore_to_main()` discarded the uncommitted work by design. Net effect: real, correct work was implemented and then wiped; each subsequent generation would re-implement and re-lose the same task — the loop could implement but never land.
- **Fix:** new `_auto_commit_uncommitted_work()` fires only when `cycle_commit_count == 0` *and* `git status --porcelain` is non-empty on the cycle branch. It commits the dirty tree (message `selfevo: auto-commit uncommitted subagent work — <title>` + a body line referencing #666), recounts commits via the existing `_count_commits_since`, and lets the unchanged gate → integrate/rollback flow (R10-R15) be the sole arbiter of whether the work lands on `main`.
- **Blocked-file handling decision:** reused the existing `_BLOCKED_FILE_PATTERNS` mechanism (already used by `_validate_mutation_surfaces`) — any changed/untracked file whose path matches a blocked pattern (`.env`, `secret`, `credential`, `token`, `private_key`, `id_rsa`, `.git`, lockfiles, ...) is excluded from `git add`/commit and reported in a print line; it stays untracked/dirty and is never staged. If nothing survives the filter, no commit is made. This is filtering-at-commit-time, not a second gate — the smoke gate remains the real arbiter of the *included* changes.
- **Result-field addition:** added `auto_committed: bool` as a sibling field inside the existing `rollback` dict written by `_write_bridge_completed_result` (least invasive — no new top-level payload key, no signature break for existing callers).
- One-line reinforcement in `build_task`'s branch-discipline section: work not committed is discarded, so commit must be the final step of a subagent turn.
- Extended `docs/specs/subagent-bridge/spec.md` with new requirement R11a (the auto-commit safety net), a new scenario, and updated R16's rollback-record shape to include `auto_committed`.

## Test plan

- [x] `tests/test_bridge_cycle_branch.py` — new `TestAutoCommitUncommittedWork` (dirty tree gets committed; clean tree no-op; blocked-pattern file excluded and left untracked; only-blocked-files commits nothing) and `TestFullCycleFlowWithAutoCommit` (dirty+0-commits+green-gate → integrates and advances origin/main; dirty+0-commits+failing-gate → not integrated, origin/main unchanged, forensic branch kept WITH the auto-commit; clean tree+0 commits stays a no-op; subagent-committed-normally path unaffected)
- [x] Fixed an unrelated fragility surfaced by the change: `tests/test_mutation_surfaces.py` AST-extracts `_validate_mutation_surfaces` plus any module-level assignment mentioning `_BLOCKED_FILE_PATTERNS`; a first draft of the new helper used a one-line set-comprehension that got swept into that extraction and broke it. Rewrote the exclusion logic as an explicit for-loop to avoid tripping that AST walk (documented inline in the code).
- [x] `python -m pytest tests/ -q` → **1066 passed**
- [x] `ruff check nanobot/runtime/bridge.py tests/test_bridge_cycle_branch.py` → no new issues (remaining findings are pre-existing, outside the diff's line ranges — confirmed via `git diff --stat origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #666