### PR TITLE
feat(runtime): minimal cycle ledger — append-only JSONL with enum outcomes (#720)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -35,6 +35,12 @@ from nanobot.bus.queue import MessageBus
 from nanobot.cli.commands import _make_provider
 from nanobot.config.loader import load_config, set_config_path
 from nanobot.observability.llm_telemetry import set_call_context
+from nanobot.runtime.cycle_ledger import (
+    record_cycle_outcome,
+    record_cycle_started,
+    record_dedup_decision,
+    record_gate_decision,
+)
 from nanobot.runtime.cycle_planning import filter_completed_priorities_from_goal_text
 from nanobot.runtime.stop_guards import REVISION_CAP_DEFAULT, revision_outcome
 
@@ -999,6 +1005,16 @@ async def _main_impl():
         print('already_handled')
         return 0
 
+    # #720: cycle_id resolved once, up front, so every ledger row for this
+    # cycle (write-ahead start, dedup, gate, terminal outcome) joins on the
+    # same value. Branch is not known yet (resolved by _setup_cycle_branch
+    # below) — the write-ahead row below records it as None.
+    _cycle_id = str(req.get('cycle_id') or request_id)
+    # #720 piece 3: write-ahead cycle marker, appended BEFORE any dedup check
+    # or subagent spawn — a crashed/timed-out cycle leaves this row with no
+    # matching terminal outcome row, a deterministic recovery signal.
+    record_cycle_started(STATE_DIR, _cycle_id, request_id, None)
+
     # ── #680 defense-in-depth: HEAD-on-main precondition ────────────────────
     # _restore_to_main() below only WARNs when it fails (see the `finally` in
     # the cycle-branch block ~line 1287) — it does not abort the *current*
@@ -1044,6 +1060,9 @@ async def _main_impl():
                 'reason': 'head_on_main_precondition_failed',
                 'auto_committed': False,
             },
+        )
+        record_cycle_outcome(
+            STATE_DIR, _cycle_id, 'failed', 'head_on_main_precondition_failed', [], None,
         )
         return 0
 
@@ -1147,6 +1166,8 @@ async def _main_impl():
                 'Marked [Done] in MEMORY.md. No re-execution needed.',
             ],
         )
+        record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_duplicate', _found_commit)
+        record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done', [], None)
         return 0
     # #716: _task_already_done above only catches proposals that already landed
     # as a real git commit. A proposal that was blocked/rolled-back/produced no
@@ -1184,7 +1205,15 @@ async def _main_impl():
                 'reason': 'recent_duplicate_failure',
             },
         )
+        record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_recent_failure', _dup_check_title)
+        record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'recent_duplicate_failure', [], None)
         return 0
+
+    else:
+        # #720 piece 4: neither pre-spawn suppression fired — the dedup
+        # heuristic's own "proceeded" decision, so #705 can measure the
+        # heuristic's false-positive rate (matched vs. proceeded counts).
+        record_dedup_decision(STATE_DIR, _cycle_id, 'proceeded', None)
 
     # One-time migration: backfill backlog_title into existing result files
     # so _get_previous_attempts() can match by artifact title.
@@ -1211,7 +1240,8 @@ async def _main_impl():
     # origin/main advances only via _integrate_cycle_to_main() below, and only
     # after the smoke gate passes (R12-R15).
     _selfevo_repo = STATE_DIR.parent / 'eeebot-self-evolving'
-    _cycle_id = str(req.get('cycle_id') or request_id)
+    # _cycle_id was already resolved up front (right after request_id, before
+    # the write-ahead ledger marker) — reused here unchanged.
     _cycle_setup = _setup_cycle_branch(_selfevo_repo, _cycle_id)
     cycle_branch = _cycle_setup['branch']
     main_sha_before = _cycle_setup['main_sha']
@@ -1241,6 +1271,9 @@ async def _main_impl():
                 'main_sha_after': main_sha_before,
                 'reason': _cycle_setup['reason'],
             },
