### PR TITLE
feat(runtime): pre/post cycle git tags — exact dedup anchor + rollback audit (#721)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -36,6 +36,7 @@ from nanobot.cli.commands import _make_provider
 from nanobot.config.loader import load_config, set_config_path
 from nanobot.observability.llm_telemetry import set_call_context
 from nanobot.runtime.cycle_ledger import (
+    VALID_OUTCOMES,
     record_cycle_outcome,
     record_cycle_started,
     record_dedup_decision,
@@ -59,6 +60,11 @@ try:
     FAILURE_SUPPRESS_HOURS = float(os.environ.get('SUBAGENT_BRIDGE_FAILURE_SUPPRESS_HOURS', '24').strip() or '24')
 except ValueError:
     FAILURE_SUPPRESS_HOURS = 24.0
+
+# #721: bounded cap on how many local pre-cycle-*/cycle-* tags _prune_cycle_tags
+# inspects per bridge run — a pathologically large tag namespace (e.g. a stuck
+# retention env) must never turn pruning into an unbounded git operation.
+_PRUNE_TAG_CAP = 500
 
 
 def load_json(path: Path):
@@ -372,6 +378,17 @@ def _diff_against_remote_touches_only(repo_root: 'Path', remote_ref: str, allowe
     return all(f in allowed for f in changed)
 
 
+def _safe_ref_id(cycle_id: str) -> str:
+    """Sanitize a cycle_id into a safe git ref component (branch/tag name).
+
+    Shared by ``_setup_cycle_branch`` (branch names) and the #721 tag helpers
+    (tag names) — both need the same character restriction and length cap.
+    """
+    import re as _re_ref
+
+    return _re_ref.sub(r'[^A-Za-z0-9._-]', '-', str(cycle_id or 'unknown'))[:80]
+
+
 def _setup_cycle_branch(repo_root: 'Path', cycle_id: str) -> dict:
     """Isolate the upcoming subagent run on a fresh branch off ``origin/main``.
 
@@ -385,10 +402,9 @@ def _setup_cycle_branch(repo_root: 'Path', cycle_id: str) -> dict:
     ``"not_a_git_repo"``, ``"dirty_tree"``, ``"fetch_failed"``, ``"checkout_failed"``.
     Never raises — git/subprocess failures degrade to a blocked result.
     """
-    import re as _re3
     import subprocess as _sp_setup
 
-    safe_cycle_id = _re3.sub(r'[^A-Za-z0-9._-]', '-', str(cycle_id or 'unknown'))[:80]
+    safe_cycle_id = _safe_ref_id(cycle_id)
     branch = f'selfevo/cycle-{safe_cycle_id}'
 
     if not repo_root.is_dir():
@@ -455,6 +471,135 @@ def _integrate_cycle_to_main(repo_root: 'Path', cycle_branch: str, main_sha_befo
 
     main_sha_after = _sp_int.run(git + ['rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
     return {'ok': True, 'main_sha_after': main_sha_after, 'reason': None}
+
+
+def _safe_rev_parse(repo_root: 'Path', ref: str) -> str:
+    """``git rev-parse <ref>``, returning ``''`` on any failure (never raises)."""
+    import subprocess as _sp_rp
+
+    try:
+        result = _sp_rp.run(
+            _git_cmd(repo_root) + ['rev-parse', ref], capture_output=True, text=True, timeout=10,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ''
+    except Exception:
+        return ''
+
+
+def _cycle_tag_exists(repo_root: 'Path', tag_name: str) -> bool:
+    """Return True iff the local tag ``tag_name`` exists. Fail-open (False on any error)."""
+    import subprocess as _sp_texist
+
+    try:
+        if not repo_root.is_dir():
+            return False
+        result = _sp_texist.run(
+            _git_cmd(repo_root) + ['tag', '--list', tag_name], capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0 and tag_name in result.stdout.split()
+    except Exception:
+        return False
+
+
+def _tag_cycle_pre(repo_root: 'Path', cycle_id: str, main_sha: str) -> None:
+    """Tag ``pre-cycle-<id>`` at ``main_sha`` — the pre half of the #721 bracket.
+
+    KB-mined a-evolve pattern (``pre-evo-*``/``evo-*`` version tags): every
+    cycle gets a git-native rollback anchor bracketing its mutation, without
+    any new storage. LOCAL ONLY — never pushed to origin; ``origin/main``
+    only ever advances via ``_integrate_cycle_to_main``'s explicit push.
+    Fail-open (a tag failure must never block a cycle); ``-f`` so a retried
+    cycle reusing the same ``cycle_id`` overwrites cleanly instead of erroring.
+    """
+    if not main_sha:
+        return
+    import subprocess as _sp_tagpre
+
+    try:
+        if not repo_root.is_dir():
+            return
+        _sp_tagpre.run(
+            _git_cmd(repo_root) + ['tag', '-f', f'pre-cycle-{_safe_ref_id(cycle_id)}', main_sha],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        pass
+
+
+def _tag_cycle_post(repo_root: 'Path', cycle_id: str, outcome: str, sha: str | None = None) -> None:
+    """Tag ``cycle-<id>-<outcome>`` at the terminal HEAD — the post half of the #721 bracket.
+
+    ``outcome`` should be the same enum value passed to this cycle's
+    ``cycle_ledger.record_cycle_outcome`` call — coerced to ``'failed'`` if not
+    one of :data:`nanobot.runtime.cycle_ledger.VALID_OUTCOMES`, mirroring that
+    function's own coercion so the tag and the ledger row can never disagree.
+    ``sha`` defaults to the repo's current HEAD when omitted — used by the
+    pre-spawn skip paths, which terminate before any cycle branch exists.
+    Fail-open, local-only — see :func:`_tag_cycle_pre`.
+    """
+    if outcome not in VALID_OUTCOMES:
+        outcome = 'failed'
+    import subprocess as _sp_tagpost
+
+    try:
+        if not repo_root.is_dir():
+            return
+        target = sha or _safe_rev_parse(repo_root, 'HEAD')
+        if not target:
+            return
+        _sp_tagpost.run(
+            _git_cmd(repo_root) + ['tag', '-f', f'cycle-{_safe_ref_id(cycle_id)}-{outcome}', target],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        pass
+
+
+def _prune_cycle_tags(repo_root: 'Path', keep_days: int | None = None) -> None:
+    """Delete local ``pre-cycle-*``/``cycle-*`` tags older than the retention window (#721).
+
+    Bounded (inspects at most :data:`_PRUNE_TAG_CAP` tags per run) and
+    fail-open: any git failure here must never block a bridge cycle.
+    Local-only — no tag is ever pushed, so this never touches origin.
+    ``keep_days`` defaults to ``CYCLE_TAG_RETENTION_DAYS`` (default 30),
+    mirroring ``cycle_ledger``'s own ``CYCLE_LEDGER_RETENTION_DAYS`` pattern.
+    """
+    import subprocess as _sp_prune
+    import time as _time_prune
+
+    if keep_days is None:
+        raw = os.environ.get('CYCLE_TAG_RETENTION_DAYS', '').strip()
+        try:
+            keep_days = max(1, int(raw)) if raw else 30
+        except ValueError:
+            keep_days = 30
+
+    try:
+        if not repo_root.is_dir():
+            return
+        git = _git_cmd(repo_root)
+        listed = _sp_prune.run(
+            git + ['tag', '--list', 'pre-cycle-*', 'cycle-*'],
+            capture_output=True, text=True, timeout=10,
+        )
+        if listed.returncode != 0:
+            return
+        tag_names = [t for t in listed.stdout.splitlines() if t.strip()][:_PRUNE_TAG_CAP]
+        if not tag_names:
+            return
+        cutoff = _time_prune.time() - (keep_days * 86400)
+        for tag in tag_names:
+            try:
+                dated = _sp_prune.run(
+                    git + ['log', '-1', '--format=%ct', tag], capture_output=True, text=True, timeout=10,
+                )
+                ts = int(dated.stdout.strip())
+            except Exception:
+                continue
+            if ts < cutoff:
+                _sp_prune.run(git + ['tag', '-d', tag], capture_output=True, text=True, timeout=10)
+    except Exception:
+        pass
 
 
 def _cleanup_cycle_branch(repo_root: 'Path', cycle_branch: str) -> bool:
@@ -973,6 +1118,12 @@ async def main():
 
 
 async def _main_impl():
+    # #721: bounded, fail-open tag pruning — run once per bridge invocation
+    # (this function runs exactly once per process, per `main()`'s docstring),
+    # right after the concurrency lock in `main()` is held, before anything
+    # else touches the shared checkout.
+    _prune_cycle_tags(STATE_DIR.parent / 'eeebot-self-evolving')
+
     outbox = load_json(STATE_DIR / 'outbox' / 'report.index.json') or {}
     goals = load_json(STATE_DIR / 'goals' / 'registry.json') or {}
     report_source = (outbox.get('source') or '').strip()
@@ -1064,6 +1215,8 @@ async def _main_impl():
         record_cycle_outcome(
             STATE_DIR, _cycle_id, 'failed', 'head_on_main_precondition_failed', [], None,
         )
+        # #721: no cycle branch exists yet on this path — tag at current HEAD.
+        _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'failed')
         return 0
 
     goal_text = (
@@ -1100,6 +1253,37 @@ async def _main_impl():
         except Exception:
             pass
     backlog_title: str = _artifact_data.get('next_bounded_candidate', {}).get('title', '')
+
+    # #721: tag-first dedup — checked BEFORE the fuzzy keyword heuristic below.
+    # An exact `cycle-<id>-success` tag means THIS cycle_id already completed
+    # successfully (e.g. a retried/replayed request) — a structured, exact
+    # match, unlike the keyword heuristic. Same-title-but-different-cycle_id
+    # duplicates are NOT caught here (there is no tag for a different
+    # cycle_id) — those still rely on _task_already_done's keyword heuristic
+    # below, which stays exactly as it was as the semantic-dup fallback.
+    _cycle_success_tag = f'cycle-{_safe_ref_id(_cycle_id)}-success'
+    if _cycle_tag_exists(_selfevo_repo_check, _cycle_success_tag):
+        print(f'bridge: cycle {_cycle_id} already tagged {_cycle_success_tag}; skipping subagent spawn')
+        handled_marker.write_text(str(req_path), encoding='utf-8')
+        _write_bridge_completed_result(
+            state_dir=STATE_DIR,
+            req=req,
+            request_id=request_id,
+            cycle_id=req.get('cycle_id') or '',
+            goal_id=goal_id,
+            files_changed=[],
+            commits_pushed=0,
+            result_status='already_done',
+            backlog_title=backlog_title,
+            key_learnings=[
+                f'Cycle {_cycle_id} already carries a success tag ({_cycle_success_tag}) — an '
+                'exact retry/replay of a completed cycle. Skipped without spawning a subagent.',
+            ],
+        )
+        record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_duplicate', f'tag:{_cycle_success_tag}')
+        record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done_tag', [], None)
+        _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
+        return 0
 
     # Before spawning: detect if task is already done in recent git commits.
     # If yes, mark Done in MEMORY.md, write result, and exit without spawning.
@@ -1168,6 +1352,8 @@ async def _main_impl():
         )
         record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_duplicate', _found_commit)
         record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done', [], None)
+        # #721: no cycle branch on this path — tag at current HEAD.
+        _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
         return 0
     # #716: _task_already_done above only catches proposals that already landed
     # as a real git commit. A proposal that was blocked/rolled-back/produced no
@@ -1207,6 +1393,8 @@ async def _main_impl():
         )
         record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_recent_failure', _dup_check_title)
         record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'recent_duplicate_failure', [], None)
+        # #721: no cycle branch on this path — tag at current HEAD.
+        _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
         return 0
 
     else:
@@ -1275,7 +1463,15 @@ async def _main_impl():
         record_cycle_outcome(
             STATE_DIR, _cycle_id, 'failed', _cycle_setup['reason'], [], cycle_branch,
         )
+        # #721: cycle branch setup itself failed — tag at main_sha_before
+        # (may be '' if even the pre-checkout rev-parse failed; _tag_cycle_post
+        # falls back to current HEAD in that case).
+        _tag_cycle_post(_selfevo_repo, _cycle_id, 'failed', main_sha_before)
         return 0
+
+    # #721: pre-cycle tag at main_sha_before, right after cycle-branch setup
+    # succeeds — the pre half of the pre/post bracket (see _tag_cycle_pre).
+    _tag_cycle_pre(_selfevo_repo, _cycle_id, main_sha_before)
 
     # #718: the subagent must write into the git checkout the bridge branches,
     # commits, gates, and integrates (_selfevo_repo) — not TARGET_WORKSPACE
@@ -1706,6 +1902,18 @@ async def _main_impl():
     record_cycle_outcome(
         STATE_DIR, _cycle_id, _cycle_outcome, _rollback_reason, files_changed, cycle_branch,
     )
+    # #721: post-cycle tag at the terminal HEAD, same outcome value as the
+    # ledger row above. Integrated -> main_sha_after (shared checkout stayed on
+    # main, now at the merge commit). Not integrated -> the cycle branch's own
+    # tip if it still exists (the finally block above only restores the shared
+    # checkout to main; it does not delete the cycle branch ref except on a
+    # successful integrate), falling back to main_sha_before when there were no
+    # commits at all (or the branch ref lookup itself fails).
+    _post_tag_sha = (
+        main_sha_after if _integrated
+        else (_safe_rev_parse(_selfevo_repo, cycle_branch) or main_sha_before)
+    )
+    _tag_cycle_post(_selfevo_repo, _cycle_id, _cycle_outcome, _post_tag_sha)
 
     # Structured lesson recording after a successful integrated commit
     if _integrated:

--- a/tests/test_bridge_cycle_tags.py
+++ b/tests/test_bridge_cycle_tags.py
@@ -1,0 +1,302 @@
+"""Tests for #721: pre/post cycle git tags — exact dedup anchor + rollback audit.
+
+Covers the tag helper trio added to nanobot/runtime/bridge.py
+(``_tag_cycle_pre``, ``_tag_cycle_post``, ``_prune_cycle_tags``) plus the
+tag-first pre-spawn dedup path, against real temp git repos. Reuses the
+bridge-integration harness from tests/test_cycle_ledger.py (bare "origin" +
+working clone standing in for the shared ``eeebot-self-evolving`` checkout).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import bridge
+from tests.test_cycle_ledger import (
+    _FakeSubagentManager,
+    _git,
+    _init_selfevo_repo,
+    _read_ledger,
+    _run,
+    _seed_bridge_request,
+)
+
+
+def _commit_days_ago(work: Path, filename: str, content: str, message: str, days_ago: int) -> str:
+    """Create a commit backdated ``days_ago`` days via GIT_AUTHOR_DATE/
+    GIT_COMMITTER_DATE (git's env vars want ``@<epoch> <tz>``, not a fuzzy
+    "N days ago" string — for pruning tests).
+    """
+    (work / filename).write_text(content)
+    _run(work, "add", filename)
+    epoch = int(time.time()) - (days_ago * 86400)
+    date = f"@{epoch} +0000"
+    env = {**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date}
+    subprocess.run(_git(work) + ["commit", "-m", message], env=env, capture_output=True, text=True, check=True)
+    return _run(work, "rev-parse", "HEAD").stdout.strip()
+
+
+class _ExplodingSubagentManager:
+    """Stand-in that fails the test if a subagent is ever spawned — used to
+    prove the tag-first dedup path skips BEFORE any spawn attempt."""
+
+    def __init__(self, *, workspace, **_kwargs):
+        self.workspace = workspace
+
+    async def spawn(self, **_kwargs):
+        raise AssertionError("subagent should not have been spawned — tag-first dedup should have skipped")
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    """Mirrors tests/test_cycle_ledger.py / tests/test_bridge_cycle_branch.py:
+    point the bounded gate's core-smoke set at the one test file these
+    fixtures create.
+    """
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
+
+
+# ─── unit-level tag helper tests ───────────────────────────────────────────────
+
+
+class TestSafeRefId:
+    def test_sanitizes_unsafe_characters(self):
+        assert bridge._safe_ref_id("abc/def xyz") == "abc-def-xyz"
+
+    def test_empty_falls_back_to_unknown(self):
+        assert bridge._safe_ref_id("") == "unknown"
+        assert bridge._safe_ref_id(None) == "unknown"
+
+
+class TestTagCyclePre:
+    def test_creates_tag_at_given_sha(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        main_sha = _run(work, "rev-parse", "main").stdout.strip()
+
+        bridge._tag_cycle_pre(work, "cycle-1", main_sha)
+
+        tags = _run(work, "tag", "--list").stdout.split()
+        assert "pre-cycle-cycle-1" in tags
+        assert _run(work, "rev-parse", "pre-cycle-cycle-1").stdout.strip() == main_sha
+
+    def test_force_overwrites_on_retry(self, tmp_path):
+        """A retried cycle re-using the same cycle_id must not error (`-f`)."""
+        origin, work = _init_selfevo_repo(tmp_path)
+        main_sha = _run(work, "rev-parse", "main").stdout.strip()
+
+        bridge._tag_cycle_pre(work, "cycle-1", main_sha)
+        # Should not raise even though the tag already exists.
+        bridge._tag_cycle_pre(work, "cycle-1", main_sha)
+
+        tags = _run(work, "tag", "--list").stdout.split()
+        assert tags.count("pre-cycle-cycle-1") == 1
+
+    def test_fail_open_on_missing_repo(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        bridge._tag_cycle_pre(missing, "cycle-1", "deadbeef")  # must not raise
+
+    def test_no_op_on_empty_sha(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        bridge._tag_cycle_pre(work, "cycle-1", "")
+        assert _run(work, "tag", "--list").stdout.split() == []
+
+
+class TestTagCyclePost:
+    def test_creates_tag_encoding_outcome(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        sha = _run(work, "rev-parse", "main").stdout.strip()
+
+        bridge._tag_cycle_post(work, "cycle-1", "success", sha)
+
+        tags = _run(work, "tag", "--list").stdout.split()
+        assert "cycle-cycle-1-success" in tags
+        assert _run(work, "rev-parse", "cycle-cycle-1-success").stdout.strip() == sha
+
+    def test_invalid_outcome_coerced_to_failed(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        sha = _run(work, "rev-parse", "main").stdout.strip()
+
+        bridge._tag_cycle_post(work, "cycle-1", "not-a-real-outcome", sha)
+
+        tags = _run(work, "tag", "--list").stdout.split()
+        assert "cycle-cycle-1-failed" in tags
+
+    def test_defaults_to_current_head_when_sha_omitted(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        head = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        bridge._tag_cycle_post(work, "cycle-1", "skipped-duplicate")
+
+        assert _run(work, "rev-parse", "cycle-cycle-1-skipped-duplicate").stdout.strip() == head
+
+    def test_fail_open_on_missing_repo(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        bridge._tag_cycle_post(missing, "cycle-1", "success")  # must not raise
+
+
+class TestCycleTagExists:
+    def test_true_when_tag_present(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        sha = _run(work, "rev-parse", "main").stdout.strip()
+        bridge._tag_cycle_post(work, "cycle-1", "success", sha)
+        assert bridge._cycle_tag_exists(work, "cycle-cycle-1-success") is True
+
+    def test_false_when_absent(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+        assert bridge._cycle_tag_exists(work, "cycle-nope-success") is False
+
+    def test_false_fail_open_on_missing_repo(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        assert bridge._cycle_tag_exists(missing, "cycle-1-success") is False
+
+
+class TestPruneCycleTags:
+    def test_deletes_old_keeps_recent(self, tmp_path):
+        origin, work = _init_selfevo_repo(tmp_path)
+
+        old_sha = _commit_days_ago(work, "old.txt", "old", "old commit", 40)
+        _run(work, "tag", "pre-cycle-old")
+        _run(work, "tag", "cycle-old-success")
+
+        recent_sha = _commit_days_ago(work, "recent.txt", "recent", "recent commit", 1)
+        _run(work, "tag", "pre-cycle-recent")
+        assert old_sha and recent_sha
+
+        bridge._prune_cycle_tags(work, keep_days=30)
+
+        tags = _run(work, "tag", "--list").stdout.split()
+        assert "pre-cycle-old" not in tags
+        assert "cycle-old-success" not in tags
+        assert "pre-cycle-recent" in tags
+
+    def test_respects_env_override(self, tmp_path, monkeypatch):
+        origin, work = _init_selfevo_repo(tmp_path)
+        _commit_days_ago(work, "old.txt", "old", "old commit", 10)
+        _run(work, "tag", "pre-cycle-old")
+
+        monkeypatch.setenv("CYCLE_TAG_RETENTION_DAYS", "5")
+        bridge._prune_cycle_tags(work)
+
+        assert "pre-cycle-old" not in _run(work, "tag", "--list").stdout.split()
+
+    def test_fail_open_on_missing_repo(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        bridge._prune_cycle_tags(missing)  # must not raise
+
+    def test_bounded_by_cap(self, tmp_path, monkeypatch):
+        """Even with a large tag namespace, pruning must not blow up — bounded
+        by _PRUNE_TAG_CAP. Exercised at a much smaller scale for test speed."""
+        origin, work = _init_selfevo_repo(tmp_path)
+        monkeypatch.setattr(bridge, "_PRUNE_TAG_CAP", 2)
+        sha = _run(work, "rev-parse", "main").stdout.strip()
+        for i in range(5):
+            _run(work, "tag", f"pre-cycle-t{i}", sha)
+        bridge._prune_cycle_tags(work, keep_days=30)  # must not raise; recent tags kept regardless
+        assert len(_run(work, "tag", "--list").stdout.split()) == 5
+
+
+# ─── full bridge-cycle integration ──────────────────────────────────────────────
+
+
+class TestBridgeCycleTagIntegration:
+    def test_full_green_cycle_leaves_pre_and_post_tags(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        origin, work = _init_selfevo_repo(base)
+        main_sha_before = _run(work, "rev-parse", "main").stdout.strip()
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "SubagentManager", _FakeSubagentManager)
+        monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+
+        _seed_bridge_request(state_dir, "req-tags", "cycle-tags")
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        tags = _run(work, "tag", "--list").stdout.split()
+        assert "pre-cycle-cycle-tags" in tags
+        assert "cycle-cycle-tags-success" in tags
+
+        assert _run(work, "rev-parse", "pre-cycle-cycle-tags").stdout.strip() == main_sha_before
+
+        # The post tag is written right after the terminal ledger row — before
+        # the (separate, best-effort) structured-lesson commit that may land
+        # on main afterward — so assert ancestry rather than exact equality
+        # with the final origin/main tip.
+        post_sha = _run(work, "rev-parse", "cycle-cycle-tags-success").stdout.strip()
+        assert post_sha != main_sha_before
+        ancestor = subprocess.run(
+            _git(work) + ["merge-base", "--is-ancestor", post_sha, "main"], capture_output=True,
+        )
+        assert ancestor.returncode == 0
+
+    def test_tag_first_dedup_skips_before_spawn(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        origin, work = _init_selfevo_repo(base)
+        # Pre-seed a success tag for this exact cycle_id, simulating a retried/
+        # replayed request whose cycle already completed successfully.
+        _run(work, "tag", "cycle-cycle-dup-success")
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "SubagentManager", _ExplodingSubagentManager)
+        monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+
+        _seed_bridge_request(state_dir, "req-dup-tag", "cycle-dup")
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        phases = [r["phase"] for r in rows]
+        assert phases == ["started", "dedup", "outcome"]
+        assert rows[1]["decision"] == "skipped_duplicate"
+        assert rows[1]["matched_against"] == "tag:cycle-cycle-dup-success"
+        assert rows[2]["outcome"] == "skipped-duplicate"
+
+    def test_fail_open_tag_failure_never_breaks_a_green_cycle(self, tmp_path, monkeypatch):
+        """A tagging failure (here: refs/tags made unwritable, so every
+        ``git tag`` call in the cycle fails) must never surface as a bridge
+        cycle failure — tags are pure observability, layered on top of the
+        real ``git tag`` calls (not mocked out), so this exercises the actual
+        internal try/except in _tag_cycle_pre/_tag_cycle_post/_prune_cycle_tags."""
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        origin, work = _init_selfevo_repo(base)
+
+        tags_dir = work / ".git" / "refs" / "tags"
+        tags_dir.mkdir(parents=True, exist_ok=True)
+        tags_dir.chmod(0o500)
+        try:
+            monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+            monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+            monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+            monkeypatch.setattr(bridge, "SubagentManager", _FakeSubagentManager)
+            monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+
+            _seed_bridge_request(state_dir, "req-tagfail", "cycle-tagfail")
+
+            result = asyncio.run(bridge._main_impl())
+            assert result == 0
+
+            rows = _read_ledger(state_dir)
+            outcome_rows = [r for r in rows if r["phase"] == "outcome"]
+            assert outcome_rows[-1]["outcome"] == "success"
+            # The permission block means no tag was actually written — proving
+            # the failure was swallowed rather than silently skipped by luck.
+            assert _run(work, "tag", "--list").stdout.strip() == ""
+        finally:
+            tags_dir.chmod(0o700)


### PR DESCRIPTION
KB-mined a-evolve pattern (pre-evo-*/evo-* version tags). Refs #721, #720, #713, #716.

## What
- `pre-cycle-<id>` tag at main_sha_before (right after cycle-branch setup) and `cycle-<id>-<outcome>` at the terminal HEAD — outcome uses the same enum as the #720 ledger. Local tags only, never pushed; fail-open (a tag failure can never break a cycle).
- **Tag-first dedup**: an exact `cycle-<id>-success` tag short-circuits the request before the keyword heuristic (which stays as the semantic-duplicate fallback); the #720 ledger records `matched_against=tag:<name>`.
- Bounded pruning: `CYCLE_TAG_RETENTION_DAYS` (default 30), cap 500 tags inspected per run, invoked once per bridge run.

## Tests
20 new (`tests/test_bridge_cycle_tags.py`): unit (create/overwrite/fail-open), pruning (retention, env override, cap), and 3 full bridge-cycle integration tests (green cycle tags, tag-first skip before spawn, real fail-open via read-only refs/tags). Full suite **1286 passed, 0 failed**; zero new ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)