### PR TITLE
feat: bounded fast smoke gate — import-smoke + affected tests + core smoke (#686)

### DIFF
--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -1,10 +1,18 @@
 # Subagent Bridge — spec
 
-_Status: current. Last updated: 2026-07-07 (#680: defense-in-depth follow-up to
+_Status: current. Last updated: 2026-07-07 (#686: the smoke gate (R10/R11) is
+now BOUNDED — import-smoke of changed files + tests they affect + a small
+fixed core smoke set, computed by `_select_gate_tests`, instead of the full
+`pytest tests/` suite. Rationale: the subagent's mutation surface is already
+bounded (core `nanobot/` is hard-blocked, #678), so full-suite validation of
+core belongs to product CI + re-seed-time verification, not a 300s per-cycle
+gate that the full suite (601s measured) can no longer fit. Every #678
+fail-safe/hard-block property is preserved against the smaller selection).
+Previous entry: 2026-07-07, #680: defense-in-depth follow-up to
 #678 — an exclusive non-blocking `flock` on `bridge.lock` guards against
 concurrent bridge runs (R26), and a HEAD-on-main precondition re-asserts the
 shared checkout is clean and on `main` before any bookkeeping runs, aborting
-with a `blocked` result if it cannot be repaired (R27)). Previous entry:
+with a `blocked` result if it cannot be repaired (R27)). Earlier entry:
 2026-07-07, #678: integration-gate hardening — mutation-surface/blocked-pattern
 violations are now a hard block (R12a), the smoke gate fails safe on
 missing/empty suites and harness exceptions instead of passing (R11 rewritten),
@@ -22,9 +30,10 @@ coordinator (a lightweight bookkeeper that does not write code) queues bounded
 subagent requests under the state root; the bridge picks the oldest queued
 request, builds a concrete prompt from the source artifact, and runs the
 mandatory local executor model to actually implement the change. Each cycle is
-isolated on its own git branch off `origin/main`, gated by the full `pytest
-tests/` suite, and integrated into `main` only when that gate passes — so a
-broken or unverified cycle never reaches `main`.
+isolated on its own git branch off `origin/main`, gated by a bounded smoke
+selection (import-smoke of changed files + tests they affect + a small fixed
+core smoke set — R10, #686), and integrated into `main` only when that gate
+passes — so a broken or unverified cycle never reaches `main`.
 
 > This is **product** runtime behavior. Explanatory detail and host operations
 > are in `docs/SYSTEM_OPERATION_REFERENCE.md` §6–§7 (`EEEPC_AGENT_RUNTIME_INSTRUCTIONS.md`
@@ -105,39 +114,68 @@ executor run does not stop early or hand off instead of acting:
 
 ### Smoke gate
 - R10. After the subagent commits, the bridge SHALL gate the cycle with
-  `_run_smoke_tests`, which runs the FULL `pytest tests/` suite via the runtime's
-  own interpreter (`sys.executable -m pytest -x -q --tb=native`, 300s timeout)
-  inside the isolated checkout. This is intentionally not an import-only check
-  of changed files — an updated 2026-07 revision of this requirement; see
-  "History" below. (#668: the bare system `python3` lacks runtime dependencies
-  and `--tb=short`/60s produced spurious INTERNALERROR/timeout failures on the
-  eeepc host; `sys.executable` + `--tb=native` + 300s reflect the environment
-  and runtime the gate must actually exercise.) The pytest subprocess SHALL run
-  with a sanitized environment (`_sanitized_smoke_env`), stripping every key
-  starting with `STATE_DIR`, `NANOBOT_`, `SUBAGENT_`, `EEEBOT_`,
-  `TARGET_WORKSPACE`, `LITELLM_`, `GOAL_`, `SOURCE_`, or `SELFEVO_` from
-  `os.environ` before the call, rather than inheriting the bridge systemd
-  unit's environment wholesale. (#668 env-pollution finding: without
-  sanitization, the subprocess inherits the bridge unit's `STATE_DIR` and
-  friends, and target-repo tests that read process env to locate state
-  observe LIVE production state instead of a hermetic fixture — deterministically
-  reproduced via `tests/test_active_lane_continue.py` passing in a clean env and
-  failing with the bridge env sourced, on identical code. The gate must
-  evaluate the repo hermetically, not against live runtime state.)
+  `_run_smoke_tests`, which runs a **BOUNDED** selection via the runtime's own
+  interpreter (`sys.executable`, 300s timeout) inside the isolated checkout,
+  computed by `_select_gate_tests(repo_root, changed_files)` from the cycle's
+  changed-file set (`_changed_files_and_violations`, `pre_spawn_sha..HEAD`):
+  1. **Import-smoke**: `sys.executable -m py_compile <changed .py files>` —
+     a syntax/compile error fails the gate immediately, before pytest
+     collection even starts. Only a compile check, deliberately not an actual
+     import of arbitrary changed modules (which may have side effects);
+     import-time errors are caught by phase 2's affected tests instead.
+  2. **Targeted pytest**: `sys.executable -m pytest <test paths> -q --tb=native
+     -p no:cacheprovider`, where `<test paths>` is the union of (a) each
+     changed file's corresponding test module(s) — `scripts/foo.py` →
+     `tests/test_foo.py`; any changed file's stem also fuzzy-matches
+     `tests/test_*<stem>*.py`; a changed `tests/test_*.py` file selects
+     itself — and (b) a small fixed **core smoke set**
+     (`_CORE_SMOKE_TESTS`: `tests/test_import_hygiene.py`,
+     `tests/test_config_schema.py`, `tests/test_config_paths.py`) that always
+     runs regardless of what changed, for cross-cutting breakage.
+  - **Rationale (#686):** the subagent's mutation surface is bounded to
+    `scripts/`, `docs/`, `memory/`, `lessons/`, `tests/` — core `nanobot/` is
+    hard-blocked (R12a) — so the bulk of the full suite (core `nanobot/`
+    tests) cannot have been broken by a cycle; re-running it every cycle
+    against a 300s gate timeout was pure waste (measured 601s for the full
+    product suite on the host — #672's re-seed showstopper). Full-suite
+    validation of core is **product CI** (every product PR) plus **re-seed-time
+    verification**, not this per-cycle gate. This changes only WHICH tests the
+    gate runs; the gate DECISION shape in `main()`
+    (blocked → mutation → smoke → integrate) and every #678 property below are
+    unchanged.
+  The pytest subprocess (both phases) SHALL run with a sanitized environment
+  (`_sanitized_smoke_env`), stripping every key starting with `STATE_DIR`,
+  `NANOBOT_`, `SUBAGENT_`, `EEEBOT_`, `TARGET_WORKSPACE`, `LITELLM_`, `GOAL_`,
+  `SOURCE_`, or `SELFEVO_` from `os.environ` before the call, rather than
+  inheriting the bridge systemd unit's environment wholesale. (#668
+  env-pollution finding: without sanitization, the subprocess inherits the
+  bridge unit's `STATE_DIR` and friends, and target-repo tests that read
+  process env to locate state observe LIVE production state instead of a
+  hermetic fixture — deterministically reproduced via
+  `tests/test_active_lane_continue.py` passing in a clean env and failing with
+  the bridge env sourced, on identical code. The gate must evaluate the repo
+  hermetically, not against live runtime state.)
 - R11. If no commits landed on the cycle branch, the smoke gate SHALL be
   skipped entirely (nothing to test) and the cycle branch SHALL be discarded
-  without touching `main`. A missing/empty `tests/` directory, a suite that
-  collects zero tests, a pytest timeout, or any other harness exception
-  (subprocess crash, `FileNotFoundError` for a missing `pytest`, ...) SHALL
-  **fail the gate** (`_run_smoke_tests` returns `(False, reason)`) — this
-  runtime always has tests, so their absence, emptiness, or an unexplained
-  harness failure is suspicious, never a benign skip.
+  without touching `main`. A missing/empty `tests/` directory, an empty
+  selection (`_select_gate_tests` returns no test paths at all — e.g. no
+  changed file maps to an existing test AND none of `_CORE_SMOKE_TESTS`
+  exists in this tree), a suite that collects zero tests, a pytest timeout,
+  or any other harness exception (subprocess crash, `FileNotFoundError` for a
+  missing `pytest`, an import-smoke `py_compile` failure, ...) SHALL **fail
+  the gate** (`_run_smoke_tests` returns `(False, reason)`) — this runtime
+  always has tests, so their absence, emptiness, or an unexplained harness
+  failure is suspicious, never a benign skip. A changed file with no matching
+  test is fine (the core smoke set still runs) — an empty selection is only
+  reached when there is truly nothing to check, and that is a hard fail, not
+  an auto-pass.
   - History: an earlier draft of this requirement (through #653) described an
     import-only syntax check of only the changed `.py` files. That was never
-    implemented; `_run_smoke_tests` has always run the full suite. #653
-    corrected the requirement text to match the running code (CLAUDE.md
-    "executable truth wins") rather than implementing the cheaper import-only
-    check, since the full suite is a strictly stronger gate.
+    implemented; `_run_smoke_tests` ran the full suite from #653 through
+    #686. #653 corrected the requirement text to match the running code
+    (CLAUDE.md "executable truth wins") rather than implementing the cheaper
+    import-only check, since the full suite was then a strictly stronger
+    (if increasingly unaffordable) gate.
   - **Reversal (#678, finding 2/4):** through 2026-07-06 this requirement said
     the opposite — missing tests, an empty suite, a timeout-adjacent harness
     exception, and a missing `pytest` binary all `return True` ("skip" =
@@ -147,6 +185,11 @@ executor run does not stop early or hand off instead of acting:
     subprocess crash (OOM/OSError/disk-full) integrated untested code. Both
     now fail closed; only a genuine `_sp.TimeoutExpired` was already `False`
     and is unchanged.
+  - **Narrowed (#686):** the full-suite gate described immediately above
+    (2026-07-06 through 2026-07-07) is replaced by the bounded selection in
+    R10. Every fail-safe property in this requirement is preserved against
+    the new, smaller selection — an emptied selection is treated exactly like
+    the emptied-suite case it replaces.
 - R11b. Before running pytest, the gate SHALL compare a hermetic proxy for
   suite size — the count of `def test_` occurrences across `tests/**/*.py`
   (`_count_tests`) — in the cycle's working tree against the same count

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1225,8 +1225,10 @@ async def _main_impl():
         # R12: bounded revisions — cap configurable (default 3), never unbounded.
         if cycle_commit_count > 0 and _selfevo_repo.is_dir():
             _smoke_ran = True
+            # #686: files_changed here reflects the initial commit(s) computed
+            # above (lines ~1199-1218) — the bounded gate selects tests from it.
             _smoke_passed, _smoke_output = _run_smoke_tests_with_shrink_guard(
-                _selfevo_repo, _baseline_test_count,
+                _selfevo_repo, _baseline_test_count, changed_files=files_changed,
             )
             print(f'smoke: {"PASS" if _smoke_passed else "FAIL"}')
             while not _smoke_passed and _repair_attempts < _max_repair_attempts:
@@ -1273,12 +1275,25 @@ async def _main_impl():
                 if _repair_new > cycle_commit_count:
                     print(f'cycle-branch: {_repair_new - cycle_commit_count} additional commit(s) (repair {_repair_attempts})')
                     cycle_commit_count = _repair_new
+                # #686: recompute the changed-file set before EVERY gate re-run,
+                # not just once — a repair turn can add/rename files, and the
+                # bounded gate must select tests against the CURRENT diff, the
+                # same "recompute after repair" discipline #678 F1/F3 applies to
+                # the mutation-surface check. On git failure this keeps the
+                # last-known files_changed rather than gating on an empty set.
+                _rc_files, _rc_blocked, _rc_mut = _changed_files_and_violations(
+                    _selfevo_repo, _pre_spawn_sha,
+                )
+                if _rc_files or _rc_blocked or _rc_mut:
+                    files_changed, _blocked_pattern_violations, _mutation_violations = (
+                        _rc_files, _rc_blocked, _rc_mut
+                    )
                 # Re-run smoke tests after repair. Re-applying the shrink guard
                 # on every retry (not just the first check) closes the path
                 # where a repair turn iteratively deletes/weakens tests to make
                 # the suite pass (#678 F2).
                 _smoke_passed, _smoke_output = _run_smoke_tests_with_shrink_guard(
-                    _selfevo_repo, _baseline_test_count,
+                    _selfevo_repo, _baseline_test_count, changed_files=files_changed,
                 )
                 print(f'smoke (after repair {_repair_attempts}): {"PASS" if _smoke_passed else "FAIL"}')
         # ─────────────────────────────────────────────────────────────────────
@@ -1540,6 +1555,87 @@ _SMOKE_ENV_STRIP_PREFIXES = (
 )
 
 
+# #686: small, fixed, hermetic set of cross-cutting tests always run by the
+# bounded gate, regardless of which files a cycle touched. Keeps catching
+# breakage that isn't localized to a single changed file (e.g. an import-path
+# regression) without paying for the full ~600s suite every cycle. Chosen for
+# speed + criticality: import hygiene (nanobot.* import-only enforcement) and
+# the config schema/path tests are all sub-second, dependency-free unit tests.
+_CORE_SMOKE_TESTS = (
+    'tests/test_import_hygiene.py',
+    'tests/test_config_schema.py',
+    'tests/test_config_paths.py',
+)
+
+
+def _select_gate_tests(
+    repo_root: 'Path', changed_files: 'list[str]',
+) -> 'tuple[list[str], list[str]]':
+    """Map a cycle's changed files to (test_paths, import_targets) for the bounded gate.
+
+    #686: the subagent's mutation surface is bounded (scripts/docs/memory/
+    lessons/tests — core ``nanobot/`` is hard-blocked, #678), so a per-cycle
+    gate only needs to validate what a cycle can actually change, not the
+    whole product suite (that's product CI + re-seed-time verification, see
+    docs/specs/subagent-bridge/spec.md R10/R11).
+
+    - ``import_targets``: every changed ``*.py`` file that still exists in the
+      working tree (deleted files are skipped — nothing to compile).
+    - ``test_paths``: for each changed file, its corresponding test module(s)
+      (``scripts/foo.py`` -> ``tests/test_foo.py``; ``nanobot/x/y.py`` ->
+      ``tests/test_y.py`` plus any ``tests/test_*y*.py``; a changed
+      ``tests/test_*.py`` file -> itself), plus the fixed :data:`_CORE_SMOKE_TESTS`
+      set. Only paths that exist in the working tree are returned. Order is
+      deterministic (sorted) so gate output/tests are stable.
+
+    Returns ``([], [])`` only when there is nothing to check at all (no
+    changed .py files, no matching tests, AND none of the core smoke tests
+    exist in this tree) — callers treat that as "nothing to gate on", never
+    as an auto-pass.
+    """
+    import_targets: 'set[str]' = set()
+    test_paths: 'set[str]' = set()
+
+    for f in changed_files:
+        f = f.strip()
+        if not f:
+            continue
+        if f.endswith('.py') and (repo_root / f).exists():
+            import_targets.add(f)
+
+        path = Path(f)
+        stem = path.stem
+        if not stem:
+            continue
+
+        # A changed test file affects itself directly.
+        if f.startswith('tests/') and path.name.startswith('test_') and f.endswith('.py'):
+            if (repo_root / f).exists():
+                test_paths.add(f)
+            continue
+
+        # Direct name mapping: <anything>/<stem>.py -> tests/test_<stem>.py
+        candidate = f'tests/test_{stem}.py'
+        if (repo_root / candidate).exists():
+            test_paths.add(candidate)
+
+        # Fuzzy mapping: any test module whose name contains the stem, so a
+        # rename or a submodule (nanobot/x/y.py) still finds tests/test_*y*.py.
+        tests_dir = repo_root / 'tests'
+        if tests_dir.is_dir():
+            try:
+                for match in tests_dir.glob(f'test_*{stem}*.py'):
+                    test_paths.add(str(match.relative_to(repo_root)))
+            except (OSError, ValueError):
+                pass
+
+    for core in _CORE_SMOKE_TESTS:
+        if (repo_root / core).exists():
+            test_paths.add(core)
+
+    return sorted(test_paths), sorted(import_targets)
+
+
 def _sanitized_smoke_env() -> dict:
     """Build a subprocess env for the smoke-test gate with runtime state stripped.
 
@@ -1564,14 +1660,35 @@ def _sanitized_smoke_env() -> dict:
     }
 
 
-def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]':
-    """Run pytest smoke tests in repo_root after a subagent commit.
+def _run_smoke_tests(
+    repo_root: 'Path', changed_files: 'list[str] | None' = None, timeout: int = 300,
+) -> 'tuple[bool, str]':
+    """Run a BOUNDED smoke gate in repo_root after a subagent commit (#686).
 
     Returns (passed: bool, output: str) where output is truncated to 2000 chars.
-    - timeout: seconds before treating as failure
-    - missing/empty tests dir, no tests collected, or any harness error: FAIL
-      (fail-safe — see #678 finding 2/4: a self-evolving repo always has tests,
-      so their absence or an unexplained harness crash is suspicious, not benign).
+
+    Replaces the previous "run all of tests/" gate with a targeted selection,
+    since the subagent's mutation surface is bounded (scripts/docs/memory/
+    lessons/tests only — core nanobot/ is hard-blocked, #678): the bulk of the
+    full suite (core nanobot/ tests) cannot have been broken by a cycle, so
+    re-running it every cycle is pure waste against the 300s gate timeout.
+    Full-suite validation of core is product CI + re-seed-time verification
+    (docs/specs/subagent-bridge/spec.md R10/R11), not this per-cycle gate.
+
+    Two phases, both fail-safe (never pass-open):
+    1. Import-smoke: ``python -m py_compile`` every changed ``*.py`` file. A
+       syntax/compile error fails the gate immediately, before pytest even
+       runs. (py_compile only — it deliberately does NOT actually import
+       arbitrary changed modules, which may have side effects; import-time
+       errors are caught by the affected tests in phase 2 instead.)
+    2. Targeted pytest: the union of tests affected by the changed files plus
+       the fixed :data:`_CORE_SMOKE_TESTS` set (see :func:`_select_gate_tests`),
+       run with the same hermetic env as before (#668).
+
+    ``changed_files`` of ``None`` or ``[]`` still runs the core smoke set (never
+    an auto-pass — see #678 finding 2/4): a self-evolving repo always has
+    tests, so an empty selection when core tests are also missing is FAIL, not
+    skip.
 
     Runs with sys.executable (the runtime's own venv interpreter, with all deps
     installed) rather than the bare system python — see #668: a bare `python3`
@@ -1591,9 +1708,41 @@ def _run_smoke_tests(repo_root: 'Path', timeout: int = 300) -> 'tuple[bool, str]
         # #678 F2: a missing tests/ directory (e.g. a cycle that `rm -rf tests/`)
         # previously turned a failing change green. Fail closed instead.
         return False, 'no tests directory (fail-safe: #678)'
+
+    changed_files = changed_files or []
+    test_paths, import_targets = _select_gate_tests(repo_root, changed_files)
+
+    # Phase 1: import-smoke via py_compile — catches syntax/compile breakage
+    # in every changed .py file before pytest collection even starts.
+    if import_targets:
+        try:
+            compile_result = _sp.run(
+                [sys.executable, '-m', 'py_compile', *import_targets],
+                capture_output=True, text=True, timeout=timeout, cwd=str(repo_root),
+                env=_sanitized_smoke_env(),
+            )
+        except _sp.TimeoutExpired:
+            return False, 'import-smoke (py_compile) timed out'
+        except Exception as exc:
+            # #678 F4 parity: a crash in the compile-check subprocess itself is
+            # suspicious, not benign — fail closed.
+            return False, f'import-smoke harness error (fail-safe: #686): {exc}'
+        if compile_result.returncode != 0:
+            output = (compile_result.stdout + compile_result.stderr).strip()
+            output = output[-2000:] if len(output) > 2000 else output
+            return False, f'import-smoke FAIL (py_compile):\n{output}'
+
+    # #678 F2 parity: an empty test selection is NOT an auto-pass. This only
+    # happens when there are changed files but neither they nor the fixed
+    # core-smoke set map to any test file present in the tree — treat that
+    # the same as an emptied suite.
+    if not test_paths:
+        return False, 'no tests selected for gate (fail-safe: #686/#678)'
+
     try:
         result = _sp.run(
-            [sys.executable, '-m', 'pytest', str(tests_dir), '-x', '-q', '--tb=native', '--no-header'],
+            [sys.executable, '-m', 'pytest', *test_paths,
+             '-q', '--tb=native', '-p', 'no:cacheprovider'],
             capture_output=True, text=True, timeout=timeout, cwd=str(repo_root),
             env=_sanitized_smoke_env(),
         )
@@ -1672,7 +1821,8 @@ def _count_tests_at_ref(repo_root: 'Path', ref: str) -> int:
 
 
 def _run_smoke_tests_with_shrink_guard(
-    repo_root: 'Path', baseline_test_count: int, timeout: int = 300,
+    repo_root: 'Path', baseline_test_count: int,
+    changed_files: 'list[str] | None' = None, timeout: int = 300,
 ) -> 'tuple[bool, str]':
     """Gate wrapper: fail immediately if the cycle's test count dropped below baseline.
 
@@ -1682,6 +1832,12 @@ def _run_smoke_tests_with_shrink_guard(
     not just once. ``baseline_test_count`` of 0 means "could not establish a
     baseline" and never blocks (nothing to compare against); otherwise a strictly
     lower current count fails the gate without needing to run pytest at all.
+
+    The shrink guard itself counts tests present in the WHOLE tree (unchanged
+    by #686) — it is independent of which tests the bounded gate below actually
+    executes, so a cycle can't dodge it by only touching untested files.
+    ``changed_files`` is forwarded to :func:`_run_smoke_tests` for the bounded
+    selection (#686); see there for the import-smoke + affected + core design.
     """
     if baseline_test_count > 0:
         current = _count_tests(repo_root)
@@ -1690,7 +1846,7 @@ def _run_smoke_tests_with_shrink_guard(
                 f'suite-shrink guard (#678): test count dropped from '
                 f'{baseline_test_count} to {current} vs main baseline'
             )
-    return _run_smoke_tests(repo_root, timeout=timeout)
+    return _run_smoke_tests(repo_root, changed_files=changed_files, timeout=timeout)
 
 
 # Commit subject prefixes that are maintenance-only and should not count as

--- a/tests/test_bounded_gate.py
+++ b/tests/test_bounded_gate.py
@@ -1,0 +1,329 @@
+"""Tests for #686: bounded fast smoke gate.
+
+Replaces "run all of tests/" with a targeted selection: import-smoke of
+changed .py files, tests affected by what changed, plus a small fixed core
+smoke set. Exercises ``_select_gate_tests`` directly and ``_run_smoke_tests``
+end to end against temp repos, mirroring the fixture style of
+tests/test_bridge_cycle_branch.py (real git repos, no mocked subprocess for
+the integration-style cases).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import bridge
+
+
+def _git(repo: Path) -> list[str]:
+    return ["git", "-c", f"safe.directory={repo}", "-C", str(repo)]
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(_git(repo) + list(args), capture_output=True, text=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Minimal working repo (no bare origin needed for these tests)."""
+    work = tmp_path / "work"
+    work.mkdir()
+    _run(work, "init", "-q", "--initial-branch=main")
+    _run(work, "config", "user.email", "bridge@test.local")
+    _run(work, "config", "user.name", "bridge-test")
+    (work / "tests").mkdir()
+    (work / "tests" / "test_import_hygiene.py").write_text(
+        "def test_hygiene():\n    assert True\n"
+    )
+    _run(work, "add", "-A")
+    _run(work, "commit", "-q", "-m", "init")
+    return work
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    """As in test_bridge_cycle_branch.py: point the core set at a file this
+    module's synthetic repos actually create.
+    """
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_import_hygiene.py",))
+
+
+class TestSelectGateTests:
+    def test_script_change_selects_its_test_plus_core(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "scripts").mkdir()
+        (work / "scripts" / "foo.py").write_text("def foo():\n    return 1\n")
+        (work / "tests" / "test_foo.py").write_text(
+            "def test_foo():\n    assert True\n"
+        )
+        # An unrelated core-looking test that must NOT be pulled in just
+        # because it happens to exist — only the fixed _CORE_SMOKE_TESTS set
+        # and files matching the changed stem are selected.
+        (work / "tests" / "test_unrelated.py").write_text(
+            "def test_unrelated():\n    assert True\n"
+        )
+
+        test_paths, import_targets = bridge._select_gate_tests(
+            work, ["scripts/foo.py"]
+        )
+
+        assert "tests/test_foo.py" in test_paths
+        assert "tests/test_import_hygiene.py" in test_paths  # core set
+        assert "tests/test_unrelated.py" not in test_paths
+        assert import_targets == ["scripts/foo.py"]
+
+    def test_changed_test_file_selects_itself(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "tests" / "test_bar.py").write_text(
+            "def test_bar():\n    assert True\n"
+        )
+
+        test_paths, import_targets = bridge._select_gate_tests(
+            work, ["tests/test_bar.py"]
+        )
+
+        assert "tests/test_bar.py" in test_paths
+        assert "tests/test_import_hygiene.py" in test_paths
+        assert "tests/test_bar.py" in import_targets
+
+    def test_no_matching_test_still_returns_core_set(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "docs").mkdir()
+        (work / "docs" / "notes.md").write_text("# notes\n")
+
+        test_paths, import_targets = bridge._select_gate_tests(
+            work, ["docs/notes.md"]
+        )
+
+        assert test_paths == ["tests/test_import_hygiene.py"]
+        assert import_targets == []  # not a .py file
+
+    def test_deleted_file_not_included_as_import_target(self, tmp_path):
+        work = _init_repo(tmp_path)
+        # Changed-file set can include files no longer present at HEAD
+        # (deleted by the cycle) — nothing to py_compile there.
+        test_paths, import_targets = bridge._select_gate_tests(
+            work, ["scripts/deleted.py"]
+        )
+        assert import_targets == []
+        assert test_paths == ["tests/test_import_hygiene.py"]
+
+
+class TestImportSmoke:
+    def test_syntax_error_fails_gate_before_pytest_runs(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "scripts").mkdir()
+        (work / "scripts" / "broken.py").write_text("def broken(:\n    pass\n")
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=["scripts/broken.py"])
+
+        assert passed is False
+        assert "import-smoke" in output
+
+    def test_valid_syntax_proceeds_to_pytest(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "scripts").mkdir()
+        (work / "scripts" / "ok.py").write_text("def ok():\n    return 1\n")
+
+        passed, _output = bridge._run_smoke_tests(work, changed_files=["scripts/ok.py"])
+
+        assert passed is True  # core smoke test still passes
+
+
+class TestAffectedAndCoreTests:
+    def test_affected_test_fails_gate(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "scripts").mkdir()
+        (work / "scripts" / "foo.py").write_text("def foo():\n    return 1\n")
+        (work / "tests" / "test_foo.py").write_text(
+            "def test_foo():\n    assert False\n"
+        )
+        _run(work, "add", "-A")
+        _run(work, "commit", "-q", "-m", "feat: add foo + failing test")
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=["scripts/foo.py"])
+
+        assert passed is False
+        assert "test_foo" in output
+
+    def test_affected_test_passes_and_core_passes_gate_passes(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "scripts").mkdir()
+        (work / "scripts" / "foo.py").write_text("def foo():\n    return 1\n")
+        (work / "tests" / "test_foo.py").write_text(
+            "def test_foo():\n    assert True\n"
+        )
+        _run(work, "add", "-A")
+        _run(work, "commit", "-q", "-m", "feat: add foo + passing test")
+
+        passed, _output = bridge._run_smoke_tests(work, changed_files=["scripts/foo.py"])
+
+        assert passed is True
+
+    def test_no_matching_test_core_smoke_still_runs_not_an_autopass(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "docs").mkdir()
+        (work / "docs" / "notes.md").write_text("# notes\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-q", "-m", "docs: add notes")
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=["docs/notes.md"])
+
+        # Core smoke test exists and passes -> gate passes, but it actually
+        # ran something (not a bare auto-pass on an empty selection).
+        assert passed is True
+        assert "test_import_hygiene" in output or "1 passed" in output
+
+    def test_core_smoke_failure_fails_gate_even_with_unrelated_change(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "tests" / "test_import_hygiene.py").write_text(
+            "def test_hygiene():\n    assert False\n"
+        )
+        (work / "docs").mkdir()
+        (work / "docs" / "notes.md").write_text("# notes\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-q", "-m", "docs: add notes (core broken)")
+
+        passed, _output = bridge._run_smoke_tests(work, changed_files=["docs/notes.md"])
+
+        assert passed is False
+
+
+class TestFailSafe:
+    def test_missing_core_and_no_affected_tests_fails_closed(self, tmp_path):
+        work = _init_repo(tmp_path)
+        (work / "tests" / "test_import_hygiene.py").unlink()
+        (work / "docs").mkdir()
+        (work / "docs" / "notes.md").write_text("# notes\n")
+        _run(work, "add", "-A")
+        _run(work, "commit", "-q", "-m", "docs: add notes")
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=["docs/notes.md"])
+
+        assert passed is False
+        assert "no tests selected" in output
+
+    def test_missing_tests_directory_fails_gate(self, tmp_path):
+        work = _init_repo(tmp_path)
+        import shutil
+
+        shutil.rmtree(work / "tests")
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=["docs/notes.md"])
+
+        assert passed is False
+        assert "no tests directory" in output
+
+    def test_pytest_timeout_fails_gate(self, tmp_path, monkeypatch):
+        work = _init_repo(tmp_path)
+
+        def _boom(*_args, **kwargs):
+            raise subprocess.TimeoutExpired("pytest", kwargs.get("timeout", 300))
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=[])
+
+        assert passed is False
+        assert "timed out" in output
+
+    def test_harness_exception_fails_closed(self, tmp_path, monkeypatch):
+        work = _init_repo(tmp_path)
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+
+        passed, output = bridge._run_smoke_tests(work, changed_files=[])
+
+        assert passed is False
+        assert "smoke harness error" in output
+
+
+class TestIntegrationFullCycle:
+    """End-to-end: bounded gate wired into the same setup -> gate -> integrate
+    shape used by test_bridge_cycle_branch.py's TestFullCycleFlow, but driving
+    the bounded selection via changed_files derived from a real diff.
+    """
+
+    def _bare_origin_and_clone(self, tmp_path):
+        origin = tmp_path / "origin.git"
+        work = tmp_path / "work"
+        subprocess.run(
+            ["git", "init", "--bare", "--initial-branch=main", str(origin)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+        _run(work, "config", "user.email", "bridge@test.local")
+        _run(work, "config", "user.name", "bridge-test")
+        _run(work, "checkout", "-B", "main")
+        (work / "tests").mkdir()
+        (work / "tests" / "test_import_hygiene.py").write_text(
+            "def test_hygiene():\n    assert True\n"
+        )
+        _run(work, "add", ".")
+        _run(work, "commit", "-m", "init")
+        _run(work, "push", "origin", "HEAD:main")
+        return origin, work
+
+    def test_scripts_change_with_passing_test_integrates(self, tmp_path):
+        origin, work = self._bare_origin_and_clone(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "bounded-green")
+        assert setup["ok"]
+        pre_spawn_sha = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        (work / "scripts").mkdir()
+        (work / "scripts" / "foo.py").write_text("def foo():\n    return 1\n")
+        (work / "tests" / "test_foo.py").write_text(
+            "def test_foo():\n    assert True\n"
+        )
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "feat: add foo")
+
+        files_changed, blocked, mutation = bridge._changed_files_and_violations(
+            work, pre_spawn_sha
+        )
+        assert not blocked and not mutation
+        passed, _output = bridge._run_smoke_tests(work, changed_files=files_changed)
+        assert passed is True
+
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], setup["main_sha"])
+        assert integ["ok"] is True
+        assert (
+            subprocess.run(
+                _git(origin) + ["rev-parse", "main"], capture_output=True, text=True
+            ).stdout.strip()
+            == integ["main_sha_after"]
+        )
+
+    def test_scripts_change_with_failing_test_does_not_integrate(self, tmp_path):
+        origin, work = self._bare_origin_and_clone(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "bounded-fail")
+        assert setup["ok"]
+        main_sha_before = setup["main_sha"]
+        pre_spawn_sha = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        (work / "scripts").mkdir()
+        (work / "scripts" / "foo.py").write_text("def foo():\n    return 1\n")
+        (work / "tests" / "test_foo.py").write_text(
+            "def test_foo():\n    assert False\n"
+        )
+        _run(work, "add", "-A")
+        _run(work, "commit", "-m", "feat: add foo (broken test)")
+
+        files_changed, blocked, mutation = bridge._changed_files_and_violations(
+            work, pre_spawn_sha
+        )
+        assert not blocked and not mutation
+        passed, _output = bridge._run_smoke_tests(work, changed_files=files_changed)
+        assert passed is False
+
+        # Gate failed -> never integrate; restore checkout to main.
+        restored = bridge._restore_to_main(work)
+        assert restored is True
+        origin_main = subprocess.run(
+            _git(origin) + ["rev-parse", "main"], capture_output=True, text=True
+        ).stdout.strip()
+        assert origin_main == main_sha_before

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -14,7 +14,21 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from nanobot.runtime import bridge
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    """#686: the bounded gate's real core-smoke set names paths in THIS repo
+    (tests/test_import_hygiene.py etc.), which don't exist in the synthetic
+    "origin"/"work" repos this file builds. Point the core set at the one test
+    file those fixtures actually create (tests/test_smoke.py) so the existing
+    full-suite-style assertions below (which predate the bounded gate and only
+    ever had that one test file to run) keep exercising the same content.
+    """
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
 
 
 def _git(repo: Path) -> list[str]:

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -22,6 +22,19 @@ _BRIDGE_PATH = Path(__file__).parent.parent / 'nanobot' / 'runtime' / 'bridge.py
 # fix) — pull them in alongside it so the AST-extraction sandbox has them.
 _SMOKE_DEPS = ('_SMOKE_ENV_STRIP_PREFIXES', '_sanitized_smoke_env')
 
+# #686: _run_smoke_tests now delegates test SELECTION to _select_gate_tests
+# (mapping changed files -> affected + core test paths against the real repo
+# tree at nanobot/runtime/bridge.py's own project layout — meaningless against
+# an empty tmp_path). These tests only exercise the pytest-invocation/env/
+# fail-safe plumbing of _run_smoke_tests itself, so a fixed stub selection
+# (one always-selected dummy test path, no import targets) stands in for the
+# real mapping — the same shape #526/#668 originally tested against the
+# (then-unconditional) `tests/` directory.
+_SELECT_GATE_TESTS_STUB = textwrap.dedent("""\
+    def _select_gate_tests(repo_root, changed_files):
+        return (['tests/test_dummy.py'], [])
+""")
+
 
 def _extract_fn(name: str, extra_setup: str = '') -> object:
     """AST-parse the bridge, extract a function (+ its known deps) by name, exec in isolation."""
@@ -30,6 +43,7 @@ def _extract_fn(name: str, extra_setup: str = '') -> object:
     names_needed = {name}
     if name == '_run_smoke_tests':
         names_needed.update(_SMOKE_DEPS)
+        extra_setup = _SELECT_GATE_TESTS_STUB + extra_setup
     srcs: dict[str, str] = {}
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.Assign)):


### PR DESCRIPTION
## Summary

Replaces the bridge smoke gate's "run all of `tests/`" with a **bounded** selection. Per #678, the subagent's mutation surface is already bounded to `scripts/`, `docs/`, `memory/`, `lessons/`, `tests/` — core `nanobot/` is hard-blocked — so the bulk of the full suite (core `nanobot/` tests) cannot have been broken by a per-cycle change. Re-running it every cycle was pure waste: measured 601s (10 min) for the full product suite on the eeepc host, which no longer fits either the 300s gate timeout or the systemd unit budget (the #672 re-seed showstopper).

## Selection algorithm (`_select_gate_tests`)

For each changed file (from `_changed_files_and_violations`, `pre_spawn_sha..HEAD`):
- **Import targets**: every changed `*.py` file that still exists in the working tree.
- **Affected tests**: `scripts/foo.py` → `tests/test_foo.py`; a submodule (`nanobot/x/y.py`) also fuzzy-matches any `tests/test_*y*.py`; a changed `tests/test_*.py` file selects itself.
- **Core smoke set** (`_CORE_SMOKE_TESTS`, always included, small + fast + dependency-free): `tests/test_import_hygiene.py`, `tests/test_config_schema.py`, `tests/test_config_paths.py`.

## Gate execution (`_run_smoke_tests`)

1. **Import-smoke**: `sys.executable -m py_compile <changed .py files>` — a syntax/compile error fails the gate immediately, before pytest collection even runs. Deliberately py_compile only (not an actual import of arbitrary changed modules, which may have side effects) — import-time errors are caught by phase 2's affected tests instead.
2. **Targeted pytest**: `sys.executable -m pytest <affected ∪ core paths> -q --tb=native -p no:cacheprovider`, same hermetic env (`_sanitized_smoke_env`, #668), same 300s timeout.

## #678 properties preserved (this PR only changes WHICH tests run)

- Empty selection is **not** an auto-pass: a changed file with no matching test still runs the core set; if truly nothing selects (no affected test AND no core test exists) → `no tests selected for gate (fail-safe: #686/#678)` → FAIL.
- Missing `tests/` dir, `no tests ran`/`collected 0 items`, harness exception, timeout, missing pytest → all still FAIL closed, unchanged from #678.
- Suite-shrink guard (`_run_smoke_tests_with_shrink_guard`) is **unchanged** — it counts `def test_` across the whole tree via `_count_tests`/`_count_tests_at_ref`, independent of what the bounded gate actually executes, so a cycle can't dodge it by only touching untested files.
- Mutation-surface hard block, blocked-pattern block, constrained ungated bookkeeping pushes: untouched — this PR does not touch the gate *decision* shape in `main()` (blocked → mutation → smoke → integrate), only what `_run_smoke_tests` executes.

## Recompute-per-repair wiring

`main()` now recomputes `files_changed` via `_changed_files_and_violations` immediately before **every** gate evaluation — the initial run and each repair-loop retry — not just once, mirroring the same discipline #678 already applies to the mutation-surface/blocked-pattern check (a repair turn can add/rename files; the bounded gate must select tests against the current diff, not the pre-repair one).

## Test results

- `tests/test_bounded_gate.py` (new): selection algorithm, import-smoke syntax-error-fails-first, affected-test pass/fail, core-smoke-always-runs (not an auto-pass), fail-safe cases (missing core+no affected, missing tests dir, timeout, harness exception), and two full setup→gate→integrate/rollback integration tests.
- `tests/test_bridge_cycle_branch.py`, `tests/test_repair_loop.py`: updated to work with the bounded gate (an autouse fixture points `_CORE_SMOKE_TESTS`/a stub `_select_gate_tests` at the synthetic fixture repos' own test file) — all pre-existing assertions kept green.
- Full suite: `python -m pytest tests/ -q` → **1162 passed** in ~51s (venv: `python3.11 -m venv .venv && .venv/bin/pip install -e .[dev]`).
- `ruff check` on touched files: no new issues (pre-existing findings in `bridge.py`/`test_repair_loop.py` confirmed present on `origin/main` too, unrelated to this change).

## Coverage trade-off

Per-cycle gate now validates only the changed surface (+ a small fixed core sanity check), not the whole product. Full-suite validation of core `nanobot/` moves to **product CI** (every product PR, all 3 Python versions) and **re-seed-time verification** (#672) — this is intentional, not a weakening, since the subagent literally cannot change core code.

Part of #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)