+        )
+        record_cycle_outcome(
+            STATE_DIR, _cycle_id, 'failed', _cycle_setup['reason'], [], cycle_branch,
         )
         return 0
 
@@ -1498,6 +1531,9 @@ async def _main_impl():
                     f'blocked-pattern check: {len(_blocked_pattern_violations)} blocked '
                     f'file(s) present — {cycle_branch} kept for forensics, main left unchanged (#678 F3)'
                 )
+                record_gate_decision(
+                    STATE_DIR, _cycle_id, False, _rollback_reason, _blocked_pattern_violations,
+                )
             elif _mutation_violations:
                 # #678 F1: mutation-surface violations were previously print-only
                 # while integration was decided solely by the smoke gate. Now a
@@ -1507,7 +1543,11 @@ async def _main_impl():
                     f'mutation surfaces: {len(_mutation_violations)} violation(s) — '
                     f'{cycle_branch} kept for forensics, main left unchanged (#678 F1)'
                 )
+                record_gate_decision(
+                    STATE_DIR, _cycle_id, False, _rollback_reason, _mutation_violations,
+                )
             elif _smoke_passed:
+                record_gate_decision(STATE_DIR, _cycle_id, True, 'smoke_passed', [])
                 _integ = _integrate_cycle_to_main(_selfevo_repo, cycle_branch, main_sha_before)
                 if _integ['ok']:
                     _integrated = True
@@ -1527,6 +1567,7 @@ async def _main_impl():
                     f'smoke: cap reached ({_repair_attempts}/{_max_repair_attempts}) without pass '
                     f'— leaving {cycle_branch} unintegrated (kept for forensics)'
                 )
+                record_gate_decision(STATE_DIR, _cycle_id, False, _rollback_reason, [])
         commits_pushed = cycle_commit_count if _integrated else 0
 
         # Safety-net: mark backlog Done if subagent forgot (meaningful only once main advanced)
@@ -1642,6 +1683,28 @@ async def _main_impl():
         revisions=_revision_record,
         backlog_title=backlog_title,
         rollback=_rollback,
+    )
+    # #720: terminal ledger row, written in the SAME step as the result/merge
+    # above (never deferred) so the ledger and git state can't diverge.
+    # Outcome mapping: integrated -> success; an unexpected exception ->
+    # failed even with zero commits (not a clean no-op); zero commits
+    # otherwise -> partial (verify-materialized no-op, nothing to gate);
+    # anything else with commits but not integrated (gate/mutation-surface
+    # rejection, integrate failure) -> failed. No dedicated 'timeout' path
+    # exists in this flow today (the subagent-spawn and repair-turn
+    # asyncio.wait_for timeouts are absorbed back into the normal
+    # commit/gate accounting above, not surfaced as a distinct outcome) —
+    # 'timeout' stays a defined-but-unused enum value.
+    if _integrated:
+        _cycle_outcome = 'success'
+    elif _rollback_reason == 'internal_error':
+        _cycle_outcome = 'failed'
+    elif cycle_commit_count == 0:
+        _cycle_outcome = 'partial'
+    else:
+        _cycle_outcome = 'failed'
+    record_cycle_outcome(
+        STATE_DIR, _cycle_id, _cycle_outcome, _rollback_reason, files_changed, cycle_branch,
     )
 
     # Structured lesson recording after a successful integrated commit

