### PR TITLE
fix: smoke gate runs hermetically — sanitize subprocess env (#668)

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -102,7 +102,18 @@ executor run does not stop early or hand off instead of acting:
   "History" below. (#668: the bare system `python3` lacks runtime dependencies
   and `--tb=short`/60s produced spurious INTERNALERROR/timeout failures on the
   eeepc host; `sys.executable` + `--tb=native` + 300s reflect the environment
-  and runtime the gate must actually exercise.)
+  and runtime the gate must actually exercise.) The pytest subprocess SHALL run
+  with a sanitized environment (`_sanitized_smoke_env`), stripping every key
+  starting with `STATE_DIR`, `NANOBOT_`, `SUBAGENT_`, `EEEBOT_`,
+  `TARGET_WORKSPACE`, `LITELLM_`, `GOAL_`, `SOURCE_`, or `SELFEVO_` from
+  `os.environ` before the call, rather than inheriting the bridge systemd
+  unit's environment wholesale. (#668 env-pollution finding: without
+  sanitization, the subprocess inherits the bridge unit's `STATE_DIR` and
+  friends, and target-repo tests that read process env to locate state
+  observe LIVE production state instead of a hermetic fixture — deterministically
+  reproduced via `tests/test_active_lane_continue.py` passing in a clean env and
+  failing with the bridge env sourced, on identical code. The gate must
+  evaluate the repo hermetically, not against live runtime state.)
 - R11. If no commits landed on the cycle branch, the smoke gate SHALL be
   skipped entirely (nothing to test) and the cycle branch SHALL be discarded
   without touching `main`. Transient errors (timeouts, missing `pytest`, no

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1248,6 +1248,43 @@ def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
     return violations
 
 
+_SMOKE_ENV_STRIP_PREFIXES = (
+    'STATE_DIR',
+    'NANOBOT_',
+    'SUBAGENT_',
+    'EEEBOT_',
+    'TARGET_WORKSPACE',
+    'LITELLM_',
+    'GOAL_',
+    'SOURCE_',
+    'SELFEVO_',
+)
+
+
+def _sanitized_smoke_env() -> dict:
+    """Build a subprocess env for the smoke-test gate with runtime state stripped.
+
+    See #668 (env-pollution finding): the bridge systemd unit's environment
+    (STATE_DIR, NANOBOT_CONFIG_PATH, SUBAGENT_BRIDGE_*, TARGET_WORKSPACE,
+    LITELLM_*, ...) leaks into the pytest subprocess by default inheritance.
+    Tests in the target repo that read process env to locate state (e.g.
+    feedback-decision code consulting STATE_DIR) then observe LIVE production
+    state instead of a hermetic test fixture, producing spurious gate failures
+    that are not reproducible in a clean environment. Deterministically
+    reproduced: tests/test_active_lane_continue.py passes in a clean env and
+    fails with the bridge env sourced, on identical code.
+
+    Strips every key starting with any prefix in _SMOKE_ENV_STRIP_PREFIXES.
+    Deliberately leaves PATH/HOME/LANG/PYTHON* and provider auth vars alone —
+    only runtime-state-redirecting keys are removed.
+    """
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(_SMOKE_ENV_STRIP_PREFIXES)
+    }
+
+
 def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]':
     """Run pytest smoke tests in repo_root after a subagent commit.
 
@@ -1260,6 +1297,11 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]
     installed) rather than the bare system python — see #668: a bare `python3`
     lacks the runtime's dependencies (e.g. ddgs), producing spurious failures.
 
+    Runs with a sanitized subprocess env (see _sanitized_smoke_env / #668
+    env-pollution finding): the gate must evaluate the repo hermetically, not
+    against live runtime state leaked in via inherited STATE_DIR / NANOBOT_* /
+    SUBAGENT_* / TARGET_WORKSPACE / LITELLM_* (and related) environment keys.
+
     Inspired by Darwin Mode LEARNINGS.md §1:
     'closed-loop repair: run the failing tests, feed the traceback back → 2× improvement'
     """
@@ -1271,6 +1313,7 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]
         result = _sp.run(
             [sys.executable, '-m', 'pytest', str(tests_dir), '-x', '-q', '--tb=native', '--no-header'],
             capture_output=True, text=True, timeout=timeout, cwd=str(repo_root),
+            env=_sanitized_smoke_env(),
         )
         output = (result.stdout + result.stderr).strip()
         output = output[-2000:] if len(output) > 2000 else output  # keep tail (most relevant)

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -6,6 +6,7 @@ the full bridge module chain (avoids loguru / nanobot import errors in dev env).
 from __future__ import annotations
 
 import ast
+import os
 import subprocess
 import sys
 import textwrap
@@ -17,22 +18,37 @@ import pytest
 _BRIDGE_PATH = Path(__file__).parent.parent / 'nanobot' / 'runtime' / 'bridge.py'
 
 
+# _run_smoke_tests depends on these module-level helpers (#668 hermetic-env
+# fix) — pull them in alongside it so the AST-extraction sandbox has them.
+_SMOKE_DEPS = ('_SMOKE_ENV_STRIP_PREFIXES', '_sanitized_smoke_env')
+
+
 def _extract_fn(name: str, extra_setup: str = '') -> object:
-    """AST-parse the bridge, extract a single function by name, exec it in isolation."""
+    """AST-parse the bridge, extract a function (+ its known deps) by name, exec in isolation."""
     source = _BRIDGE_PATH.read_text()
     tree = ast.parse(source)
