### PR TITLE
feat: harvest instance script enhancements — queue cleanup + cycle logger (#672)

### DIFF
--- a/scripts/cleanup_subagent_queue.py
+++ b/scripts/cleanup_subagent_queue.py
@@ -18,6 +18,10 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 
+# Metadata files in subagents root that are NOT queue items
+_METADATA_FILES = {"archive_latest.json", "queue_index.json", "index.json"}
+
+
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -37,6 +41,8 @@ def main() -> int:
     parser.add_argument("--hours", type=int, default=24, help="Age threshold in hours (default: 24)")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be archived without moving files")
     parser.add_argument("--state-root", type=str, default=None, help="Override state root path")
+    parser.add_argument("--max-queue", type=int, default=9, help="Max remaining queue size; archive oldest to reach this (default: 9)")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON to stdout")
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parent.parent
@@ -78,9 +84,9 @@ def main() -> int:
     if results_dir.exists():
         targets.extend(results_dir.glob("*.json"))
     if subagents_root.exists():
-        # Only files directly in subagents_root, excluding directories
+        # Only files directly in subagents_root, excluding directories and metadata
         for p in subagents_root.glob("*.json"):
-            if p.is_file():
+            if p.is_file() and p.name not in _METADATA_FILES:
                 targets.append(p)
 
     for req_path in sorted(targets, key=lambda x: x.name):
@@ -106,6 +112,52 @@ def main() -> int:
         else:
             skipped += 1
 
+    # Count-based archival: if queue still exceeds --max-queue, archive oldest remaining
+    if not args.dry_run:
+        # Re-collect remaining files after age-based cleanup
+        remaining: list[Path] = []
+        if requests_dir.exists():
+            remaining.extend(requests_dir.glob("*.json"))
+        if results_dir.exists():
+            remaining.extend(results_dir.glob("*.json"))
+        if subagents_root.exists():
+            for p in subagents_root.glob("*.json"):
+                if p.is_file() and p.name not in _METADATA_FILES:
+                    remaining.append(p)
+
+        # Sort by mtime ascending (oldest first)
+        remaining.sort(key=lambda x: x.stat().st_mtime)
+
+        excess = len(remaining) - args.max_queue
+        if excess > 0:
+            print(f"Queue has {len(remaining)} files, archiving {excess} oldest to reach max-queue={args.max_queue}")
+            for req_path in remaining[:excess]:
+                dest = archive_dir / req_path.name
+                try:
+                    req_path.rename(dest)
+                    archived += 1
+                except OSError as e:
+                    print(f"  ERROR archiving {req_path.name}: {e}", file=sys.stderr)
+                    errors += 1
+    else:
+        # Dry-run: show what would be archived by count
+        remaining: list[Path] = []
+        if requests_dir.exists():
+            remaining.extend(requests_dir.glob("*.json"))
+        if results_dir.exists():
+            remaining.extend(results_dir.glob("*.json"))
+        if subagents_root.exists():
+            for p in subagents_root.glob("*.json"):
+                if p.is_file() and p.name not in _METADATA_FILES:
+                    remaining.append(p)
+        remaining.sort(key=lambda x: x.stat().st_mtime)
+        excess = len(remaining) - args.max_queue
+        if excess > 0:
+            print(f"Queue has {len(remaining)} files, would archive {excess} oldest to reach max-queue={args.max_queue}")
+            for req_path in remaining[:excess]:
+                file_mtime = datetime.fromtimestamp(req_path.stat().st_mtime, tz=timezone.utc)
+                print(f"  WOULD ARCHIVE (count): {req_path.name} (modified: {file_mtime.isoformat()})")
+
     # Update health file
     health = {}
     if health_path.exists():
@@ -119,6 +171,12 @@ def main() -> int:
     health["subagent_cleanup_count"] = health.get("subagent_cleanup_count", 0) + archived
     health["subagent_archive_count"] = len(list(archive_dir.glob("*.json")))
     health["subagent_requests_remaining"] = len(list(requests_dir.glob("*.json"))) if requests_dir.exists() else 0
+    # Record total remaining queue count (root + requests + results) for monitoring
+    # Exclude metadata files from the count
+    remaining_root = len([p for p in subagents_root.glob("*.json") if p.is_file() and p.name not in _METADATA_FILES]) if subagents_root.exists() else 0
+    remaining_req = len(list(requests_dir.glob("*.json"))) if requests_dir.exists() else 0
+    remaining_res = len(list(results_dir.glob("*.json"))) if results_dir.exists() else 0
+    health["subagent_queue_count"] = remaining_root + remaining_req + remaining_res
 
     if not args.dry_run:
         health_path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,13 +185,229 @@ def main() -> int:
             encoding="utf-8",
         )
 
-    print(f"Cleanup complete: {archived} archived, {skipped} kept, {errors} errors")
-    if args.dry_run:
-        print("(dry-run mode — no files were moved)")
+    result = {
+        "archived": archived,
+        "kept": skipped,
+        "errors": errors,
+        "dry_run": args.dry_run,
+        "subagent_queue_count": health.get("subagent_queue_count", 0),
+        "subagent_archive_count": health.get("subagent_archive_count", 0),
+        "timestamp": _utc_now().isoformat(),
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    else:
+        print(f"Cleanup complete: {archived} archived, {skipped} kept, {errors} errors")
+        if args.dry_run:
+            print("(dry-run mode — no files were moved)")
     # NOTE: Lessons compilation is now handled in real-time by the coordinator
     # (nanobot/runtime/lessons.py :: update_lessons_from_cycle) — no batch compile needed.
     return 0
 
 
+def run_self_tests() -> int:
+    """Self-test suite for cleanup_subagent_queue.py."""
+    import shutil
+    import tempfile
+    import time
+
+    passed = 0
+    failed = 0
+
+    def check(name: str, condition: bool, detail: str = "") -> None:
+        nonlocal passed, failed
+        if condition:
+            passed += 1
+            print(f"  PASS: {name}")
+        else:
+            failed += 1
+            print(f"  FAIL: {name} — {detail}")
+
+    # --- Test _utc_now ---
+    now = _utc_now()
+    check("_utc_now returns datetime", isinstance(now, datetime))
+    check("_utc_now is timezone-aware", now.tzinfo is not None)
+
+    # --- Test _parse_timestamp ---
+    ts = _parse_timestamp("2026-01-01T12:00:00Z")
+    check("_parse_timestamp parses ISO with Z", ts is not None)
+    check("_parse_timestamp Z gives correct year", ts is not None and ts.year == 2026)
+
+    ts2 = _parse_timestamp("2026-01-01T12:00:00+00:00")
+    check("_parse_timestamp parses ISO with offset", ts2 is not None)
+
+    check("_parse_timestamp None returns None", _parse_timestamp(None) is None)
+    check("_parse_timestamp empty returns None", _parse_timestamp("") is None)
+    check("_parse_timestamp invalid returns None", _parse_timestamp("not-a-date") is None)
+
+    # --- Test archival logic with temp directory ---
+    tmpdir = tempfile.mkdtemp(prefix="cleanup_test_")
+    try:
+        state_root = Path(tmpdir)
+        requests_dir = state_root / "subagents" / "requests"
+        results_dir = state_root / "subagents" / "results"
+        subagents_root = state_root / "subagents"
+        archive_dir = state_root / "subagents" / "archive"
+        health_path = state_root / "current_health.json"
+
+        requests_dir.mkdir(parents=True, exist_ok=True)
+        results_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create a stale request file (older than 24h)
+        stale_file = requests_dir / "stale_req.json"
+        stale_file.write_text(json.dumps({"request_id": "stale-1", "created_at": "2025-01-01T00:00:00Z"}))
+        # Set mtime to 48 hours ago
+        old_time = time.time() - (48 * 3600)
+        os.utime(stale_file, (old_time, old_time))
+
+        # Create a fresh request file
+        fresh_file = requests_dir / "fresh_req.json"
+        fresh_file.write_text(json.dumps({"request_id": "fresh-1", "created_at": _utc_now().isoformat()}))
+
+        # Create a stale result file
+        stale_result = results_dir / "stale_result.json"
+        stale_result.write_text(json.dumps({"result_id": "stale-r1"}))
+        os.utime(stale_result, (old_time, old_time))
+
+        # Create a file in subagents root
+        stale_root = subagents_root / "stale_root.json"
+        stale_root.write_text(json.dumps({"id": "root-stale"}))
+        os.utime(stale_root, (old_time, old_time))
+
+        # Run cleanup with --hours 24
+        import sys
+        old_argv = sys.argv
+        sys.argv = ["cleanup_subagent_queue.py", "--hours", "24", "--state-root", tmpdir]
+        try:
+            rc = main()
+        finally:
+            sys.argv = old_argv
+
+        check("main returns 0", rc == 0)
+        check("stale request archived", not stale_file.exists())
+        check("stale request in archive", (archive_dir / "stale_req.json").exists())
+        check("fresh request kept", fresh_file.exists())
+        check("stale result archived", not stale_result.exists())
+        check("stale result in archive", (archive_dir / "stale_result.json").exists())
+        check("stale root file archived", not stale_root.exists())
+        check("stale root in archive", (archive_dir / "stale_root.json").exists())
+
+        # Check health file was written
+        check("health file exists", health_path.exists())
+        if health_path.exists():
+            health = json.loads(health_path.read_text())
+            check("health has cleanup count", "last_subagent_cleanup_count" in health)
+            check("health cleanup count is 3", health.get("last_subagent_cleanup_count") == 3)
+            check("health has timestamp", "last_subagent_cleanup_timestamp" in health)
+            check("health has archive count", "subagent_archive_count" in health)
+            check("health has remaining count", "subagent_requests_remaining" in health)
+            check("health has queue_count", "subagent_queue_count" in health)
+            check("health queue_count is 1", health.get("subagent_queue_count") == 1)  # only fresh_req.json remains
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    # --- Test dry-run mode ---
+    tmpdir2 = tempfile.mkdtemp(prefix="cleanup_dryrun_")
+    try:
+        state_root2 = Path(tmpdir2)
+        requests_dir2 = state_root2 / "subagents" / "requests"
+        requests_dir2.mkdir(parents=True, exist_ok=True)
+
+        dry_stale = requests_dir2 / "dry_stale.json"
+        dry_stale.write_text(json.dumps({"id": "dry-1"}))
+        old_time2 = time.time() - (48 * 3600)
+        os.utime(dry_stale, (old_time2, old_time2))
+
+        old_argv = sys.argv
+        sys.argv = ["cleanup_subagent_queue.py", "--hours", "24", "--dry-run", "--state-root", tmpdir2]
+        try:
+            rc = main()
+        finally:
+            sys.argv = old_argv
+
+        check("dry-run returns 0", rc == 0)
+        check("dry-run keeps file in place", dry_stale.exists())
+        check("dry-run does not create archive", not (state_root2 / "subagents" / "archive").exists() or
+              len(list((state_root2 / "subagents" / "archive").glob("*.json"))) == 0)
+    finally:
+        shutil.rmtree(tmpdir2, ignore_errors=True)
+
+    # --- Test empty state directory ---
+    tmpdir3 = tempfile.mkdtemp(prefix="cleanup_empty_")
+    try:
+        state_root3 = Path(tmpdir3)
+        # No subagents directory at all
+        old_argv = sys.argv
+        sys.argv = ["cleanup_subagent_queue.py", "--hours", "24", "--state-root", tmpdir3]
+        try:
+            rc = main()
+        finally:
+            sys.argv = old_argv
+
+        check("empty state returns 0", rc == 0)
+        check("empty state creates health file", (state_root3 / "current_health.json").exists())
+    finally:
+        shutil.rmtree(tmpdir3, ignore_errors=True)
+
+    # --- Test --json output mode ---
+    tmpdir4 = tempfile.mkdtemp(prefix="cleanup_json_")
+    try:
+        state_root4 = Path(tmpdir4)
+        requests_dir4 = state_root4 / "subagents" / "requests"
+        requests_dir4.mkdir(parents=True, exist_ok=True)
+
+        json_stale = requests_dir4 / "json_stale.json"
+        json_stale.write_text(json.dumps({"id": "json-1"}))
+        old_time4 = time.time() - (48 * 3600)
+        os.utime(json_stale, (old_time4, old_time4))
+
+        old_argv = sys.argv
+        sys.argv = ["cleanup_subagent_queue.py", "--hours", "24", "--json", "--state-root", tmpdir4]
+        try:
+            rc = main()
+        finally:
+            sys.argv = old_argv
+
+        check("json mode returns 0", rc == 0)
+        check("json mode archives stale file", not json_stale.exists())
+    finally:
+        shutil.rmtree(tmpdir4, ignore_errors=True)
+
+    # --- Test count-based archival (exceeds max-queue) ---
+    tmpdir5 = tempfile.mkdtemp(prefix="cleanup_count_")
+    try:
+        state_root5 = Path(tmpdir5)
+        requests_dir5 = state_root5 / "subagents" / "requests"
+        requests_dir5.mkdir(parents=True, exist_ok=True)
+
+        # Create 5 fresh files (all recent, so age-based won't touch them)
+        for i in range(5):
+            f = requests_dir5 / f"count_{i}.json"
+            f.write_text(json.dumps({"id": f"count-{i}"}))
+
+        old_argv = sys.argv
+        sys.argv = ["cleanup_subagent_queue.py", "--hours", "24", "--max-queue", "2", "--state-root", tmpdir5]
+        try:
+            rc = main()
+        finally:
+            sys.argv = old_argv
+
+        check("count-based returns 0", rc == 0)
+        remaining = len(list(requests_dir5.glob("*.json")))
+        check("count-based reduces to max-queue", remaining == 2)
+        archived_count = len(list((state_root5 / "subagents" / "archive").glob("*.json")))
+        check("count-based archives excess", archived_count == 3)
+    finally:
+        shutil.rmtree(tmpdir5, ignore_errors=True)
+
+    print(f"\nSelf-tests: {passed} passed, {failed} failed out of {passed + failed}")
+    return 1 if failed > 0 else 0
+
+
 if __name__ == "__main__":
+    import sys as _sys
+    if len(_sys.argv) > 1 and _sys.argv[1] == "--test":
+        raise SystemExit(run_self_tests())
     raise SystemExit(main())

--- a/scripts/cycle_logger.py
+++ b/scripts/cycle_logger.py
@@ -5,6 +5,10 @@ cycle_logger.py — prepend one-line cycle summary to memory/HISTORY.md (newest-
 Usage (from eeebot-self-evolving repo root):
     python3 scripts/cycle_logger.py --test
     python3 scripts/cycle_logger.py --cycle CYCLE_ID --action "feat: did X" --files scripts/foo.py
+    python3 scripts/cycle_logger.py --list [--count N] [--json]
+    python3 scripts/cycle_logger.py --dedup [--dry-run]
+    python3 scripts/cycle_logger.py --compact [--dry-run]
+    python3 scripts/cycle_logger.py --stats [--json]
 
 Rules:
 - Duplicate cycle_id entries are silently skipped.
@@ -14,11 +18,18 @@ Rules:
 from __future__ import annotations
 import argparse
 import datetime
+import json
+import re
 import sys
 from pathlib import Path
 
 
 HISTORY_FILE = "memory/HISTORY.md"
+_CYCLE_RE = re.compile(r"^\- (\d{4}-\d{2}-\d{2}):\s*\[([^\]]+)\]\s*(.+)$")
+_BRACKET_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})\]\s*(.+)$")
+_VERIFIED_RE = re.compile(
+    r"(?i)(verified|confirmed|already\s+implemented|no\s+changes\s+needed)"
+)
 
 
 def append_cycle_summary(
@@ -49,6 +60,183 @@ def append_cycle_summary(
     return True
 
 
+def list_cycles(repo_root: str | Path, count: int | None = None) -> list[dict]:
+    """
+    Parse HISTORY.md and return a list of cycle entries (newest-first).
+
+    Each entry: {"date": str, "cycle_id": str, "action": str}
+    """
+    root = Path(repo_root)
+    hist = root / HISTORY_FILE
+    if not hist.exists():
+        return []
+
+    entries: list[dict] = []
+    for line in hist.read_text(encoding="utf-8").splitlines():
+        m = _CYCLE_RE.match(line.strip())
+        if m:
+            entries.append({"date": m.group(1), "cycle_id": m.group(2), "action": m.group(3)})
+    return entries[:count] if count else entries
+
+
+def dedup_cycles(repo_root: str | Path, dry_run: bool = False) -> dict:
+    """
+    Remove duplicate cycle entries from HISTORY.md, keeping the first (newest) occurrence.
+
+    Returns {"total": int, "duplicates_removed": int, "kept": int, "dry_run": bool}.
+    """
+    root = Path(repo_root)
+    hist = root / HISTORY_FILE
+    if not hist.exists():
+        return {"total": 0, "duplicates_removed": 0, "kept": 0, "dry_run": dry_run}
+
+    lines = hist.read_text(encoding="utf-8").splitlines(keepends=True)
+    seen: set[str] = set()
+    kept_lines: list[str] = []
+    duplicates_removed = 0
+
+    for line in lines:
+        m = _CYCLE_RE.match(line.strip())
+        if m:
+            cycle_id = m.group(2)
+            if cycle_id in seen:
+                duplicates_removed += 1
+                continue
+            seen.add(cycle_id)
+        kept_lines.append(line)
+
+    result = {
+        "total": len(lines),
+        "duplicates_removed": duplicates_removed,
+        "kept": len(kept_lines),
+        "dry_run": dry_run,
+    }
+
+    if not dry_run and duplicates_removed > 0:
+        hist.write_text("".join(kept_lines), encoding="utf-8")
+
+    return result
+
+
+def compact_history(repo_root: str | Path, dry_run: bool = False, max_kept: int = 3) -> dict:
+    """
+    Collapse repeated verification entries for the same task into a single summary line.
+
+    Lines that match the "verified/confirmed/already implemented" pattern for the same
+    priority/task are collapsed into one entry: the first (newest) occurrence is kept,
+    and a count of collapsed entries is appended.
+
+    Returns {"total": int, "collapsed": int, "kept": int, "dry_run": bool}.
+    """
+    root = Path(repo_root)
+    hist = root / HISTORY_FILE
+    if not hist.exists():
+        return {"total": 0, "collapsed": 0, "kept": 0, "dry_run": dry_run}
+
+    lines = hist.read_text(encoding="utf-8").splitlines(keepends=True)
+    if not lines:
+        return {"total": 0, "collapsed": 0, "kept": 0, "dry_run": dry_run}
+
+    # Group lines by task/priority key
+    # Extract a "task key" from each line — e.g. "Priority 5" or "cycle_logger.py"
+    def _task_key(line: str) -> str | None:
+        # Try to extract "Priority N" or a script name
+        m_priority = re.search(r"Priority\s+(\d+)", line, re.IGNORECASE)
+        if m_priority:
+            return f"Priority {m_priority.group(1)}"
+        m_script = re.search(r"(scripts/\w+\.py)", line)
+        if m_script:
+            return m_script.group(1)
+        return None
+
+    # Identify "verification-only" lines (no real code change)
+    def _is_verification_only(line: str) -> bool:
+        return bool(_VERIFIED_RE.search(line))
+
+    # Process: keep non-verification lines, collapse verification lines by task key
+    kept_lines: list[str] = []
+    task_groups: dict[str, list[str]] = {}  # task_key -> list of verification lines
+    collapsed_count = 0
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            kept_lines.append(line)
+            continue
+
+        key = _task_key(stripped)
+        if key and _is_verification_only(stripped):
+            task_groups.setdefault(key, []).append(line)
+        else:
+            kept_lines.append(line)
+
+    # For each task group, keep the first (newest) entry and append a count
+    for key, group_lines in task_groups.items():
+        if len(group_lines) <= 1:
+            kept_lines.append(group_lines[0])
+        else:
+            # Keep the first (newest) line, append count
+            first_line = group_lines[0].rstrip("\n")
+            suffix = f" (+{len(group_lines) - 1} more verifications)"
+            kept_lines.append(first_line + suffix + "\n")
+            collapsed_count += len(group_lines) - 1
+
+    result = {
+        "total": len(lines),
+        "collapsed": collapsed_count,
+        "kept": len(kept_lines),
+        "dry_run": dry_run,
+    }
+
+    if not dry_run and collapsed_count > 0:
+        hist.write_text("".join(kept_lines), encoding="utf-8")
+
+    return result
+
+
+def cycle_stats(repo_root: str | Path) -> dict:
+    """
+    Compute statistics about HISTORY.md cycle entries.
+
+    Returns dict with: total_lines, cycle_entries, unique_cycles,
+    duplicates, date_range, top_actions.
+    """
+    root = Path(repo_root)
+    hist = root / HISTORY_FILE
+    if not hist.exists():
+        return {
+            "total_lines": 0, "cycle_entries": 0, "unique_cycles": 0,
+            "duplicates": 0, "date_range": None, "top_actions": [],
+        }
+
+    text = hist.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    entries = list_cycles(root)
+    cycle_ids = [e["cycle_id"] for e in entries]
+    unique = set(cycle_ids)
+
+    dates = [e["date"] for e in entries if e["date"]]
+    date_range = None
+    if dates:
+        date_range = {"earliest": min(dates), "latest": max(dates)}
+
+    # Top actions (by frequency of prefix before first paren or long tail)
+    from collections import Counter
+    action_prefixes: Counter = Counter()
+    for e in entries:
+        act = e["action"].split("(")[0].strip().rstrip("—–-")
+        action_prefixes[act] += 1
+
+    return {
+        "total_lines": len(lines),
+        "cycle_entries": len(entries),
+        "unique_cycles": len(unique),
+        "duplicates": len(entries) - len(unique),
+        "date_range": date_range,
+        "top_actions": action_prefixes.most_common(5),
+    }
+
+
 def _self_test(repo_root: Path) -> None:
     import tempfile, shutil
     tmp = Path(tempfile.mkdtemp())
@@ -73,22 +261,134 @@ def _self_test(repo_root: Path) -> None:
         assert ok3
         final = (tmp / HISTORY_FILE).read_text()
         assert final.count("cycle-") == 2
-        lines = [l for l in final.splitlines() if l.strip()]
+        lines = [ln for ln in final.splitlines() if ln.strip()]
         assert "cycle-xyz999" in lines[0], f"Newest must be first line, got: {lines[0]}"
         assert "cycle-abc123" in lines[1], f"Older must be second line, got: {lines[1]}"
 
-        print("PASS: 3/3 self-tests passed (newest-first order verified)")
+        # Test list_cycles
+        entries = list_cycles(tmp)
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}"
+        assert entries[0]["cycle_id"] == "cycle-xyz999"
+        assert entries[1]["cycle_id"] == "cycle-abc123"
+
+        # Test list_cycles with count
+        entries_1 = list_cycles(tmp, count=1)
+        assert len(entries_1) == 1
+        assert entries_1[0]["cycle_id"] == "cycle-xyz999"
+
+        # Test list_cycles on empty
+        assert list_cycles(tmp / "nonexistent") == []
+
+        # Test dedup_cycles — create file with duplicate cycle_ids
+        (tmp / HISTORY_FILE).write_text(
+            "- 2026-07-01: [cycle-dup1] first\n"
+            "- 2026-07-02: [cycle-dup2] unique\n"
+            "- 2026-07-03: [cycle-dup1] duplicate\n"
+            "- 2026-07-04: [cycle-dup3] another\n"
+            "- 2026-07-05: [cycle-dup2] also duplicate\n",
+            encoding="utf-8",
+        )
+        # Dry run first
+        res = dedup_cycles(tmp, dry_run=True)
+        assert res["duplicates_removed"] == 2, f"Expected 2 dups, got {res['duplicates_removed']}"
+        assert res["kept"] == 3
+        assert res["dry_run"] is True
+        # File should be unchanged after dry run
+        assert (tmp / HISTORY_FILE).read_text().count("cycle-dup1") == 2
+
+        # Actual dedup
+        res2 = dedup_cycles(tmp, dry_run=False)
+        assert res2["duplicates_removed"] == 2
+        assert res2["dry_run"] is False
+        final_text = (tmp / HISTORY_FILE).read_text()
+        assert final_text.count("cycle-dup1") == 1, "Should keep only first occurrence"
+        assert final_text.count("cycle-dup2") == 1
+        assert final_text.count("cycle-dup3") == 1
+        lines_after = [ln for ln in final_text.splitlines() if ln.strip()]
+        assert len(lines_after) == 3, f"Expected 3 lines, got {len(lines_after)}"
+
+        # Dedup on empty file
+        (tmp / HISTORY_FILE).write_text("", encoding="utf-8")
+        res3 = dedup_cycles(tmp)
+        assert res3["duplicates_removed"] == 0
+        assert res3["kept"] == 0
+
+        # Test compact_history — create file with repeated verification entries
+        (tmp / HISTORY_FILE).write_text(
+            "- 2026-07-01: [cycle-v1] feat: added X (files: scripts/x.py)\n"
+            "- 2026-07-02: [cycle-v2] chore: confirm Priority 5 (cycle_logger.py) verified for cycle-abc — 9/9 self-tests pass\n"
+            "- 2026-07-03: [cycle-v3] chore: confirm Priority 5 (cycle_logger.py) verified for cycle-def — 9/9 self-tests pass\n"
+            "- 2026-07-04: [cycle-v4] chore: confirm Priority 5 (cycle_logger.py) verified for cycle-ghi — 9/9 self-tests pass\n"
+            "- 2026-07-05: [cycle-v5] fix: corrected Y (files: scripts/y.py)\n",
+            encoding="utf-8",
+        )
+        # Dry run first
+        res = compact_history(tmp, dry_run=True)
+        assert res["collapsed"] == 2, f"Expected 2 collapsed, got {res['collapsed']}"
+        assert res["dry_run"] is True
+        # File should be unchanged after dry run
+        assert (tmp / HISTORY_FILE).read_text().count("cycle-v") == 5
+
+        # Actual compact
+        res2 = compact_history(tmp, dry_run=False)
+        assert res2["collapsed"] == 2
+        assert res2["dry_run"] is False
+        final_text = (tmp / HISTORY_FILE).read_text()
+        # Should have 3 lines: feat, chore (with +2 suffix), fix
+        lines_after = [ln for ln in final_text.splitlines() if ln.strip()]
+        assert len(lines_after) == 3, f"Expected 3 lines, got {len(lines_after)}: {lines_after}"
+        # The compacted line should mention "+2 more verifications"
+        assert "+2 more verifications" in final_text, f"Missing verification count in: {final_text}"
+        # Non-verification lines should be preserved
+        assert "feat: added X" in final_text
+        assert "fix: corrected Y" in final_text
+
+        # Compact on empty file
+        (tmp / HISTORY_FILE).write_text("", encoding="utf-8")
+        res3 = compact_history(tmp)
+        assert res3["collapsed"] == 0
+        assert res3["kept"] == 0
+
+        # Test cycle_stats — restore file with entries first
+        (tmp / HISTORY_FILE).write_text(
+            "- 2026-07-01: [cycle-s1] action A\n"
+            "- 2026-07-02: [cycle-s2] action B\n"
+            "- 2026-07-03: [cycle-s3] action C\n",
+            encoding="utf-8",
+        )
+        stats = cycle_stats(tmp)
+        assert stats["cycle_entries"] == 3, f"Expected 3 entries, got {stats['cycle_entries']}"
+        assert stats["unique_cycles"] == 3
+        assert stats["duplicates"] == 0
+        assert stats["date_range"] is not None
+        assert stats["date_range"]["earliest"] == "2026-07-01"
+        assert stats["date_range"]["latest"] == "2026-07-03"
+
+        # Stats on empty
+        (tmp / HISTORY_FILE).write_text("", encoding="utf-8")
+        stats_empty = cycle_stats(tmp)
+        assert stats_empty["cycle_entries"] == 0
+        assert stats_empty["date_range"] is None
+
+        print("PASS: 14/14 self-tests passed (newest-first + list_cycles + dedup + compact + stats verified)")
     finally:
         shutil.rmtree(tmp)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Prepend cycle summary to HISTORY.md (newest-first)")
+    parser = argparse.ArgumentParser(description="Prepend cycle summary to HISTORY.md (newest-first), dedup, compact, or show stats")
     parser.add_argument("--repo-root", default=".", help="Path to eeebot-self-evolving repo")
     parser.add_argument("--cycle", help="Cycle ID")
     parser.add_argument("--action", help="One-line description of what was done")
     parser.add_argument("--files", nargs="*", default=[], help="Files changed")
     parser.add_argument("--test", action="store_true", help="Run self-tests and exit")
+    parser.add_argument("--list", action="store_true", help="List recent cycle entries")
+    parser.add_argument("--count", type=int, default=None, help="Limit number of entries (--list)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON (--list)")
+    parser.add_argument("--dedup", action="store_true", help="Remove duplicate cycle entries from HISTORY.md")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without writing (--dedup)")
+    parser.add_argument("--stats", action="store_true", help="Show HISTORY.md statistics")
+    parser.add_argument("--compact", action="store_true", help="Collapse repeated verification entries in HISTORY.md")
     args = parser.parse_args()
 
     root = Path(args.repo_root).resolve()
@@ -97,8 +397,48 @@ def main() -> None:
         _self_test(root)
         sys.exit(0)
 
+    if args.dedup:
+        result = dedup_cycles(root, dry_run=args.dry_run)
+        mode = "DRY RUN" if result["dry_run"] else "DEDUP"
+        print(f"[{mode}] total={result['total']}, duplicates_removed={result['duplicates_removed']}, kept={result['kept']}")
+        sys.exit(0)
+
+    if args.list:
+        entries = list_cycles(root, count=args.count)
+        if args.json:
+            print(json.dumps(entries, indent=2))
+        else:
+            if not entries:
+                print("No cycle entries found.")
+            for e in entries:
+                print(f"- {e['date']}: [{e['cycle_id']}] {e['action']}")
+        sys.exit(0)
+
+    if args.stats:
+        result = cycle_stats(root)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"Lines: {result['total_lines']}")
+            print(f"Cycle entries: {result['cycle_entries']}")
+            print(f"Unique cycles: {result['unique_cycles']}")
+            print(f"Duplicates: {result['duplicates']}")
+            if result["date_range"]:
+                print(f"Date range: {result['date_range']['earliest']} to {result['date_range']['latest']}")
+            if result["top_actions"]:
+                print("Top actions:")
+                for act, cnt in result["top_actions"]:
+                    print(f"  {cnt}x {act}")
+        sys.exit(0)
+
+    if args.compact:
+        result = compact_history(root, dry_run=args.dry_run)
+        mode = "DRY RUN" if result["dry_run"] else "COMPACT"
+        print(f"[{mode}] total={result['total']}, collapsed={result['collapsed']}, kept={result['kept']}")
+        sys.exit(0)
+
     if not args.cycle or not args.action:
-        parser.error("--cycle and --action are required unless --test is given")
+        parser.error("--cycle and --action are required unless --test, --list, --stats, or --dedup is given")
 
     written = append_cycle_summary(root, args.cycle, args.action, args.files or None)
     if written:

--- a/tests/test_cleanup_subagent_queue.py
+++ b/tests/test_cleanup_subagent_queue.py
@@ -1,0 +1,166 @@
+"""
+Tests for scripts/cleanup_subagent_queue.py — harvested enhancements (issue #672):
+- --max-queue N: count-based archival once age-based cleanup still leaves >N files.
+- --json: machine-readable output mode.
+- _METADATA_FILES exclusion: metadata files are never counted/archived as queue entries.
+"""
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    """Import scripts/cleanup_subagent_queue.py as a module without running __main__."""
+    script_path = Path(__file__).parent.parent / "scripts" / "cleanup_subagent_queue.py"
+    spec = importlib.util.spec_from_file_location("cleanup_subagent_queue", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def cleanup_mod():
+    return _load_module()
+
+
+def _run_main(cleanup_mod, argv):
+    old_argv = sys.argv
+    sys.argv = ["cleanup_subagent_queue.py"] + argv
+    try:
+        return cleanup_mod.main()
+    finally:
+        sys.argv = old_argv
+
+
+def _make_fresh_file(path: Path, name: str) -> Path:
+    f = path / name
+    f.write_text(json.dumps({"id": name}))
+    return f
+
+
+def _age_file(path: Path, hours: float) -> None:
+    old_time = time.time() - (hours * 3600)
+    os.utime(path, (old_time, old_time))
+
+
+def test_max_queue_count_based_archival(cleanup_mod, tmp_path):
+    """After age-based cleanup, if more than --max-queue files remain, oldest are archived."""
+    requests_dir = tmp_path / "subagents" / "requests"
+    requests_dir.mkdir(parents=True)
+
+    # 5 fresh files — age-based cleanup won't touch any of them.
+    files = []
+    for i in range(5):
+        f = _make_fresh_file(requests_dir, f"req_{i}.json")
+        files.append(f)
+        # Stagger mtimes so ordering (oldest-first) is deterministic.
+        os.utime(f, (time.time() - (5 - i), time.time() - (5 - i)))
+
+    rc = _run_main(
+        cleanup_mod,
+        ["--hours", "24", "--max-queue", "2", "--state-root", str(tmp_path)],
+    )
+
+    assert rc == 0
+    remaining = list(requests_dir.glob("*.json"))
+    assert len(remaining) == 2
+
+    archive_dir = tmp_path / "subagents" / "archive"
+    archived = list(archive_dir.glob("*.json"))
+    assert len(archived) == 3
+    # The oldest three (req_0, req_1, req_2) should have been archived.
+    archived_names = {p.name for p in archived}
+    assert archived_names == {"req_0.json", "req_1.json", "req_2.json"}
+
+
+def test_max_queue_no_op_when_under_limit(cleanup_mod, tmp_path):
+    requests_dir = tmp_path / "subagents" / "requests"
+    requests_dir.mkdir(parents=True)
+    _make_fresh_file(requests_dir, "req_only.json")
+
+    rc = _run_main(
+        cleanup_mod,
+        ["--hours", "24", "--max-queue", "9", "--state-root", str(tmp_path)],
+    )
+
+    assert rc == 0
+    assert len(list(requests_dir.glob("*.json"))) == 1
+
+
+def test_metadata_files_excluded_from_queue_and_archival(cleanup_mod, tmp_path):
+    """archive_latest.json, queue_index.json, index.json must never be archived or counted."""
+    subagents_root = tmp_path / "subagents"
+    subagents_root.mkdir(parents=True)
+
+    metadata_names = ["archive_latest.json", "queue_index.json", "index.json"]
+    for name in metadata_names:
+        f = _make_fresh_file(subagents_root, name)
+        _age_file(f, 48)  # old enough to be archived if it were a queue entry
+
+    rc = _run_main(
+        cleanup_mod,
+        ["--hours", "24", "--max-queue", "0", "--state-root", str(tmp_path)],
+    )
+
+    assert rc == 0
+    # Metadata files must remain in place, untouched.
+    for name in metadata_names:
+        assert (subagents_root / name).exists()
+
+    archive_dir = subagents_root / "archive"
+    if archive_dir.exists():
+        archived_names = {p.name for p in archive_dir.glob("*.json")}
+        assert archived_names.isdisjoint(set(metadata_names))
+
+    health = json.loads((tmp_path / "current_health.json").read_text())
+    assert health["subagent_queue_count"] == 0
+
+
+def test_json_output_mode(cleanup_mod, tmp_path, capsys):
+    requests_dir = tmp_path / "subagents" / "requests"
+    requests_dir.mkdir(parents=True)
+    f = _make_fresh_file(requests_dir, "stale.json")
+    _age_file(f, 48)
+
+    rc = _run_main(
+        cleanup_mod,
+        ["--hours", "24", "--json", "--state-root", str(tmp_path)],
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert payload["archived"] == 1
+    assert payload["kept"] == 0
+    assert payload["errors"] == 0
+    assert payload["dry_run"] is False
+    assert "subagent_queue_count" in payload
+    assert "subagent_archive_count" in payload
+    assert "timestamp" in payload
+
+
+def test_json_output_mode_dry_run(cleanup_mod, tmp_path, capsys):
+    requests_dir = tmp_path / "subagents" / "requests"
+    requests_dir.mkdir(parents=True)
+    f = _make_fresh_file(requests_dir, "stale.json")
+    _age_file(f, 48)
+
+    rc = _run_main(
+        cleanup_mod,
+        ["--hours", "24", "--json", "--dry-run", "--state-root", str(tmp_path)],
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Dry-run mode still prints the "WOULD ARCHIVE" line before the JSON blob;
+    # the JSON blob itself must be the last, valid, parseable JSON payload.
+    json_start = captured.out.rindex("{")
+    payload = json.loads(captured.out[json_start:])
+    assert payload["dry_run"] is True
+    assert f.exists()  # nothing actually moved

--- a/tests/test_cycle_logger.py
+++ b/tests/test_cycle_logger.py
@@ -1,0 +1,183 @@
+"""
+Tests for scripts/cycle_logger.py — harvested enhancements (issue #672):
+- --list [--count N] [--json]: list recent HISTORY.md entries.
+- --dedup [--dry-run]: remove duplicate cycle entries.
+- --compact [--dry-run]: collapse repeated verification entries.
+- --stats [--json]: summary statistics.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    """Import scripts/cycle_logger.py as a module without running __main__."""
+    script_path = Path(__file__).parent.parent / "scripts" / "cycle_logger.py"
+    spec = importlib.util.spec_from_file_location("cycle_logger", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def cycle_logger():
+    return _load_module()
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    (tmp_path / "memory").mkdir()
+    return tmp_path
+
+
+def _write_history(repo: Path, text: str) -> Path:
+    hist = repo / "memory" / "HISTORY.md"
+    hist.write_text(text, encoding="utf-8")
+    return hist
+
+
+def test_list_recent_entries(cycle_logger, repo):
+    cycle_logger.append_cycle_summary(repo, "cycle-1", "feat: added A")
+    cycle_logger.append_cycle_summary(repo, "cycle-2", "feat: added B")
+    cycle_logger.append_cycle_summary(repo, "cycle-3", "feat: added C")
+
+    entries = cycle_logger.list_cycles(repo)
+    assert len(entries) == 3
+    # Newest first.
+    assert entries[0]["cycle_id"] == "cycle-3"
+    assert entries[2]["cycle_id"] == "cycle-1"
+
+
+def test_list_with_count(cycle_logger, repo):
+    cycle_logger.append_cycle_summary(repo, "cycle-1", "feat: added A")
+    cycle_logger.append_cycle_summary(repo, "cycle-2", "feat: added B")
+
+    entries = cycle_logger.list_cycles(repo, count=1)
+    assert len(entries) == 1
+    assert entries[0]["cycle_id"] == "cycle-2"
+
+
+def test_list_empty_history(cycle_logger, repo):
+    assert cycle_logger.list_cycles(repo) == []
+
+
+def test_dedup_removes_duplicate(cycle_logger, repo):
+    _write_history(
+        repo,
+        "- 2026-07-01: [cycle-a] first\n"
+        "- 2026-07-02: [cycle-b] unique\n"
+        "- 2026-07-03: [cycle-a] duplicate\n",
+    )
+
+    result = cycle_logger.dedup_cycles(repo, dry_run=False)
+
+    assert result["duplicates_removed"] == 1
+    assert result["kept"] == 2
+    text = (repo / "memory" / "HISTORY.md").read_text()
+    assert text.count("cycle-a") == 1
+    assert "cycle-b" in text
+
+
+def test_dedup_dry_run_does_not_write(cycle_logger, repo):
+    original = (
+        "- 2026-07-01: [cycle-a] first\n"
+        "- 2026-07-03: [cycle-a] duplicate\n"
+    )
+    _write_history(repo, original)
+
+    result = cycle_logger.dedup_cycles(repo, dry_run=True)
+
+    assert result["duplicates_removed"] == 1
+    assert result["dry_run"] is True
+    assert (repo / "memory" / "HISTORY.md").read_text() == original
+
+
+def test_compact_collapses_verification_entries(cycle_logger, repo):
+    _write_history(
+        repo,
+        "- 2026-07-01: [cycle-v1] feat: added X (files: scripts/x.py)\n"
+        "- 2026-07-02: [cycle-v2] chore: confirm Priority 5 verified for cycle-abc — 9/9 self-tests pass\n"
+        "- 2026-07-03: [cycle-v3] chore: confirm Priority 5 verified for cycle-def — 9/9 self-tests pass\n"
+        "- 2026-07-04: [cycle-v4] fix: corrected Y (files: scripts/y.py)\n",
+    )
+
+    result = cycle_logger.compact_history(repo, dry_run=False)
+
+    assert result["collapsed"] == 1
+    text = (repo / "memory" / "HISTORY.md").read_text()
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    assert len(lines) == 3
+    assert "+1 more verifications" in text
+    assert "feat: added X" in text
+    assert "fix: corrected Y" in text
+
+
+def test_compact_dry_run_does_not_write(cycle_logger, repo):
+    original = (
+        "- 2026-07-01: [cycle-v1] chore: confirm Priority 5 verified — pass\n"
+        "- 2026-07-02: [cycle-v2] chore: confirm Priority 5 verified — pass\n"
+    )
+    _write_history(repo, original)
+
+    result = cycle_logger.compact_history(repo, dry_run=True)
+
+    assert result["collapsed"] == 1
+    assert (repo / "memory" / "HISTORY.md").read_text() == original
+
+
+def test_stats_summary(cycle_logger, repo):
+    _write_history(
+        repo,
+        "- 2026-07-01: [cycle-s1] action A\n"
+        "- 2026-07-02: [cycle-s2] action B\n"
+        "- 2026-07-03: [cycle-s3] action C\n",
+    )
+
+    stats = cycle_logger.cycle_stats(repo)
+
+    assert stats["cycle_entries"] == 3
+    assert stats["unique_cycles"] == 3
+    assert stats["duplicates"] == 0
+    assert stats["date_range"] == {"earliest": "2026-07-01", "latest": "2026-07-03"}
+
+
+def test_stats_json_via_cli(cycle_logger, repo, capsys):
+    cycle_logger.append_cycle_summary(repo, "cycle-1", "feat: added A")
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = ["cycle_logger.py", "--repo-root", str(repo), "--stats", "--json"]
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            cycle_logger.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["cycle_entries"] == 1
+
+
+def test_list_json_via_cli(cycle_logger, repo, capsys):
+    cycle_logger.append_cycle_summary(repo, "cycle-1", "feat: added A")
+    cycle_logger.append_cycle_summary(repo, "cycle-2", "feat: added B")
+
+    import sys
+
+    old_argv = sys.argv
+    sys.argv = ["cycle_logger.py", "--repo-root", str(repo), "--list", "--count", "1", "--json"]
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            cycle_logger.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert len(payload) == 1
+    assert payload[0]["cycle_id"] == "cycle-2"


### PR DESCRIPTION
## Summary

First upstream harvest (instance → product) from the self-evolving host,
tracked under #672. The eeepc instance repo (`ozand/eeebot-self-evolving`)
diverged from product's `nanobot/` core with no valuable core innovation to
harvest (confirmed in #672's divergence analysis — Bucket B is empty), but it
did independently improve two shared `scripts/` utilities that never made it
back into product. This PR ports those two enhancements.

### `scripts/cleanup_subagent_queue.py`
- `--max-queue N`: after age-based cleanup, if more than N files remain in the
  queue, archive the oldest ones (by mtime) until the count is at or below N.
- `--json`: machine-readable output mode (archived/kept/errors/dry_run/
  subagent_queue_count/subagent_archive_count/timestamp).
- `_METADATA_FILES` exclusion set (`archive_latest.json`, `queue_index.json`,
  `index.json`) — these are never counted or archived as queue entries.

### `scripts/cycle_logger.py`
- `--list [--count N] [--json]`: list recent `memory/HISTORY.md` entries.
- `--dedup [--dry-run]`: remove duplicate `cycle_id` entries, keeping the
  first (newest) occurrence.
- `--compact [--dry-run]`: collapse repeated verification-only entries for the
  same task/priority into a single line with a "+N more verifications" suffix.
- `--stats [--json]`: summary stats (total lines, cycle entries, unique
  cycles, duplicates, date range, top action prefixes).

### Merge approach
Diffed product's version against the instance's for both files first. Both
instance versions turned out to be clean supersets of product's — the diff
showed only additions (new flags/functions/self-tests), with none of
product's existing logic altered or removed. So the instance version was
taken as-is for each file rather than hand-porting hunks. No product-only
logic was lost.

The instance's own embedded `--test` self-test harnesses came along for the
ride (kept, since they're harmless and match the instance's own convention),
but they don't run in CI, so this PR adds real pytest coverage separately.

## Test plan

- [x] `tests/test_cleanup_subagent_queue.py` (new): `--max-queue` count-based
      archival, no-op when under the limit, `_METADATA_FILES` exclusion from
      both counting and archival, `--json` output shape (normal + dry-run).
- [x] `tests/test_cycle_logger.py` (new): `--list` (with/without `--count`,
      `--json`), `--dedup` (removes duplicate, dry-run leaves file untouched),
      `--compact` (collapses repeated verification lines, dry-run untouched),
      `--stats` (summary + JSON via CLI).
- [x] Full suite: `python -m pytest tests/ -q` → 1088 passed.
- [x] `ruff check` on touched files: fixed all *new* findings introduced by
      the ported code (module-scope metadata constant instead of a
      function-local uppercase name, import ordering, ambiguous `l` variable
      names). Pre-existing baseline findings (present on `origin/main` before
      this change) were left as-is, out of scope for this PR.

Part of #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)