--- a/nanobot/runtime/cycle_ledger.py
+++ b/nanobot/runtime/cycle_ledger.py
@@ -1,0 +1,238 @@
+"""Minimal cycle ledger: one flat append-only JSONL file per self-evolving cycle.
+
+Issue #720 implements the #704 ledger design (``docs/changes/
+704-ledger-artifact-memory/design.md``) in its MINIMAL form. #704 specified
+five ledgers/artifacts, two of them net-new (a per-day ``done/`` and
+``failure/`` split). This module deliberately does NOT build that split —
+it appends every phase of every cycle (write-ahead start, dedup decision,
+gate decision, terminal outcome) to a SINGLE flat file,
+``<state_dir>/ledger/cycles.jsonl``, with one ``phase`` field distinguishing
+row kinds and one enum ``outcome`` field on the terminal row. This is the
+deviation from the design doc: no done/failure split, no per-day filename
+sharding by content. Splitting into `done`/`failure` ledgers (if ever
+needed by #705/#710) can be done by filtering this single file's `outcome`
+field — nothing here forecloses that.
+
+Grounded in the KB pattern mined for #720 (ralph ``progress.txt`` / auto-
+research ``results.tsv``): a single flat append-only log, not a database.
+
+Rotation reuses the shape of ``nanobot.observability.llm_telemetry.
+_rotate_and_prune`` (#675/#693), adapted for a single active filename rather
+than daily-named files: on each append, if ``cycles.jsonl`` already exists
+and was last modified on a PRIOR day, it is gzip-archived to
+``cycles-YYYY-MM-DD.jsonl.gz`` (named after its own last-modified day) and a
+fresh ``cycles.jsonl`` is started; any ``cycles-*.jsonl.gz`` older than the
+retention window (``CYCLE_LEDGER_RETENTION_DAYS``, default 90) is pruned.
+
+Everything here is best-effort / fail-open: a ledger write must never crash
+the bridge or change its control flow.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import gzip
+import json
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+_LEDGER_SUBDIR = "ledger"
+_LEDGER_FILENAME = "cycles.jsonl"
+_DEFAULT_RETENTION_DAYS = 90
+
+# Enum contract (#720 acceptance criteria: "Every bridge cycle ... leaves
+# exactly one terminal ledger row with an enum outcome"). An invalid/unknown
+# outcome value is coerced to 'failed' (fail-closed on the classification,
+# fail-open on the write) rather than raising or silently writing free text.
+VALID_OUTCOMES = frozenset({"success", "partial", "failed", "skipped-duplicate", "timeout"})
+VALID_DEDUP_DECISIONS = frozenset({"proceeded", "skipped_duplicate", "skipped_recent_failure"})
+
+
+def _ledger_dir(state_dir: Path) -> Path:
+    return Path(state_dir) / _LEDGER_SUBDIR
+
+
+def _retention_days() -> int:
+    raw = os.environ.get("CYCLE_LEDGER_RETENTION_DAYS", "").strip()
+    if not raw:
+        return _DEFAULT_RETENTION_DAYS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_RETENTION_DAYS
+
+
+def _day_str(name: str) -> str | None:
+    """Extract the YYYY-MM-DD stem from a ``cycles-*.jsonl.gz`` filename."""
+    prefix = "cycles-"
+    suffix = ".jsonl.gz"
+    if not (name.startswith(prefix) and name.endswith(suffix)):
+        return None
+    candidate = name[len(prefix) : -len(suffix)]
+    try:
+        datetime.strptime(candidate, "%Y-%m-%d")
+    except ValueError:
+        return None
+    return candidate
+
+
+def _rotate_and_prune(ledger_dir: Path, active_path: Path, today: str, retention_days: int) -> None:
+    """Archive a stale active file and prune expired archives.
+
+    Mirrors ``llm_telemetry._rotate_and_prune``'s shape (gzip prior content,
+    prune expired ``.gz`` files, best-effort per file) but adapted to a single
+    active filename: the active file is rotated by ITS OWN last-modified day
+    rather than by filename, since there is only one filename to rotate.
+    """
+    try:
+        if active_path.exists():
+            mtime_day = datetime.fromtimestamp(
+                active_path.stat().st_mtime, tz=timezone.utc
+            ).strftime("%Y-%m-%d")
+            if mtime_day != today:
+                gz_path = ledger_dir / f"cycles-{mtime_day}.jsonl.gz"
+                with open(active_path, "rb") as f_in, gzip.open(gz_path, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+                active_path.unlink()
+    except Exception:
+        pass
+
+    try:
+        from datetime import timedelta
+
+        cutoff_ordinal = (datetime.now(timezone.utc).date() - timedelta(days=retention_days)).toordinal()
+    except Exception:
+        return
+
+    for path in ledger_dir.glob("cycles-*.jsonl.gz"):
+        day = _day_str(path.name)
+        if not day:
+            continue
+        try:
+            day_ordinal = datetime.strptime(day, "%Y-%m-%d").date().toordinal()
+            if day_ordinal < cutoff_ordinal:
+                path.unlink(missing_ok=True)
+        except Exception:
+            continue
+
+
+def append_event(state_dir: Path, event: dict) -> None:
+    """Append one JSON line to the cycle ledger. Best-effort — never raises.
+
+    Adds ``ts`` if not already present. Fail-open: any failure (unwritable
+    dir, disk full, permission error, ...) is swallowed so the ledger can
+    never break the bridge cycle it is observing.
+    """
+    with contextlib.suppress(Exception):
+        record = dict(event)
+        record.setdefault("ts", datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"))
+
+        ledger_dir = _ledger_dir(state_dir)
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        active_path = ledger_dir / _LEDGER_FILENAME
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        _rotate_and_prune(ledger_dir, active_path, today, _retention_days())
+
+        with open(active_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+
+
+def record_cycle_started(
+    state_dir: Path,
+    cycle_id: str,
+    request_id: str,
+    branch: str | None,
+) -> None:
+    """Write-ahead marker: append BEFORE the subagent is spawned (claw0 pattern).
+
+    A crashed/timed-out cycle leaves this row with no matching terminal
+    ``outcome`` row — a deterministic, queryable recovery signal instead of
+    inference from file mtimes.
+    """
+    append_event(
+        state_dir,
+        {
+            "phase": "started",
+            "cycle_id": cycle_id or "",
+            "request_id": request_id or "",
+            "branch": branch or None,
+        },
+    )
+
+
+def record_dedup_decision(
+    state_dir: Path,
+    cycle_id: str,
+    decision: str,
+    matched_against: str | None,
+) -> None:
+    """Log the pre-spawn dedup heuristic's own decision (#720 piece 4).
+
+    ``decision`` is one of :data:`VALID_DEDUP_DECISIONS` — coerced to
+    ``'proceeded'`` if unrecognized (an unknown decision must not silently
+    read as a suppression).
+    """
+    if decision not in VALID_DEDUP_DECISIONS:
+        decision = "proceeded"
+    append_event(
+        state_dir,
+        {
+            "phase": "dedup",
+            "cycle_id": cycle_id or "",
+            "decision": decision,
+            "matched_against": matched_against or None,
+        },
+    )
+
+
+def record_gate_decision(
+    state_dir: Path,
+    cycle_id: str,
+    allowed: bool,
+    reason: str | None,
+    violations: list[str] | None = None,
+) -> None:
+    """Log the mutation-surface guard / smoke gate's allow-or-block decision (#720 piece 2)."""
+    append_event(
+        state_dir,
+        {
+            "phase": "gate",
+            "cycle_id": cycle_id or "",
+            "allowed": bool(allowed),
+            "reason": reason or None,
+            "violations": list(violations or []),
+        },
+    )
+
+
+def record_cycle_outcome(
+    state_dir: Path,
+    cycle_id: str,
+    outcome: str,
+    reason: str | None,
+    files_changed: list[str] | None,
+    branch: str | None,
+) -> None:
+    """Write the terminal, exactly-once-per-cycle row with an enum ``outcome``.
+
+    Must be called in the SAME step that writes the bridge result / performs
+    the merge — never deferred — so the ledger and git state never diverge
+    (KB warning this design is built to avoid). ``outcome`` not in
+    :data:`VALID_OUTCOMES` is coerced to ``'failed'`` (fail-closed
+    classification; the write itself still never raises).
+    """
+    if outcome not in VALID_OUTCOMES:
+        outcome = "failed"
+    append_event(
+        state_dir,
+        {
+            "phase": "outcome",
+            "cycle_id": cycle_id or "",
+            "outcome": outcome,
+            "reason": reason or None,
+            "files_changed": list(files_changed or []),
+            "branch": branch or None,
+        },
+    )

