### PR TITLE
fix: smoke gate runs in runtime venv with realistic timeout (#668)

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -95,10 +95,14 @@ executor run does not stop early or hand off instead of acting:
 
 ### Smoke gate
 - R10. After the subagent commits, the bridge SHALL gate the cycle with
-  `_run_smoke_tests`, which runs the FULL `pytest tests/` suite (`-x -q
-  --tb=short`, 60s timeout) inside the isolated checkout. This is intentionally
-  not an import-only check of changed files — an updated 2026-07 revision of
-  this requirement; see "History" below.
+  `_run_smoke_tests`, which runs the FULL `pytest tests/` suite via the runtime's
+  own interpreter (`sys.executable -m pytest -x -q --tb=native`, 300s timeout)
+  inside the isolated checkout. This is intentionally not an import-only check
+  of changed files — an updated 2026-07 revision of this requirement; see
+  "History" below. (#668: the bare system `python3` lacks runtime dependencies
+  and `--tb=short`/60s produced spurious INTERNALERROR/timeout failures on the
+  eeepc host; `sys.executable` + `--tb=native` + 300s reflect the environment
+  and runtime the gate must actually exercise.)
 - R11. If no commits landed on the cycle branch, the smoke gate SHALL be
   skipped entirely (nothing to test) and the cycle branch SHALL be discarded
   without touching `main`. Transient errors (timeouts, missing `pytest`, no

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1155,6 +1155,7 @@ async def main():
         revisions=_repair_attempts,
         smoke_passed=_smoke_passed,
         cap=_max_repair_attempts,
+        last_smoke_output=_smoke_output,
     ) if _smoke_ran else None
     _bridge_status = 'completed'
     if _revision_record and _revision_record['outcome'] == 'blocked':
@@ -1247,13 +1248,17 @@ def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
     return violations
 
 
-def _run_smoke_tests(repo_root: 'Path', timeout: int = 60) -> 'tuple[bool, str]':
+def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]':
     """Run pytest smoke tests in repo_root after a subagent commit.
 
     Returns (passed: bool, output: str) where output is truncated to 2000 chars.
     - timeout: seconds before treating as failure
     - no tests found: returns (True, 'no tests')
     - pytest not available: returns (True, 'pytest unavailable — skip')
+
+    Runs with sys.executable (the runtime's own venv interpreter, with all deps
+    installed) rather than the bare system python — see #668: a bare `python3`
+    lacks the runtime's dependencies (e.g. ddgs), producing spurious failures.
 
     Inspired by Darwin Mode LEARNINGS.md §1:
     'closed-loop repair: run the failing tests, feed the traceback back → 2× improvement'
@@ -1264,7 +1269,7 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 60) -> 'tuple[bool, str]'
         return True, 'no tests directory'
     try:
         result = _sp.run(
-            ['python3', '-m', 'pytest', str(tests_dir), '-x', '-q', '--tb=short', '--no-header'],
+            [sys.executable, '-m', 'pytest', str(tests_dir), '-x', '-q', '--tb=native', '--no-header'],
             capture_output=True, text=True, timeout=timeout, cwd=str(repo_root),
         )
         output = (result.stdout + result.stderr).strip()

--- a/nanobot/runtime/stop_guards.py
+++ b/nanobot/runtime/stop_guards.py
@@ -232,11 +232,17 @@ def revision_outcome(
     revisions: int,
     smoke_passed: bool,
     cap: int = REVISION_CAP_DEFAULT,
+    last_smoke_output: str | None = None,
 ) -> dict[str, Any]:
     """Summarise a smoke-gate repair loop for the bridge result artifact (R12).
 
     Returns a record whose ``outcome`` is ``"blocked"`` once the revision cap is
     reached without passing — revisions are never unbounded.
