### PR TITLE
fix: loop never stalls on already-done hypotheses — LLM-driven novelty + reliable retire/restart (#695)

### DIFF
--- a/docs/specs/self-evolving-runtime/spec.md
+++ b/docs/specs/self-evolving-runtime/spec.md
@@ -62,6 +62,33 @@ an open-ended chat session. The learning signal is the HADI arc
   candidate...", or a `generated_from_*`/`feedback_*`/`retire_*` source) —
   so the loop never feeds its own meta-task description back to itself as
   "new" content.
+- R28 (issue #695). Once a generation's whole synthesize→materialize→verify
+  chain is complete (all three tasks in `COMPLETED_TASK_STATUSES`, including a
+  verify result that came back `already_done`) and no verify request is still
+  in flight, the planner (`_derive_feedback_decision`,
+  `nanobot/runtime/cycle_feedback.py`) SHALL reopen the chain
+  (`start_next_improvement_generation`) in the SAME cycle that lands on
+  `record-reward` — it SHALL NOT require a second consecutive
+  `record-reward` cycle to "confirm" reward accounting first. A same-task
+  confirmation round-trip is a fragile fixed point: R11's stall-switch
+  (`_switch_off_stalled_lane`, `nanobot/runtime/cycle_persist.py`) sees the
+  decision re-select the lane it just stalled on and reroutes to a CORE
+  bookkeeping task before the second cycle can land, permanently stalling the
+  loop on an already-done hypothesis (the live incident this issue fixed).
+- R29 (issue #695). When `_synthesize_hypothesis_from_state` (R26) is
+  exhausted — goal vectors and a state signal both exist, but every (signal,
+  vector) combination it can compose is already done in git log — candidate
+  generation SHALL fall through to `_open_ended_novelty_directive`
+  (`nanobot/runtime/cycle_planning.py`) before the legacy todo.md/research-feed
+  fallbacks. Unlike R26's generator, this directive's title is fixed and
+  deliberately generic (never names a concrete gap), so it can never itself
+  become "already done" and never gets skipped by the bridge's
+  `_task_already_done` keyword-overlap check
+  (`nanobot/runtime/bridge.py`). Its instructions hand the subagent (LLM) the
+  goal vectors plus a list of recently-done commit subjects and ask it to
+  invent AND implement one genuinely new bounded improvement itself — novelty
+  is delegated entirely to the subagent's judgment rather than to a
+  deterministic template, so it cannot collapse into a repeating bounded set.
 
 ### Evidence / observability
 - R7. From durable state alone, the runtime SHALL be able to answer: active goal,

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -132,6 +132,7 @@ from nanobot.runtime.cycle_planning import (  # noqa: F401
     _generation_scoped_verification_id,
     _inferred_generated_candidates_from_tasks,
     _latest_failure_learning,
+    _open_ended_novelty_directive,
     _parse_backlog_task_from_goal_text,
     _parse_backlog_task_from_memory,
     _pick_candidate_from_research_feed,

--- a/nanobot/runtime/cycle_feedback.py
+++ b/nanobot/runtime/cycle_feedback.py
@@ -780,6 +780,52 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
         and materialized_artifact_payload.get("task_id") == MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID
         and _materialize_task_completed
     ):
+        # Issue #695: when the *whole* synthesize->materialize->verify chain for
+        # this generation is already done (not just materialize) and no verify
+        # request is still in flight, there is nothing left to "confirm" — the
+        # two-consecutive-cycle record-reward round-trip below
+        # (post_materialization_reward_already_confirmed) is a fragile memory
+        # that R11's stall-switch (cycle_persist._switch_off_stalled_lane)
+        # routinely erases before the second cycle lands (same failure class
+        # #664 documented for CORE bookkeeping tasks). Reopen the chain in one
+        # step instead of waiting for a confirmation that a stall can prevent
+        # from ever arriving — this is the same restart the "stable" fallback
+        # below performs, just reachable without a same-task fixed point.
+        _verify_task_for_reward_check = _task_by_id.get("subagent-verify-materialized-improvement")
+        _chain_complete_for_reward_check = (
+            _verify_task_for_reward_check is not None
+            and _task_status(_verify_task_for_reward_check) in COMPLETED_TASK_STATUSES
+        )
+        if _chain_complete_for_reward_check and not _has_live_verify_request_queue(state_root):
+            selected_task = _synthesized_next_improvement_candidate(
+                current_task_id=current_task_id,
+                strong_pass_count=strong_pass_count,
+                goal_artifact_signature=strong_pass_signature_list,
+                status="active",
+            )
+            return {
+                "mode": "start_next_improvement_generation",
+                "reason": (
+                    "synthesize/materialize/verify chain for the prior generation is fully "
+                    "complete and no verify work is in flight; reopen the chain in one step "
+                    "instead of a same-task reward-confirmation round-trip that a stall-switch "
+                    "can erase before it completes"
+                ),
+                "reward_value": reward_value,
+                "current_task_id": current_task_id,
+                "current_task_class": current_task_class,
+                "repeat_block_count": repeat_block_count,
+                "repeat_block_failure_class": repeat_block_failure_class,
+                "goal_artifact_signature": strong_pass_signature_list,
+                "strong_pass_count": strong_pass_count,
+                "retire_goal_artifact_pair": False,
+                "selected_task_id": selected_task.get("task_id") or selected_task.get("taskId"),
+                "selected_task_class": _task_action_class(selected_task.get("task_id") or selected_task.get("taskId")),
+                "selection_source": "feedback_start_next_improvement_generation",
+                "selected_task_title": selected_task.get("title") or selected_task.get("summary") or selected_task.get("task_id"),
+                "selected_task_label": _render_task_selection(selected_task),
+                "artifact_path": str(materialized_artifact_path),
+            }
         selected_task = _task_by_id.get("record-reward") or {"task_id": "record-reward", "title": "Record cycle reward"}
         return {
             "mode": "record_reward_after_synthesized_materialization",

--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -709,6 +709,89 @@ def _synthesize_hypothesis_from_state(
     return None  # every (signal, vector) combination was already done
 
 
+# Issue #695: a stable, deliberately generic directive title. It never names a
+# concrete gap (unlike _synthesize_hypothesis_from_state's composed titles), so
+# it can never itself match "already done in git log" — the diverse, LLM-authored
+# commit messages the subagent produces for genuinely new work essentially never
+# share 3+ keywords with these rare/distinctive words (verified against this
+# repo's own git log). That keeps the bridge's _task_already_done keyword-overlap
+# check (nanobot/runtime/bridge.py) from ever falsely skipping this fallback.
+_OPEN_ENDED_NOVELTY_TITLE = (
+    "Open-ended novelty directive: invent and land one genuinely new committable improvement"
+)
+
+
+def _open_ended_novelty_directive(
+    state_root: Path,
+    selfevo_repo_root: Path | None,
+    workspace: Path,
+) -> dict[str, Any] | None:
+    """Fallback 2b (issue #695): LLM-driven novelty once the deterministic generator is exhausted.
+
+    _synthesize_hypothesis_from_state (issue #690) composes a title that names
+    the concrete state-signal gap it grounds on — that makes it precise, but
+    also fragile: once every (signal, vector) combination it can compose is
+    already done in git log, it has nothing left to try and returns None. The
+    previous fallbacks below it (todo.md, research-feed) are legacy/near-dead
+    and can hand back stale or self-referential work — never a genuine novel
+    improvement.
+
+    This fallback fires under the same preconditions
+    (goal_text vectors parse, at least one state signal exists) but does NOT
+    compose a concrete title itself. Instead it hands the subagent a STABLE,
+    open-ended directive: invent and implement ONE new bounded improvement
+    toward the goal vectors, grounded in the subagent's own read of the
+    current repo/host state, explicitly avoiding a list of recently-done
+    commit subjects. The novelty is delegated entirely to the subagent (LLM)
+    — the fixed directive title never collapses into a repeating bounded set
+    the way a deterministically pre-composed title can.
+
+    Returns None only when goal_text is missing/unparseable or no goal vectors
+    are found — mirrors _synthesize_hypothesis_from_state's own preconditions
+    minus the per-combination dedup loop (there is nothing left to dedup: the
+    directive intentionally never names concrete already-done work).
+    """
+    goal_text_path = state_root / "goals" / "goal_text.json"
+    if not goal_text_path.exists():
+        return None
+    try:
+        data = json.loads(goal_text_path.read_text(encoding="utf-8", errors="replace"))
+    except Exception:
+        return None
+    text = data.get("text") if isinstance(data, dict) else None
+    if not isinstance(text, str):
+        return None
+    vectors = _parse_goal_vectors_from_text(text)
+    if not vectors:
+        return None
+
+    git_log = ""
+    if selfevo_repo_root is not None and selfevo_repo_root.is_dir():
+        git_log = _recent_git_log(selfevo_repo_root)
+    recent_titles = ", ".join(
+        line.split(" ", 1)[1].strip()
+        for line in git_log.splitlines()[:12]
+        if " " in line
+    )
+    vector_summary = "; ".join(f"Vector {v['number']}: {v['statement'][:200]}" for v in vectors)
+    instructions = (
+        "Every concrete improvement candidate this generator can compose from current state "
+        "signals is already done in git log. Propose AND implement ONE genuinely NEW, concrete, "
+        "bounded, committable improvement toward the project goal vectors below, grounded in your "
+        "own reading of the current repo/host state (code, tests, docs, host metrics, lessons). "
+        "It must produce a real git commit (code/script/tool/doc). Do NOT restate this directive "
+        "as your commit message; invent the concrete work yourself. "
+        f"Goal vectors: {vector_summary[:500]}. "
+        f"It must NOT duplicate any of these recently-done items: {recent_titles[:400]}."
+    )
+    return {
+        "priority": 100,
+        "title": _OPEN_ENDED_NOVELTY_TITLE,
+        "instructions": instructions[:1400],
+        "source": "open_ended_novelty_directive",
+    }
+
+
 def _write_materialized_improvement_artifact(
     *,
     state_root: Path,
@@ -751,6 +834,15 @@ def _write_materialized_improvement_artifact(
     # _synthesize_hypothesis_from_state for the full generator contract.
     if backlog_task is None:
         backlog_task = _synthesize_hypothesis_from_state(state_root, _selfevo_root, workspace) if workspace is not None else None
+
+    # Fallback 2b (issue #695, exhausted-generator robustness): once every
+    # (signal, vector) combination the #690 generator can compose is already
+    # done, shift novelty to the subagent (LLM) via a stable open-ended
+    # directive instead of falling through to the dead/legacy fallbacks below.
+    # See _open_ended_novelty_directive for why its title can never itself be
+    # dedup-skipped as already_done.
+    if backlog_task is None:
+        backlog_task = _open_ended_novelty_directive(state_root, _selfevo_root, workspace) if workspace is not None else None
 
     # Fallback 3: legacy no-op — todo.md does not exist in the release
     # workspace (only in the separate eeebot-self-evolving instance repo), so

--- a/tests/test_autonomy_stagnation_followthrough.py
+++ b/tests/test_autonomy_stagnation_followthrough.py
@@ -10,6 +10,7 @@ from nanobot.runtime.coordinator import (
     _build_task_plan_snapshot,
     _derive_feedback_decision,
     _subagent_lane_health,
+    _switch_off_stalled_lane,
 )
 
 
@@ -1286,3 +1287,141 @@ def test_maintenance_rotation_converges_to_synthesize_instead_of_rotating_foreve
         assert decision is not None, f'no restart decision while stuck on {rotating_task_id}'
         assert decision['mode'] == 'start_next_improvement_generation'
         assert decision['selected_task_id'] == 'synthesize-next-improvement-candidate'
+
+
+def _live_host_already_done_verify_snapshot(*, materialized_artifact_path: str) -> dict:
+    """Mirrors the live host state/goals/current.json snapshot from issue #695.
+
+    The verify lane already retired (#656's should_retire_subagent_lane marked
+    it 'done' after the bridge terminalized the request as 'already_done'),
+    landing current_task_id on record-reward for the FIRST time this
+    generation — before #664's two-consecutive-cycle
+    post_materialization_reward_already_confirmed memory has had a chance to
+    record anything.
+    """
+    return {
+        'current_task_id': 'record-reward',
+        'materialized_improvement_artifact_path': materialized_artifact_path,
+        'feedback_decision': {
+            'mode': 'retire_completed_subagent_lane',
+            'current_task_id': 'subagent-verify-materialized-improvement',
+            'selected_task_id': 'record-reward',
+            'selection_source': 'feedback_completed_subagent_retire',
+        },
+        'tasks': [
+            {'task_id': 'synthesize-next-improvement-candidate', 'status': 'done'},
+            {'task_id': 'materialize-synthesized-improvement', 'status': 'done'},
+            {
+                'task_id': 'subagent-verify-materialized-improvement',
+                'status': 'done',
+                'terminal_reason': 'terminal_noop_or_no_material_change',
+            },
+            {'task_id': 'refresh-approval-gate', 'status': 'pending'},
+            {'task_id': 'run-bounded-turn', 'status': 'pending'},
+            {'task_id': 'record-reward', 'status': 'active'},
+        ],
+    }
+
+
+def _write_already_done_verify_result(state_root: Path, *, cycle_id: str) -> None:
+    request_dir = state_root / 'subagents' / 'requests'
+    result_dir = state_root / 'subagents' / 'results'
+    request_dir.mkdir(parents=True, exist_ok=True)
+    result_dir.mkdir(parents=True, exist_ok=True)
+    request_id = f'subagent-verify-materialized-improvement-{cycle_id}-43af65dc'
+    (request_dir / f'request-{cycle_id}.json').write_text(json.dumps({
+        'task_id': 'subagent-verify-materialized-improvement',
+        'request_id': request_id,
+        'request_status': 'queued',
+    }), encoding='utf-8')
+    (result_dir / f'result-{request_id}.json').write_text(json.dumps({
+        'schema_version': 'subagent-result-v1',
+        'request_id': request_id,
+        'result_status': 'already_done',
+    }), encoding='utf-8')
+
+
+def test_already_done_verify_retires_and_restarts_in_one_step_not_two(tmp_path: Path) -> None:
+    # Issue #695 live repro: request-cycle-25172f6ccb8a's verify already came
+    # back 'already_done' and the verify lane already retired (task status
+    # 'done'), landing current_task_id on record-reward. Before this fix,
+    # _derive_feedback_decision required a SECOND consecutive record-reward
+    # cycle (the post_materialization_reward_already_confirmed memory) to
+    # advance past a same-task ("record_reward_after_synthesized_materialization"
+    # selecting record-reward again) fixed point — a precondition R11's
+    # stall-switch (cycle_persist._switch_off_stalled_lane) routinely erased
+    # before the second cycle could land, permanently stalling the loop on an
+    # already-done hypothesis. It must now advance in ONE step.
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+    artifact = state_root / 'improvements' / 'materialized-cycle-25172f6ccb8a.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({'task_id': 'materialize-synthesized-improvement'}), encoding='utf-8')
+    _write_already_done_verify_result(state_root, cycle_id='cycle-25172f6ccb8a')
+
+    task_plan = _live_host_already_done_verify_snapshot(materialized_artifact_path=str(artifact))
+
+    decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+    assert decision is not None
+    assert decision['mode'] == 'start_next_improvement_generation'
+    assert decision['selection_source'] == 'feedback_start_next_improvement_generation'
+    assert decision['selected_task_id'] == 'synthesize-next-improvement-candidate'
+    assert decision['selected_task_id'] != 'record-reward'
+
+
+def test_already_done_verify_restart_survives_stall_switch(tmp_path: Path) -> None:
+    # The same repro as above, but also driven through R11's stall-switch
+    # (cycle_persist._switch_off_stalled_lane) with the previous cycle
+    # recorded as stalled on record-reward — the exact condition that used to
+    # bounce the decision back to a CORE bookkeeping task
+    # (selection_source=switch_stalled_lane) before the second confirmation
+    # cycle could ever happen. The restart decision already selects a
+    # different task than the stalled lane, so it must survive untouched.
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+    artifact = state_root / 'improvements' / 'materialized-cycle-25172f6ccb8a.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({'task_id': 'materialize-synthesized-improvement'}), encoding='utf-8')
+    _write_already_done_verify_result(state_root, cycle_id='cycle-25172f6ccb8a')
+
+    task_plan = _live_host_already_done_verify_snapshot(materialized_artifact_path=str(artifact))
+    decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+    assert decision['mode'] == 'start_next_improvement_generation'
+
+    previous_experiment = {'current_task_id': 'record-reward', 'stall': {'stop': True}}
+    final_decision = _switch_off_stalled_lane(decision, task_plan, previous_experiment)
+
+    assert final_decision is decision
+    assert final_decision['mode'] == 'start_next_improvement_generation'
+    assert final_decision['selected_task_id'] == 'synthesize-next-improvement-candidate'
+    assert final_decision['selection_source'] != 'switch_stalled_lane'
+
+
+def test_record_reward_waits_for_confirmation_when_verify_not_yet_done(tmp_path: Path) -> None:
+    # Guard: preserve pre-#695 behavior when the verify step of THIS
+    # generation genuinely has not finished yet (chain incomplete) — the
+    # one-step restart must NOT fire; the existing two-cycle
+    # reward-confirmation path still applies.
+    goals_dir = tmp_path / 'state' / 'goals'
+    goals_dir.mkdir(parents=True)
+    (goals_dir / 'history').mkdir()
+    state_root = tmp_path / 'state'
+    artifact = state_root / 'improvements' / 'materialized-cycle-pending-verify.json'
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(json.dumps({'task_id': 'materialize-synthesized-improvement'}), encoding='utf-8')
+
+    task_plan = _live_host_already_done_verify_snapshot(materialized_artifact_path=str(artifact))
+    for task in task_plan['tasks']:
+        if task['task_id'] == 'subagent-verify-materialized-improvement':
+            task['status'] = 'active'
+
+    decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+
+    assert decision is not None
+    assert decision['mode'] == 'record_reward_after_synthesized_materialization'
+    assert decision['selected_task_id'] == 'record-reward'

--- a/tests/test_state_synthesized_hypothesis.py
+++ b/tests/test_state_synthesized_hypothesis.py
@@ -13,8 +13,10 @@ import json
 import subprocess
 from pathlib import Path
 
+from nanobot.runtime.bridge import _task_already_done
 from nanobot.runtime.coordinator import (
     MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
+    _open_ended_novelty_directive,
     _pick_candidate_from_research_feed,
     _research_feed_entry_is_self_referential,
     _synthesize_hypothesis_from_state,
@@ -208,6 +210,98 @@ def test_pick_candidate_from_research_feed_skips_self_referential_entry(tmp_path
     candidate = _pick_candidate_from_research_feed(state_root)
     assert candidate is not None
     assert candidate["title"] == "A genuinely external research candidate"
+
+
+def test_open_ended_novelty_directive_fires_once_generator_is_exhausted(tmp_path: Path):
+    # Issue #695: when every (signal, vector) combination the deterministic
+    # #690 generator can compose is already done in git log (the same
+    # exhausted scenario as test_dedup_returns_none_when_every_combination_
+    # already_done above), the loop must not fall through to the dead/legacy
+    # fallbacks — it must hand the subagent a stable, open-ended directive.
+    state_root = tmp_path / "state"
+    _write_goal_text(state_root)
+
+    (state_root / "host_metrics").mkdir(parents=True)
+    (state_root / "host_metrics" / "metrics.jsonl").write_text(
+        json.dumps({"cpu_percent": 92}) + "\n", encoding="utf-8",
+    )
+
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        *DONE_GIT_LOG_MESSAGES,
+        "feat: self optimization constrained hardware close gap latest host metrics sample (#702)",
+        "feat: owner utility creative output close gap latest host metrics sample (#703)",
+    )
+
+    # Confirm the deterministic generator really is exhausted first.
+    assert _synthesize_hypothesis_from_state(state_root, repo, tmp_path) is None
+
+    directive = _open_ended_novelty_directive(state_root, repo, tmp_path)
+    assert directive is not None
+    assert directive["source"] == "open_ended_novelty_directive"
+    assert "invent" in directive["title"].lower()
+    assert "genuinely NEW" in directive["instructions"]
+    # Recently-done work is listed so the subagent's own invention avoids it.
+    assert "already done in git log" in directive["instructions"]
+
+
+def test_open_ended_novelty_directive_returns_none_without_goal_vectors(tmp_path: Path):
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    assert _open_ended_novelty_directive(state_root, None, tmp_path) is None
+
+
+def test_open_ended_novelty_title_is_never_falsely_already_done(tmp_path: Path):
+    # Issue #695: the directive's title must never itself trip the bridge's
+    # _task_already_done keyword-overlap check (>=3 matching words with a
+    # real, non-maintenance commit subject) — otherwise the bridge would
+    # skip spawning the subagent for a directive that, by design, never
+    # names concrete already-done work.
+    state_root = tmp_path / "state"
+    _write_goal_text(state_root)
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        *DONE_GIT_LOG_MESSAGES,
+        "feat: self optimization constrained hardware close gap latest host metrics sample (#702)",
+        "feat: owner utility creative output close gap latest host metrics sample (#703)",
+        "fix: bridge auto-commits uncommitted subagent work — Vector 1 gap closure",
+        "feat: continuous hypothesis generation from goal vectors x state — loop never idles",
+    )
+    directive = _open_ended_novelty_directive(state_root, repo, tmp_path)
+    assert directive is not None
+    assert _task_already_done(directive["title"], repo) is False
+
+
+def test_materialized_artifact_routes_open_ended_directive_when_generator_exhausted(tmp_path: Path):
+    state_root = tmp_path / "state"
+    _write_goal_text(state_root)
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        *DONE_GIT_LOG_MESSAGES,
+        "feat: self optimization constrained hardware close gap latest host metrics sample (#702)",
+        "feat: owner utility creative output close gap latest host metrics sample (#703)",
+    )
+    (state_root / "host_metrics").mkdir(parents=True)
+    (state_root / "host_metrics" / "metrics.jsonl").write_text(
+        json.dumps({"cpu_percent": 92}) + "\n", encoding="utf-8",
+    )
+
+    path = _write_materialized_improvement_artifact(
+        state_root=state_root,
+        cycle_id="cycle-695-exhausted",
+        goal_id="goal-bootstrap",
+        current_task_id=MATERIALIZE_SYNTHESIZED_IMPROVEMENT_ID,
+        summary="s",
+        reward_signal={"value": 0.8},
+        feedback_decision={"mode": "synthesize_next_candidate"},
+        selfevo_repo_root=repo,
+        workspace=tmp_path,
+    )
+    assert path is not None
+    artifact = json.loads(Path(path).read_text(encoding="utf-8"))
+    nbc = artifact["next_bounded_candidate"]
+    assert "invent" in nbc["title"].lower()
+    assert not _task_already_done(nbc["title"], repo)
 
 
 def test_pick_candidate_from_research_feed_returns_none_when_all_self_referential(tmp_path: Path):


### PR DESCRIPTION
## Diagnosis

Live symptom (confirmed via read-only host inspection): the loop was stuck 30+ min on `request-cycle-25172f6ccb8a`, whose task was a Vector-1 hypothesis already integrated at `7dc70ea`. The bridge correctly terminalized the verify request as `already_done`; `_subagent_lane_health` correctly reported `state="completed"` for it (verified against the actual host request/result files); `cycle_planning.py`'s `should_retire_subagent_lane` correctly retired the verify lane (task marked `done`, `current_task_id` advanced to `record-reward`). So the #656/#664 machinery itself was working.

**Root cause** is one step further down, in `_derive_feedback_decision` (`nanobot/runtime/cycle_feedback.py`): once `current_task_id == "record-reward"` with a completed materialize artifact present, the function hard-returns `mode="record_reward_after_synthesized_materialization"`, `selected_task_id="record-reward"` — i.e. it re-selects the SAME task — **unless** `post_materialization_reward_already_confirmed` is already `True`, which requires the *previous* cycle's *persisted* decision to already be this exact mode/selection (a two-consecutive-cycle memory #664 itself flagged as fragile).

That same-task decision (`selected_task_id == current_task_id == "record-reward"`) is precisely the condition R11's stall-switch (`cycle_persist._switch_off_stalled_lane`) treats as "still on the stalled lane" — it doesn't skip the override, and reroutes to a CORE bookkeeping task (`refresh-approval-gate`) before the second confirmation cycle can ever land. The two-cycle memory then never accumulates (the persisted decision each time is `switch_stalled_lane`, not `record_reward_after_synthesized_materialization`), so the chain restart (`start_next_improvement_generation`, #664) never fires — permanently stalling the loop on the already-done hypothesis. Reproduced exactly with the live host's own request/result JSON mirrored into a temp state dir and calling `_subagent_lane_health`/`_derive_feedback_decision` directly.

## Fix

**Retire/restart ordering** — in the `record-reward` branch of `_derive_feedback_decision`: when the verify task (not just materialize) is *also* already complete and no verify request is in flight, reopen the chain (`start_next_improvement_generation`) in the **same** cycle instead of waiting for a same-task confirmation that a stall can erase. This removes the fragile two-cycle dependency entirely for this case; the pre-existing two-cycle confirmation path is preserved (with a regression test) for the case where verify genuinely hasn't finished yet.

**Novelty design (why LLM-driven, per the task's robustness ask)** — added `_open_ended_novelty_directive` (`nanobot/runtime/cycle_planning.py`) as a new fallback tier, inserted between the #690 deterministic generator (`_synthesize_hypothesis_from_state`) and the legacy todo.md/research-feed fallbacks. It fires once every (signal, vector) combination the deterministic generator can compose is already done in git log. Its title (`"Open-ended novelty directive: invent and land one genuinely new committable improvement"`) is **fixed and deliberately generic** — unlike the #690 generator's title, it never names a concrete gap, so it can never itself become "already done" and can never be falsely skipped by the bridge's `_task_already_done` keyword-overlap check (verified: the title shares 0 words with recent real commit subjects, and a dedicated test asserts `_task_already_done(title, repo) is False`). Its instructions hand the subagent the goal vectors plus a list of recently-done commit subjects and ask it to invent AND implement the concrete work itself — the LLM carries the novelty, not a template, so it structurally cannot collapse into a repeating bounded set the way the deterministic generator's exhaustion does.

I kept the deterministic #690 generator as the primary fallback (it's precise/grounded and its dedup works correctly per the issue) and only added the open-ended directive as what fires *after* it is exhausted — minimal-diff, reuses the same goal-vector-parsing/git-log helpers, no new subsystem.

## Tests

`tests/test_autonomy_stagnation_followthrough.py` (+3):
- `test_already_done_verify_retires_and_restarts_in_one_step_not_two` — reproduces the exact live state (verify task `done`, `already_done` result file, materialized artifact present) and asserts the restart fires in one step, not two.
- `test_already_done_verify_restart_survives_stall_switch` — drives the same decision through `_switch_off_stalled_lane` with the previous cycle stalled on `record-reward`; asserts it survives unchanged (not `switch_stalled_lane`).
- `test_record_reward_waits_for_confirmation_when_verify_not_yet_done` — guard: when verify genuinely hasn't finished, the pre-#695 two-cycle confirmation path still applies (no regression).

`tests/test_state_synthesized_hypothesis.py` (+4):
- `test_open_ended_novelty_directive_fires_once_generator_is_exhausted` — exhausted-generator scenario produces the directive.
- `test_open_ended_novelty_directive_returns_none_without_goal_vectors` — precondition guard.
- `test_open_ended_novelty_title_is_never_falsely_already_done` — the title never trips the bridge's dedup check.
- `test_materialized_artifact_routes_open_ended_directive_when_generator_exhausted` — end-to-end through `_write_materialized_improvement_artifact`.

Full suite: `python -m pytest tests/ -q` → **1192 passed** (was 1185 on `main`; +7 new). `ruff check` on all touched files: same 12 pre-existing errors as `main` (confirmed via `git stash`), no new issues; both test files clean.

## Docs

Added R28/R29 to `docs/specs/self-evolving-runtime/spec.md` documenting the one-step retire/restart requirement and the open-ended novelty fallback contract.

Part of #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)