### PR TITLE
fix: decouple generate->execute — fresh materialization always spawns (#700)

### DIFF
--- a/docs/specs/self-evolving-runtime/spec.md
+++ b/docs/specs/self-evolving-runtime/spec.md
@@ -106,18 +106,47 @@ an open-ended chat session. The learning signal is the HADI arc
   force-remediation) — the only lanes where "stuck on the same task" is
   still a meaningful stall signal rather than a live-recomputed decision
   that happens to repeat.
-- R32 (issue #697). The planner SHALL track `cycles_since_productive_spawn`,
-  an integer persisted in the existing `state/goals/current.json` snapshot
-  (no new state file), incremented once per cycle by default and reset to 0
-  only when that cycle's live subagent request files include a genuinely new,
-  non-`already_done` `subagent-verify-materialized-improvement` or
+- R32 (issue #697, ordering fixed by #700). The planner SHALL track
+  `cycles_since_productive_spawn`, an integer persisted in the existing
+  `state/goals/current.json` snapshot (no new state file), incremented once
+  per cycle by default and reset to 0 only when that cycle's live subagent
+  request files include a genuinely new, non-`already_done`
+  `subagent-verify-materialized-improvement` or
   `materialize-pass-streak-improvement` request that was not already known
   the previous cycle. If this counter exceeds `IDLE_BACKSTOP_CYCLE_LIMIT`
   (6, `nanobot/runtime/cycle_observe.py`), the planner SHALL force a fresh
   synthesize-generation restart on the next cycle regardless of
   `_generation_phase`'s own conclusion — a liveness net that bounds the
   worst-case stall duration even if a future change reintroduces a sink
-  `_generation_phase` does not yet cover.
+  `_generation_phase` does not yet cover. Issue #700 fix: this check MUST be
+  evaluated in `cycle_feedback._derive_feedback_decision` before the
+  retire/restart-mode replay short-circuit (the block that returns a
+  recorded decision unchanged when `current_task_id` hasn't moved) — placed
+  after, the short-circuit returned the same decision every cycle once the
+  planner landed in one of those modes, and the backstop counter could climb
+  past the limit without the force-restart ever firing (the live host symptom:
+  "stuck on record-reward/retire modes with 0 spawns").
+- R33 (issue #700). Independent of `_derive_feedback_decision`'s mode/lane
+  state, the coordinator's per-cycle path (`run_self_evolving_cycle`,
+  `nanobot/runtime/coordinator.py`, right after the normal feedback-decision
+  handoff calls `_write_subagent_request_artifact`) SHALL run a decouple
+  guard, `cycle_planning._ensure_verify_request_for_fresh_materialization`,
+  every cycle: it finds the newest `state/improvements/materialized-*.json`
+  artifact, skips it if its hypothesis title is already done in the selfevo
+  git log (`_title_already_done_in_git_log`/`_recent_git_log`), and otherwise
+  writes a verify request for it via the same
+  `_write_subagent_request_artifact` helper the normal handoff uses (so
+  schema/fields stay identical) — reliably making "generate → execute"
+  true regardless of the feedback-decision tangle. Both call sites share one
+  liveness guard, `_live_verify_request_for_artifact`: a request already
+  written for the same `source_artifact` blocks a duplicate UNLESS its
+  correlated result has already resolved to a terminal status
+  (`_TERMINAL_SUBAGENT_RESULT_STATUSES`: already_done/completed/no_commit/
+  blocked) — a stale queued request that already resolved does not count as
+  live and never blocks a fresh write for the next generation. This also
+  fixes the root cause of the accumulated stale-request pile: the normal
+  handoff previously wrote a brand-new request file every cycle it re-landed
+  on the verify task, even while an unresolved one was still in flight.
 - R29 (issue #695). When `_synthesize_hypothesis_from_state` (R26) is
   exhausted — goal vectors and a state signal both exist, but every (signal,
   vector) combination it can compose is already done in git log — candidate

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -129,6 +129,7 @@ from nanobot.runtime.cycle_planning import (  # noqa: F401
     _build_task_plan_snapshot,
     _curriculum_level,
     _derive_generated_candidates,
+    _ensure_verify_request_for_fresh_materialization,
     _generation_scoped_verification_id,
     _inferred_generated_candidates_from_tasks,
     _latest_failure_learning,
@@ -477,6 +478,23 @@ async def run_self_evolving_cycle(
     )
     if subagent_request_path:
         experiment["budget_used"]["subagents"] = max(int(experiment["budget_used"].get("subagents") or 0), 1)
+
+    # Issue #700 decouple guard: independent of feedback_decision's mode/lane,
+    # guarantee a fresh (non-already_done) materialized-improvement artifact
+    # always gets a verify request written so the bridge reliably spawns.
+    # A no-op when the normal handoff above already wrote (or a prior cycle
+    # already has) a live request for the same artifact.
+    decoupled_verify_request_path = _ensure_verify_request_for_fresh_materialization(
+        state_root=state_root,
+        cycle_id=cycle_id,
+        goal_id=active_goal,
+        workspace=workspace,
+    )
+    if decoupled_verify_request_path and not subagent_request_path:
+        subagent_request_path = decoupled_verify_request_path
+        current_plan["subagent_request_path"] = subagent_request_path
+        experiment["budget_used"]["subagents"] = max(int(experiment["budget_used"].get("subagents") or 0), 1)
+
     subagent_materialization_summary = materialize_subagent_requests(
         state_root=state_root,
         now=_utc_now(now),

--- a/nanobot/runtime/cycle_feedback.py
+++ b/nanobot/runtime/cycle_feedback.py
@@ -755,15 +755,6 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
         if bridge_handled:
             ambition_underutilization_reasons = [r for r in ambition_underutilization_reasons if r != "subagents_unused"]
 
-    if (
-        isinstance(recorded_feedback_decision, dict)
-        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane", "retire_completed_subagent_lane", "start_next_improvement_generation"}
-        and recorded_feedback_decision.get("current_task_id") == current_task_id
-        and recorded_feedback_decision.get("selected_task_id")
-        and recorded_feedback_decision.get("selected_task_id") != current_task_id
-    ):
-        return recorded_feedback_decision
-
     repeat_block_failure_class = None
     repeat_block_count = 0
     if latest_history and (latest_history.get("result_status") or latest_history.get("status")) == "BLOCK":
@@ -796,6 +787,47 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
         if strong_pass_signature is not None
         else None
     )
+
+    # Issue #700: the idle backstop (see below) MUST be evaluated before the
+    # retire/restart-mode replay short-circuit that follows — otherwise once
+    # the planner lands in one of those modes and current_task_id stops
+    # changing, the short-circuit returns the SAME recorded decision every
+    # cycle forever and the backstop's force-restart can never fire (the
+    # exact "stuck on record-reward/retire modes with 0 spawns" host symptom).
+    # Step 2 (repeat-block force_remediation) still outranks the backstop, so
+    # it is evaluated first via the same guard used below.
+    try:
+        cycles_since_productive_spawn = int(task_plan.get("cycles_since_productive_spawn") or 0)
+    except (TypeError, ValueError):
+        cycles_since_productive_spawn = 0
+    if cycles_since_productive_spawn > IDLE_BACKSTOP_CYCLE_LIMIT and not (
+        repeat_block_failure_class and repeat_block_count >= REPEATED_BLOCK_LIMIT
+    ):
+        return _generation_restart_decision(
+            current_task_id=current_task_id,
+            current_task_class=current_task_class,
+            reward_value=reward_value,
+            repeat_block_count=repeat_block_count,
+            repeat_block_failure_class=repeat_block_failure_class,
+            strong_pass_signature_list=strong_pass_signature_list,
+            strong_pass_count=strong_pass_count,
+            artifact_path=task_plan.get("materialized_improvement_artifact_path"),
+            reason=(
+                f"idle backstop: no productive subagent spawn in over "
+                f"{IDLE_BACKSTOP_CYCLE_LIMIT} cycles ({cycles_since_productive_spawn}); "
+                "forcing a fresh synthesize generation regardless of the current "
+                "generation phase"
+            ),
+        )
+
+    if (
+        isinstance(recorded_feedback_decision, dict)
+        and recorded_feedback_decision.get("mode") in {"retire_terminal_selfevo_lane", "retire_terminal_noop_lane", "retire_stale_subagent_lane", "retire_completed_subagent_lane", "start_next_improvement_generation"}
+        and recorded_feedback_decision.get("current_task_id") == current_task_id
+        and recorded_feedback_decision.get("selected_task_id")
+        and recorded_feedback_decision.get("selected_task_id") != current_task_id
+    ):
+        return recorded_feedback_decision
 
     # Issue #580 follow-up: current_task_id itself can be an orphan left behind
     # by removed code (e.g. a live cycle already made it "active" before the
@@ -844,36 +876,10 @@ def _derive_feedback_decision(task_plan: dict[str, Any] | None, goals_dir: Path,
     _materialize_task_status = _task_status(materialize_task)
     _materialize_task_completed = _materialize_task_status in COMPLETED_TASK_STATUSES
     reward_accounted_artifact_path = task_plan.get("generation_reward_accounted_artifact_path")
-
-    # Issue #697 decide_next_lane step 3: the idle backstop. If no productive
-    # (non-already_done) subagent spawn has happened in IDLE_BACKSTOP_CYCLE_
-    # LIMIT cycles, force a fresh synthesize generation regardless of
-    # generation_phase — a liveness net independent of the driver's own
-    # correctness. Step 2 (repeat-block force_remediation, evaluated further
-    # below) still outranks the backstop, so defer to it here.
-    try:
-        cycles_since_productive_spawn = int(task_plan.get("cycles_since_productive_spawn") or 0)
-    except (TypeError, ValueError):
-        cycles_since_productive_spawn = 0
-    if cycles_since_productive_spawn > IDLE_BACKSTOP_CYCLE_LIMIT and not (
-        repeat_block_failure_class and repeat_block_count >= REPEATED_BLOCK_LIMIT
-    ):
-        return _generation_restart_decision(
-            current_task_id=current_task_id,
-            current_task_class=current_task_class,
-            reward_value=reward_value,
-            repeat_block_count=repeat_block_count,
-            repeat_block_failure_class=repeat_block_failure_class,
-            strong_pass_signature_list=strong_pass_signature_list,
-            strong_pass_count=strong_pass_count,
-            artifact_path=materialized_artifact_path,
-            reason=(
-                f"idle backstop: no productive subagent spawn in over "
-                f"{IDLE_BACKSTOP_CYCLE_LIMIT} cycles ({cycles_since_productive_spawn}); "
-                "forcing a fresh synthesize generation regardless of the current "
-                "generation phase"
-            ),
-        )
+    # (Issue #700: the idle-backstop check that used to live here was moved
+    # above the retire/restart-mode replay short-circuit — see the block near
+    # the top of this function, right after strong_pass_signature_list is
+    # computed — so it can no longer be starved by that short-circuit.)
 
     # Issue #697 decide_next_lane steps 4/6/7/8, scoped to the record-reward +
     # materialize-completed context: this collapses the removed branches

--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -1054,6 +1054,42 @@ def _generation_scoped_verification_id(*, semantic_task_id: str, cycle_id: str, 
     return f"{semantic_task_id}-{cycle_id}-{artifact_hash}"
 
 
+def _live_verify_request_for_artifact(
+    *,
+    state_root: Path,
+    source_artifact_path: str,
+    task_id: str = "subagent-verify-materialized-improvement",
+) -> Path | None:
+    """Return the path of an existing LIVE verify request correlated to
+    source_artifact_path, or None if none exists.
+
+    Issue #700: a request counts as "live" (still in flight, blocking a
+    duplicate write) unless its correlated result file already carries a
+    terminal result_status (``_TERMINAL_SUBAGENT_RESULT_STATUSES``:
+    already_done/completed/no_commit/blocked). A STALE queued request whose
+    result already resolved does NOT count as live and must not block a
+    fresh write for the same artifact — this is what lets the accumulated
+    stale requests on a stuck host be safely ignored.
+    """
+    request_dir = state_root / "subagents" / "requests"
+    result_dir = state_root / "subagents" / "results"
+    if not request_dir.exists():
+        return None
+    for path, _mtime in _json_files_sorted_by_mtime(True, request_dir):
+        payload = _safe_read_json(path)
+        if not isinstance(payload, dict) or payload.get("task_id") != task_id:
+            continue
+        if payload.get("source_artifact") != source_artifact_path:
+            continue
+        result_path = _result_path_for(result_dir, path, payload)
+        result_payload = _safe_read_json(result_path) if result_path.exists() else None
+        result_status = result_payload.get("result_status") if isinstance(result_payload, dict) else None
+        if result_status in _TERMINAL_SUBAGENT_RESULT_STATUSES:
+            continue  # stale — already has a terminal result, doesn't block
+        return path
+    return None
+
+
 def _write_subagent_request_artifact(
     *,
     state_root: Path,
@@ -1075,6 +1111,18 @@ def _write_subagent_request_artifact(
         # Use os.scandir-based helper to avoid double-stat penalty of glob()+stat().
         _materialized = [p for p, _ in _json_files_sorted_by_mtime(True, improvements_dir) if p.name.startswith("materialized-")] if improvements_dir.exists() else []
         source_artifact = str(_materialized[0]) if _materialized else None
+
+    # Issue #700: never write a second live request for the same generation.
+    # If a non-terminally-resulted request already exists for source_artifact,
+    # reuse it instead of minting a duplicate (this is the root cause of the
+    # accumulated stale-request pile and of the idle-backstop counter
+    # resetting on every re-selection of the same generation).
+    if source_artifact:
+        existing_live = _live_verify_request_for_artifact(
+            state_root=state_root, source_artifact_path=str(source_artifact)
+        )
+        if existing_live is not None:
+            return str(existing_live)
 
     # Attach relevant lessons context so subagent can avoid known pitfalls
     lessons_context: dict[str, Any] = {}
@@ -1141,6 +1189,81 @@ def _write_subagent_request_artifact(
     }
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     return str(path)
+
+
+def _ensure_verify_request_for_fresh_materialization(
+    *,
+    state_root: Path,
+    cycle_id: str,
+    goal_id: str,
+    workspace: Path | None = None,
+    selfevo_repo_root: Path | None = None,
+) -> str | None:
+    """Issue #700 decouple guard: generate->execute safety net.
+
+    Runs every cycle in the coordinator's cycle-run path — deliberately
+    OUTSIDE ``_derive_feedback_decision`` — so a fresh materialized-
+    improvement hypothesis always reliably gets a verify request written,
+    independent of the feedback decision's current mode/lane. Logic:
+
+    1. Find the newest ``state/improvements/materialized-*.json`` artifact.
+       If none exists, nothing to do.
+    2. If its hypothesis title is already done in the selfevo git log
+       (``_title_already_done_in_git_log`` / ``_recent_git_log``), do
+       nothing — dedup.
+    3. Otherwise, write a verify request via the same
+       ``_write_subagent_request_artifact`` helper the normal feedback-
+       decision handoff uses (identical schema/fields). That helper's own
+       liveness check (``_live_verify_request_for_artifact``) makes this a
+       no-op — returning the existing path rather than a duplicate — when a
+       live (non-terminally-resulted) request already exists for this exact
+       artifact, whether written by the normal handoff earlier this same
+       cycle or by a prior cycle. Stale requests that already resolved to a
+       terminal result (already_done/completed/no_commit/blocked) do not
+       count as live and never block a fresh write.
+    """
+    improvements_dir = state_root / "improvements"
+    if not improvements_dir.exists():
+        return None
+    materialized = [
+        p for p, _mtime in _json_files_sorted_by_mtime(True, improvements_dir)
+        if p.name.startswith("materialized-")
+    ]
+    if not materialized:
+        return None
+    newest_path = materialized[0]
+    artifact = _safe_read_json(newest_path)
+    if not isinstance(artifact, dict):
+        return None
+
+    title = str(
+        (artifact.get("next_bounded_candidate") or {}).get("title")
+        or (artifact.get("derived_candidate") or {}).get("title")
+        or ""
+    ).strip()
+    _selfevo_root = selfevo_repo_root or (state_root.parent / "eeebot-self-evolving")
+    if title and _selfevo_root.is_dir():
+        git_log = _recent_git_log(_selfevo_root)
+        if git_log and _title_already_done_in_git_log(title, git_log):
+            return None  # already done — dedup, nothing to spawn
+
+    fallback_plan: dict[str, Any] = {
+        "current_task_id": "subagent-verify-materialized-improvement",
+        "tasks": [],
+        "materialized_improvement_artifact_path": str(newest_path),
+        "feedback_decision": artifact.get("feedback_decision"),
+        "concrete_improvement_statement": artifact.get("concrete_improvement_statement"),
+        "hadi_cycle": artifact.get("hadi_cycle"),
+        "selected_task_title": title or None,
+        "current_task": title or None,
+    }
+    return _write_subagent_request_artifact(
+        state_root=state_root,
+        cycle_id=cycle_id,
+        goal_id=goal_id,
+        current_plan=fallback_plan,
+        workspace=workspace,
+    )
 
 
 def _write_research_feed(

--- a/tests/test_decouple_generate_execute.py
+++ b/tests/test_decouple_generate_execute.py
@@ -1,0 +1,294 @@
+"""Issue #700: decouple generate->execute — a fresh materialized-improvement
+hypothesis that is NOT already done in git and has NO live verify request
+must reliably get a verify request written, independent of
+``_derive_feedback_decision``'s mode/lane state.
+
+5+ prior fixes (#656/#664/#690/#695/#697) tried to fix the feedback-decision
+tangle itself and each eventually stalled again on the live host. This suite
+models the DIRTY LIVE STATE that hid every prior bug: an accumulated pile of
+stale queued verify requests that already resolved to a terminal result,
+sitting alongside a genuinely fresh materialization with no live request.
+Clean fixtures alone are not sufficient coverage for this issue.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime.cycle_feedback import IDLE_BACKSTOP_CYCLE_LIMIT, _derive_feedback_decision
+from nanobot.runtime.cycle_planning import (
+    _ensure_verify_request_for_fresh_materialization,
+    _live_verify_request_for_artifact,
+    _write_subagent_request_artifact,
+)
+
+
+def _write_materialized_artifact(improvements_dir: Path, *, name: str, title: str, feedback_decision: dict | None = None) -> Path:
+    improvements_dir.mkdir(parents=True, exist_ok=True)
+    path = improvements_dir / name
+    path.write_text(json.dumps({
+        "schema_version": "materialized-improvement-v1",
+        "task_id": "materialize-synthesized-improvement",
+        "next_bounded_candidate": {"title": title},
+        "derived_candidate": {"title": title},
+        "feedback_decision": feedback_decision,
+    }), encoding="utf-8")
+    return path
+
+
+def _write_stale_request_with_terminal_result(
+    state_root: Path, *, idx: int, source_artifact: str = "/nonexistent/stale-artifact.json"
+) -> None:
+    request_dir = state_root / "subagents" / "requests"
+    result_dir = state_root / "subagents" / "results"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    result_dir.mkdir(parents=True, exist_ok=True)
+    request_id = f"stale-req-{idx}"
+    (request_dir / f"request-cycle-stale-{idx}.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "task_id": "subagent-verify-materialized-improvement",
+        "request_id": request_id,
+        "request_status": "queued",
+        "source_artifact": source_artifact,
+    }), encoding="utf-8")
+    (result_dir / f"result-{request_id}.json").write_text(json.dumps({
+        "schema_version": "subagent-result-v1",
+        "request_id": request_id,
+        "result_status": "already_done",
+    }), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The core invariant: dirty accumulated-stale-request state must not block a
+# fresh verify request from being written for a genuinely fresh generation.
+# ---------------------------------------------------------------------------
+
+def test_fresh_materialization_gets_verify_request_despite_five_stale_terminal_requests(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+    improvements_dir = state_root / "improvements"
+
+    # The accumulated host mess: 5 stale requests, all request_status=queued,
+    # each already carrying a terminal (already_done) result.
+    for i in range(5):
+        _write_stale_request_with_terminal_result(state_root, idx=i)
+
+    # A fresh Vector-2-style hypothesis materialization with no live request.
+    fresh_artifact = _write_materialized_artifact(
+        improvements_dir,
+        name="materialized-cycle-fresh700.json",
+        title="Vector-2: reduce control-plane summary write latency",
+    )
+
+    result_path = _ensure_verify_request_for_fresh_materialization(
+        state_root=state_root,
+        cycle_id="cycle-fresh700",
+        goal_id="goal-bootstrap",
+    )
+
+    assert result_path is not None
+    written = json.loads(Path(result_path).read_text(encoding="utf-8"))
+    assert written["task_id"] == "subagent-verify-materialized-improvement"
+    assert written["source_artifact"] == str(fresh_artifact)
+    assert written["request_status"] == "queued"
+
+    # The 5 stale requests must remain untouched (ignored, not consumed).
+    stale_requests = list((state_root / "subagents" / "requests").glob("request-cycle-stale-*.json"))
+    assert len(stale_requests) == 5
+
+
+def test_fresh_materialization_already_done_in_git_log_gets_no_request(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_root = tmp_path / "state"
+    improvements_dir = state_root / "improvements"
+    _write_materialized_artifact(
+        improvements_dir,
+        name="materialized-cycle-done700.json",
+        title="Refresh the approval gate TTL handling",
+    )
+
+    import nanobot.runtime.cycle_planning as cycle_planning_mod
+
+    monkeypatch.setattr(
+        cycle_planning_mod,
+        "_recent_git_log",
+        lambda repo_root, since="14 days ago": "abcd123 fix: refresh the approval gate TTL handling (#701)",
+    )
+    monkeypatch.setattr(Path, "is_dir", lambda self: True)
+
+    result_path = _ensure_verify_request_for_fresh_materialization(
+        state_root=state_root,
+        cycle_id="cycle-done700",
+        goal_id="goal-bootstrap",
+    )
+
+    assert result_path is None
+    assert not (state_root / "subagents" / "requests").exists()
+
+
+def test_existing_live_request_for_the_same_artifact_is_not_duplicated(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+    improvements_dir = state_root / "improvements"
+    artifact_path = _write_materialized_artifact(
+        improvements_dir,
+        name="materialized-cycle-live700.json",
+        title="Vector-3: dashboard latency instrumentation",
+    )
+
+    # A live (non-terminal-result) request already exists for this exact
+    # artifact — written by the normal feedback-decision handoff earlier.
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "request-cycle-already-live.json").write_text(json.dumps({
+        "schema_version": "subagent-request-v1",
+        "task_id": "subagent-verify-materialized-improvement",
+        "request_id": "already-live-req",
+        "request_status": "queued",
+        "source_artifact": str(artifact_path),
+    }), encoding="utf-8")
+
+    result_path = _ensure_verify_request_for_fresh_materialization(
+        state_root=state_root,
+        cycle_id="cycle-live700-guard",
+        goal_id="goal-bootstrap",
+    )
+
+    # No duplicate written — the guard's write helper returns the existing
+    # live request's path instead of minting a new one.
+    assert result_path == str(request_dir / "request-cycle-already-live.json")
+    all_requests = list(request_dir.glob("*.json"))
+    assert len(all_requests) == 1
+
+
+def test_write_subagent_request_artifact_itself_dedups_against_a_live_request(tmp_path: Path) -> None:
+    # Unit-level check of the shared liveness guard used by both the normal
+    # handoff (_write_subagent_request_artifact) and the #700 decouple guard.
+    state_root = tmp_path / "state"
+    request_dir = state_root / "subagents" / "requests"
+    request_dir.mkdir(parents=True, exist_ok=True)
+    (request_dir / "request-cycle-a.json").write_text(json.dumps({
+        "task_id": "subagent-verify-materialized-improvement",
+        "request_id": "req-a",
+        "request_status": "queued",
+        "source_artifact": "/some/artifact.json",
+    }), encoding="utf-8")
+
+    first = _live_verify_request_for_artifact(state_root=state_root, source_artifact_path="/some/artifact.json")
+    assert first == request_dir / "request-cycle-a.json"
+
+    path_b = _write_subagent_request_artifact(
+        state_root=state_root,
+        cycle_id="cycle-b",
+        goal_id="goal-bootstrap",
+        current_plan={
+            "current_task_id": "subagent-verify-materialized-improvement",
+            "tasks": [],
+            "materialized_improvement_artifact_path": "/some/artifact.json",
+        },
+    )
+
+    assert path_b == str(request_dir / "request-cycle-a.json")
+    assert not (request_dir / "request-cycle-b.json").exists()
+
+
+def test_stale_terminal_request_does_not_count_as_live(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+    _write_stale_request_with_terminal_result(state_root, idx=0, source_artifact="/some/artifact.json")
+
+    assert _live_verify_request_for_artifact(state_root=state_root, source_artifact_path="/some/artifact.json") is None
+
+
+# ---------------------------------------------------------------------------
+# Backstop counter: force-restart must fire at the limit even while the
+# planner is replaying a retire/restart-mode recorded decision — this is
+# the early-return short-circuit that previously starved the backstop.
+# ---------------------------------------------------------------------------
+
+def test_backstop_force_restart_wins_over_a_replayed_retire_mode_decision(tmp_path: Path) -> None:
+    goals_dir = tmp_path / "state" / "goals"
+    goals_dir.mkdir(parents=True)
+    (goals_dir / "history").mkdir()
+
+    # The planner is stuck replaying the SAME retire-mode decision every
+    # cycle (current_task_id never changes) — before the #700 fix this early
+    # return happened BEFORE the idle-backstop check ever ran.
+    recorded_feedback_decision = {
+        "mode": "retire_stale_subagent_lane",
+        "current_task_id": "record-reward",
+        "selected_task_id": "subagent-verify-materialized-improvement",
+    }
+    task_plan = {
+        "current_task_id": "record-reward",
+        "feedback_decision": recorded_feedback_decision,
+        "cycles_since_productive_spawn": IDLE_BACKSTOP_CYCLE_LIMIT + 1,
+        "tasks": [{"task_id": "record-reward", "status": "active"}],
+    }
+
+    decision = _derive_feedback_decision(task_plan, goals_dir, state_root=tmp_path / "state")
+
+    assert decision is not None
+    assert decision["mode"] == "start_next_improvement_generation"
+    assert decision["mode"] != recorded_feedback_decision["mode"]
+
+
+def test_backstop_counter_increments_across_six_no_spawn_cycles_and_force_restarts(tmp_path: Path) -> None:
+    goals_dir = tmp_path / "state" / "goals"
+    goals_dir.mkdir(parents=True)
+    (goals_dir / "history").mkdir()
+    state_root = tmp_path / "state"
+
+    fired_at = None
+    for cycle in range(IDLE_BACKSTOP_CYCLE_LIMIT + 2):
+        task_plan = {
+            "current_task_id": "record-reward",
+            "cycles_since_productive_spawn": cycle,
+            "tasks": [{"task_id": "record-reward", "status": "active"}],
+        }
+        decision = _derive_feedback_decision(task_plan, goals_dir, state_root=state_root)
+        if decision is not None and decision.get("mode") == "start_next_improvement_generation":
+            fired_at = cycle
+            break
+
+    assert fired_at is not None
+    assert fired_at == IDLE_BACKSTOP_CYCLE_LIMIT + 1
+
+
+def test_backstop_counter_resets_to_zero_on_a_real_spawn(tmp_path: Path) -> None:
+    from nanobot.runtime.cycle_planning import _build_task_plan_snapshot
+
+    workspace = tmp_path / "workspace"
+    state_root = workspace / "state"
+    goals = state_root / "goals"
+    goals.mkdir(parents=True)
+    (goals / "current.json").write_text(json.dumps({"cycles_since_productive_spawn": 5}), encoding="utf-8")
+
+    request_dir = state_root / "subagents" / "requests"
+    result_dir = state_root / "subagents" / "results"
+    request_dir.mkdir(parents=True)
+    result_dir.mkdir(parents=True)
+    (request_dir / "request-real-spawn.json").write_text(json.dumps({
+        "task_id": "subagent-verify-materialized-improvement",
+        "request_id": "req-real-spawn",
+        "request_status": "queued",
+    }), encoding="utf-8")
+    (result_dir / "result-req-real-spawn.json").write_text(json.dumps({
+        "request_id": "req-real-spawn",
+        "result_status": "completed",
+    }), encoding="utf-8")
+
+    plan = _build_task_plan_snapshot(
+        workspace=workspace,
+        cycle_id="cycle-real-spawn",
+        goal_id="goal-bootstrap",
+        result_status="PASS",
+        approval_gate_state="fresh",
+        next_hint="continue",
+        experiment={"reward_signal": {"value": 1.0}, "budget": {}, "budget_used": {}, "outcome": "keep"},
+        report_path=tmp_path / "report.json",
+        history_path=tmp_path / "history.json",
+        improvement_score=1.0,
+        feedback_decision=None,
+        goals_dir=goals,
+    )
+
+    assert plan["cycles_since_productive_spawn"] == 0


### PR DESCRIPTION
## Summary

Operator decision after 5+ planner-decision fixes (#656/#664/#690/#695/#697) failed to sustain productive cycles: **decouple execution from the feedback-decision tangle instead of fixing the tangle again.**

### The decouple guard — where it lives

`nanobot/runtime/cycle_planning._ensure_verify_request_for_fresh_materialization` is a new function called from `coordinator.run_self_evolving_cycle`, right after the existing `_write_subagent_request_artifact` call (the normal feedback-decision handoff) — **not** inside `_derive_feedback_decision`. It runs unconditionally every cycle as a safety net:

1. Find the newest `state/improvements/materialized-*.json` artifact. None → no-op.
2. If its `next_bounded_candidate`/`derived_candidate` title is already done in the selfevo git log (reusing `_title_already_done_in_git_log` + `_recent_git_log`) → no-op (dedup).
3. Otherwise write a verify request via the **same** `_write_subagent_request_artifact` helper the normal handoff uses, so schema/fields are identical to a normal handoff-written request — no hand-rolled JSON.

### How stale requests are excluded (shared liveness guard)

Both the decouple guard and the normal handoff now go through one liveness check, `_live_verify_request_for_artifact`: a request already written for the same `source_artifact` blocks a duplicate **unless** its correlated result (via `_result_path_for`) has already resolved to a terminal status (`_TERMINAL_SUBAGENT_RESULT_STATUSES`: already_done/completed/no_commit/blocked). A stale queued request whose result already resolved does not count as live and never blocks a fresh write.

This also fixes the root cause of the accumulated stale-request pile on the host: `_write_subagent_request_artifact` previously minted a brand-new request file every cycle it re-landed on the verify task, even while an unresolved request for the same generation was still in flight. It now returns the existing live request's path instead.

### Backstop-counter root cause + fix

`cycles_since_productive_spawn`'s own increment/reset math (in `cycle_planning._build_task_plan_snapshot`) was already correct in isolation (tests confirm this pre-existed and still pass unchanged). The real bug was in **enforcement**: `cycle_feedback._derive_feedback_decision` had an early-return short-circuit (replaying a recorded retire/restart-mode decision unchanged while `current_task_id` hasn't moved) that ran **before** the idle-backstop check. Once the planner landed in one of those modes and stopped changing `current_task_id`, that short-circuit returned the same decision every single cycle forever — the backstop's force-restart could never fire, no matter how high the counter climbed. This is the exact live-host symptom: "stuck on record-reward/retire modes with 0 spawns."

Fix: moved the idle-backstop check to run **before** that short-circuit (repeat-block force-remediation still outranks the backstop, as before — same guard, just relocated together with its dependencies).

### Import-hygiene check (#697 follow-up)

Grepped the whole tree for `_has_live_verify_request_queue` (the function the issue named as a live-probe import failure) and other names removed in #695/#697 (`post_materialization_reward_already_confirmed`, `repeated_synthesized_materialization_completion`). Confirmed: fully removed (definition + every call site) in #695/#697; the only remaining occurrences are comments/test names referencing history. No dangling import anywhere.

### Tests — dirty live state (`tests/test_decouple_generate_execute.py`)

- 5 stale `request-cycle-*.json`, all `request_status=queued`, each WITH a terminal `already_done` result, plus one fresh materialized non-already-done hypothesis with no live request → asserts a fresh verify request is written and the stale ones are left untouched.
- Fresh materialization already done in git log → no new request (dedup).
- A live (non-terminal) request already exists for the artifact → no duplicate (both at the guard level and the shared `_write_subagent_request_artifact` level).
- Stale terminal request does not count as live (unit check of `_live_verify_request_for_artifact`).
- Backstop force-restart wins over a replayed retire-mode decision (regression test for the reorder fix).
- Backstop counter increments across 6 no-spawn cycles and force-restarts exactly at `IDLE_BACKSTOP_CYCLE_LIMIT + 1`.
- Backstop counter resets to 0 on a real spawn.

## Test plan
- [x] `python -m pytest tests/ -q` — 1221 passed (was 1213 before; +8 new tests, no regressions)
- [x] `ruff check` on touched files — 12 pre-existing findings, confirmed identical on origin/main (none introduced by this change)
- [ ] Deploy to the stuck host; confirm within a couple cycles a verify request is written for the existing fresh Vector-2 materialization and the bridge spawns a real subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #700