### PR TITLE
fix(security): harden autonomous integration gate — enforce surfaces, fail-safe gate, gate pushes (#678)

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -1,9 +1,14 @@
 # Subagent Bridge — spec
 
-_Status: current. Last updated: 2026-07-06 (#666: R11a auto-commit safety net
-for uncommitted subagent work added; #653: R8-R15 cycle-branch isolation
-implemented in code; R10/R11 corrected to describe the full-pytest gate that
-was already running)._
+_Status: current. Last updated: 2026-07-07 (#678: integration-gate hardening —
+mutation-surface/blocked-pattern violations are now a hard block (R12a), the
+smoke gate fails safe on missing/empty suites and harness exceptions instead of
+passing (R11 rewritten), a suite-shrink guard closes the repair-loop-weakening
+path (R11b), and every bookkeeping push that runs outside the gated
+integration path is scope-constrained to its intended file(s) (R16a). Previous
+entry: 2026-07-06, #666: R11a auto-commit safety net for uncommitted subagent
+work added; #653: R8-R15 cycle-branch isolation implemented in code; R10/R11
+corrected to describe the full-pytest gate that was already running)._
 
 ## Purpose
 
@@ -116,15 +121,40 @@ executor run does not stop early or hand off instead of acting:
   evaluate the repo hermetically, not against live runtime state.)
 - R11. If no commits landed on the cycle branch, the smoke gate SHALL be
   skipped entirely (nothing to test) and the cycle branch SHALL be discarded