-    func_src = None
+    names_needed = {name}
+    if name == '_run_smoke_tests':
+        names_needed.update(_SMOKE_DEPS)
+    srcs: dict[str, str] = {}
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == name:
-            func_src = ast.get_source_segment(source, node)
-            break
-    assert func_src, f'{name} not found in bridge script'
+        if isinstance(node, (ast.FunctionDef, ast.Assign)):
+            node_name = None
+            if isinstance(node, ast.FunctionDef):
+                node_name = node.name
+            elif isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                node_name = node.targets[0].id
+            if node_name in names_needed:
+                srcs[node_name] = ast.get_source_segment(source, node)
+    missing = names_needed - srcs.keys()
+    assert not missing, f'{missing} not found in bridge script'
     ns: dict = {}
+    ordered_src = '\n'.join(srcs[n] for n in names_needed)
     exec(
         f'import subprocess, json, os, re, sys, time\nfrom pathlib import Path\n'
         f'from unittest.mock import MagicMock\n'
         f'{extra_setup}\n'
-        f'{func_src}',
+        f'{ordered_src}',
         ns,
     )
     return ns[name]
@@ -123,6 +139,51 @@ def test_smoke_pytest_not_found_returns_true(tmp_path):
         passed, output = fn(tmp_path)
     assert passed is True
     assert 'unavailable' in output
+
+
+# ─── #668: hermetic env for the smoke-test subprocess ────────────────────────
+
+_POLLUTED_ENV_KEYS = {
+    'STATE_DIR': '/var/lib/eeepc-agent/self-evolving-agent/state',
+    'NANOBOT_CONFIG_PATH': '/run/user/1001/nanobot-eeepc/config.json',
+    'SUBAGENT_BRIDGE_STATE_DIR': '/var/lib/eeepc-agent/self-evolving-agent/state/subagent_bridge',
+    'SUBAGENT_BRIDGE_MODEL': 'cl/gemini-3.5-flash-low',
+    'EEEBOT_SOME_FLAG': '1',
+    'TARGET_WORKSPACE': '/opt/eeepc-agent/runtimes/self-evolving-agent/current',
+    'LITELLM_API_KEY': 'sk-secret',
+    'LITELLM_BASE_URL': 'https://litellm.internal',
+    'GOAL_ID': 'goal-1',
+    'SOURCE_COMMIT': 'deadbeef',
+    'SELFEVO_SURFACES_DIR': '/opt/eeepc-agent/surfaces',
+}
+
+
+def test_smoke_subprocess_env_strips_runtime_state_keys(tmp_path, monkeypatch):
+    """#668: pytest subprocess env must not inherit runtime-state keys from the bridge unit."""
+    for key, value in _POLLUTED_ENV_KEYS.items():
+        monkeypatch.setenv(key, value)
+    fn = _extract_fn('_run_smoke_tests')
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout='1 passed\n', stderr='')
+        (tmp_path / 'tests').mkdir()
+        fn(tmp_path)
+    passed_env = mock_run.call_args.kwargs['env']
+    for key in _POLLUTED_ENV_KEYS:
+        assert key not in passed_env, f'{key} leaked into smoke-test subprocess env'
+
+
+def test_smoke_subprocess_env_retains_path_and_home(tmp_path, monkeypatch):
+    """#668: sanitization must not strip generic vars needed to run pytest at all."""
+    monkeypatch.setenv('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state')
+    fn = _extract_fn('_run_smoke_tests')
+    with patch('subprocess.run') as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout='1 passed\n', stderr='')
+        (tmp_path / 'tests').mkdir()
+        fn(tmp_path)
+    passed_env = mock_run.call_args.kwargs['env']
+    assert passed_env.get('PATH') == os.environ.get('PATH')
+    if 'HOME' in os.environ:
+        assert passed_env.get('HOME') == os.environ['HOME']
 
 
 # ─── build_task repair_context ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `_run_smoke_tests` in `nanobot/runtime/bridge.py` spawned pytest with `subprocess.run(...)` inheriting the bridge systemd unit's environment as-is: `STATE_DIR`, `NANOBOT_CONFIG_PATH`, `SUBAGENT_BRIDGE_*`, `TARGET_WORKSPACE`, `LITELLM_*`, `HOME=/opt/eeepc-agent`, etc.
- Deterministic repro from the issue (forensic branch `9d1b9e95a93e`, same code, same interpreter): `tests/test_active_lane_continue.py` passes in a clean env and fails with the bridge env sourced, because feedback-decision code consults live state via `STATE_DIR` and gets `{}` instead of the test fixture's expectations.
- Fix: `_sanitized_smoke_env()` copies `os.environ` and strips every key starting with `STATE_DIR`, `NANOBOT_`, `SUBAGENT_`, `EEEBOT_`, `TARGET_WORKSPACE`, `LITELLM_`, `GOAL_`, `SOURCE_`, or `SELFEVO_` (the last two found by grepping `nanobot/runtime/cycle_observe.py` and `cycle_feedback.py` for additional state-redirecting env reads beyond what the issue listed). `PATH`/`HOME`/`LANG`/`PYTHON*` and provider-auth vars are left untouched. Passed as `env=` to the `subprocess.run` call.
- Docstring + `docs/specs/subagent-bridge/spec.md` R10 updated to state the gate must evaluate the repo hermetically, not against live runtime state.

## Test plan
- [x] Extended `tests/test_repair_loop.py`: new tests assert the subprocess env (captured via monkeypatched `subprocess.run`) lacks all stripped-prefix keys (simulating a polluted `os.environ` with `STATE_DIR`/`NANOBOT_CONFIG_PATH`/`LITELLM_API_KEY`/etc.) while retaining `PATH`/`HOME`.
- [x] `python -m pytest tests/ -q` → 1073 passed.
- [x] `ruff check nanobot/runtime/bridge.py tests/test_repair_loop.py` → same 12 pre-existing findings as on `origin/main` (verified via stash diff); no new issues introduced.

Part of #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)