### PR TITLE
feat: LLM call telemetry — per-call JSONL + report (#675)

### DIFF
--- a/docs/specs/self-evolving-runtime/spec.md
+++ b/docs/specs/self-evolving-runtime/spec.md
@@ -54,6 +54,39 @@ an open-ended chat session. The learning signal is the HADI arc
   minted with both `base_commit` and `candidate_patch_hash` null for a
   materialize-lane origin that has no verified diff.
 
+#### LLM call telemetry (issue #675)
+
+Every LLM call in nanobot goes through the single choke point
+`nanobot.providers.base.LLMProvider.chat_with_retry`. That call hooks
+`nanobot.observability.llm_telemetry.record_llm_call`, which appends one
+best-effort JSON line per call to `<dir>/YYYY-MM-DD.jsonl` (daily rotation),
+where `<dir>` resolves from `LLM_CALLS_DIR`, else `<STATE_DIR>/llm_calls`,
+else `~/.nanobot/llm_calls`. A telemetry failure never breaks the LLM call —
+the whole write path is wrapped and swallows any exception.
+
+Each line has: `ts` (UTC ISO-8601), `model`, `duration_ms`, `prompt_tokens`,
+`completion_tokens`, `total_tokens` (0 when the provider's `usage` dict omits
+a field), `finish_reason`, `retries` (transient-error retry attempts before
+this call returned), `cycle_id`, `component`.
+
+`cycle_id`/`component` are attributed via a `contextvars.ContextVar` that
+entry points set for the duration of their work:
+- `nanobot.runtime.bridge.main()` — `component=bridge`.
+- `nanobot.runtime.tool_harness.run_tool_harness_request()` —
+  `component=tool_harness` (propagated across the harness's dedicated thread
+  via `contextvars.copy_context()`, since a new thread does not inherit the
+  calling thread's context by default).
+- `nanobot.runtime.coordinator.run_self_evolving_cycle()` — `component=
+  coordinator`, wrapping the `execute_turn()` call where the cycle's own LLM
+  work happens.
+
+This JSONL complements (does not replace) the LiteLLM proxy's own spend/
+latency logs: the proxy has authoritative per-model cost; this file adds the
+cycle_id/component attribution the proxy lacks, so `scripts/llm_calls_report.py`
+can show per-model latency/token stats and per-cycle LLM wall-time (a
+utilization proxy for how much of a ~10-minute cycle is spent waiting on the
+LLM) — `--json` for machine consumption, human table by default.
+
 ### Roles
 - R9. The coordinator SHALL maintain goal alignment, backlog/prioritization,
   experiment contracts, subagent launches, evaluation, and durable state — and SHALL

--- a/nanobot/observability/__init__.py
+++ b/nanobot/observability/__init__.py
@@ -1,0 +1,7 @@
+"""Observability helpers for the nanobot runtime (issue #675).
+
+Currently just per-LLM-call telemetry (:mod:`nanobot.observability.llm_telemetry`).
+Kept intentionally small — no tracing/metrics framework, just a JSONL append
+that complements the LiteLLM proxy's own spend/latency logs with the
+cycle_id/component context the proxy doesn't have.
+"""

--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -1,0 +1,107 @@
+"""Per-LLM-call telemetry: one JSONL line per call through ``chat_with_retry``.
+
+Issue #675: the operator wants visibility into per-model speed/cost and how
+much of a self-evolving cycle's wall-time is actually spent waiting on the
+LLM. ``nanobot.providers.base.LLMProvider.chat_with_retry`` is the single
+choke point every LLM call in nanobot goes through, so that's where this
+module is hooked in.
+
+This module deliberately does very little:
+
+- a ``contextvars.ContextVar`` that entry points (bridge/tool_harness/
+  coordinator) set so calls can be attributed to a ``cycle_id``/``component``;
+- ``record_llm_call()``, which appends ONE JSON line to a daily-rotated file.
+
+No OpenTelemetry, no metrics DB, no cost computation (pricing lives in the
+LiteLLM proxy — this JSONL complements the proxy's own spend/latency logs by
+adding the cycle_id/component context the proxy lacks). Everything here is
+best-effort: a telemetry failure must never break the actual LLM call.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from contextvars import ContextVar, Token
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+_CALL_CONTEXT: ContextVar[dict[str, str] | None] = ContextVar("_llm_call_context", default=None)
+
+
+def set_call_context(cycle_id: str | None, component: str | None) -> Token:
+    """Set the current (cycle_id, component) attribution context.
+
+    Returns a token that must be passed to :func:`reset_call_context` to
+    restore whatever context was active before (so nested calls don't leak
+    into the caller's context once they finish).
+    """
+    return _CALL_CONTEXT.set({"cycle_id": cycle_id or "", "component": component or ""})
+
+
+def reset_call_context(token: Token) -> None:
+    """Restore the call context captured by the matching ``set_call_context``."""
+    with contextlib.suppress(Exception):
+        _CALL_CONTEXT.reset(token)
+
+
+@contextlib.contextmanager
+def call_context(cycle_id: str | None, component: str | None) -> Iterator[None]:
+    """Context manager form of :func:`set_call_context` / :func:`reset_call_context`."""
+    token = set_call_context(cycle_id, component)
+    try:
+        yield
+    finally:
+        reset_call_context(token)
+
+
+def _llm_calls_dir() -> Path:
+    env_dir = os.environ.get("LLM_CALLS_DIR", "").strip()
+    if env_dir:
+        return Path(env_dir)
+    state_dir = os.environ.get("STATE_DIR", "").strip()
+    if state_dir:
+        return Path(state_dir) / "llm_calls"
+    return Path.home() / ".nanobot" / "llm_calls"
+
+
+def record_llm_call(
+    *,
+    model: str | None,
+    duration_ms: float,
+    usage: dict[str, Any] | None,
+    finish_reason: str | None,
+    retries: int,
+) -> None:
+    """Append one JSONL line describing an LLM call. Best-effort — never raises.
+
+    Reads the ambient (cycle_id, component) context set by the caller's entry
+    point (see :func:`call_context`); both default to "" when unset.
+    """
+    try:
+        ctx = _CALL_CONTEXT.get() or {}
+        usage = usage or {}
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "model": model or "",
+            "duration_ms": round(duration_ms, 3),
+            "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+            "completion_tokens": int(usage.get("completion_tokens") or 0),
+            "total_tokens": int(usage.get("total_tokens") or 0),
+            "finish_reason": finish_reason or "",
+            "retries": int(retries),
+            "cycle_id": ctx.get("cycle_id") or "",
+            "component": ctx.get("component") or "",
+        }
+
+        out_dir = _llm_calls_dir()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        out_path = out_dir / f"{day}.jsonl"
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception:
+        # Telemetry must never break the LLM call it is observing.
+        pass

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -2,11 +2,14 @@
 
 import asyncio
 import json
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
 from loguru import logger
+
+from nanobot.observability.llm_telemetry import record_llm_call
 
 
 @dataclass
@@ -252,18 +255,36 @@ class LLMProvider(ABC):
             reasoning_effort=reasoning_effort, tool_choice=tool_choice,
         )
 
+        # Issue #675: chat_with_retry is the single choke point every LLM call
+        # goes through, so it's where per-call telemetry is recorded — on
+        # every return path (success, non-transient error, image-stripped
+        # retry, final exhausted-retries error).
+        call_start = time.monotonic()
+        resolved_model = model or self.get_default_model()
+
+        def _record(response: LLMResponse, retries: int) -> LLMResponse:
+            record_llm_call(
+                model=resolved_model,
+                duration_ms=(time.monotonic() - call_start) * 1000,
+                usage=response.usage,
+                finish_reason=response.finish_reason,
+                retries=retries,
+            )
+            return response
+
         for attempt, delay in enumerate(self._CHAT_RETRY_DELAYS, start=1):
             response = await self._safe_chat(**kw)
 
             if response.finish_reason != "error":
-                return response
+                return _record(response, attempt - 1)
 
             if not self._is_transient_error(response.content):
                 stripped = self._strip_image_content(messages)
                 if stripped is not None:
                     logger.warning("Non-transient LLM error with image content, retrying without images")
-                    return await self._safe_chat(**{**kw, "messages": stripped})
-                return response
+                    response = await self._safe_chat(**{**kw, "messages": stripped})
+                    return _record(response, attempt - 1)
+                return _record(response, attempt - 1)
 
             logger.warning(
                 "LLM transient error (attempt {}/{}), retrying in {}s: {}",
@@ -272,7 +293,8 @@ class LLMProvider(ABC):
             )
             await asyncio.sleep(delay)
 
-        return await self._safe_chat(**kw)
+        response = await self._safe_chat(**kw)
+        return _record(response, len(self._CHAT_RETRY_DELAYS))
 
     @abstractmethod
     def get_default_model(self) -> str:

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -29,6 +29,7 @@ from nanobot.agent.subagent import SubagentManager
 from nanobot.bus.queue import MessageBus
 from nanobot.cli.commands import _make_provider
 from nanobot.config.loader import load_config, set_config_path
+from nanobot.observability.llm_telemetry import set_call_context
 from nanobot.runtime.stop_guards import REVISION_CAP_DEFAULT, revision_outcome
 
 STATE_DIR = Path(os.environ.get('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state'))
@@ -752,6 +753,11 @@ async def main():
         return 0
 
     request_id = req.get('request_id') or req.get('verification_task_id') or str(req_path)
+    # Issue #675: attribute every LLM call this cycle makes to this bridge
+    # invocation. This process runs once per cycle (asyncio.run(main()) via
+    # cli_main()) and exits afterward, so there is no need to reset the
+    # context — it never outlives this process.
+    set_call_context(req.get('cycle_id') or request_id, "bridge")
     safe_id = request_id.replace('/', '_')[:120]
     handled_marker = BRIDGE_STATE_DIR / f'handled_{safe_id}.txt'
     if handled_marker.exists():

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from nanobot.observability.llm_telemetry import call_context
 from nanobot.runtime._io import read_json_safe as _safe_read_json
 from nanobot.runtime._io import utc_iso as _utc_iso
 from nanobot.runtime._io import utc_now as _utc_now
@@ -207,7 +208,10 @@ async def run_self_evolving_cycle(
     decision: str | None = None
     if approval_gate["state"] == "fresh":
         try:
-            execution_response = await execute_turn(selected_tasks)
+            # Issue #675: attribute this cycle's LLM calls (component=coordinator)
+            # for the duration of the actual work turn.
+            with call_context(cycle_id, "coordinator"):
+                execution_response = await execute_turn(selected_tasks)
             promotion_candidate_id = f"promotion-{uuid.uuid4().hex[:12]}"
             review_status = "not_ready_for_policy_review"
             decision = "not_ready_for_policy_review"

--- a/nanobot/runtime/tool_harness.py
+++ b/nanobot/runtime/tool_harness.py
@@ -18,6 +18,7 @@ here (those are gated to phase 2/3 per the design and issue #643's decision).
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import json
 import os
 import re
@@ -27,6 +28,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
+from nanobot.observability.llm_telemetry import call_context
 from nanobot.runtime._io import utc_iso as _utc_iso
 from nanobot.runtime.stop_guards import STOP_REASON_GATE_CLEAN
 from nanobot.runtime.stop_guards import derive_stop_reason as _derive_stop_reason
@@ -623,6 +625,10 @@ def _run_async(coro: Any) -> Any:
     (``coordinator.run_self_evolving_cycle``); ``asyncio.run()`` would raise
     in the latter case, so a running loop pushes the harness loop onto its
     own dedicated thread/event loop instead.
+
+    The dedicated thread starts with a fresh ``contextvars.Context`` by
+    default, which would silently drop the llm_telemetry call_context set by
+    the caller (issue #675); ``copy_context()`` carries it across.
     """
     try:
         asyncio.get_running_loop()
@@ -631,10 +637,11 @@ def _run_async(coro: Any) -> Any:
 
     result_box: dict[str, Any] = {}
     error_box: dict[str, BaseException] = {}
+    ctx = contextvars.copy_context()
 
     def _runner() -> None:
         try:
-            result_box["result"] = asyncio.run(coro)
+            result_box["result"] = ctx.run(asyncio.run, coro)
         except BaseException as exc:  # noqa: BLE001 - re-raised on the caller's thread
             error_box["error"] = exc
 
@@ -728,14 +735,17 @@ def run_tool_harness_request(
         {"role": "user", "content": _harness_task_prompt(request)},
     ]
 
-    result = _run_async(run_harness_loop(
-        provider,
-        model=resolved_model,
-        messages=messages,
-        ops=ops,
-        budget=budget,
-        journal_path=journal_path,
-    ))
+    # Issue #675: attribute the harness's LLM calls to this request's cycle.
+    cycle_id = str(request.get("cycle_id") or request.get("cycleId") or "")
+    with call_context(cycle_id, "tool_harness"):
+        result = _run_async(run_harness_loop(
+            provider,
+            model=resolved_model,
+            messages=messages,
+            ops=ops,
+            budget=budget,
+            journal_path=journal_path,
+        ))
 
     return {
         "ok": result["stop_reason"] == STOP_REASON_GATE_CLEAN,

--- a/scripts/llm_calls_report.py
+++ b/scripts/llm_calls_report.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+llm_calls_report.py — summarize the llm_calls/*.jsonl telemetry (issue #675).
+
+Reads the daily-rotated JSONL files written by
+``nanobot.observability.llm_telemetry.record_llm_call`` (one line per LLM
+call through ``chat_with_retry``) and aggregates:
+
+- per-model: count, avg/p50/p95 duration_ms, total tokens
+- per-cycle: total LLM wall-time (sum of duration_ms) — a utilization proxy
+  for how much of a self-evolving cycle is spent waiting on the LLM
+- overall totals
+
+Usage:
+    python3 scripts/llm_calls_report.py [--dir PATH] [--since YYYY-MM-DD] [--json]
+
+Defaults: --dir is $LLM_CALLS_DIR, else $STATE_DIR/llm_calls, else
+~/.nanobot/llm_calls (same resolution order as the writer).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _default_dir() -> Path:
+    env_dir = os.environ.get("LLM_CALLS_DIR", "").strip()
+    if env_dir:
+        return Path(env_dir)
+    state_dir = os.environ.get("STATE_DIR", "").strip()
+    if state_dir:
+        return Path(state_dir) / "llm_calls"
+    return Path.home() / ".nanobot" / "llm_calls"
+
+
+def load_records(directory: Path, since: str | None = None) -> list[dict[str, Any]]:
+    """Load and parse all JSONL records under *directory*, optionally filtered by day."""
+    records: list[dict[str, Any]] = []
+    if not directory.is_dir():
+        return records
+    for path in sorted(directory.glob("*.jsonl")):
+        if since and path.stem < since:
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
+    return records
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    k = (len(sorted_values) - 1) * pct
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = k - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate records into per-model, per-cycle, and overall summaries."""
+    per_model: dict[str, dict[str, Any]] = {}
+    per_cycle: dict[str, float] = {}
+    total_calls = 0
+    total_duration_ms = 0.0
+    total_tokens = 0
+
+    for rec in records:
+        model = rec.get("model") or "(unknown)"
+        duration_ms = float(rec.get("duration_ms") or 0.0)
+        tokens = int(rec.get("total_tokens") or 0)
+        cycle_id = rec.get("cycle_id") or ""
+
+        bucket = per_model.setdefault(model, {"count": 0, "durations": [], "total_tokens": 0})
+        bucket["count"] += 1
+        bucket["durations"].append(duration_ms)
+        bucket["total_tokens"] += tokens
+
+        if cycle_id:
+            per_cycle[cycle_id] = per_cycle.get(cycle_id, 0.0) + duration_ms
+
+        total_calls += 1
+        total_duration_ms += duration_ms
+        total_tokens += tokens
+
+    per_model_summary = {}
+    for model, bucket in per_model.items():
+        durations = sorted(bucket["durations"])
+        count = bucket["count"]
+        per_model_summary[model] = {
+            "count": count,
+            "avg_duration_ms": round(sum(durations) / count, 2) if count else 0.0,
+            "p50_duration_ms": round(_percentile(durations, 0.50), 2),
+            "p95_duration_ms": round(_percentile(durations, 0.95), 2),
+            "total_tokens": bucket["total_tokens"],
+        }
+
+    per_cycle_summary = {
+        cycle_id: round(total, 2)
+        for cycle_id, total in sorted(per_cycle.items(), key=lambda kv: kv[1], reverse=True)
+    }
+
+    return {
+        "totals": {
+            "calls": total_calls,
+            "duration_ms": round(total_duration_ms, 2),
+            "tokens": total_tokens,
+        },
+        "per_model": per_model_summary,
+        "per_cycle_duration_ms": per_cycle_summary,
+    }
+
+
+def _print_table(summary: dict[str, Any]) -> None:
+    totals = summary["totals"]
+    print(f"Total calls: {totals['calls']}  "
+          f"Total LLM wall-time: {totals['duration_ms']:.0f}ms  "
+          f"Total tokens: {totals['tokens']}")
+    print()
+
+    print("Per model:")
+    print(f"  {'model':<30} {'count':>6} {'avg_ms':>10} {'p50_ms':>10} {'p95_ms':>10} {'tokens':>10}")
+    for model, stats in sorted(summary["per_model"].items(), key=lambda kv: kv[1]["count"], reverse=True):
+        print(f"  {model:<30} {stats['count']:>6} {stats['avg_duration_ms']:>10.1f} "
+              f"{stats['p50_duration_ms']:>10.1f} {stats['p95_duration_ms']:>10.1f} {stats['total_tokens']:>10}")
+    print()
+
+    print("Per cycle (LLM wall-time, utilization proxy):")
+    if not summary["per_cycle_duration_ms"]:
+        print("  (no cycle_id attribution in this data)")
+    else:
+        for cycle_id, duration_ms in summary["per_cycle_duration_ms"].items():
+            print(f"  {cycle_id:<30} {duration_ms:>10.0f}ms")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", type=Path, default=None, help="llm_calls directory (default: env-resolved)")
+    parser.add_argument("--since", type=str, default=None, help="only include files from YYYY-MM-DD onward")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of a table")
+    args = parser.parse_args(argv)
+
+    directory = args.dir or _default_dir()
+    records = load_records(directory, since=args.since)
+    summary = aggregate(records)
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        _print_table(summary)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_llm_calls_report.py
+++ b/tests/test_llm_calls_report.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/llm_calls_report.py (issue #675)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    """Import scripts/llm_calls_report.py as a module without running __main__."""
+    script_path = Path(__file__).parent.parent / "scripts" / "llm_calls_report.py"
+    spec = importlib.util.spec_from_file_location("llm_calls_report", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def report_module():
+    return _load_module()
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def test_load_records_reads_all_jsonl_files(tmp_path, report_module):
+    _write_jsonl(tmp_path / "2026-07-01.jsonl", [{"model": "m1"}])
+    _write_jsonl(tmp_path / "2026-07-02.jsonl", [{"model": "m2"}, {"model": "m2"}])
+
+    records = report_module.load_records(tmp_path)
+    assert len(records) == 3
+
+
+def test_load_records_since_filters_by_day(tmp_path, report_module):
+    _write_jsonl(tmp_path / "2026-07-01.jsonl", [{"model": "m1"}])
+    _write_jsonl(tmp_path / "2026-07-05.jsonl", [{"model": "m2"}])
+
+    records = report_module.load_records(tmp_path, since="2026-07-03")
+    assert len(records) == 1
+    assert records[0]["model"] == "m2"
+
+
+def test_load_records_skips_malformed_lines(tmp_path, report_module):
+    path = tmp_path / "2026-07-01.jsonl"
+    path.write_text('{"model": "m1"}\nnot-json\n{"model": "m2"}\n', encoding="utf-8")
+
+    records = report_module.load_records(tmp_path)
+    assert len(records) == 2
+
+
+def test_load_records_missing_dir_returns_empty(tmp_path, report_module):
+    records = report_module.load_records(tmp_path / "does-not-exist")
+    assert records == []
+
+
+def test_aggregate_per_model_and_per_cycle(report_module):
+    records = [
+        {"model": "m1", "duration_ms": 100.0, "total_tokens": 10, "cycle_id": "c1"},
+        {"model": "m1", "duration_ms": 200.0, "total_tokens": 20, "cycle_id": "c1"},
+        {"model": "m2", "duration_ms": 50.0, "total_tokens": 5, "cycle_id": "c2"},
+    ]
+
+    summary = report_module.aggregate(records)
+
+    assert summary["totals"]["calls"] == 3
+    assert summary["totals"]["duration_ms"] == pytest.approx(350.0)
+    assert summary["totals"]["tokens"] == 35
+
+    assert summary["per_model"]["m1"]["count"] == 2
+    assert summary["per_model"]["m1"]["total_tokens"] == 30
+    assert summary["per_model"]["m1"]["avg_duration_ms"] == pytest.approx(150.0)
+
+    assert summary["per_model"]["m2"]["count"] == 1
+    assert summary["per_model"]["m2"]["total_tokens"] == 5
+
+    assert summary["per_cycle_duration_ms"]["c1"] == pytest.approx(300.0)
+    assert summary["per_cycle_duration_ms"]["c2"] == pytest.approx(50.0)
+
+
+def test_aggregate_handles_missing_cycle_id(report_module):
+    records = [{"model": "m1", "duration_ms": 10.0, "total_tokens": 1}]
+    summary = report_module.aggregate(records)
+    assert summary["per_cycle_duration_ms"] == {}
+
+
+def test_aggregate_empty_records(report_module):
+    summary = report_module.aggregate([])
+    assert summary["totals"]["calls"] == 0
+    assert summary["per_model"] == {}
+    assert summary["per_cycle_duration_ms"] == {}
+
+
+def test_main_json_output(tmp_path, report_module, capsys):
+    _write_jsonl(tmp_path / "2026-07-01.jsonl", [
+        {"model": "m1", "duration_ms": 10.0, "total_tokens": 1, "cycle_id": "c1"},
+    ])
+
+    rc = report_module.main(["--dir", str(tmp_path), "--json"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["totals"]["calls"] == 1
+
+
+def test_main_table_output(tmp_path, report_module, capsys):
+    _write_jsonl(tmp_path / "2026-07-01.jsonl", [
+        {"model": "m1", "duration_ms": 10.0, "total_tokens": 1, "cycle_id": "c1"},
+    ])
+
+    rc = report_module.main(["--dir", str(tmp_path)])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "Total calls: 1" in out
+    assert "m1" in out

--- a/tests/test_llm_telemetry.py
+++ b/tests/test_llm_telemetry.py
@@ -1,0 +1,128 @@
+"""Tests for nanobot.observability.llm_telemetry (issue #675)."""
+
+import json
+
+import pytest
+
+from nanobot.observability.llm_telemetry import (
+    call_context,
+    record_llm_call,
+    reset_call_context,
+    set_call_context,
+)
+
+
+def _read_jsonl(path):
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def test_record_llm_call_writes_well_formed_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    record_llm_call(
+        model="un/qwen3.6-27b-mtp",
+        duration_ms=123.456,
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        finish_reason="stop",
+        retries=0,
+    )
+
+    files = list(tmp_path.glob("*.jsonl"))
+    assert len(files) == 1
+    records = _read_jsonl(files[0])
+    assert len(records) == 1
+    rec = records[0]
+
+    assert rec["model"] == "un/qwen3.6-27b-mtp"
+    assert rec["duration_ms"] == pytest.approx(123.456)
+    assert rec["prompt_tokens"] == 10
+    assert rec["completion_tokens"] == 5
+    assert rec["total_tokens"] == 15
+    assert rec["finish_reason"] == "stop"
+    assert rec["retries"] == 0
+    assert rec["cycle_id"] == ""
+    assert rec["component"] == ""
+    assert rec["ts"].endswith("Z")
+
+
+def test_record_llm_call_defaults_missing_usage_fields_to_zero(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    record_llm_call(model=None, duration_ms=1.0, usage=None, finish_reason=None, retries=2)
+
+    rec = _read_jsonl(next(tmp_path.glob("*.jsonl")))[0]
+    assert rec["model"] == ""
+    assert rec["prompt_tokens"] == 0
+    assert rec["completion_tokens"] == 0
+    assert rec["total_tokens"] == 0
+    assert rec["finish_reason"] == ""
+    assert rec["retries"] == 2
+
+
+def test_state_dir_fallback_used_when_llm_calls_dir_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("LLM_CALLS_DIR", raising=False)
+    monkeypatch.setenv("STATE_DIR", str(tmp_path))
+
+    record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+
+    assert (tmp_path / "llm_calls").is_dir()
+    assert list((tmp_path / "llm_calls").glob("*.jsonl"))
+
+
+def test_call_context_flows_into_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    with call_context("cycle-abc", "bridge"):
+        record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+
+    rec = _read_jsonl(next(tmp_path.glob("*.jsonl")))[0]
+    assert rec["cycle_id"] == "cycle-abc"
+    assert rec["component"] == "bridge"
+
+
+def test_call_context_nesting_restores_prior_context(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    with call_context("outer", "coordinator"):
+        with call_context("inner", "tool_harness"):
+            record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+        record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+
+    records = _read_jsonl(next(tmp_path.glob("*.jsonl")))
+    assert records[0]["cycle_id"] == "inner"
+    assert records[0]["component"] == "tool_harness"
+    assert records[1]["cycle_id"] == "outer"
+    assert records[1]["component"] == "coordinator"
+
+
+def test_set_and_reset_call_context_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    token = set_call_context("cycle-1", "bridge")
+    record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+    reset_call_context(token)
+    record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+
+    records = _read_jsonl(next(tmp_path.glob("*.jsonl")))
+    assert records[0]["cycle_id"] == "cycle-1"
+    assert records[1]["cycle_id"] == ""
+
+
+def test_record_llm_call_is_best_effort_on_fs_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    def _raise_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", _raise_open)
+
+    # Must not raise despite the simulated fs failure.
+    record_llm_call(model="m", duration_ms=1.0, usage={}, finish_reason="stop", retries=0)
+
+
+def test_record_llm_call_is_best_effort_on_bad_usage_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    # usage is not a dict-like object at all -> .get() would raise AttributeError.
+    record_llm_call(model="m", duration_ms=1.0, usage="not-a-dict", finish_reason="stop", retries=0)  # type: ignore[arg-type]

--- a/tests/test_provider_retry.py
+++ b/tests/test_provider_retry.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import pytest
 
@@ -211,3 +212,76 @@ async def test_image_fallback_without_meta_uses_default_placeholder() -> None:
         content = msg.get("content")
         if isinstance(content, list):
             assert any("[image omitted]" in (b.get("text") or "") for b in content)
+
+
+# ---------------------------------------------------------------------------
+# LLM call telemetry hook (issue #675)
+# ---------------------------------------------------------------------------
+
+
+def _read_jsonl(path):
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_records_telemetry_on_success(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    provider = ScriptedProvider([
+        LLMResponse(
+            content="ok",
+            finish_reason="stop",
+            usage={"prompt_tokens": 3, "completion_tokens": 7, "total_tokens": 10},
+        ),
+    ])
+
+    response = await provider.chat_with_retry(
+        messages=[{"role": "user", "content": "hello"}],
+        model="un/qwen3.6-27b-mtp",
+    )
+
+    assert response.content == "ok"
+    rec = _read_jsonl(next(tmp_path.glob("*.jsonl")))[0]
+    assert rec["model"] == "un/qwen3.6-27b-mtp"
+    assert rec["finish_reason"] == "stop"
+    assert rec["prompt_tokens"] == 3
+    assert rec["completion_tokens"] == 7
+    assert rec["total_tokens"] == 10
+    assert rec["retries"] == 0
+    assert rec["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_records_telemetry_with_retries(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    async def _fake_sleep(delay: int) -> None:
+        return None
+
+    monkeypatch.setattr("nanobot.providers.base.asyncio.sleep", _fake_sleep)
+
+    provider = ScriptedProvider([
+        LLMResponse(content="429 rate limit", finish_reason="error"),
+        LLMResponse(content="ok", finish_reason="stop", usage={"total_tokens": 5}),
+    ])
+
+    response = await provider.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    assert response.content == "ok"
+    records = _read_jsonl(next(tmp_path.glob("*.jsonl")))
+    # Only the final (successful) return path records telemetry.
+    assert len(records) == 1
+    assert records[0]["retries"] == 1
+    assert records[0]["total_tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_chat_with_retry_uses_default_model_when_unspecified(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    provider = ScriptedProvider([LLMResponse(content="ok")])
+    await provider.chat_with_retry(messages=[{"role": "user", "content": "hello"}])
+
+    rec = _read_jsonl(next(tmp_path.glob("*.jsonl")))[0]
+    assert rec["model"] == "test-model"


### PR DESCRIPTION
## Summary

Operator wants visibility into agent LLM usage: per-model speed/cost, and how much of a ~10-min self-evolving cycle is actually spent waiting on the LLM (to inform bigger-tasks vs shorter-cycles vs phased plan→execute→test decisions later — this issue is measurement only, no cycle redesign).

**Choke point:** `nanobot/providers/base.py::LLMProvider.chat_with_retry` is the single call every LLM request in nanobot goes through — it already has `model`, the response's `usage`/`finish_reason`, and the retry loop. The retry loop is unchanged; the hook wraps a monotonic start time and calls `record_llm_call(...)` on every return path (success, non-transient error, image-stripped retry, final exhausted-retries error), with `retries` = attempts already made before that return.

**New module:** `nanobot/observability/llm_telemetry.py`
- `contextvars.ContextVar` holding `{cycle_id, component}`, with `set_call_context`/`reset_call_context` and a `call_context(...)` context manager.
- `record_llm_call(*, model, duration_ms, usage, finish_reason, retries)` appends ONE JSON line to `<dir>/YYYY-MM-DD.jsonl` (daily rotation), where `<dir>` = `LLM_CALLS_DIR` env, else `<STATE_DIR>/llm_calls`, else `~/.nanobot/llm_calls` — no hardcoded host paths.
- Entirely best-effort: the whole write path is wrapped in `except Exception: pass` so a telemetry failure (fs error, bad usage shape) never breaks the LLM call it's observing.

**Fields per JSONL line:** `ts` (UTC ISO-8601), `model`, `duration_ms`, `prompt_tokens`, `completion_tokens`, `total_tokens` (0 when absent from `usage`), `finish_reason`, `retries`, `cycle_id`, `component`.

**Entry-point coverage — full, all three attributed:**
- `nanobot.runtime.bridge.main()` — `component=bridge`, `cycle_id` from the pending request. One-shot process (`asyncio.run(main())` via `cli_main()`), so the context is set without a matching reset (it never outlives the process).
- `nanobot.runtime.tool_harness.run_tool_harness_request()` — `component=tool_harness`, `cycle_id` from the request, wrapped in `call_context(...)`. Because the harness sometimes runs its coroutine on a dedicated thread (`_run_async`, used when a loop is already running), that thread does **not** inherit the calling thread's contextvars by default — fixed by capturing `contextvars.copy_context()` before spawning the thread and running the coroutine inside it, so attribution survives both code paths.
- `nanobot.runtime.coordinator.run_self_evolving_cycle()` — `component=coordinator`, `cycle_id` generated in the same function, wrapping the `execute_turn(...)` call where the cycle's actual work happens.

**Report script:** `scripts/llm_calls_report.py` (stdlib-only, ~170 lines) — reads the JSONL file(s) under `--dir` (same env resolution as the writer), optional `--since YYYY-MM-DD`, aggregates per-model {count, avg/p50/p95 duration_ms, total tokens} and per-cycle total LLM wall-time (utilization proxy). Human table by default, `--json` for machine consumption.

Complements — does not replace — the LiteLLM proxy's own spend/latency logs: the proxy is the source of truth for cost; this JSONL adds the cycle_id/component context the proxy lacks.

Docs: added an "LLM call telemetry (issue #675)" subsection to `docs/specs/self-evolving-runtime/spec.md` describing the JSONL contract, attribution entry points, and the report script.

## Test plan
- [x] `tests/test_llm_telemetry.py` — well-formed JSONL line, missing-usage defaults to 0, `STATE_DIR` fallback, contextvar flows into the record, nesting restores prior context, token-based set/reset, best-effort on fs error and on malformed `usage`.
- [x] `tests/test_provider_retry.py` (extended) — success path records telemetry with correct model/tokens/finish_reason/retries=0; transient-error-then-success records retries=1 (only the terminal return writes a line); default-model resolution when `model` is omitted.
- [x] `tests/test_llm_calls_report.py` — JSONL loading (multi-file, `--since` filter, malformed-line skip, missing dir), per-model/per-cycle aggregation, empty input, `--json` and table `main()` output.
- [x] Full suite: `python -m pytest tests/ -q` → 1108 passed (in a fresh worktree venv).
- [x] `ruff check` on all touched/new files: clean (pre-existing `bridge.py`/`coordinator.py` lint findings are unchanged from `main`, not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125qdhCSXD9qCxmmFvoK5uv

Part of #675