-  without touching `main`. Transient errors (timeouts, missing `pytest`, no
-  `tests/` directory) SHALL NOT hard-fail the gate — `_run_smoke_tests` returns
-  a pass with an explanatory message in those cases.
+  without touching `main`. A missing/empty `tests/` directory, a suite that
+  collects zero tests, a pytest timeout, or any other harness exception
+  (subprocess crash, `FileNotFoundError` for a missing `pytest`, ...) SHALL
+  **fail the gate** (`_run_smoke_tests` returns `(False, reason)`) — this
+  runtime always has tests, so their absence, emptiness, or an unexplained
+  harness failure is suspicious, never a benign skip.
   - History: an earlier draft of this requirement (through #653) described an
     import-only syntax check of only the changed `.py` files. That was never
     implemented; `_run_smoke_tests` has always run the full suite. #653
     corrected the requirement text to match the running code (CLAUDE.md
     "executable truth wins") rather than implementing the cheaper import-only
     check, since the full suite is a strictly stronger gate.
+  - **Reversal (#678, finding 2/4):** through 2026-07-06 this requirement said
+    the opposite — missing tests, an empty suite, a timeout-adjacent harness
+    exception, and a missing `pytest` binary all `return True` ("skip" =
+    pass). A two-lens adversarial security review confirmed this let a cycle
+    that `rm -rf tests/` (or otherwise emptied the suite) turn a failing
+    change green, and a bare `except Exception: return True` meant a pytest
+    subprocess crash (OOM/OSError/disk-full) integrated untested code. Both
+    now fail closed; only a genuine `_sp.TimeoutExpired` was already `False`
+    and is unchanged.
+- R11b. Before running pytest, the gate SHALL compare a hermetic proxy for
+  suite size — the count of `def test_` occurrences across `tests/**/*.py`
+  (`_count_tests`) — in the cycle's working tree against the same count
+  captured at `origin/main` before the cycle branch was created
+  (`_count_tests_at_ref`, read via `git show <ref>:<path>`, no checkout
+  needed). If the cycle's count is lower, the gate SHALL fail immediately
+  with a `suite-shrink guard` reason, without needing to run pytest at all.
+  This check SHALL be re-applied on every gate evaluation, including each
+  closed-loop repair retry (R12), not only the first — otherwise a repair
+  turn could iteratively delete or weaken tests across revisions until the
+  (now-smaller) suite happens to pass. A baseline of `0` (unreadable ref, no
+  `tests/` at `origin/main`) never blocks — there is nothing to compare
+  against.
 - R11a. If no commits landed on the cycle branch but the working tree is dirty
   (`git status --porcelain` non-empty), the bridge SHALL commit those changes
   itself (`_auto_commit_uncommitted_work`) before applying R11 — excluding any
@@ -143,7 +173,30 @@ executor run does not stop early or hand off instead of acting:
 ### Integration to main
 - R12. The bridge SHALL integrate the cycle branch into `main` (merge `--no-ff`
   the subagent's HEAD onto a fresh `origin/main`, then push) ONLY when the smoke
-  gate passes.
+  gate passes **and** R12a's mutation-surface/blocked-pattern check is clean.
+- R12a. The bridge SHALL apply `_validate_mutation_surfaces` to every file
+  changed across ALL of the cycle's commits (the subagent's own `git commit`s,
+  not only the R11a auto-commit fallback) and treat any violation as a **hard
+  block on integration** — `_integrate_cycle_to_main` SHALL NOT be called, the
+  cycle branch SHALL be kept for forensics exactly like a failed smoke gate
+  (R13), and `main` SHALL be left untouched. Two violation classes are
+  distinguished for the resulting rollback reason: a filename matching
+  `_BLOCKED_FILE_PATTERNS` (secret-shaped names, lockfiles, `.git` internals,
+  ...) anywhere in the changed files → `blocked_file_present`; a file outside
+  `_ALLOWED_PATH_PREFIXES` (`surfaces/`, `scripts/`, `memory/`, `lessons/`,
+  `docs/`, `tests/`) → `mutation_surface_violation`.
+  - **Reversal (#678, findings 1 and 3):** through 2026-07-06,
+    `_validate_mutation_surfaces` violations were only printed —
+    integration was decided solely by the smoke gate, so a cycle editing core
+    `nanobot/`, `.github/workflows/`, `pyproject.toml`, or `bridge.py` itself
+    would integrate as long as pytest happened to pass. Separately, the
+    `_BLOCKED_FILE_PATTERNS` secret-filename filter ran only inside the R11a
+    auto-commit fallback (i.e. only when the subagent forgot to commit); a
+    subagent that committed normally had no secret-pattern screening at all.
+    Both gaps are closed by the same enforcement point, since
+    `_validate_mutation_surfaces` already checked blocked patterns across all
+    changed files — the fix was making its output authoritative rather than
+    advisory.
 - R13. When the smoke gate fails, the bridge SHALL leave the commits on the cycle
   branch, SHALL keep `main` clean (no merge/push), and SHALL record a learning
   artifact; the cycle branch SHALL be kept for inspection.
@@ -167,6 +220,25 @@ executor run does not stop early or hand off instead of acting:
   subagent committed on the cycle branch) — this is the one semantic change
   from the pre-#653 field, which counted any subagent commit regardless of
   whether it survived the gate.
+- R16a. Several bridge code paths commit and `git push origin main` directly,
+  with **no smoke gate at all**: the already-done bookkeeping mark (runs before
+  `_setup_cycle_branch`, on most cycles), the post-integration backlog-done
+  safety net, the memory archiver (which **executes** `scripts/memory_archiver.py`
+  from the target repo), and the structured-lesson recorder. Each such push
+  SHALL be preceded by `_diff_against_remote_touches_only(repo, "origin/main",
+  allowed)`, comparing the diff about to be published against an explicit
+  allow-set for that path (`{"memory/MEMORY.md"}` for the already-done and
+  backlog-done paths, the archiver's own declared `files_changed` output for
+  the archiver, `{"lessons/lessons.yaml"}` for the lesson recorder). The push
+  SHALL be skipped (logged, not raised) whenever the diff is empty or touches
+  anything outside the allow-set — defense-in-depth, since none of these paths
+  otherwise has a gate standing between a commit and `origin/main`.
+  - **Added (#678, findings 5 and 6):** previously each of these four sites was
+    a bare, unconstrained `git push origin main` — a bug in the bookkeeping
+    logic (or an archiver script mutating something unexpected) had a direct,
+    ungated path to `main`. This requirement does not change the intended
+    (successful) behavior of any of the four bookkeeping flows, only adds a
+    refusal on an out-of-scope diff.
 
 ### Tool harness — phase 1 (read-only tools, #643)
 - R17. `nanobot.runtime.subagent_materializer.materialize_subagent_requests`
@@ -256,6 +328,16 @@ executor run does not stop early or hand off instead of acting:
   artifact records `rollback.integrated=false`, and the cycle branch is
   retained for inspection.
 
+### Scenario: mutation-surface violation blocks integration
+- Given a subagent commit on `selfevo/cycle-<id>` touches a file outside
+  `_ALLOWED_PATH_PREFIXES` (e.g. `nanobot/foo.py`) or matching
+  `_BLOCKED_FILE_PATTERNS` (e.g. `id_rsa`)
+- When the bridge evaluates the cycle for integration, regardless of whether
+  the smoke gate itself passed
+- Then `_integrate_cycle_to_main` is never called, `main` is left untouched,
+  and the cycle branch is kept for forensics with rollback reason
+  `mutation_surface_violation` or `blocked_file_present` respectively.
+
 ### Scenario: uncommitted subagent work is auto-committed before the gate
 - Given a subagent edited files on `selfevo/cycle-<id>` via `edit_file`/`write_file`
   but ended its turn without running `git commit` (dirty tree, `cycle_commit_count == 0`)
@@ -282,7 +364,9 @@ executor run does not stop early or hand off instead of acting:
   (#637; recoverable from git history).
 - Code (authoritative): `nanobot/runtime/bridge.py`
   (`main`, `find_pending_request`, `_is_real_result`, `build_task`,
-  `_setup_cycle_branch`, `_run_smoke_tests`, `_integrate_cycle_to_main`,
+  `_setup_cycle_branch`, `_run_smoke_tests`, `_run_smoke_tests_with_shrink_guard`,
+  `_count_tests`, `_count_tests_at_ref`, `_validate_mutation_surfaces`,
+  `_diff_against_remote_touches_only`, `_integrate_cycle_to_main`,
   `_cleanup_cycle_branch`, `_auto_commit_uncommitted_work`).
   `scripts/eeepc_self_evolving_subagent_bridge.py`
   is a thin wrapper that calls `nanobot.runtime.bridge.cli_main`.

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -284,6 +284,37 @@ def _git_cmd(repo_root: 'Path') -> list[str]:
     return ['git', '-c', f'safe.directory={repo_root}', '-C', str(repo_root)]
 
 
+def _changed_files_and_violations(repo_root: 'Path', base_sha: str) -> 'tuple[list[str], list[str], list[str]]':
+    """Compute the full changed-file set of ``base_sha..HEAD`` and split its surface violations.
+
+    #678 F1/F3: returns ``(files_changed, blocked_pattern_violations,
+    mutation_violations)`` for ALL commits since ``base_sha`` (the pre-spawn
+    SHA), so it reflects the initial subagent commit(s) AND every subsequent
+    repair-turn commit. The gate decision recomputes this immediately before it
+    decides whether to integrate — a repair subagent that edits core ``nanobot/``
+    or drops a secret-shaped file must be caught even though the first commit was
+    clean. On any git failure returns ``([], [], [])`` — the caller keeps the
+    last-known lists rather than silently treating a broken diff as "clean".
+
+    ``blocked_pattern_violations`` are secret/lockfile/.git filename matches
+    (``_BLOCKED_FILE_PATTERNS``); ``mutation_violations`` are edits outside
+    ``_ALLOWED_PATH_PREFIXES``.
+    """
+    import subprocess as _sp
+    git = _git_cmd(repo_root)
+    try:
+        diff = _sp.run(git + ['diff', '--name-only', base_sha, 'HEAD'], capture_output=True, text=True)
+    except Exception:
+        return [], [], []
+    if diff.returncode != 0:
+        return [], [], []
+    files_changed = [f for f in diff.stdout.splitlines() if f.strip()]
+    violations = _validate_mutation_surfaces(files_changed)
+    blocked = [v for v in violations if v.startswith('blocked filename pattern')]
+    mutation = [v for v in violations if v not in blocked]
+    return files_changed, blocked, mutation
+
+
 def _diff_against_remote_touches_only(repo_root: 'Path', remote_ref: str, allowed: 'set[str]') -> bool:
     """Return True iff every file changed between ``remote_ref`` and local HEAD is in ``allowed``.
 
@@ -1046,29 +1077,20 @@ async def main():
                     )
             if _new_commits > 0:
                 cycle_commit_count = _new_commits
-                # Get list of changed files across all new commits
-                _diff = _sp.run(
-                    _git_se + ['diff', '--name-only', _pre_spawn_sha, 'HEAD'],
-                    capture_output=True, text=True,
+                # #678 F1/F3: initial changed-file set + violation split, for
+                # logging. This is RECOMPUTED after the repair loop (just before
+                # the gate decision) so the enforced lists reflect every commit,
+                # not only the first — see the recompute below.
+                files_changed, _blocked_pattern_violations, _mutation_violations = (
+                    _changed_files_and_violations(_selfevo_repo, _pre_spawn_sha)
                 )
-                if _diff.returncode == 0:
-                    files_changed = [f for f in _diff.stdout.splitlines() if f.strip()]
-                    _violations = _validate_mutation_surfaces(files_changed)
-                    if _violations:
-                        print(f'mutation surfaces: {len(_violations)} violation(s):')
-                        for v in _violations:
-                            print(f'  ! {v}')
-                        # #678 F1/F3: split so the gate decision can report a
-                        # precise rollback_reason — blocked filenames (secrets,
-                        # lockfiles, ...) vs. edits outside the allowed surfaces.
-                        _blocked_pattern_violations = [
-                            v for v in _violations if v.startswith('blocked filename pattern')
-                        ]
-                        _mutation_violations = [
-                            v for v in _violations if v not in _blocked_pattern_violations
-                        ]
-                    else:
-                        print(f'mutation surfaces: clean ({len(files_changed)} file(s) changed)')
+                _violations = _blocked_pattern_violations + _mutation_violations
+                if _violations:
+                    print(f'mutation surfaces: {len(_violations)} violation(s):')
+                    for v in _violations:
+                        print(f'  ! {v}')
+                else:
+                    print(f'mutation surfaces: clean ({len(files_changed)} file(s) changed)')
                 print(f'cycle-branch: {cycle_commit_count} new commit(s) on {cycle_branch}')
         else:
             print(f'cycle-branch: eeebot-self-evolving not found at {_selfevo_repo}')
@@ -1139,6 +1161,18 @@ async def main():
                 )
                 print(f'smoke (after repair {_repair_attempts}): {"PASS" if _smoke_passed else "FAIL"}')
         # ─────────────────────────────────────────────────────────────────────
+
+        # #678 F1/F3: recompute the changed-file set and violation split across
+        # ALL commits (initial + every repair turn) right before the gate
+        # decides. Without this, a repair subagent editing core nanobot/,
+        # .github/workflows, bridge.py, or committing a secret-shaped file would
+        # slip past the surface/blocked-pattern check, which was computed only
+        # from the FIRST commit above. files_changed also becomes the final set
+        # used downstream (backlog-done message, structured lesson).
+        if cycle_commit_count > 0 and _selfevo_repo.is_dir():
+            _fc, _bpv, _mv = _changed_files_and_violations(_selfevo_repo, _pre_spawn_sha)
+            if _fc or _bpv or _mv:
+                files_changed, _blocked_pattern_violations, _mutation_violations = _fc, _bpv, _mv
 
         # ── Gate decision: integrate to main ONLY on green (R12-R15) ─────────
         if cycle_commit_count > 0:

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -284,6 +284,31 @@ def _git_cmd(repo_root: 'Path') -> list[str]:
     return ['git', '-c', f'safe.directory={repo_root}', '-C', str(repo_root)]
 
 
+def _diff_against_remote_touches_only(repo_root: 'Path', remote_ref: str, allowed: 'set[str]') -> bool:
+    """Return True iff every file changed between ``remote_ref`` and local HEAD is in ``allowed``.
+
+    #678 F5/F6: several bookkeeping code paths (already_done mark-done, memory
+    archiver, structured lesson) commit and ``git push origin main`` directly,
+    with NO smoke gate at all. This is the only thing standing between those
+    paths and an unconstrained push — it must be checked immediately before each
+    such push. Returns False (refuse to push) on any git failure, or when there
+    is nothing to push, or when the diff touches anything outside ``allowed`` —
+    fail closed in every ambiguous case.
+    """
+    import subprocess as _sp
+    git = _git_cmd(repo_root)
+    try:
+        diff = _sp.run(git + ['diff', '--name-only', remote_ref, 'HEAD'], capture_output=True, text=True)
+    except Exception:
+        return False
+    if diff.returncode != 0:
+        return False
+    changed = [f.strip() for f in diff.stdout.splitlines() if f.strip()]
+    if not changed:
+        return False
+    return all(f in allowed for f in changed)
+
+
 def _setup_cycle_branch(repo_root: 'Path', cycle_id: str) -> dict:
     """Isolate the upcoming subagent run on a fresh branch off ``origin/main``.
 
@@ -811,10 +836,22 @@ async def main():
                 backlog_title=backlog_title,
                 what_was_done=f'task detected as already done via git log: {_found_commit[:60]}',
             )
-            _sp_check.run(
-                _git_chk + ['push', 'origin', 'main'],
-                capture_output=True,
-            )
+            # #678 F5: this path runs BEFORE _setup_cycle_branch, with NO smoke
+            # gate at all, on most cycles. Previously it was a bare
+            # `git push origin main` — constrain it to only push when the
+            # resulting diff is pure MEMORY.md bookkeeping.
+            if _diff_against_remote_touches_only(
+                _selfevo_repo_check, 'origin/main', {'memory/MEMORY.md'},
+            ):
+                _sp_check.run(
+                    _git_chk + ['push', 'origin', 'main'],
+                    capture_output=True,
+                )
+            else:
+                print(
+                    'bridge: already_done bookkeeping touched more than memory/MEMORY.md '
+                    'or nothing to push — skipping ungated push (#678 F5)'
+                )
         handled_marker.write_text(str(req_path), encoding='utf-8')
         _write_bridge_completed_result(
             state_dir=STATE_DIR,
@@ -914,6 +951,12 @@ async def main():
     _pre_spawn_sha_file = STATE_DIR / 'bridge_pre_spawn.sha'
     _pre_spawn_sha = _capture_pre_spawn_sha(_selfevo_repo, _pre_spawn_sha_file)
 
+    # #678 F2: baseline test count at origin/main, captured via git blobs (no
+    # checkout needed — the shared checkout already moved to the cycle branch
+    # above). Used by _run_smoke_tests_with_shrink_guard to fail the gate if the
+    # cycle's tree collects fewer tests than main had before this cycle.
+    _baseline_test_count = _count_tests_at_ref(_selfevo_repo, 'origin/main')
+
     import subprocess as _sp
     files_changed: list[str] = []
     cycle_commit_count = 0
@@ -921,6 +964,11 @@ async def main():
     _auto_committed = False
     _integrated = False
     _rollback_reason: 'str | None' = None
+    # #678 F1/F3: mutation-surface / blocked-pattern violations across ALL cycle
+    # commits (not just the auto-commit fallback) — populated below once
+    # files_changed is known, enforced as a hard block in the gate decision.
+    _mutation_violations: 'list[str]' = []
+    _blocked_pattern_violations: 'list[str]' = []
     main_sha_after = main_sha_before
     _repair_attempts = 0
     _smoke_passed = True
@@ -1010,6 +1058,15 @@ async def main():
                         print(f'mutation surfaces: {len(_violations)} violation(s):')
                         for v in _violations:
                             print(f'  ! {v}')
+                        # #678 F1/F3: split so the gate decision can report a
+                        # precise rollback_reason — blocked filenames (secrets,
+                        # lockfiles, ...) vs. edits outside the allowed surfaces.
+                        _blocked_pattern_violations = [
+                            v for v in _violations if v.startswith('blocked filename pattern')
+                        ]
+                        _mutation_violations = [
+                            v for v in _violations if v not in _blocked_pattern_violations
+                        ]
                     else:
                         print(f'mutation surfaces: clean ({len(files_changed)} file(s) changed)')
                 print(f'cycle-branch: {cycle_commit_count} new commit(s) on {cycle_branch}')
@@ -1025,7 +1082,9 @@ async def main():
         # R12: bounded revisions — cap configurable (default 3), never unbounded.
         if cycle_commit_count > 0 and _selfevo_repo.is_dir():
             _smoke_ran = True
-            _smoke_passed, _smoke_output = _run_smoke_tests(_selfevo_repo)
+            _smoke_passed, _smoke_output = _run_smoke_tests_with_shrink_guard(
+                _selfevo_repo, _baseline_test_count,
+            )
             print(f'smoke: {"PASS" if _smoke_passed else "FAIL"}')
             while not _smoke_passed and _repair_attempts < _max_repair_attempts:
                 _repair_attempts += 1
@@ -1071,14 +1130,36 @@ async def main():
                 if _repair_new > cycle_commit_count:
                     print(f'cycle-branch: {_repair_new - cycle_commit_count} additional commit(s) (repair {_repair_attempts})')
                     cycle_commit_count = _repair_new
-                # Re-run smoke tests after repair
-                _smoke_passed, _smoke_output = _run_smoke_tests(_selfevo_repo)
+                # Re-run smoke tests after repair. Re-applying the shrink guard
+                # on every retry (not just the first check) closes the path
+                # where a repair turn iteratively deletes/weakens tests to make
+                # the suite pass (#678 F2).
+                _smoke_passed, _smoke_output = _run_smoke_tests_with_shrink_guard(
+                    _selfevo_repo, _baseline_test_count,
+                )
                 print(f'smoke (after repair {_repair_attempts}): {"PASS" if _smoke_passed else "FAIL"}')
         # ─────────────────────────────────────────────────────────────────────
 
         # ── Gate decision: integrate to main ONLY on green (R12-R15) ─────────
         if cycle_commit_count > 0:
-            if _smoke_passed:
+            if _blocked_pattern_violations:
+                # #678 F3: a secret-shaped/blocked filename anywhere in the
+                # cycle's commits is a hard block, regardless of smoke result.
+                _rollback_reason = 'blocked_file_present'
+                print(
+                    f'blocked-pattern check: {len(_blocked_pattern_violations)} blocked '
+                    f'file(s) present — {cycle_branch} kept for forensics, main left unchanged (#678 F3)'
+                )
+            elif _mutation_violations:
+                # #678 F1: mutation-surface violations were previously print-only
+                # while integration was decided solely by the smoke gate. Now a
+                # hard block — same shape as the gate_failed branch below.
+                _rollback_reason = 'mutation_surface_violation'
+                print(
+                    f'mutation surfaces: {len(_mutation_violations)} violation(s) — '
+                    f'{cycle_branch} kept for forensics, main left unchanged (#678 F1)'
+                )
+            elif _smoke_passed:
                 _integ = _integrate_cycle_to_main(_selfevo_repo, cycle_branch, main_sha_before)
                 if _integ['ok']:
                     _integrated = True
@@ -1108,9 +1189,20 @@ async def main():
                 what_was_done=f'bridge subagent committed {commits_pushed} commit(s): {", ".join(files_changed[:3])}',
             )
             if marked:
-                _git2 = _git_cmd(_selfevo_repo)
-                _sp.run(_git2 + ['push', 'origin', 'main'], capture_output=True)
-                print(f'bridge-memory: moved "{backlog_title[:60]}" to Completed in MEMORY.md')
+                # #678 F6: defense-in-depth — this commit already ran with zero
+                # gate; refuse to push if the diff somehow touches anything
+                # beyond memory/MEMORY.md bookkeeping.
+                if _diff_against_remote_touches_only(
+                    _selfevo_repo, 'origin/main', {'memory/MEMORY.md'},
+                ):
+                    _git2 = _git_cmd(_selfevo_repo)
+                    _sp.run(_git2 + ['push', 'origin', 'main'], capture_output=True)
+                    print(f'bridge-memory: moved "{backlog_title[:60]}" to Completed in MEMORY.md')
+                else:
+                    print(
+                        'bridge-memory: backlog-done diff touched more than memory/MEMORY.md '
+                        '— skipping ungated push (#678 F6)'
+                    )
 
         # Memory archiver: run after each integrated commit if MEMORY.md is large or archive is stale
         if _integrated:
@@ -1129,13 +1221,26 @@ async def main():
                         )
                         if _arch_result.get('action') == 'archived':
                             _git3 = _git_cmd(_selfevo_repo)
-                            for _f in _arch_result.get('files_changed', []):
+                            _arch_declared_files = set(_arch_result.get('files_changed', []))
+                            for _f in _arch_declared_files:
                                 _sp.run(_git3 + ['add', _f], capture_output=True)
                             _sp.run(_git3 + ['commit', '-m',
                                              f'chore: archive {_arch_result.get("weeks_archived", 0)} week(s) to MEMORY_ARCHIVE.md'],
                                     capture_output=True)
-                            _sp.run(_git3 + ['push', 'origin', 'main'], capture_output=True)
-                            print(f'bridge-memory: archived {_arch_result.get("weeks_archived", 0)} week(s) to MEMORY_ARCHIVE.md')
+                            # #678 F6: memory_archiver EXECUTES script code with
+                            # zero gate; refuse to push if the commit's diff
+                            # includes anything beyond the archiver's own
+                            # declared output files.
+                            if _diff_against_remote_touches_only(
+                                _selfevo_repo, 'origin/main', _arch_declared_files,
+                            ):
+                                _sp.run(_git3 + ['push', 'origin', 'main'], capture_output=True)
+                                print(f'bridge-memory: archived {_arch_result.get("weeks_archived", 0)} week(s) to MEMORY_ARCHIVE.md')
+                            else:
+                                print(
+                                    'bridge-memory: archiver diff touched files outside its declared '
+                                    'output set — skipping ungated push (#678 F6)'
+                                )
             except Exception:
                 pass  # never block on archiver failure
     except Exception as exc:
@@ -1210,8 +1315,18 @@ async def main():
                     _git4 + ['commit', '-m', f'chore: record structured lesson for [{req.get("cycle_id","")[:12]}]'],
                     capture_output=True,
                 )
-                _sp.run(_git4 + ['push', 'origin', 'main'], capture_output=True)
-                print(f'bridge-lesson: recorded structured lesson to lessons/lessons.yaml')
+                # #678 F6: defense-in-depth — refuse to push if the commit's
+                # diff touches anything beyond lessons/lessons.yaml.
+                if _diff_against_remote_touches_only(
+                    _selfevo_repo, 'origin/main', {'lessons/lessons.yaml'},
+                ):
+                    _sp.run(_git4 + ['push', 'origin', 'main'], capture_output=True)
+                    print(f'bridge-lesson: recorded structured lesson to lessons/lessons.yaml')
+                else:
+                    print(
+                        'bridge-lesson: lesson diff touched more than lessons/lessons.yaml '
+                        '— skipping ungated push (#678 F6)'
+                    )
         except Exception:
             pass  # never block on lesson recording failure
 
@@ -1232,7 +1347,10 @@ def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
     """Validate that changed files respect the bounded mutation surface contract.
 
     Returns a list of VIOLATIONS (empty list = clean).
-    Violations are logged as warnings but do NOT block execution in v1.
+    #678 F1/F3: violations are a HARD BLOCK on integration (see main()'s gate
+    decision) — previously they were only printed while integration was decided
+    solely by the smoke-test gate, so a cycle touching core nanobot/, CI config,
+    or bridge.py itself could integrate as long as pytest happened to pass.
 
     Inspired by Darwin Mode safety.ts (ruvnet/agent-harness-generator):
     BLOCKED_FILENAME_PATTERNS, APPROVED_FILES, inspectVariant().
@@ -1296,8 +1414,9 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]
 
     Returns (passed: bool, output: str) where output is truncated to 2000 chars.
     - timeout: seconds before treating as failure
-    - no tests found: returns (True, 'no tests')
-    - pytest not available: returns (True, 'pytest unavailable — skip')
+    - missing/empty tests dir, no tests collected, or any harness error: FAIL
+      (fail-safe — see #678 finding 2/4: a self-evolving repo always has tests,
+      so their absence or an unexplained harness crash is suspicious, not benign).
 
     Runs with sys.executable (the runtime's own venv interpreter, with all deps
     installed) rather than the bare system python — see #668: a bare `python3`
@@ -1314,7 +1433,9 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]
     import subprocess as _sp
     tests_dir = repo_root / 'tests'
     if not tests_dir.exists():
-        return True, 'no tests directory'
+        # #678 F2: a missing tests/ directory (e.g. a cycle that `rm -rf tests/`)
+        # previously turned a failing change green. Fail closed instead.
+        return False, 'no tests directory (fail-safe: #678)'
     try:
         result = _sp.run(
             [sys.executable, '-m', 'pytest', str(tests_dir), '-x', '-q', '--tb=native', '--no-header'],
@@ -1324,15 +1445,97 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]
         output = (result.stdout + result.stderr).strip()
         output = output[-2000:] if len(output) > 2000 else output  # keep tail (most relevant)
         if 'no tests ran' in output or 'collected 0 items' in output:
-            return True, 'no tests'
+            # #678 F2: an emptied suite previously passed the gate. Fail closed.
+            return False, 'no tests collected (fail-safe: #678)'
         passed = result.returncode == 0
         return passed, output
     except _sp.TimeoutExpired:
         return False, 'pytest timed out'
-    except FileNotFoundError:
-        return True, 'pytest unavailable — skip'
+    except FileNotFoundError as exc:
+        # #678 F4: pytest is always installed in the runtime venv (sys.executable
+        # above); a genuinely missing pytest module is itself suspicious on the
+        # host, so fail closed rather than silently skipping the gate.
+        return False, f'pytest unavailable (fail-safe: #678): {exc}'
     except Exception as exc:
-        return True, f'smoke test error (skipped): {exc}'
+        # #678 F4: previously `return True` here — a pytest subprocess crash
+        # (OOM/OSError/disk-full) integrated untested code. Fail closed.
+        return False, f'smoke harness error (fail-safe: #678): {exc}'
+
+
+def _count_tests(repo_root: 'Path') -> int:
+    """Count ``def test_`` occurrences across ``tests/**/*.py`` in the working tree.
+
+    A cheap, hermetic proxy for suite size (#678 F2 suite-shrink guard) — avoids
+    a second pytest collection pass just to get a number. Returns 0 if there is
+    no tests/ directory or nothing readable; callers treat 0 as "unknown", never
+    as a negative signal on its own.
+    """
+    tests_dir = repo_root / 'tests'
+    if not tests_dir.exists():
+        return 0
+    count = 0
+    for f in tests_dir.rglob('*.py'):
+        try:
+            count += f.read_text(encoding='utf-8', errors='ignore').count('def test_')
+        except Exception:
+            pass
+    return count
+
+
+def _count_tests_at_ref(repo_root: 'Path', ref: str) -> int:
+    """Count ``def test_`` occurrences across ``tests/**/*.py`` at a git ref, without checkout.
+
+    Reads blobs via ``git show <ref>:<path>`` so it works while the working tree
+    is checked out to a different branch (e.g. capturing the pre-cycle baseline
+    for origin/main right after ``_setup_cycle_branch`` has already moved the
+    checkout to the cycle branch). Returns 0 on any git failure (missing ref, no
+    tests/ tree at that ref, ...) — a 0 baseline is treated as "nothing to compare
+    against" by :func:`_run_smoke_tests_with_shrink_guard`, never as a violation.
+    """
+    import subprocess as _sp
+    git = _git_cmd(repo_root)
+    try:
+        ls = _sp.run(git + ['ls-tree', '-r', '--name-only', ref, '--', 'tests/'],
+                      capture_output=True, text=True)
+    except Exception:
+        return 0
+    if ls.returncode != 0:
+        return 0
+    count = 0
+    for path in ls.stdout.splitlines():
+        path = path.strip()
+        if not path.endswith('.py'):
+            continue
+        try:
+            show = _sp.run(git + ['show', f'{ref}:{path}'], capture_output=True, text=True)
+        except Exception:
+            continue
+        if show.returncode != 0:
+            continue
+        count += show.stdout.count('def test_')
+    return count
+
+
+def _run_smoke_tests_with_shrink_guard(
+    repo_root: 'Path', baseline_test_count: int, timeout: int = 300,
+) -> 'tuple[bool, str]':
+    """Gate wrapper: fail immediately if the cycle's test count dropped below baseline.
+
+    #678 F2: without this, a repair loop could iteratively delete or weaken tests
+    across revisions until the suite happens to pass — closing that path requires
+    checking suite size on every gate evaluation (initial AND each repair retry),
+    not just once. ``baseline_test_count`` of 0 means "could not establish a
+    baseline" and never blocks (nothing to compare against); otherwise a strictly
+    lower current count fails the gate without needing to run pytest at all.
+    """
+    if baseline_test_count > 0:
+        current = _count_tests(repo_root)
+        if current < baseline_test_count:
+            return False, (
+                f'suite-shrink guard (#678): test count dropped from '
+                f'{baseline_test_count} to {current} vs main baseline'
+            )
+    return _run_smoke_tests(repo_root, timeout=timeout)
 
 
 # Commit subject prefixes that are maintenance-only and should not count as

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -468,6 +468,65 @@ class TestMutationSurfaceHardBlock:
         assert _origin_main_sha(origin) == integ["main_sha_after"]
 
 
+class TestRepairTurnSurfaceViolationIsCaught:
+    """F1/F3 (repair-loop gap, #679 review): the changed-file set and its
+    violation split are recomputed from pre_spawn_sha..HEAD AFTER the repair
+    loop, so a repair turn that edits core nanobot/ (or drops a blocked file)
+    is caught even when the INITIAL commit was on an allowed surface.
+    """
+
+    def test_clean_initial_then_repair_edits_core_is_blocked(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "repair-mutsurf")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+        pre_spawn_sha = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        # Initial subagent commit: allowed surface only → clean.
+        (work / "scripts").mkdir()
+        _commit_file(work, "scripts/util.py", "x = 1\n", "feat: add utility script")
+        files0, blocked0, mut0 = bridge._changed_files_and_violations(work, pre_spawn_sha)
+        assert files0 == ["scripts/util.py"]
+        assert blocked0 == [] and mut0 == []
+
+        # Repair turn commits an edit to core nanobot/ (outside allowed paths).
+        (work / "nanobot").mkdir()
+        _commit_file(work, "nanobot/core.py", "y = 2\n", "fix: touch core during repair")
+
+        # Recompute across ALL commits (the fix) — the violation must surface now.
+        files1, blocked1, mut1 = bridge._changed_files_and_violations(work, pre_spawn_sha)
+        assert "nanobot/core.py" in files1
+        assert mut1, "repair-turn core edit must be flagged as a mutation-surface violation"
+
+        # Gate decision shape: violations present -> never integrate.
+        integrated = False
+        if not (blocked1 or mut1):
+            integ = bridge._integrate_cycle_to_main(work, setup["branch"], main_sha_before)
+            integrated = integ["ok"]
+        assert integrated is False
+        assert _origin_main_sha(origin) == main_sha_before
+        branches = _run(work, "branch", "--list", setup["branch"]).stdout
+        assert setup["branch"] in branches
+
+    def test_clean_initial_then_repair_adds_secret_is_blocked(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "repair-secret")
+        assert setup["ok"]
+        pre_spawn_sha = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        (work / "scripts").mkdir()
+        _commit_file(work, "scripts/util.py", "x = 1\n", "feat: add utility script")
+        _, blocked0, _ = bridge._changed_files_and_violations(work, pre_spawn_sha)
+        assert blocked0 == []
+
+        # Repair turn commits a secret-shaped file.
+        _commit_file(work, "id_rsa", "FAKE-KEY\n", "chore: stash a key during repair")
+
+        _files, blocked1, _mut = bridge._changed_files_and_violations(work, pre_spawn_sha)
+        assert blocked1, "repair-turn secret file must be flagged as blocked_file_present"
+        assert any("blocked filename pattern" in v for v in blocked1)
+
+
 class TestBlockedPatternAcrossAllCommits:
     """F3: the secret-pattern filter must apply to ALL cycle commits, not just
     the auto-commit fallback."""

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -405,3 +405,247 @@ class TestFullCycleFlow:
         assert setup["branch"] in branches
         log = _run(work, "log", setup["branch"], "--oneline").stdout
         assert "breaking change" in log
+
+
+# ─── #678: harden the autonomous integration gate ────────────────────────────
+#
+# The tests below exercise the six CONFIRMED findings from the #678 adversarial
+# review. They follow the existing pattern of this file: drive the real git
+# helpers directly (never a mocked git) against temp "origin" + "work" repos,
+# and assert the gate-decision SHAPE main() now enforces (mutation-surface /
+# blocked-pattern violations and a failed gate all skip _integrate_cycle_to_main
+# and leave origin/main untouched with the cycle branch kept for forensics —
+# main() wires these primitives together but is not itself unit-tested here,
+# consistent with the rest of this suite).
+
+
+class TestMutationSurfaceHardBlock:
+    """F1: mutation-surface violations must hard-block integration, not just print."""
+
+    def test_violation_blocks_integration_and_main_stays_untouched(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "mutsurf")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+
+        (work / "nanobot").mkdir()
+        _commit_file(work, "nanobot/foo.py", "x = 1\n", "feat: edit core module")
+
+        files_changed = ["nanobot/foo.py"]
+        violations = bridge._validate_mutation_surfaces(files_changed)
+        assert violations, "editing nanobot/ must be flagged"
+
+        # Gate decision shape (#678 F1): violations present -> never call
+        # _integrate_cycle_to_main at all.
+        integrated = False
+        if not violations:
+            integ = bridge._integrate_cycle_to_main(work, setup["branch"], main_sha_before)
+            integrated = integ["ok"]
+
+        assert integrated is False
+        assert _origin_main_sha(origin) == main_sha_before
+        branches = _run(work, "branch", "--list", setup["branch"]).stdout
+        assert setup["branch"] in branches
+
+    def test_legit_surfaces_scripts_docs_memory_still_pass(self, tmp_path):
+        """Legit cycles editing the allowed surfaces must NOT be blocked."""
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "legit")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+
+        (work / "scripts").mkdir()
+        (work / "memory").mkdir()
+        _commit_file(work, "scripts/util.py", "x = 1\n", "feat: add utility script")
+        _commit_file(work, "memory/MEMORY.md", "# memory\n", "chore: update memory")
+
+        files_changed = ["scripts/util.py", "memory/MEMORY.md"]
+        violations = bridge._validate_mutation_surfaces(files_changed)
+        assert violations == []
+
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], main_sha_before)
+        assert integ["ok"] is True
+        assert _origin_main_sha(origin) == integ["main_sha_after"]
+
+
+class TestBlockedPatternAcrossAllCommits:
+    """F3: the secret-pattern filter must apply to ALL cycle commits, not just
+    the auto-commit fallback."""
+
+    def test_blocked_file_in_direct_commit_blocks_integration(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "blockedfile")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+
+        # Subagent committed normally (NOT via the auto-commit fallback) with a
+        # blocked-pattern file included.
+        _commit_file(work, "id_rsa", "FAKE-KEY-CONTENT\n", "chore: add key file")
+
+        files_changed = ["id_rsa"]
+        violations = bridge._validate_mutation_surfaces(files_changed)
+        assert violations
+        assert any("blocked filename pattern" in v for v in violations)
+
+        integrated = False  # gate decision: blocked -> never integrate
+        assert integrated is False
+        assert _origin_main_sha(origin) == main_sha_before
+        branches = _run(work, "branch", "--list", setup["branch"]).stdout
+        assert setup["branch"] in branches
+
+
+class TestSmokeGateFailSafe:
+    """F2/F4: the gate must fail closed on missing/empty suites, harness
+    exceptions, and a suite-shrink guard must close the repair-loop-weakening
+    path."""
+
+    def test_missing_tests_directory_fails_gate(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        bridge._setup_cycle_branch(work, "notests")
+        import shutil
+        shutil.rmtree(work / "tests")
+        (work / "dummy.py").write_text("x = 1\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "chore: remove tests directory")
+
+        passed, output = bridge._run_smoke_tests(work)
+
+        assert passed is False
+        assert "no tests directory" in output
+
+    def test_emptied_suite_fails_gate(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        bridge._setup_cycle_branch(work, "emptysuite")
+        (work / "tests" / "test_smoke.py").unlink()
+        (work / "tests" / "__init__.py").write_text("")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "chore: empty the test suite")
+
+        passed, output = bridge._run_smoke_tests(work)
+
+        assert passed is False
+
+    def test_harness_exception_fails_closed(self, tmp_path, monkeypatch):
+        origin, work = _init_repo(tmp_path)
+        bridge._setup_cycle_branch(work, "harnesserr")
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        passed, output = bridge._run_smoke_tests(work)
+
+        assert passed is False
+        assert "smoke harness error" in output
+
+    def test_suite_shrink_guard_fails_when_test_count_drops(self, tmp_path):
+        origin, work = _init_repo(tmp_path)  # baseline: 1 test function
+        setup = bridge._setup_cycle_branch(work, "shrink")
+        baseline = bridge._count_tests_at_ref(work, "origin/main")
+        assert baseline == 1
+
+        # Cycle guts the test function without deleting the file/dir.
+        (work / "tests" / "test_smoke.py").write_text("# tests removed\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "feat: quietly remove test coverage")
+        assert bridge._count_tests(work) == 0
+
+        passed, output = bridge._run_smoke_tests_with_shrink_guard(work, baseline)
+
+        assert passed is False
+        assert "suite-shrink guard" in output
+        # never got as far as invoking pytest for this failure
+        assert setup["ok"]
+
+    def test_suite_shrink_guard_allows_growing_suite(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        bridge._setup_cycle_branch(work, "grow")
+        baseline = bridge._count_tests_at_ref(work, "origin/main")
+        assert baseline == 1
+
+        _commit_file(
+            work, "tests/test_extra.py",
+            "def test_extra():\n    assert True\n",
+            "test: add extra coverage",
+        )
+        assert bridge._count_tests(work) == 2
+
+        passed, _output = bridge._run_smoke_tests_with_shrink_guard(work, baseline)
+
+        assert passed is True
+
+
+class TestAlreadyDonePushGate:
+    """F5: the already_done bookkeeping path must never bare-push; only a
+    diff that touches memory/MEMORY.md exclusively may be pushed."""
+
+    def test_memory_only_diff_is_pushable(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        (work / "memory").mkdir()
+        (work / "memory" / "MEMORY.md").write_text("# memory\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "chore: move task to Completed")
+
+        assert bridge._diff_against_remote_touches_only(
+            work, "origin/main", {"memory/MEMORY.md"}
+        ) is True
+
+    def test_non_memory_diff_blocks_push_and_main_stays_untouched(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        before = _origin_main_sha(origin)
+        (work / "memory").mkdir()
+        (work / "memory" / "MEMORY.md").write_text("# memory\n")
+        (work / "extra_stray_file.py").write_text("leak = 1\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "chore: move task to Completed (with stray file)")
+
+        should_push = bridge._diff_against_remote_touches_only(
+            work, "origin/main", {"memory/MEMORY.md"}
+        )
+        assert should_push is False
+        # Bridge would skip the push here — assert we never pushed.
+        assert _origin_main_sha(origin) == before
+
+
+class TestPostIntegrationBookkeepingPushGate:
+    """F6: post-integration writes (backlog-done, memory archiver, structured
+    lesson) must refuse to push when their diff includes anything beyond the
+    intended file(s)."""
+
+    def test_extra_file_in_diff_skips_push(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "postint")
+        _commit_file(work, "feature.py", "x = 1\n", "feat: add feature")
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], setup["main_sha"])
+        assert integ["ok"]
+        main_after_integration = integ["main_sha_after"]
+
+        # Simulate a lesson-recording commit that also touches an unexpected file.
+        (work / "lessons").mkdir()
+        (work / "lessons" / "lessons.yaml").write_text("lessons: []\n")
+        (work / "unexpected.py").write_text("x = 2\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "chore: record structured lesson (with stray file)")
+
+        should_push = bridge._diff_against_remote_touches_only(
+            work, "origin/main", {"lessons/lessons.yaml"}
+        )
+        assert should_push is False
+        assert _origin_main_sha(origin) == main_after_integration
+
+    def test_intended_file_only_diff_allows_push(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "postint-clean")
+        _commit_file(work, "feature2.py", "x = 1\n", "feat: add feature2")
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], setup["main_sha"])
+        assert integ["ok"]
+
+        (work / "lessons").mkdir()
+        (work / "lessons" / "lessons.yaml").write_text("lessons: []\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "chore: record structured lesson")
+
+        assert bridge._diff_against_remote_touches_only(
+            work, "origin/main", {"lessons/lessons.yaml"}
+        ) is True

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -103,22 +103,26 @@ def test_smoke_fail_when_tests_fail(tmp_path):
     assert '1 failed' in output
 
 
-def test_smoke_no_tests_dir_returns_true(tmp_path):
-    """No tests/ directory → (True, 'no tests directory')."""
+def test_smoke_no_tests_dir_returns_false(tmp_path):
+    """No tests/ directory → (False, ...) — #678 F2: fail-safe, not a free pass.
+
+    A self-evolving repo always has tests; their absence (e.g. a cycle that
+    `rm -rf tests/`) is suspicious and must not turn a bad change green.
+    """
     fn = _extract_fn('_run_smoke_tests')
     passed, output = fn(tmp_path)
-    assert passed is True
+    assert passed is False
     assert 'no tests' in output
 
 
-def test_smoke_no_tests_collected_returns_true(tmp_path):
-    """'collected 0 items' in output → treat as pass."""
+def test_smoke_no_tests_collected_returns_false(tmp_path):
+    """'collected 0 items' in output → fail closed (#678 F2), not a free pass."""
     fn = _extract_fn('_run_smoke_tests')
     with patch('subprocess.run') as mock_run:
         mock_run.return_value = MagicMock(returncode=5, stdout='collected 0 items\n', stderr='')
         (tmp_path / 'tests').mkdir()
         passed, _ = fn(tmp_path)
-    assert passed is True
+    assert passed is False
 
 
 def test_smoke_timeout_returns_false(tmp_path):
@@ -131,13 +135,18 @@ def test_smoke_timeout_returns_false(tmp_path):
     assert 'timed out' in output
 
 
-def test_smoke_pytest_not_found_returns_true(tmp_path):
-    """FileNotFoundError → (True, 'pytest unavailable')."""
+def test_smoke_pytest_not_found_returns_false(tmp_path):
+    """FileNotFoundError → (False, ...) — #678 F4: fail closed.
+
+    pytest is always installed in the runtime venv (sys.executable is used to
+    invoke it); a genuinely missing pytest is itself suspicious on the host, not
+    a benign condition to skip past.
+    """
     fn = _extract_fn('_run_smoke_tests')
     with patch('subprocess.run', side_effect=FileNotFoundError('python3')):
         (tmp_path / 'tests').mkdir()
         passed, output = fn(tmp_path)
-    assert passed is True
+    assert passed is False
     assert 'unavailable' in output
 
 


### PR DESCRIPTION
## Summary

Hardens the unsupervised autonomous cycle-integration path in `nanobot/runtime/bridge.py` — the code that decides what reaches `eeebot-self-evolving`'s `main` unattended. Implements all 6 CONFIRMED findings from the #678 two-lens adversarial review (git-invariants + content-safety).

### F1 — mutation surfaces are now a hard block
`_validate_mutation_surfaces` violations were previously only `print`ed; integration was decided solely by the smoke gate, so a cycle editing core `nanobot/`, `.github/workflows/`, `pyproject.toml`, or `bridge.py` itself could integrate as long as pytest happened to pass. Now: any violation sets `rollback_reason='mutation_surface_violation'`, skips `_integrate_cycle_to_main`, and leaves the cycle branch for forensics — same shape as a `gate_failed` cycle. Legit surfaces (`surfaces/`, `scripts/`, `memory/`, `lessons/`, `docs/`, `tests/`) are unaffected.
**Test:** `TestMutationSurfaceHardBlock` — a commit touching `nanobot/foo.py` is flagged and never reaches `_integrate_cycle_to_main`; `origin/main` stays untouched. A companion test confirms `scripts/`+`memory/` edits still integrate cleanly.

### F2 — gate fails safe on missing/empty suite, plus a suite-shrink guard
`_run_smoke_tests` previously returned `True` for a missing `tests/` directory and for `collected 0 items`/`no tests ran` — a cycle that `rm -rf tests/` (or emptied it) turned a failing change green. Both now return `False`. Added `_count_tests`/`_count_tests_at_ref` (cheap `def test_` counting via git blobs, no checkout needed) and `_run_smoke_tests_with_shrink_guard`, which fails the gate immediately if the cycle's test count drops below the `origin/main` baseline captured right after cycle-branch setup — re-applied on **every** gate evaluation including repair retries, closing the path where a repair loop could iteratively weaken tests until they pass.
**Tests:** `TestSmokeGateFailSafe` — missing tests dir → FAIL; emptied test function (dir/file present, 0 tests) → FAIL via `_run_smoke_tests` directly; suite-shrink guard FAILs on a dropped count and PASSes (defers to pytest) on a grown count.

### F3 — secret-pattern filter now applies to all cycle commits
The `_BLOCKED_FILE_PATTERNS` check previously ran only in the auto-commit fallback (`_auto_commit_uncommitted_work`, only reached when the subagent forgot to `git commit`). A subagent that committed normally had zero secret-pattern screening. `_validate_mutation_surfaces` already checked blocked patterns across *all* changed files — enforcing F1 makes that check authoritative for every commit path, with a distinguishable `rollback_reason='blocked_file_present'`.
**Test:** `TestBlockedPatternAcrossAllCommits` — a normal (non-auto-commit) `git commit` adding `id_rsa` is flagged and blocked.

### F4 — gate fails closed on harness exceptions
`except Exception: return True` previously integrated untested code on any pytest subprocess crash (OOM/OSError/disk-full). Now returns `False` with the exception message. `FileNotFoundError` (missing pytest) also now fails closed — pytest is always present in the runtime venv (`sys.executable` is used to invoke it), so its absence is itself suspicious. `TimeoutExpired` was already `False` and is unchanged.
**Test:** `test_harness_exception_fails_closed` — `subprocess.run` monkeypatched to raise `OSError` → `_run_smoke_tests` returns `False`.

### F5 — already-done bookkeeping push is now scope-constrained
The `already_done` fast path (runs on most cycles, before `_setup_cycle_branch`, with zero gate) previously did a bare `git push origin main` after `_try_mark_backlog_done`. Added `_diff_against_remote_touches_only(repo, ref, allowed)` — the push now only fires if the diff about to be published touches `memory/MEMORY.md` exclusively; otherwise it's skipped and logged.
**Test:** `TestAlreadyDonePushGate` — a memory-only diff is pushable; a diff with a stray extra file is not, and `origin/main` stays at its pre-commit SHA.

### F6 — post-integration bookkeeping pushes are now scope-constrained
Three more direct commit+push-to-main sites had zero gate: post-integration backlog-done mark, the memory archiver (which **executes** `scripts/memory_archiver.py` from the target repo), and the structured-lesson recorder. Each now uses the same `_diff_against_remote_touches_only` guard — `{'memory/MEMORY.md'}` for backlog-done, the archiver's own declared `files_changed` output for the archiver, `{'lessons/lessons.yaml'}` for the lesson recorder.
**Test:** `TestPostIntegrationBookkeepingPushGate` — a lesson commit with a stray extra file is refused; a clean lessons-only commit is allowed.

## Suite-shrink baseline
Captured once per cycle, right after `_setup_cycle_branch` (which already did the `origin/main` fetch): `_count_tests_at_ref(_selfevo_repo, 'origin/main')` reads `git ls-tree` + `git show <ref>:<path>` for every `tests/**/*.py` blob at that ref and counts `def test_` occurrences — no checkout required, so it works even though the shared checkout has already moved to the cycle branch. A baseline of `0` (unreadable ref / no `tests/` at that ref) never blocks.

## Adjustments to pre-existing tests
`tests/test_repair_loop.py` had 3 tests asserting the *old* fail-open behavior (`test_smoke_no_tests_dir_returns_true`, `test_smoke_no_tests_collected_returns_true`, `test_smoke_pytest_not_found_returns_true`) — those assertions were the vulnerability itself, so they're updated (renamed to `*_returns_false`) to assert the new fail-safe behavior. No other pre-existing test needed changes; all cycle-branch isolation/rollback tests in `tests/test_bridge_cycle_branch.py` are untouched and still pass.

## Test plan
- [x] 12 new regression tests in `tests/test_bridge_cycle_branch.py`, one (or more) per finding, plus legit-cycle-still-passes cases for F1 and F2.
- [x] 3 pre-existing tests in `tests/test_repair_loop.py` updated to match the new fail-safe contract.
- [x] Full suite: `python -m pytest tests/ -q` → **1120 passed**.
- [x] `ruff check` on all touched files → no new issues (12 pre-existing, unrelated issues confirmed present on `origin/main` too, via `git stash`).
- [x] `docs/specs/subagent-bridge/spec.md` updated: R11/R12 rewritten for fail-safe behavior, new R11b (suite-shrink guard), R12a (mutation-surface hard block), R16a (scope-constrained ungated pushes), plus a new scenario and updated code references.
- [x] `memory/HISTORY.md` intentionally not touched (per task constraints).

Out of scope (tracked separately per #678's "plausible" items): flock/concurrency locking, and the top-of-`main()` HEAD-on-main precondition assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125qdhCSXD9qCxmmFvoK5uv