+
+    last_smoke_output: the most recent smoke-test output (stdout+stderr, already
+    tail-truncated by the caller), persisted verbatim (re-truncated to 2000 chars
+    here as a safety net) so a failed gate is diagnosable from the result
+    artifact alone without a manual worktree re-run (#668).
     """
     cap = max(0, int(cap))
     revisions = max(0, int(revisions))
@@ -247,7 +253,7 @@ def revision_outcome(
         outcome = "blocked"
     else:
         outcome = "unresolved"
-    return {
+    record: dict[str, Any] = {
         "gate": "smoke",
         "count": revisions,
         "max": cap,
@@ -255,3 +261,6 @@ def revision_outcome(
         "capped": capped,
         "outcome": outcome,
     }
+    if last_smoke_output is not None:
+        record["last_smoke_output"] = last_smoke_output[-2000:]
+    return record

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import ast
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -28,7 +29,7 @@ def _extract_fn(name: str, extra_setup: str = '') -> object:
     assert func_src, f'{name} not found in bridge script'
     ns: dict = {}
     exec(
-        f'import subprocess, json, os, re, time\nfrom pathlib import Path\n'
+        f'import subprocess, json, os, re, sys, time\nfrom pathlib import Path\n'
         f'from unittest.mock import MagicMock\n'
         f'{extra_setup}\n'
         f'{func_src}',
@@ -48,6 +49,29 @@ def test_smoke_pass_when_all_tests_pass(tmp_path):
         passed, output = fn(tmp_path)
     assert passed is True
     assert '1 passed' in output
+
+
+def test_smoke_uses_runtime_venv_interpreter_and_native_tb(tmp_path):
+    """#668: argv must start with sys.executable (not bare python3) and use --tb=native."""
+    fn = _extract_fn('_run_smoke_tests')
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout='1 passed\n', stderr='')
+        (tmp_path / 'tests').mkdir()
+        fn(tmp_path)
+    argv = mock_run.call_args.args[0]
+    assert argv[0] == sys.executable
+    assert '--tb=native' in argv
+    assert '--tb=short' not in argv
+
+
+def test_smoke_default_timeout_is_300(tmp_path):
+    """#668: default timeout raised from 60s to 300s (full suite ~135s on eeepc host)."""
+    fn = _extract_fn('_run_smoke_tests')
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout='1 passed\n', stderr='')
+        (tmp_path / 'tests').mkdir()
+        fn(tmp_path)
+    assert mock_run.call_args.kwargs['timeout'] == 300
 
 
 def test_smoke_fail_when_tests_fail(tmp_path):

--- a/tests/test_stop_guards.py
+++ b/tests/test_stop_guards.py
@@ -172,6 +172,28 @@ def test_default_constants():
     assert MAX_ITERATIONS_DEFAULT == 12
 
 
+def test_revision_outcome_omits_last_smoke_output_when_not_given():
+    rec = revision_outcome(revisions=1, smoke_passed=True, cap=3)
+    assert "last_smoke_output" not in rec
+
+
+def test_revision_outcome_persists_last_smoke_output():
+    """#668: the failed-gate output must land in the record for forensics."""
+    rec = revision_outcome(
+        revisions=3, smoke_passed=False, cap=3, last_smoke_output="FAILED tests/test_x.py",
+    )
+    assert rec["last_smoke_output"] == "FAILED tests/test_x.py"
+
+
+def test_revision_outcome_truncates_last_smoke_output_to_2000_chars():
+    long_output = 'x' * 3000 + 'TAIL'
+    rec = revision_outcome(
+        revisions=1, smoke_passed=False, cap=3, last_smoke_output=long_output,
+    )
+    assert len(rec["last_smoke_output"]) == 2000
+    assert rec["last_smoke_output"].endswith('TAIL')
+
+
 # ── R13: budget_exceeded ─────────────────────────────────────────────────────
 
 _CAPS = {"max_requests": 2, "max_tool_calls": 12, "max_subagents": 2, "max_timeout_seconds": 900}


### PR DESCRIPTION
## Summary
- `_run_smoke_tests` now runs `sys.executable -m pytest` instead of bare `python3` — the runtime executes from a venv (`/opt/eeepc-agent/venv`) with all deps installed; the system python is missing packages like `ddgs`.
- Default timeout raised 60s → 300s — the full suite takes ~135s on the i386 eeepc host, so 60s guaranteed a timeout FAIL regardless of test outcome.
- `--tb=short` → `--tb=native` — `--tb=short` triggers a pytest INTERNALERROR (`SystemError: AST constructor recursion depth mismatch`) when rendering failure tracebacks on this host; `--tb=native` avoids the source re-parsing that crashes.
- `revision_outcome()` (nanobot/runtime/stop_guards.py) now accepts `last_smoke_output` and persists it (truncated to 2000 chars) on the revisions record written by the bridge, so a failed gate is diagnosable from the result artifact alone without a manual worktree re-run.
- `docs/specs/subagent-bridge/spec.md` R10 updated to match (previously named `python3`/60s/`--tb=short` literally).

Live evidence cited in #668 (forensic branch `selfevo/cycle-cycle-cbc9b86cd681`): with venv python + `--tb=native` + 300s timeout the full suite is **837 passed in 135s**; with the old system python + `--tb=short` + 60s the gate hit timeout, an INTERNALERROR, and spurious `ddgs`-related failures on identical code.

## Test plan
- [x] Updated `tests/test_repair_loop.py`: new assertions that argv starts with `sys.executable` (not `python3`), uses `--tb=native` (not `--tb=short`), and default timeout is 300.
- [x] Updated `tests/test_stop_guards.py`: `revision_outcome` tests for `last_smoke_output` presence/omission and 2000-char truncation.
- [x] Full suite: `python -m pytest tests/ -q` → 1071 passed.
- [x] `ruff check` on touched files → no new issues (13 pre-existing issues confirmed unchanged via stash diff, none in edited lines).

Part of #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)