--- a/tests/test_cycle_ledger.py
+++ b/tests/test_cycle_ledger.py
@@ -1,0 +1,326 @@
+"""Tests for #720: minimal cycle ledger — append-only JSONL with enum outcomes.
+
+Covers the standalone ``nanobot.runtime.cycle_ledger`` module (append/read
+round-trip, fail-open behavior, rotation, one-terminal-row-per-cycle
+semantics via the typed helpers, enum enforcement) plus a light
+bridge-integration check that a full green cycle and an ``already_done``
+pre-spawn skip each leave the expected started/dedup/gate/outcome rows in
+``<state_dir>/ledger/cycles.jsonl``.
+"""
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import bridge, cycle_ledger
+
+
+def _read_ledger(state_dir: Path) -> list[dict]:
+    path = state_dir / "ledger" / "cycles.jsonl"
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+# ─── append_event / round-trip ────────────────────────────────────────────────
+
+
+class TestAppendEvent:
+    def test_append_and_read_round_trip(self, tmp_path):
+        cycle_ledger.append_event(tmp_path, {"phase": "started", "cycle_id": "c1"})
+        cycle_ledger.append_event(tmp_path, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"})
+
+        rows = _read_ledger(tmp_path)
+        assert len(rows) == 2
+        assert rows[0]["phase"] == "started"
+        assert rows[0]["cycle_id"] == "c1"
+        assert "ts" in rows[0]
+        assert rows[1]["outcome"] == "success"
+
+    def test_creates_parent_dir(self, tmp_path):
+        state_dir = tmp_path / "does" / "not" / "exist" / "yet"
+        cycle_ledger.append_event(state_dir, {"phase": "started"})
+        assert (state_dir / "ledger" / "cycles.jsonl").exists()
+
+    def test_fail_open_on_unwritable_dir(self, tmp_path, monkeypatch):
+        """An append that can't write (e.g. mkdir raising) must never propagate."""
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+        # Must not raise.
+        cycle_ledger.append_event(tmp_path, {"phase": "started"})
+
+    def test_fail_open_on_unserializable_event(self, tmp_path):
+        """A non-JSON-serializable value falls back to str() via default=str,
+        but if something still blows up, append_event swallows it."""
+        cycle_ledger.append_event(tmp_path, {"phase": "started", "weird": object()})
+        rows = _read_ledger(tmp_path)
+        assert len(rows) == 1
+        assert "weird" in rows[0]
+
+
+# ─── typed helpers ─────────────────────────────────────────────────────────────
+
+
+class TestTypedHelpers:
+    def test_record_cycle_started_writes_phase_started(self, tmp_path):
+        cycle_ledger.record_cycle_started(tmp_path, "cycle-1", "req-1", None)
+        rows = _read_ledger(tmp_path)
+        assert rows[0] == {
+            "phase": "started",
+            "cycle_id": "cycle-1",
+            "request_id": "req-1",
+            "branch": None,
+            "ts": rows[0]["ts"],
+        }
+
+    def test_record_dedup_decision_valid_values(self, tmp_path):
+        for decision in cycle_ledger.VALID_DEDUP_DECISIONS:
+            cycle_ledger.record_dedup_decision(tmp_path, "c1", decision, "match-x")
+        rows = _read_ledger(tmp_path)
+        assert {r["decision"] for r in rows} == set(cycle_ledger.VALID_DEDUP_DECISIONS)
+
+    def test_record_dedup_decision_unknown_coerced_to_proceeded(self, tmp_path):
+        cycle_ledger.record_dedup_decision(tmp_path, "c1", "bogus-decision", None)
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["decision"] == "proceeded"
+
+    def test_record_gate_decision_allow_and_block(self, tmp_path):
+        cycle_ledger.record_gate_decision(tmp_path, "c1", True, "smoke_passed", [])
+        cycle_ledger.record_gate_decision(tmp_path, "c1", False, "mutation_surface_violation", ["nanobot/x.py"])
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["allowed"] is True
+        assert rows[0]["violations"] == []
+        assert rows[1]["allowed"] is False
+        assert rows[1]["violations"] == ["nanobot/x.py"]
+
+    def test_record_cycle_outcome_valid_enum(self, tmp_path):
+        cycle_ledger.record_cycle_outcome(tmp_path, "c1", "success", None, ["a.py"], "selfevo/cycle-1")
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["outcome"] == "success"
+        assert rows[0]["files_changed"] == ["a.py"]
+        assert rows[0]["branch"] == "selfevo/cycle-1"
+
+    def test_record_cycle_outcome_invalid_enum_coerced_to_failed(self, tmp_path):
+        """#720 test-plan contract: an invalid outcome value is coerced to
+        'failed' rather than raising or writing free text."""
+        cycle_ledger.record_cycle_outcome(tmp_path, "c1", "not-a-real-outcome", "weird", [], None)
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["outcome"] == "failed"
+
+    def test_one_terminal_row_per_cycle(self, tmp_path):
+        """Exercising the full helper set for one cycle produces exactly one
+        'outcome'-phase row (the others are 'started'/'dedup'/'gate')."""
+        cycle_ledger.record_cycle_started(tmp_path, "c1", "req-1", None)
+        cycle_ledger.record_dedup_decision(tmp_path, "c1", "proceeded", None)
+        cycle_ledger.record_gate_decision(tmp_path, "c1", True, "smoke_passed", [])
+        cycle_ledger.record_cycle_outcome(tmp_path, "c1", "success", None, ["a.py"], "selfevo/cycle-1")
+
+        rows = _read_ledger(tmp_path)
+        outcome_rows = [r for r in rows if r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert [r["phase"] for r in rows] == ["started", "dedup", "gate", "outcome"]
+
+
+# ─── rotation ──────────────────────────────────────────────────────────────────
+
+
+class TestRotation:
+    def test_rotates_stale_active_file_to_gz(self, tmp_path):
+        ledger_dir = tmp_path / "ledger"
+        ledger_dir.mkdir()
+        active = ledger_dir / "cycles.jsonl"
+        active.write_text('{"phase": "started"}\n', encoding="utf-8")
+
+        import os
+
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).timestamp()
+        os.utime(active, (yesterday, yesterday))
+
+        # New append triggers rotation before writing the new line.
+        cycle_ledger.append_event(tmp_path, {"phase": "started", "cycle_id": "today"})
+
+        gz_files = list(ledger_dir.glob("cycles-*.jsonl.gz"))
+        assert len(gz_files) == 1
+        with gzip.open(gz_files[0], "rt", encoding="utf-8") as fh:
+            archived = fh.read()
+        assert '"phase": "started"' in archived
+
+        # Active file now contains only today's fresh row.
+        rows = _read_ledger(tmp_path)
+        assert len(rows) == 1
+        assert rows[0]["cycle_id"] == "today"
+
+    def test_prunes_archives_past_retention(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CYCLE_LEDGER_RETENTION_DAYS", "5")
+        ledger_dir = tmp_path / "ledger"
+        ledger_dir.mkdir()
+
+        old_day = (datetime.now(timezone.utc).date() - timedelta(days=30)).strftime("%Y-%m-%d")
+        recent_day = (datetime.now(timezone.utc).date() - timedelta(days=1)).strftime("%Y-%m-%d")
+        old_gz = ledger_dir / f"cycles-{old_day}.jsonl.gz"
+        recent_gz = ledger_dir / f"cycles-{recent_day}.jsonl.gz"
+        with gzip.open(old_gz, "wt", encoding="utf-8") as fh:
+            fh.write('{"phase": "started"}\n')
+        with gzip.open(recent_gz, "wt", encoding="utf-8") as fh:
+            fh.write('{"phase": "started"}\n')
+
+        cycle_ledger.append_event(tmp_path, {"phase": "started", "cycle_id": "new"})
+
+        assert not old_gz.exists()
+        assert recent_gz.exists()
+
+    def test_retention_env_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("CYCLE_LEDGER_RETENTION_DAYS", raising=False)
+        assert cycle_ledger._retention_days() == 90
+        monkeypatch.setenv("CYCLE_LEDGER_RETENTION_DAYS", "10")
+        assert cycle_ledger._retention_days() == 10
+        monkeypatch.setenv("CYCLE_LEDGER_RETENTION_DAYS", "not-a-number")
+        assert cycle_ledger._retention_days() == 90
+
+
+# ─── light bridge integration ─────────────────────────────────────────────────
+
+
+def _git(repo: Path) -> list[str]:
+    return ["git", "-c", f"safe.directory={repo}", "-C", str(repo)]
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(_git(repo) + list(args), capture_output=True, text=True)
+
+
+def _init_selfevo_repo(base: Path) -> tuple[Path, Path]:
+    """Build a bare 'origin' + a working clone at base/'eeebot-self-evolving',
+    matching bridge.py's ``STATE_DIR.parent / 'eeebot-self-evolving'`` layout.
+    """
+    origin = base / "origin.git"
+    work = base / "eeebot-self-evolving"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(origin)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+    _run(work, "config", "user.email", "bridge@test.local")
+    _run(work, "config", "user.name", "bridge-test")
+    _run(work, "checkout", "-B", "main")
+    (work / "tests").mkdir()
+    (work / "tests" / "test_smoke.py").write_text("def test_ok():\n    assert True\n")
+    (work / "mod.py").write_text("def ok():\n    return True\n")
+    _run(work, "add", ".")
+    _run(work, "commit", "-m", "init")
+    _run(work, "push", "origin", "HEAD:main")
+    return origin, work
+
+
+def _seed_bridge_request(state_dir: Path, request_id: str, cycle_id: str, **extra) -> None:
+    (state_dir / "outbox").mkdir(parents=True, exist_ok=True)
+    (state_dir / "outbox" / "report.index.json").write_text(
+        json.dumps({"source": "test-source", "goal": {"goal_id": "goal-1"}}), encoding="utf-8",
+    )
+    (state_dir / "goals").mkdir(parents=True, exist_ok=True)
+    (state_dir / "goals" / "registry.json").write_text(
+        json.dumps({"active_goal_id": "goal-1", "goals": {"goal-1": {"text": "test goal"}}}),
+        encoding="utf-8",
+    )
+    (state_dir / "subagents" / "requests").mkdir(parents=True, exist_ok=True)
+    req = {"request_id": request_id, "cycle_id": cycle_id, **extra}
+    (state_dir / "subagents" / "requests" / f"{request_id}.json").write_text(
+        json.dumps(req), encoding="utf-8",
+    )
+
+
+class _FakeSubagentManager:
+    """Stand-in for nanobot.agent.subagent.SubagentManager: simulates a
+    subagent that commits one real change directly to the (already
+    cycle-branched) workspace repo, without spawning a real LLM turn.
+    """
+
+    def __init__(self, *, workspace, **_kwargs):
+        self.workspace = workspace
+        self._running_tasks: dict = {}
+
+    async def spawn(self, **_kwargs):
+        (self.workspace / "scripts").mkdir(exist_ok=True)
+        (self.workspace / "scripts" / "feature.py").write_text("def feature():\n    return 42\n")
+        _run(self.workspace, "add", "scripts/feature.py")
+        _run(self.workspace, "commit", "-m", "feat: add feature")
+        return "fake subagent spawned"
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    """Mirrors tests/test_bridge_cycle_branch.py: point the bounded gate's
+    core-smoke set at the one test file these fixtures create.
+    """
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
+
+
+class TestBridgeIntegrationLedgerRows:
+    def test_full_green_cycle_writes_started_gate_success(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        _init_selfevo_repo(base)
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "SubagentManager", _FakeSubagentManager)
+        # No real LLM call happens (spawn() is faked above) — avoid the
+        # "no API key configured" hard-exit in _make_provider by stubbing it.
+        monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+
+        _seed_bridge_request(state_dir, "req-green", "cycle-green")
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        phases = [r["phase"] for r in rows]
+        assert phases[0] == "started"
+        assert "dedup" in phases
+        assert "gate" in phases
+        assert phases[-1] == "outcome"
+
+        gate_rows = [r for r in rows if r["phase"] == "gate"]
+        assert gate_rows[-1]["allowed"] is True
+
+        outcome_rows = [r for r in rows if r["phase"] == "outcome"]
+        assert outcome_rows[-1]["outcome"] == "success"
+        assert "scripts/feature.py" in outcome_rows[-1]["files_changed"]
+
+    def test_already_done_skip_writes_started_then_skipped(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        # No eeebot-self-evolving repo needed: _task_already_done is stubbed
+        # directly, and _selfevo_repo_check.is_dir() is False so the
+        # HEAD-on-main precondition is skipped.
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "_task_already_done", lambda *_a, **_k: True)
+
+        _seed_bridge_request(
+            state_dir, "req-dup", "cycle-dup", task_title="implement thing xyz already done",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        phases = [r["phase"] for r in rows]
+        assert phases == ["started", "dedup", "outcome"]
+        assert rows[1]["decision"] == "skipped_duplicate"
+        assert rows[2]["outcome"] == "skipped-duplicate"


### PR DESCRIPTION
Implements the #704 ledger design in its minimal form (per #720; KB-grounded: ralph progress.txt / autoresearch results.tsv pattern — two independent KB analyses converged on this shape).

## What
- New `nanobot/runtime/cycle_ledger.py` (238 lines): one flat `<STATE_DIR>/ledger/cycles.jsonl`; fail-open `append_event`; telemetry-style rotation (`CYCLE_LEDGER_RETENTION_DAYS`, default 90 → gzip by day); typed helpers for started / dedup-decision / gate-decision / outcome rows.
- Bridge wire-ins (+65/-1, inserts only): **write-ahead started row** before any dedup/spawn; **dedup self-instrumentation** (`proceeded | skipped_duplicate | skipped_recent_failure` + matched-against); **gate evidence** (blocked_file_present / mutation_surface_violation / smoke_passed / gate_failed with violations); **terminal enum outcome** `{success, partial, failed, skipped-duplicate, timeout}` written in the same step as the bridge result (KB same-step rule: ledger and git must not diverge).
- Outcome mapping: integrated→success; internal_error→failed; completed-no-commits→partial; gate/integration rejection→failed; pre-spawn skips→skipped-duplicate; `timeout` defined-but-unused (no dedicated timeout terminal path exists today — documented inline).

## Tests
16 new (`tests/test_cycle_ledger.py`), incl. two end-to-end bridge-integration tests driving `_main_impl()` with a real temp git repo (green cycle → started→dedup→gate(allowed)→success; already_done → started→skipped→skipped-duplicate). Full suite **1266 passed, 0 failed**; zero new ruff.

## Non-goals (simplicity, per KB anti-recommendations)
No DB/SQL/Dolt, no memory platform, no new deps; report scripts remain #710; metric definitions remain #705.

Refs #720, #704, #705, #710, #716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)