### PR TITLE
feat: record full LLM prompt/response with gzip archival (#693)

### DIFF
--- a/docs/specs/self-evolving-runtime/spec.md
+++ b/docs/specs/self-evolving-runtime/spec.md
@@ -111,6 +111,39 @@ can show per-model latency/token stats and per-cycle LLM wall-time (a
 utilization proxy for how much of a ~10-minute cycle is spent waiting on the
 LLM) — `--json` for machine consumption, human table by default.
 
+#### LLM prompt/response recording (issue #693)
+
+The counts-only telemetry above answers "how much/how long" but not "what's
+actually in the prompt" — of the subagent's ~23k prompt tokens, ~14k was
+unaccounted for. `nanobot.observability.llm_telemetry.record_llm_prompt` is
+hooked into the same `chat_with_retry` choke point (right beside
+`record_llm_call`, on every return path) and persists the full assembled
+`messages` array plus the response `content`/`reasoning_content`/
+`finish_reason` for each call.
+
+- **Storage**: `<dir>/prompts/YYYY-MM-DD.jsonl` (one call per line), where
+  `<dir>` resolves the same way as the counts-only telemetry
+  (`LLM_CALLS_DIR`, else `<STATE_DIR>/llm_calls`, else `~/.nanobot/llm_calls`).
+  Each line: `ts`, `model`, `cycle_id`, `component`, `seq` (a per-cycle,
+  per-process monotonic counter), `prompt_tokens`, `completion_tokens`,
+  `finish_reason`, `messages`, `content`, `reasoning_content`.
+- **Rotation + retention (bounded disk on the constrained host)**: on every
+  write, any previous-day plain `prompts/*.jsonl` file is gzipped to
+  `.jsonl.gz` and the plain file removed; `.jsonl.gz` files older than
+  `LLM_PROMPTS_RETENTION_DAYS` (default 14) are pruned. Today's file always
+  stays plain/appendable. Both steps are best-effort — a single file's
+  gzip/prune failure is swallowed and never blocks the write or the LLM call.
+- **Secret scrub**: the serialized record is passed through a small regex
+  scrub (`sk-...`, `gh[oprsu]_...`, `Bearer ...` tokens redacted) before
+  being written — defensive, since messages already went to the provider.
+- **Toggle**: `LLM_CAPTURE_PROMPTS` — default ON; set to `0`/`false`/empty to
+  disable (privacy/perf-sensitive runs).
+- **Reader**: `scripts/llm_prompt_inspect.py --dir PATH --cycle ID --date
+  YYYY-MM-DD --call SEQ [--json]` reads plain and `.gz` daily files and, for a
+  selected call, prints each message's role/byte-size/`len//4` token estimate
+  and a truncated preview plus totals — evidence for trimming the subagent's
+  context.
+
 ### Roles
 - R9. The coordinator SHALL maintain goal alignment, backlog/prioritization,
   experiment contracts, subagent launches, evaluation, and durable state — and SHALL

--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -16,19 +16,51 @@ No OpenTelemetry, no metrics DB, no cost computation (pricing lives in the
 LiteLLM proxy — this JSONL complements the proxy's own spend/latency logs by
 adding the cycle_id/component context the proxy lacks). Everything here is
 best-effort: a telemetry failure must never break the actual LLM call.
+
+Issue #693 extends this with ``record_llm_prompt()``: the token-count
+telemetry above answers "how much/how long" but not "what's actually in the
+~23k prompt tokens" — this records the full assembled ``messages`` + response
+per call (gzip-archived, retention-pruned) so the large subagent context can
+actually be inspected (see ``scripts/llm_prompt_inspect.py``).
 """
 
 from __future__ import annotations
 
 import contextlib
+import gzip
 import json
 import os
+import re
+import shutil
 from contextvars import ContextVar, Token
 from datetime import datetime, timezone
+from itertools import count
 from pathlib import Path
 from typing import Any, Iterator
 
 _CALL_CONTEXT: ContextVar[dict[str, str] | None] = ContextVar("_llm_call_context", default=None)
+
+# Monotonic within-process sequence per cycle_id, used to order prompt
+# captures belonging to the same self-evolving cycle. Process-local is
+# sufficient: each cycle runs in its own process/subprocess.
+_PROMPT_SEQ: dict[str, "count[int]"] = {}
+
+_DEFAULT_PROMPTS_RETENTION_DAYS = 14
+
+# Best-effort secret scrub for the persisted record. Kept tiny and local
+# (rather than importing nanobot.runtime.subagent_materializer._redact_secret_text)
+# to avoid coupling nanobot.observability to nanobot.runtime.
+_SECRET_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9._-]{8,}"),
+    re.compile(r"gh[oprsu]_[A-Za-z0-9]{20,}"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{8,}"),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
 
 
 def set_call_context(cycle_id: str | None, component: str | None) -> Token:
@@ -104,4 +136,129 @@ def record_llm_call(
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
     except Exception:
         # Telemetry must never break the LLM call it is observing.
+        pass
+
+
+def _prompts_retention_days() -> int:
+    raw = os.environ.get("LLM_PROMPTS_RETENTION_DAYS", "").strip()
+    if not raw:
+        return _DEFAULT_PROMPTS_RETENTION_DAYS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_PROMPTS_RETENTION_DAYS
+
+
+def _day_str(name: str) -> str | None:
+    """Extract the YYYY-MM-DD stem from a ``*.jsonl``/``*.jsonl.gz`` filename."""
+    if name.endswith(".jsonl.gz"):
+        candidate = name[: -len(".jsonl.gz")]
+    elif name.endswith(".jsonl"):
+        candidate = name[: -len(".jsonl")]
+    else:
+        return None
+    try:
+        datetime.strptime(candidate, "%Y-%m-%d")
+    except ValueError:
+        return None
+    return candidate
+
+
+def _rotate_and_prune(prompts_dir: Path, today: str, retention_days: int) -> None:
+    """Gzip previous-day plain files and prune ``.jsonl.gz`` older than retention.
+
+    Best-effort: any single file's failure is swallowed so it can't block the
+    others or the caller.
+    """
+    for path in prompts_dir.glob("*.jsonl"):
+        day = _day_str(path.name)
+        if not day or day == today:
+            continue
+        try:
+            gz_path = path.parent / f"{path.name}.gz"
+            with open(path, "rb") as f_in, gzip.open(gz_path, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            path.unlink()
+        except Exception:
+            continue
+
+    cutoff_ordinal = None
+    try:
+        from datetime import timedelta
+
+        cutoff_ordinal = (datetime.now(timezone.utc).date() - timedelta(days=retention_days)).toordinal()
+    except Exception:
+        return
+
+    for path in prompts_dir.glob("*.jsonl.gz"):
+        day = _day_str(path.name)
+        if not day:
+            continue
+        try:
+            day_ordinal = datetime.strptime(day, "%Y-%m-%d").date().toordinal()
+            if day_ordinal < cutoff_ordinal:
+                path.unlink(missing_ok=True)
+        except Exception:
+            continue
+
+
+def record_llm_prompt(
+    *,
+    messages: list[dict[str, Any]],
+    content: str | None,
+    reasoning_content: str | None,
+    finish_reason: str | None,
+    model: str | None,
+    prompt_tokens: int | None,
+    completion_tokens: int | None,
+) -> None:
+    """Append one JSONL line with the full assembled prompt + response.
+
+    Issue #693: complements :func:`record_llm_call` (counts/timing only) by
+    persisting the actual ``messages`` sent and the response content, so the
+    large subagent context can be inspected offline (see
+    ``scripts/llm_prompt_inspect.py``). Best-effort — never raises.
+
+    Honors ``LLM_CAPTURE_PROMPTS`` (default ON; set to "0"/"false"/"" to
+    disable, e.g. for privacy or perf-sensitive runs).
+    """
+    try:
+        toggle = os.environ.get("LLM_CAPTURE_PROMPTS")
+        if toggle is not None and toggle.strip().lower() in ("0", "false", ""):
+            return
+
+        ctx = _CALL_CONTEXT.get() or {}
+        cycle_id = ctx.get("cycle_id") or ""
+        component = ctx.get("component") or ""
+
+        counter = _PROMPT_SEQ.setdefault(cycle_id, count(1))
+        seq = next(counter)
+
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "model": model or "",
+            "cycle_id": cycle_id,
+            "component": component,
+            "seq": seq,
+            "prompt_tokens": int(prompt_tokens or 0),
+            "completion_tokens": int(completion_tokens or 0),
+            "finish_reason": finish_reason or "",
+            "messages": messages or [],
+            "content": content,
+            "reasoning_content": reasoning_content,
+        }
+
+        line = _redact_secrets(json.dumps(record, ensure_ascii=False, default=str))
+
+        prompts_dir = _llm_calls_dir() / "prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        _rotate_and_prune(prompts_dir, today, _prompts_retention_days())
+
+        out_path = prompts_dir / f"{today}.jsonl"
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        # Capture must never break the LLM call it is observing.
         pass

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from loguru import logger
 
-from nanobot.observability.llm_telemetry import record_llm_call
+from nanobot.observability.llm_telemetry import record_llm_call, record_llm_prompt
 
 
 @dataclass
@@ -262,7 +262,7 @@ class LLMProvider(ABC):
         call_start = time.monotonic()
         resolved_model = model or self.get_default_model()
 
-        def _record(response: LLMResponse, retries: int) -> LLMResponse:
+        def _record(response: LLMResponse, retries: int, sent_messages: list[dict[str, Any]]) -> LLMResponse:
             record_llm_call(
                 model=resolved_model,
                 duration_ms=(time.monotonic() - call_start) * 1000,
@@ -270,21 +270,33 @@ class LLMProvider(ABC):
                 finish_reason=response.finish_reason,
                 retries=retries,
             )
+            # Issue #693: persist the full assembled prompt + response
+            # alongside the counts-only telemetry above, so the large
+            # subagent context can be inspected offline.
+            record_llm_prompt(
+                messages=sent_messages,
+                content=response.content,
+                reasoning_content=response.reasoning_content,
+                finish_reason=response.finish_reason,
+                model=resolved_model,
+                prompt_tokens=response.usage.get("prompt_tokens"),
+                completion_tokens=response.usage.get("completion_tokens"),
+            )
             return response
 
         for attempt, delay in enumerate(self._CHAT_RETRY_DELAYS, start=1):
             response = await self._safe_chat(**kw)
 
             if response.finish_reason != "error":
-                return _record(response, attempt - 1)
+                return _record(response, attempt - 1, messages)
 
             if not self._is_transient_error(response.content):
                 stripped = self._strip_image_content(messages)
                 if stripped is not None:
                     logger.warning("Non-transient LLM error with image content, retrying without images")
                     response = await self._safe_chat(**{**kw, "messages": stripped})
-                    return _record(response, attempt - 1)
-                return _record(response, attempt - 1)
+                    return _record(response, attempt - 1, stripped)
+                return _record(response, attempt - 1, messages)
 
             logger.warning(
                 "LLM transient error (attempt {}/{}), retrying in {}s: {}",
@@ -294,7 +306,7 @@ class LLMProvider(ABC):
             await asyncio.sleep(delay)
 
         response = await self._safe_chat(**kw)
-        return _record(response, len(self._CHAT_RETRY_DELAYS))
+        return _record(response, len(self._CHAT_RETRY_DELAYS), messages)
 
     @abstractmethod
     def get_default_model(self) -> str:

--- a/scripts/llm_prompt_inspect.py
+++ b/scripts/llm_prompt_inspect.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+llm_prompt_inspect.py — inspect the prompts/*.jsonl(.gz) captures (issue #693).
+
+Reads the daily-rotated (and gzip-archived) JSONL files written by
+``nanobot.observability.llm_telemetry.record_llm_prompt`` (one line per LLM
+call through ``chat_with_retry``, full assembled ``messages`` + response) and
+prints a per-message breakdown — role, byte size, an approximate token count
+(``len(text) // 4``), and a truncated preview — so it's possible to see what
+actually dominates a call's context (e.g. the ~14k unaccounted prompt tokens
+noted in issue #675/#693).
+
+Usage:
+    python3 scripts/llm_prompt_inspect.py [--dir PATH] [--cycle CYCLE_ID]
+                                           [--date YYYY-MM-DD] [--call SEQ]
+                                           [--json]
+
+Defaults: --dir is $LLM_CALLS_DIR/prompts, else $STATE_DIR/llm_calls/prompts,
+else ~/.nanobot/llm_calls/prompts (same resolution order as the writer, plus
+the "prompts" subdirectory).
+
+Selecting calls:
+- ``--date`` restricts to a single day's file (plain or ``.gz``); omit to
+  scan all available files.
+- ``--cycle`` restricts to a single cycle_id.
+- ``--call`` restricts to a single sequence number (requires --cycle or a
+  result set that already narrows to one cycle, otherwise the first match
+  per cycle is used).
+Without ``--call``, all matching calls are listed with a one-line summary;
+with ``--call``, the full per-message breakdown for that call is printed.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _default_dir() -> Path:
+    env_dir = os.environ.get("LLM_CALLS_DIR", "").strip()
+    if env_dir:
+        return Path(env_dir) / "prompts"
+    state_dir = os.environ.get("STATE_DIR", "").strip()
+    if state_dir:
+        return Path(state_dir) / "llm_calls" / "prompts"
+    return Path.home() / ".nanobot" / "llm_calls" / "prompts"
+
+
+def _iter_files(directory: Path, date: str | None) -> list[Path]:
+    if not directory.is_dir():
+        return []
+    files = sorted(directory.glob("*.jsonl")) + sorted(directory.glob("*.jsonl.gz"))
+    if date:
+        files = [f for f in files if f.name.startswith(date)]
+    return files
+
+
+def load_records(directory: Path, date: str | None = None) -> list[dict[str, Any]]:
+    """Load and parse all prompt-capture records under *directory*."""
+    records: list[dict[str, Any]] = []
+    for path in _iter_files(directory, date):
+        try:
+            opener = gzip.open if path.name.endswith(".gz") else open
+            with opener(path, "rt", encoding="utf-8") as fh:  # type: ignore[call-arg]
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
+    return records
+
+
+def _message_text(msg: dict[str, Any]) -> str:
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(item.get("text") or item.get("content") or json.dumps(item, ensure_ascii=False))
+            else:
+                parts.append(str(item))
+        return "\n".join(parts)
+    if content is None:
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            return json.dumps(tool_calls, ensure_ascii=False)
+        return ""
+    return json.dumps(content, ensure_ascii=False)
+
+
+def _est_tokens(text: str) -> int:
+    return len(text) // 4
+
+
+def summarize_call(record: dict[str, Any], preview_chars: int = 80) -> dict[str, Any]:
+    """Return a per-message breakdown (role, bytes, est. tokens, preview) + totals."""
+    messages = record.get("messages") or []
+    breakdown = []
+    total_bytes = 0
+    total_tokens = 0
+    for idx, msg in enumerate(messages):
+        text = _message_text(msg)
+        size = len(text.encode("utf-8", errors="replace"))
+        tokens = _est_tokens(text)
+        total_bytes += size
+        total_tokens += tokens
+        preview = text[:preview_chars].replace("\n", " ")
+        if len(text) > preview_chars:
+            preview += "..."
+        breakdown.append(
+            {
+                "index": idx,
+                "role": msg.get("role", ""),
+                "bytes": size,
+                "est_tokens": tokens,
+                "preview": preview,
+            }
+        )
+    response_text = (record.get("content") or "") + (record.get("reasoning_content") or "")
+    return {
+        "cycle_id": record.get("cycle_id", ""),
+        "component": record.get("component", ""),
+        "seq": record.get("seq"),
+        "model": record.get("model", ""),
+        "ts": record.get("ts", ""),
+        "finish_reason": record.get("finish_reason", ""),
+        "prompt_tokens": record.get("prompt_tokens", 0),
+        "completion_tokens": record.get("completion_tokens", 0),
+        "messages": breakdown,
+        "message_count": len(messages),
+        "total_message_bytes": total_bytes,
+        "total_message_est_tokens": total_tokens,
+        "response_bytes": len(response_text.encode("utf-8", errors="replace")),
+        "response_est_tokens": _est_tokens(response_text),
+    }
+
+
+def select_calls(
+    records: list[dict[str, Any]],
+    cycle: str | None,
+    call: int | None,
+) -> list[dict[str, Any]]:
+    selected = records
+    if cycle:
+        selected = [r for r in selected if r.get("cycle_id") == cycle]
+    if call is not None:
+        selected = [r for r in selected if r.get("seq") == call]
+    return selected
+
+
+def _print_summary_line(record: dict[str, Any]) -> None:
+    print(
+        f"{record.get('ts', '')}  cycle={record.get('cycle_id') or '-':<20} "
+        f"component={record.get('component') or '-':<12} seq={record.get('seq')!s:<4} "
+        f"model={record.get('model', ''):<24} "
+        f"prompt_tokens={record.get('prompt_tokens', 0):<7} "
+        f"completion_tokens={record.get('completion_tokens', 0)}"
+    )
+
+
+def _print_call_detail(summary: dict[str, Any]) -> None:
+    print(f"cycle_id={summary['cycle_id']} component={summary['component']} seq={summary['seq']}")
+    print(f"model={summary['model']} ts={summary['ts']} finish_reason={summary['finish_reason']}")
+    print(
+        f"reported prompt_tokens={summary['prompt_tokens']} "
+        f"completion_tokens={summary['completion_tokens']}"
+    )
+    print()
+    print(f"{'idx':>4}  {'role':<10} {'bytes':>8} {'~tokens':>8}  preview")
+    for msg in summary["messages"]:
+        print(f"{msg['index']:>4}  {msg['role']:<10} {msg['bytes']:>8} {msg['est_tokens']:>8}  {msg['preview']}")
+    print()
+    print(
+        f"TOTAL messages={summary['message_count']} bytes={summary['total_message_bytes']} "
+        f"~tokens={summary['total_message_est_tokens']}"
+    )
+    print(f"response bytes={summary['response_bytes']} ~tokens={summary['response_est_tokens']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dir", type=Path, default=None, help="prompts directory (default: resolved like the writer)")
+    parser.add_argument("--cycle", default=None, help="filter to a single cycle_id")
+    parser.add_argument("--date", default=None, help="filter to a single day (YYYY-MM-DD)")
+    parser.add_argument("--call", type=int, default=None, help="show full per-message breakdown for this seq")
+    parser.add_argument("--json", action="store_true", help="emit raw JSON instead of a human table")
+    args = parser.parse_args(argv)
+
+    directory = args.dir or _default_dir()
+    records = load_records(directory, args.date)
+    selected = select_calls(records, args.cycle, args.call)
+
+    if not selected:
+        if args.json:
+            print(json.dumps([]))
+        else:
+            print(f"No matching prompt captures found under {directory}", file=sys.stderr)
+        return 0
+
+    if args.call is not None:
+        summaries = [summarize_call(r) for r in selected]
+        if args.json:
+            print(json.dumps(summaries, ensure_ascii=False, indent=2))
+        else:
+            for summary in summaries:
+                _print_call_detail(summary)
+                print()
+        return 0
+
+    if args.json:
+        print(json.dumps(selected, ensure_ascii=False, indent=2))
+    else:
+        for record in selected:
+            _print_summary_line(record)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_llm_prompt_recording.py
+++ b/tests/test_llm_prompt_recording.py
@@ -1,0 +1,285 @@
+"""Tests for nanobot.observability.llm_telemetry.record_llm_prompt (issue #693)."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from nanobot.observability.llm_telemetry import call_context, record_llm_prompt
+from scripts import llm_prompt_inspect
+
+
+def _read_jsonl(path):
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def _read_jsonl_gz(path):
+    with gzip.open(path, "rt", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def _sample_messages():
+    return [
+        {"role": "system", "content": "You are a helpful agent."},
+        {"role": "user", "content": "Do the thing."},
+        {"role": "assistant", "content": "Sure, doing it now."},
+    ]
+
+
+def test_record_llm_prompt_writes_well_formed_line(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+    monkeypatch.delenv("LLM_CAPTURE_PROMPTS", raising=False)
+
+    with call_context("cycle-1", "coordinator"):
+        record_llm_prompt(
+            messages=_sample_messages(),
+            content="all done",
+            reasoning_content="thinking...",
+            finish_reason="stop",
+            model="un/qwen3.6-27b-mtp",
+            prompt_tokens=42,
+            completion_tokens=7,
+        )
+
+    prompts_dir = tmp_path / "prompts"
+    files = list(prompts_dir.glob("*.jsonl"))
+    assert len(files) == 1
+    records = _read_jsonl(files[0])
+    assert len(records) == 1
+    rec = records[0]
+
+    assert rec["model"] == "un/qwen3.6-27b-mtp"
+    assert rec["cycle_id"] == "cycle-1"
+    assert rec["component"] == "coordinator"
+    assert rec["seq"] == 1
+    assert rec["prompt_tokens"] == 42
+    assert rec["completion_tokens"] == 7
+    assert rec["finish_reason"] == "stop"
+    assert rec["content"] == "all done"
+    assert rec["reasoning_content"] == "thinking..."
+    assert rec["messages"] == _sample_messages()
+    assert rec["ts"].endswith("Z")
+
+
+def test_record_llm_prompt_sequence_increments_per_cycle(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    with call_context("cycle-seq", "bridge"):
+        record_llm_prompt(
+            messages=_sample_messages(), content="a", reasoning_content=None,
+            finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+        )
+        record_llm_prompt(
+            messages=_sample_messages(), content="b", reasoning_content=None,
+            finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+        )
+
+    records = _read_jsonl(next((tmp_path / "prompts").glob("*.jsonl")))
+    assert [r["seq"] for r in records] == [1, 2]
+
+
+def test_toggle_off_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+    monkeypatch.setenv("LLM_CAPTURE_PROMPTS", "0")
+
+    record_llm_prompt(
+        messages=_sample_messages(), content="x", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+
+    assert not (tmp_path / "prompts").exists() or not list((tmp_path / "prompts").glob("*.jsonl"))
+
+
+@pytest.mark.parametrize("off_value", ["0", "false", "False", ""])
+def test_toggle_off_variants(tmp_path, monkeypatch, off_value):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+    monkeypatch.setenv("LLM_CAPTURE_PROMPTS", off_value)
+
+    record_llm_prompt(
+        messages=_sample_messages(), content="x", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+
+    prompts_dir = tmp_path / "prompts"
+    assert not prompts_dir.exists() or not list(prompts_dir.glob("*.jsonl"))
+
+
+def test_toggle_on_explicit_value(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+    monkeypatch.setenv("LLM_CAPTURE_PROMPTS", "1")
+
+    record_llm_prompt(
+        messages=_sample_messages(), content="x", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+
+    assert list((tmp_path / "prompts").glob("*.jsonl"))
+
+
+def test_secret_scrub_redacts_persisted_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    messages = [
+        {"role": "user", "content": "here is my key sk-abcdefghijklmnop and Bearer abcdefgh12345678"},
+    ]
+    record_llm_prompt(
+        messages=messages, content="ok", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+
+    files = list((tmp_path / "prompts").glob("*.jsonl"))
+    raw = files[0].read_text(encoding="utf-8")
+    assert "sk-abcdefghijklmnop" not in raw
+    assert "Bearer abcdefgh12345678" not in raw
+    assert "[REDACTED]" in raw
+
+
+def test_day_rollover_gzips_previous_day_and_prunes_old(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+    monkeypatch.setenv("LLM_PROMPTS_RETENTION_DAYS", "14")
+
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir(parents=True)
+
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    too_old = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
+
+    yesterday_file = prompts_dir / f"{yesterday}.jsonl"
+    yesterday_file.write_text(json.dumps({"seq": 1}) + "\n", encoding="utf-8")
+
+    old_gz = prompts_dir / f"{too_old}.jsonl.gz"
+    with gzip.open(old_gz, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps({"seq": 1}) + "\n")
+
+    record_llm_prompt(
+        messages=_sample_messages(), content="today", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+
+    # Yesterday's plain file got gzipped and removed.
+    assert not yesterday_file.exists()
+    assert (prompts_dir / f"{yesterday}.jsonl.gz").exists()
+    gz_records = _read_jsonl_gz(prompts_dir / f"{yesterday}.jsonl.gz")
+    assert gz_records == [{"seq": 1}]
+
+    # The too-old archive got pruned.
+    assert not old_gz.exists()
+
+    # Today's file stays plain and appendable.
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert (prompts_dir / f"{today}.jsonl").exists()
+
+
+def test_best_effort_open_failure_does_not_raise(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    def _raise_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("builtins.open", _raise_open)
+
+    record_llm_prompt(
+        messages=_sample_messages(), content="x", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+
+
+def test_best_effort_gzip_failure_does_not_raise(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir(parents=True)
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    (prompts_dir / f"{yesterday}.jsonl").write_text("{}\n", encoding="utf-8")
+
+    import nanobot.observability.llm_telemetry as telemetry
+
+    def _raise_gzip_open(*args, **kwargs):
+        raise OSError("no space")
+
+    monkeypatch.setattr(telemetry.gzip, "open", _raise_gzip_open)
+
+    # Must not raise despite the simulated gzip failure; today's write still happens.
+    record_llm_prompt(
+        messages=_sample_messages(), content="x", reasoning_content=None,
+        finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+    )
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert (prompts_dir / f"{today}.jsonl").exists()
+
+
+# --- scripts/llm_prompt_inspect.py -----------------------------------------
+
+
+def test_llm_prompt_inspect_aggregates_plain_and_gz(tmp_path):
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir(parents=True)
+
+    plain_record = {
+        "ts": "2026-07-01T00:00:00Z",
+        "model": "m1",
+        "cycle_id": "cycle-a",
+        "component": "coordinator",
+        "seq": 1,
+        "prompt_tokens": 100,
+        "completion_tokens": 10,
+        "finish_reason": "stop",
+        "messages": [
+            {"role": "system", "content": "x" * 40},
+            {"role": "user", "content": "y" * 20},
+        ],
+        "content": "response text",
+        "reasoning_content": None,
+    }
+    gz_record = {
+        "ts": "2026-06-30T00:00:00Z",
+        "model": "m2",
+        "cycle_id": "cycle-b",
+        "component": "bridge",
+        "seq": 1,
+        "prompt_tokens": 50,
+        "completion_tokens": 5,
+        "finish_reason": "stop",
+        "messages": [{"role": "user", "content": "z" * 8}],
+        "content": "ok",
+        "reasoning_content": None,
+    }
+
+    (prompts_dir / "2026-07-01.jsonl").write_text(json.dumps(plain_record) + "\n", encoding="utf-8")
+    with gzip.open(prompts_dir / "2026-06-30.jsonl.gz", "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps(gz_record) + "\n")
+
+    records = llm_prompt_inspect.load_records(prompts_dir)
+    assert len(records) == 2
+
+    cycle_a = llm_prompt_inspect.select_calls(records, "cycle-a", None)
+    assert len(cycle_a) == 1
+
+    summary = llm_prompt_inspect.summarize_call(cycle_a[0])
+    assert summary["message_count"] == 2
+    assert summary["total_message_bytes"] == 60
+    assert summary["total_message_est_tokens"] == 60 // 4
+    assert summary["response_bytes"] == len("response text")
+
+    call = llm_prompt_inspect.select_calls(records, "cycle-b", 1)
+    assert len(call) == 1
+    assert call[0]["model"] == "m2"
+
+
+def test_llm_prompt_inspect_date_filter(tmp_path):
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir(parents=True)
+    (prompts_dir / "2026-07-01.jsonl").write_text(
+        json.dumps({"seq": 1, "cycle_id": "a", "messages": []}) + "\n", encoding="utf-8"
+    )
+    (prompts_dir / "2026-07-02.jsonl").write_text(
+        json.dumps({"seq": 1, "cycle_id": "b", "messages": []}) + "\n", encoding="utf-8"
+    )
+
+    records = llm_prompt_inspect.load_records(prompts_dir, date="2026-07-01")
+    assert len(records) == 1
+    assert records[0]["cycle_id"] == "a"


### PR DESCRIPTION
## Summary
- Adds `record_llm_prompt()` to `nanobot/observability/llm_telemetry.py`, hooked into `chat_with_retry` (`nanobot/providers/base.py`) right beside the existing `record_llm_call` (#675), on every return path (success, non-transient error, image-stripped retry, exhausted-retries).
- Persists the **full assembled `messages` array** + response `content`/`reasoning_content`/`finish_reason` per real LLM call, correlated with `ts`, `model`, `cycle_id`, `component`, a per-cycle `seq`, and `prompt_tokens`/`completion_tokens` — so the ~14k unaccounted subagent prompt tokens (noted in #675/#693) can finally be inspected.
- Adds `scripts/llm_prompt_inspect.py` (stdlib-only) to read the captures and print a per-message role/byte-size/`len//4`-token-estimate/preview breakdown, plus totals, filterable by `--cycle`/`--date`/`--call`, with `--json`.

## Storage / rotation / retention (bounded disk on the constrained host)
- Path: `<dir>/prompts/YYYY-MM-DD.jsonl` where `<dir>` resolves the same way as #675's counts-only telemetry (`LLM_CALLS_DIR` → `<STATE_DIR>/llm_calls` → `~/.nanobot/llm_calls`).
- On every write: any **previous-day plain** `prompts/*.jsonl` gets gzipped to `.jsonl.gz` and the plain file removed; `.jsonl.gz` files older than `LLM_PROMPTS_RETENTION_DAYS` (default **14**) are pruned. Today's file always stays plain/appendable.
- All of the above is best-effort — any single file's gzip/prune/write error is swallowed and never blocks the LLM call it's observing (same discipline as `record_llm_call`).

## Toggle
`LLM_CAPTURE_PROMPTS` — default **ON** per operator decision; set to `0`/`false`/empty to disable (privacy/perf-sensitive runs).

## Secret scrub
The serialized record is passed through a small local regex scrub (`sk-...`, `gh[oprsu]_...`, `Bearer ...` redacted) before being written. Kept local to `nanobot.observability` rather than importing `nanobot.runtime.subagent_materializer._redact_secret_text`, to avoid coupling observability to runtime (messages are already sent to the provider, so this is defense-in-depth, not the primary control).

## Docs
Updated `docs/specs/self-evolving-runtime/spec.md` with a new "LLM prompt/response recording (issue #693)" subsection alongside the existing #675 telemetry section.

## Test plan
- [x] New `tests/test_llm_prompt_recording.py`: well-formed record + full messages/response/correlation, per-cycle seq increments, day-rollover gzip + retention prune, best-effort on open()/gzip.open() failures, toggle on/off (incl. `0`/`false`/`""`/`1` variants), secret scrub, and `scripts/llm_prompt_inspect.py` aggregation (plain + gz, cycle/date filters, per-message totals).
- [x] `python -m pytest tests/ -q` — **1185 passed**
- [x] `ruff check` on touched files — no *new* issues (4 pre-existing `W293` in `nanobot/providers/base.py`, unrelated to this diff, confirmed via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #693