### PR TITLE
feat(scripts): read-only loop metrics report over the cycle ledger (#710)

### DIFF
--- a/scripts/loop_metrics_report.py
+++ b/scripts/loop_metrics_report.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""
+loop_metrics_report.py — read-only #705 metrics report over the #720 cycle ledger.
+
+Issue #710 implements the report *script* against two design-only contracts:
+``docs/changes/705-observability-metrics/metrics.md`` (the nine metric
+definitions) and ``report-spec.md`` (the JSON/table output shapes). #705 was
+written before #720 landed and assumed a done/failure-ledger split
+(``docs/changes/704-ledger-artifact-memory/design.md``) that #720 deliberately
+did not build; #720's ``nanobot.runtime.cycle_ledger`` instead appends every
+phase of a cycle (``started`` / ``dedup`` / ``gate`` / ``outcome``) to a single
+flat ``cycles.jsonl``. This script computes the #705 contract's MINIMAL
+computable form directly against that ledger shape:
+
+- cycle counts by terminal ``outcome`` (success/partial/failed/
+  skipped-duplicate/timeout/incomplete)
+- ``duplicate_rate`` / ``genuinely_new_proposal_rate`` (outcome ==
+  ``skipped-duplicate`` vs. total terminal cycles)
+- ``productive_spawn_rate`` / ``gate_pass_rate`` / ``integration_rate``
+  (derived from ``gate`` rows and the terminal ``outcome``)
+- a gate-fail reason breakdown (from ``gate`` rows with ``allowed=False``,
+  plus terminal ``failed``/``timeout`` outcomes that never reached a gate row)
+- a dedup-decision breakdown (from ``dedup`` rows), including the top
+  ``matched_against`` values — a heuristic-quality signal
+- the liveness watchdog (``healthy``/``degraded``/``dead``) per
+  ``report-spec.md``'s thresholds
+
+Metrics named in the #705 catalog whose inputs do not exist in the #720
+ledger — ``protected_surface_rejections`` (no ``target_paths`` field, a #707
+gap), ``cost_per_integrated_change`` (would require a telemetry join, out of
+scope: this script's only source of truth is the ledger, no results-dir or
+telemetry scraping), ``harvestable_upstream_ratio`` (no
+``general_or_host_local`` field, a #672 harvest-classification gap), and
+``human_intervention_needed`` (no stop-guard/restore-failure ledger field,
+the #707 gap the metric catalog itself names) — are emitted as
+``"value": null`` with an explanatory ``"note"``, per the #705 contract's
+explicit gap-visibility rule ("never a fabricated 0 or 1").
+
+Adapted from the instance's autonomously-built ``loop_health_report.py``
+(P10, commit 6a365ac), harvested per the #672 harvest flow: the ``--test``
+self-check style and the compact human-table rendering approach are reused;
+the primary data source here is the ledger (cycles.jsonl + rotated
+``cycles-*.jsonl.gz``), not a results-dir JSON scrape, to keep one source of
+truth.
+
+Read-only: this script never writes anything but stdout.
+
+Usage:
+    python3 scripts/loop_metrics_report.py [--state-dir PATH] [--days N] [--json]
+    python3 scripts/loop_metrics_report.py --test
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# Same default as nanobot.runtime.bridge.STATE_DIR — kept independent (no
+# import of runtime code) so this script has zero non-stdlib dependencies.
+_DEFAULT_STATE_DIR = "/var/lib/eeepc-agent/self-evolving-agent/state"
+
+# Liveness thresholds — report-spec.md "Parameters" table.
+LIVENESS_DAYS_DEFAULT = 7
+DUPLICATE_SATURATION_THRESHOLD = 0.8
+
+
+def _default_state_dir() -> Path:
+    env_dir = os.environ.get("STATE_DIR", "").strip()
+    if env_dir:
+        return Path(env_dir)
+    return Path(_DEFAULT_STATE_DIR)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def load_ledger_rows(state_dir: Path, days: int) -> list[dict[str, Any]]:
+    """Read ``ledger/cycles.jsonl`` plus any in-window rotated ``.gz`` files.
+
+    Rows without a parseable ``ts`` are dropped (best-effort, matches the
+    ledger's own fail-open philosophy) rather than crashing the report.
+    """
+    ledger_dir = Path(state_dir) / "ledger"
+    if not ledger_dir.is_dir():
+        return []
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    rows: list[dict[str, Any]] = []
+
+    def _consume(lines: list[str]) -> None:
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = _parse_ts(rec.get("ts"))
+            if ts is None or ts < cutoff:
+                continue
+            rows.append(rec)
+
+    active_path = ledger_dir / "cycles.jsonl"
+    if active_path.exists():
+        try:
+            _consume(active_path.read_text(encoding="utf-8").splitlines())
+        except OSError:
+            pass
+
+    for gz_path in sorted(ledger_dir.glob("cycles-*.jsonl.gz")):
+        try:
+            with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
+                _consume(fh.read().splitlines())
+        except (OSError, gzip.BadGzipFile):
+            continue
+
+    return rows
+
+
+def group_by_cycle(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Group ledger rows by ``cycle_id`` into ``{started, dedup, gate: [...], outcome}``.
+
+    If more than one row of a singleton phase (``started``/``dedup``/
+    ``outcome``) exists for a cycle_id, the chronologically last one wins —
+    mirrors ``metrics.md``'s "Conventions" rule for duplicate `cycle_id`
+    entries (count once, keep the last, never double-count).
+    """
+    cycles: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        cycle_id = row.get("cycle_id") or ""
+        if not cycle_id:
+            continue
+        bucket = cycles.setdefault(
+            cycle_id, {"started": None, "dedup": None, "gate": [], "outcome": None}
+        )
+        phase = row.get("phase")
+        if phase == "gate":
+            bucket["gate"].append(row)
+        elif phase in ("started", "dedup", "outcome"):
+            bucket[phase] = row
+    return cycles
+
+
+def _rate(numerator: int, denominator: int) -> dict[str, Any]:
+    value = round(numerator / denominator, 4) if denominator else None
+    return {"value": value, "numerator": numerator, "denominator": denominator, "n_window": denominator}
+
+
+def compute_metrics(cycles: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    total = len(cycles)
+
+    outcome_counts: Counter[str] = Counter()
+    for data in cycles.values():
+        outcome_row = data["outcome"]
+        outcome_counts[outcome_row["outcome"] if outcome_row else "incomplete"] += 1
+
+    terminal_total = sum(v for k, v in outcome_counts.items() if k != "incomplete")
+    duplicate_count = outcome_counts.get("skipped-duplicate", 0)
+    success_count = outcome_counts.get("success", 0)
+
+    duplicate_rate = _rate(duplicate_count, terminal_total)
+    genuinely_new_proposal_rate = _rate(terminal_total - duplicate_count, terminal_total)
+
+    # Spawned = reached a terminal outcome other than the pre-spawn duplicate skip.
+    spawned_cycle_ids = [
+        cid
+        for cid, data in cycles.items()
+        if data["outcome"] and data["outcome"]["outcome"] != "skipped-duplicate"
+    ]
+    spawned_total = len(spawned_cycle_ids)
+
+    gated_cycle_ids = [cid for cid in spawned_cycle_ids if cycles[cid]["gate"]]
+    gated_total = len(gated_cycle_ids)
+    gate_pass_count = sum(
+        1 for cid in gated_cycle_ids if cycles[cid]["gate"][-1].get("allowed") is True
+    )
+
+    productive_spawn_rate = _rate(gated_total, spawned_total)
+    gate_pass_rate = _rate(gate_pass_count, gated_total)
+    integration_rate_of_gated = _rate(success_count, gated_total)
+    integration_rate_of_spawned = _rate(success_count, spawned_total)
+
+    gate_fail_breakdown = _gate_fail_breakdown(cycles)
+    dedup_breakdown = _dedup_breakdown(cycles)
+
+    metrics: dict[str, Any] = {
+        "genuinely_new_proposal_rate": genuinely_new_proposal_rate,
+        "duplicate_rate": duplicate_rate,
+        "productive_spawn_rate": productive_spawn_rate,
+        "gate_pass_rate": gate_pass_rate,
+        "integration_rate": {
+            "of_gated": integration_rate_of_gated,
+            "of_spawned": integration_rate_of_spawned,
+        },
+        "protected_surface_rejections": {
+            "value": None,
+            "note": (
+                "no target_paths field in the #720 flat cycle ledger "
+                "(cf. #705 metrics.md §6) — pending a #707 ledger-write-point addition"
+            ),
+        },
+        "cost_per_integrated_change": {
+            "value": None,
+            "note": (
+                "requires a telemetry join (llm_calls/*.jsonl); this script's "
+                "source of truth is the cycle ledger only, per #710 scope"
+            ),
+        },
+        "harvestable_upstream_ratio": {
+            "value": None,
+            "note": (
+                "no general_or_host_local classification field in the #720 ledger "
+                "(cf. #705 metrics.md §8) — pending a #672 harvest-pass classification"
+            ),
+        },
+        "human_intervention_needed": {
+            "value": None,
+            "note": (
+                "no stop-guard/restore-failure ledger field yet "
+                "(#705 metrics.md §9's named #707 dependency)"
+            ),
+        },
+    }
+
+    return {
+        "n_cycles": total,
+        "outcome_counts": dict(outcome_counts),
+        "metrics": metrics,
+        "gate_fail_breakdown": gate_fail_breakdown,
+        "dedup_breakdown": dedup_breakdown,
+    }
+
+
+def _gate_fail_breakdown(cycles: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    """Categorical (stage, reason) counts, ordered gate -> outcome -> unclassified."""
+    counts: Counter[tuple[str, str | None]] = Counter()
+
+    for data in cycles.values():
+        for gate_row in data["gate"]:
+            if gate_row.get("allowed") is False:
+                reason = gate_row.get("reason") or None
+                counts[("gate", reason)] += 1
+
+        outcome_row = data["outcome"]
+        if outcome_row and outcome_row["outcome"] in ("failed", "timeout"):
+            # Only attribute to "outcome" stage if no gate row already explains
+            # the failure — avoids double counting the same terminal failure.
+            has_gate_fail = any(g.get("allowed") is False for g in data["gate"])
+            if not has_gate_fail:
+                reason = outcome_row.get("reason") or None
+                stage = "outcome" if reason else "unclassified"
+                counts[(stage, reason)] += 1
+
+    total_failures = sum(counts.values())
+    stage_order = {"gate": 0, "outcome": 1, "unclassified": 2}
+    rows = []
+    for (stage, reason), count in counts.items():
+        rows.append(
+            {
+                "stage": stage,
+                "reason": reason,
+                "count": count,
+                "share_of_failures": round(count / total_failures, 4) if total_failures else None,
+            }
+        )
+    rows.sort(key=lambda r: (stage_order.get(r["stage"], 99), -r["count"]))
+    return rows
+
+
+def _dedup_breakdown(cycles: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    decision_counts: Counter[str] = Counter()
+    matched_against: Counter[str] = Counter()
+
+    for data in cycles.values():
+        dedup_row = data["dedup"]
+        if dedup_row is None:
+            decision_counts["(no dedup row)"] += 1
+            continue
+        decision_counts[dedup_row.get("decision") or "unclassified"] += 1
+        matched = dedup_row.get("matched_against")
+        if matched:
+            matched_against[matched] += 1
+
+    return {
+        "by_decision": dict(decision_counts),
+        "top_matched_against": [
+            {"matched_against": k, "count": v} for k, v in matched_against.most_common(10)
+        ],
+    }
+
+
+def compute_liveness(cycles: dict[str, dict[str, Any]], duplicate_rate_value: float | None) -> dict[str, Any]:
+    last_cycle_ts: str | None = None
+    last_productive_ts: str | None = None
+
+    for data in cycles.values():
+        for row in (data["started"], data["dedup"], *data["gate"], data["outcome"]):
+            if row and row.get("ts"):
+                if last_cycle_ts is None or row["ts"] > last_cycle_ts:
+                    last_cycle_ts = row["ts"]
+        outcome_row = data["outcome"]
+        if outcome_row and outcome_row.get("outcome") == "success" and outcome_row.get("ts"):
+            if last_productive_ts is None or outcome_row["ts"] > last_productive_ts:
+                last_productive_ts = outcome_row["ts"]
+
+    if not cycles:
+        state = "dead"
+    elif last_productive_ts is not None and (
+        duplicate_rate_value is None or duplicate_rate_value < DUPLICATE_SATURATION_THRESHOLD
+    ):
+        state = "healthy"
+    else:
+        state = "degraded"
+
+    return {
+        "state": state,
+        "last_productive_ts": last_productive_ts,
+        "last_cycle_ts": last_cycle_ts,
+    }
+
+
+def build_report(state_dir: Path, days: int) -> dict[str, Any]:
+    rows = load_ledger_rows(state_dir, days)
+    cycles = group_by_cycle(rows)
+    computed = compute_metrics(cycles)
+    liveness = compute_liveness(cycles, computed["metrics"]["duplicate_rate"]["value"])
+
+    now = datetime.now(timezone.utc)
+    window_start = (now - timedelta(days=days)).isoformat().replace("+00:00", "Z")
+    window_end = now.isoformat().replace("+00:00", "Z")
+
+    return {
+        "window": {
+            "start": window_start,
+            "end": window_end,
+            "n_cycles": computed["n_cycles"],
+            "params": {
+                "days": days,
+                "duplicate_rate_saturation_threshold": DUPLICATE_SATURATION_THRESHOLD,
+            },
+        },
+        "generated_at": window_end,
+        "liveness": liveness,
+        "outcome_counts": computed["outcome_counts"],
+        "metrics": computed["metrics"],
+        "gate_fail_breakdown": computed["gate_fail_breakdown"],
+        "dedup_breakdown": computed["dedup_breakdown"],
+    }
+
+
+def _fmt_rate(metric: dict[str, Any]) -> str:
+    value = metric.get("value")
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def render_table(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    window = report["window"]
+    lines.append(
+        f"Loop metrics report — window {window['start']} .. {window['end']} "
+        f"({window['n_cycles']} cycles, generated {report['generated_at']})"
+    )
+    lines.append("")
+
+    liveness = report["liveness"]
+    lines.append(
+        f"Liveness: {liveness['state'].upper()}  "
+        f"last_productive={liveness['last_productive_ts'] or 'n/a'}  "
+        f"last_cycle={liveness['last_cycle_ts'] or 'n/a'}"
+    )
+    lines.append("")
+
+    lines.append("Outcome counts:")
+    if report["outcome_counts"]:
+        for outcome, count in sorted(report["outcome_counts"].items(), key=lambda kv: -kv[1]):
+            lines.append(f"  {outcome:<20} {count}")
+    else:
+        lines.append("  (no cycles in window)")
+    lines.append("")
+
+    m = report["metrics"]
+    lines.append("Core metrics:")
+    lines.append(f"  {'metric':<32} {'value':>8} {'num':>6} {'den':>6}")
+    for name in ("genuinely_new_proposal_rate", "duplicate_rate", "productive_spawn_rate", "gate_pass_rate"):
+        row = m[name]
+        lines.append(f"  {name:<32} {_fmt_rate(row):>8} {row['numerator']:>6} {row['denominator']:>6}")
+    for sub_name, row in (("integration_rate.of_gated", m["integration_rate"]["of_gated"]),
+                          ("integration_rate.of_spawned", m["integration_rate"]["of_spawned"])):
+        lines.append(f"  {sub_name:<32} {_fmt_rate(row):>8} {row['numerator']:>6} {row['denominator']:>6}")
+    lines.append("")
+
+    lines.append("Gate-fail reason breakdown:")
+    non_zero = [r for r in report["gate_fail_breakdown"] if r["count"] > 0]
+    if non_zero:
+        lines.append(f"  {'stage':<14} {'reason':<40} {'count':>6} {'share':>8}")
+        for row in non_zero:
+            share = f"{row['share_of_failures'] * 100:.1f}%" if row["share_of_failures"] is not None else "n/a"
+            lines.append(f"  {row['stage']:<14} {str(row['reason']):<40} {row['count']:>6} {share:>8}")
+    else:
+        lines.append("  (no gate/outcome failures in window)")
+    lines.append("")
+
+    lines.append("Dedup-decision breakdown:")
+    dedup = report["dedup_breakdown"]
+    if dedup["by_decision"]:
+        for decision, count in sorted(dedup["by_decision"].items(), key=lambda kv: -kv[1]):
+            lines.append(f"  {decision:<28} {count}")
+    else:
+        lines.append("  (no dedup rows in window)")
+    if dedup["top_matched_against"]:
+        lines.append("  Top matched_against:")
+        for entry in dedup["top_matched_against"]:
+            lines.append(f"    {entry['matched_against']:<40} {entry['count']}")
+    lines.append("")
+
+    lines.append("Metrics pending upstream inputs (null, per #705 gap-visibility rule):")
+    for name in ("protected_surface_rejections", "cost_per_integrated_change", "harvestable_upstream_ratio", "human_intervention_needed"):
+        lines.append(f"  {name}: n/a — {m[name]['note']}")
+
+    return "\n".join(lines)
+
+
+def _self_test() -> None:
+    """Build a temp fixture ledger with a known mix of cycles and assert the report."""
+    import shutil
+    import tempfile
+
+    tmp = tempfile.mkdtemp()
+    try:
+        state_dir = Path(tmp)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True)
+
+        now = datetime.now(timezone.utc)
+
+        def ts(minutes_ago: int) -> str:
+            return (now - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z")
+
+        rows = [
+            # c1: proceeded -> gate allowed -> success (productive + integrated)
+            {"phase": "started", "cycle_id": "c1", "ts": ts(50)},
+            {"phase": "dedup", "cycle_id": "c1", "decision": "proceeded", "matched_against": None, "ts": ts(49)},
+            {"phase": "gate", "cycle_id": "c1", "allowed": True, "reason": None, "ts": ts(48)},
+            {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "reason": None, "ts": ts(47)},
+            # c2: proceeded -> gate rejected (gate_failed)
+            {"phase": "started", "cycle_id": "c2", "ts": ts(40)},
+            {"phase": "dedup", "cycle_id": "c2", "decision": "proceeded", "matched_against": None, "ts": ts(39)},
+            {"phase": "gate", "cycle_id": "c2", "allowed": False, "reason": "gate_failed", "ts": ts(38)},
+            {"phase": "outcome", "cycle_id": "c2", "outcome": "failed", "reason": "gate_failed", "ts": ts(37)},
+            # c3: skipped as duplicate before spawn
+            {"phase": "started", "cycle_id": "c3", "ts": ts(30)},
+            {"phase": "dedup", "cycle_id": "c3", "decision": "skipped_duplicate", "matched_against": "done:title-x", "ts": ts(29)},
+            {"phase": "outcome", "cycle_id": "c3", "outcome": "skipped-duplicate", "reason": None, "ts": ts(29)},
+            # c4: proceeded, no gate row, failed with no_commit-style reason
+            {"phase": "started", "cycle_id": "c4", "ts": ts(20)},
+            {"phase": "dedup", "cycle_id": "c4", "decision": "proceeded", "matched_against": None, "ts": ts(19)},
+            {"phase": "outcome", "cycle_id": "c4", "outcome": "failed", "reason": "no_commit", "ts": ts(18)},
+        ]
+        with open(ledger_dir / "cycles.jsonl", "w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row) + "\n")
+
+        # A rotated gzip file, well within the window, adding one more success.
+        gz_rows = [
+            {"phase": "started", "cycle_id": "c5", "ts": ts(10)},
+            {"phase": "dedup", "cycle_id": "c5", "decision": "proceeded", "matched_against": None, "ts": ts(9)},
+            {"phase": "gate", "cycle_id": "c5", "allowed": True, "reason": None, "ts": ts(8)},
+            {"phase": "outcome", "cycle_id": "c5", "outcome": "success", "reason": None, "ts": ts(7)},
+        ]
+        import gzip as _gzip
+
+        yesterday = (now.date()).isoformat()
+        gz_path = ledger_dir / f"cycles-{yesterday}.jsonl.gz"
+        with _gzip.open(gz_path, "wt", encoding="utf-8") as fh:
+            for row in gz_rows:
+                fh.write(json.dumps(row) + "\n")
+
+        report = build_report(state_dir, days=7)
+
+        assert report["window"]["n_cycles"] == 5, report["window"]["n_cycles"]
+        assert report["outcome_counts"]["success"] == 2
+        assert report["outcome_counts"]["failed"] == 2
+        assert report["outcome_counts"]["skipped-duplicate"] == 1
+
+        m = report["metrics"]
+        assert m["duplicate_rate"]["value"] == pytest_approx(1 / 5)
+        assert m["duplicate_rate"]["numerator"] == 1
+        assert m["duplicate_rate"]["denominator"] == 5
+
+        assert m["genuinely_new_proposal_rate"]["value"] == pytest_approx(4 / 5)
+
+        # spawned = 4 (all but c3, the precheck-duplicate skip);
+        # gated = 3 (c1, c2, c5 all reached a gate row; c4 did not)
+        assert m["productive_spawn_rate"]["denominator"] == 4
+        assert m["productive_spawn_rate"]["numerator"] == 3
+        assert m["gate_pass_rate"]["denominator"] == 3
+        assert m["gate_pass_rate"]["numerator"] == 2
+        assert m["integration_rate"]["of_spawned"]["numerator"] == 2
+        assert m["integration_rate"]["of_spawned"]["denominator"] == 4
+        assert m["integration_rate"]["of_gated"]["numerator"] == 2
+        assert m["integration_rate"]["of_gated"]["denominator"] == 3
+
+        for name in ("protected_surface_rejections", "cost_per_integrated_change", "harvestable_upstream_ratio", "human_intervention_needed"):
+            assert m[name]["value"] is None
+            assert "note" in m[name]
+
+        breakdown = {(r["stage"], r["reason"]): r["count"] for r in report["gate_fail_breakdown"]}
+        assert breakdown[("gate", "gate_failed")] == 1
+        assert breakdown[("outcome", "no_commit")] == 1
+
+        dedup = report["dedup_breakdown"]
+        assert dedup["by_decision"]["proceeded"] == 4
+        assert dedup["by_decision"]["skipped_duplicate"] == 1
+        assert dedup["top_matched_against"][0]["matched_against"] == "done:title-x"
+
+        assert report["liveness"]["state"] == "healthy"
+
+        # Empty-ledger case: must render cleanly, not crash.
+        empty_dir = Path(tempfile.mkdtemp())
+        try:
+            empty_report = build_report(empty_dir, days=7)
+            assert empty_report["liveness"]["state"] == "dead"
+            assert empty_report["window"]["n_cycles"] == 0
+            table = render_table(empty_report)
+            assert "DEAD" in table
+        finally:
+            shutil.rmtree(empty_dir)
+
+        print("PASS: loop_metrics_report self-tests passed.")
+        print()
+        print(render_table(report))
+    finally:
+        shutil.rmtree(tmp)
+
+
+def pytest_approx(value: float):
+    """Tiny stdlib-only stand-in so ``--test`` doesn't need pytest installed."""
+    return round(value, 6)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-dir", type=Path, default=None, help="state dir containing ledger/ (default: env-resolved)")
+    parser.add_argument("--days", type=int, default=LIVENESS_DAYS_DEFAULT, help="window size in days (default: 7)")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of a table")
+    parser.add_argument("--test", action="store_true", help="run self-tests against a temp fixture ledger and exit")
+    args = parser.parse_args(argv)
+
+    if args.test:
+        _self_test()
+        return 0
+
+    state_dir = args.state_dir or _default_state_dir()
+    report = build_report(state_dir, days=args.days)
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_table(report))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_loop_metrics_report.py
+++ b/tests/test_loop_metrics_report.py
@@ -1,0 +1,297 @@
+"""Tests for scripts/loop_metrics_report.py (issue #710).
+
+Builds a fixture cycle ledger (matching ``nanobot.runtime.cycle_ledger``'s
+row shapes) with a known mix of cycles and asserts each computed metric,
+the liveness states (healthy/degraded/dead), gzip-rotated-file window
+inclusion, and that an empty ledger renders a clean 'dead/no data' report
+instead of crashing.
+"""
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    """Import scripts/loop_metrics_report.py as a module without running __main__."""
+    script_path = Path(__file__).parent.parent / "scripts" / "loop_metrics_report.py"
+    spec = importlib.util.spec_from_file_location("loop_metrics_report", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def mod():
+    return _load_module()
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _ts(now: datetime, minutes_ago: int) -> str:
+    return (now - timedelta(minutes=minutes_ago)).isoformat().replace("+00:00", "Z")
+
+
+def _make_ledger(tmp_path: Path, now: datetime) -> Path:
+    """A mixed fixture: 1 success (gated+passed), 1 gate-fail, 1 precheck-duplicate,
+    1 no_commit-style failure with no gate row, and one more success in a rotated
+    gzip file — used across most of the tests below.
+    """
+    state_dir = tmp_path
+    ledger_dir = state_dir / "ledger"
+    ledger_dir.mkdir(parents=True)
+
+    rows = [
+        {"phase": "started", "cycle_id": "c1", "ts": _ts(now, 50)},
+        {"phase": "dedup", "cycle_id": "c1", "decision": "proceeded", "matched_against": None, "ts": _ts(now, 49)},
+        {"phase": "gate", "cycle_id": "c1", "allowed": True, "reason": None, "ts": _ts(now, 48)},
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "reason": None, "ts": _ts(now, 47)},
+
+        {"phase": "started", "cycle_id": "c2", "ts": _ts(now, 40)},
+        {"phase": "dedup", "cycle_id": "c2", "decision": "proceeded", "matched_against": None, "ts": _ts(now, 39)},
+        {"phase": "gate", "cycle_id": "c2", "allowed": False, "reason": "gate_failed", "ts": _ts(now, 38)},
+        {"phase": "outcome", "cycle_id": "c2", "outcome": "failed", "reason": "gate_failed", "ts": _ts(now, 37)},
+
+        {"phase": "started", "cycle_id": "c3", "ts": _ts(now, 30)},
+        {"phase": "dedup", "cycle_id": "c3", "decision": "skipped_duplicate", "matched_against": "done:title-x", "ts": _ts(now, 29)},
+        {"phase": "outcome", "cycle_id": "c3", "outcome": "skipped-duplicate", "reason": None, "ts": _ts(now, 29)},
+
+        {"phase": "started", "cycle_id": "c4", "ts": _ts(now, 20)},
+        {"phase": "dedup", "cycle_id": "c4", "decision": "proceeded", "matched_against": None, "ts": _ts(now, 19)},
+        {"phase": "outcome", "cycle_id": "c4", "outcome": "failed", "reason": "no_commit", "ts": _ts(now, 18)},
+    ]
+    _write_jsonl(ledger_dir / "cycles.jsonl", rows)
+
+    gz_rows = [
+        {"phase": "started", "cycle_id": "c5", "ts": _ts(now, 10)},
+        {"phase": "dedup", "cycle_id": "c5", "decision": "proceeded", "matched_against": None, "ts": _ts(now, 9)},
+        {"phase": "gate", "cycle_id": "c5", "allowed": True, "reason": None, "ts": _ts(now, 8)},
+        {"phase": "outcome", "cycle_id": "c5", "outcome": "success", "reason": None, "ts": _ts(now, 7)},
+    ]
+    gz_path = ledger_dir / f"cycles-{now.date().isoformat()}.jsonl.gz"
+    with gzip.open(gz_path, "wt", encoding="utf-8") as fh:
+        for row in gz_rows:
+            fh.write(json.dumps(row) + "\n")
+
+    return state_dir
+
+
+# ─── load / group ──────────────────────────────────────────────────────────
+
+
+def test_load_ledger_rows_missing_dir_returns_empty(tmp_path, mod):
+    rows = mod.load_ledger_rows(tmp_path / "does-not-exist", days=7)
+    assert rows == []
+
+
+def test_load_ledger_rows_includes_gzip_files_in_window(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    rows = mod.load_ledger_rows(state_dir, days=7)
+    cycle_ids = {r.get("cycle_id") for r in rows}
+    assert "c5" in cycle_ids  # from the gzip file
+    assert "c1" in cycle_ids  # from the active file
+
+
+def test_load_ledger_rows_excludes_out_of_window_gzip(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    old_ts = (now - timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    gz_path = ledger_dir / "cycles-2026-01-01.jsonl.gz"
+    with gzip.open(gz_path, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps({"phase": "started", "cycle_id": "old1", "ts": old_ts}) + "\n")
+
+    rows = mod.load_ledger_rows(tmp_path, days=7)
+    assert rows == []
+
+
+def test_load_ledger_rows_skips_malformed_lines(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    path = ledger_dir / "cycles.jsonl"
+    good = json.dumps({"phase": "started", "cycle_id": "c1", "ts": _ts(now, 1)})
+    path.write_text(good + "\nnot-json\n", encoding="utf-8")
+
+    rows = mod.load_ledger_rows(tmp_path, days=7)
+    assert len(rows) == 1
+
+
+def test_group_by_cycle_keeps_last_of_singleton_phases(mod):
+    rows = [
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "failed", "ts": "2026-01-01T00:00:00Z"},
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": "2026-01-01T00:01:00Z"},
+    ]
+    cycles = mod.group_by_cycle(rows)
+    assert cycles["c1"]["outcome"]["outcome"] == "success"
+
+
+def test_group_by_cycle_accumulates_gate_rows(mod):
+    rows = [
+        {"phase": "gate", "cycle_id": "c1", "allowed": False, "reason": "r1"},
+        {"phase": "gate", "cycle_id": "c1", "allowed": True, "reason": None},
+    ]
+    cycles = mod.group_by_cycle(rows)
+    assert len(cycles["c1"]["gate"]) == 2
+
+
+def test_group_by_cycle_ignores_rows_without_cycle_id(mod):
+    rows = [{"phase": "started", "cycle_id": ""}, {"phase": "started"}]
+    cycles = mod.group_by_cycle(rows)
+    assert cycles == {}
+
+
+# ─── metrics ───────────────────────────────────────────────────────────────
+
+
+def test_full_report_metrics(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    report = mod.build_report(state_dir, days=7)
+
+    assert report["window"]["n_cycles"] == 5
+    assert report["outcome_counts"]["success"] == 2
+    assert report["outcome_counts"]["failed"] == 2
+    assert report["outcome_counts"]["skipped-duplicate"] == 1
+
+    m = report["metrics"]
+    assert m["duplicate_rate"]["value"] == pytest.approx(1 / 5)
+    assert m["duplicate_rate"]["numerator"] == 1
+    assert m["duplicate_rate"]["denominator"] == 5
+
+    assert m["genuinely_new_proposal_rate"]["value"] == pytest.approx(4 / 5)
+
+    # spawned = 4 (all but c3, the precheck-duplicate skip); gated = 2 (c1, c5 passed; c2 gate ran)
+    assert m["productive_spawn_rate"]["denominator"] == 4
+    assert m["productive_spawn_rate"]["numerator"] == 3  # c1, c2, c5 all reached a gate row
+    assert m["gate_pass_rate"]["denominator"] == 3
+    assert m["gate_pass_rate"]["numerator"] == 2  # c1, c5 passed; c2 failed
+    assert m["integration_rate"]["of_spawned"]["numerator"] == 2
+    assert m["integration_rate"]["of_spawned"]["denominator"] == 4
+    assert m["integration_rate"]["of_gated"]["numerator"] == 2
+    assert m["integration_rate"]["of_gated"]["denominator"] == 3
+
+
+def test_metrics_with_unavailable_inputs_are_null_with_note(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    report = mod.build_report(state_dir, days=7)
+    m = report["metrics"]
+    for name in (
+        "protected_surface_rejections",
+        "cost_per_integrated_change",
+        "harvestable_upstream_ratio",
+        "human_intervention_needed",
+    ):
+        assert m[name]["value"] is None
+        assert "note" in m[name] and m[name]["note"]
+
+
+def test_gate_fail_breakdown_attributes_gate_and_outcome_stages(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    report = mod.build_report(state_dir, days=7)
+    breakdown = {(r["stage"], r["reason"]): r["count"] for r in report["gate_fail_breakdown"]}
+    assert breakdown[("gate", "gate_failed")] == 1
+    assert breakdown[("outcome", "no_commit")] == 1
+
+
+def test_dedup_breakdown_counts_decisions_and_top_matched_against(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    report = mod.build_report(state_dir, days=7)
+    dedup = report["dedup_breakdown"]
+    assert dedup["by_decision"]["proceeded"] == 4
+    assert dedup["by_decision"]["skipped_duplicate"] == 1
+    assert dedup["top_matched_against"][0] == {"matched_against": "done:title-x", "count": 1}
+
+
+# ─── liveness ──────────────────────────────────────────────────────────────
+
+
+def test_liveness_healthy_when_success_and_low_duplicate_rate(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    report = mod.build_report(state_dir, days=7)
+    assert report["liveness"]["state"] == "healthy"
+    assert report["liveness"]["last_productive_ts"] is not None
+
+
+def test_liveness_degraded_when_activity_but_no_success(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    rows = [
+        {"phase": "started", "cycle_id": "c1", "ts": _ts(now, 10)},
+        {"phase": "dedup", "cycle_id": "c1", "decision": "proceeded", "ts": _ts(now, 9)},
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "failed", "reason": "no_commit", "ts": _ts(now, 8)},
+    ]
+    _write_jsonl(ledger_dir / "cycles.jsonl", rows)
+
+    report = mod.build_report(tmp_path, days=7)
+    assert report["liveness"]["state"] == "degraded"
+    assert report["liveness"]["last_productive_ts"] is None
+
+
+def test_liveness_degraded_when_duplicate_rate_saturated(tmp_path, mod):
+    now = datetime.now(timezone.utc)
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    rows = []
+    # 4 duplicates, 1 success -> duplicate_rate = 0.8, at the saturation threshold (>=)
+    for i in range(4):
+        cid = f"dup{i}"
+        rows.append({"phase": "dedup", "cycle_id": cid, "decision": "skipped_duplicate", "ts": _ts(now, 10 + i)})
+        rows.append({"phase": "outcome", "cycle_id": cid, "outcome": "skipped-duplicate", "ts": _ts(now, 10 + i)})
+    rows.append({"phase": "dedup", "cycle_id": "ok1", "decision": "proceeded", "ts": _ts(now, 5)})
+    rows.append({"phase": "gate", "cycle_id": "ok1", "allowed": True, "ts": _ts(now, 4)})
+    rows.append({"phase": "outcome", "cycle_id": "ok1", "outcome": "success", "ts": _ts(now, 3)})
+    _write_jsonl(ledger_dir / "cycles.jsonl", rows)
+
+    report = mod.build_report(tmp_path, days=7)
+    assert report["metrics"]["duplicate_rate"]["value"] == pytest.approx(0.8)
+    assert report["liveness"]["state"] == "degraded"
+
+
+def test_liveness_dead_when_empty_ledger(tmp_path, mod):
+    report = mod.build_report(tmp_path, days=7)
+    assert report["liveness"]["state"] == "dead"
+    assert report["window"]["n_cycles"] == 0
+    assert report["liveness"]["last_cycle_ts"] is None
+
+
+def test_empty_ledger_renders_clean_table_not_a_crash(tmp_path, mod):
+    report = mod.build_report(tmp_path, days=7)
+    table = mod.render_table(report)
+    assert "DEAD" in table
+    assert "no cycles in window" in table
+    assert "n/a" in table
+
+
+# ─── CLI / self-test ───────────────────────────────────────────────────────
+
+
+def test_self_test_runs_without_error(mod, capsys):
+    mod._self_test()
+    captured = capsys.readouterr()
+    assert "PASS" in captured.out
+
+
+def test_main_json_output(tmp_path, mod, capsys, monkeypatch):
+    now = datetime.now(timezone.utc)
+    state_dir = _make_ledger(tmp_path, now)
+    exit_code = mod.main(["--state-dir", str(state_dir), "--json"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["window"]["n_cycles"] == 5


### PR DESCRIPTION
Implements the #705 report contract's minimal computable form over the #720 cycle ledger. **Harvested** from the instance's autonomously-built loop_health_report.py (P10, instance commit 6a365ac) per the #672 flow — adapted to the ledger as single source of truth. Refs #710, #705, #720, #716.

## What
`scripts/loop_metrics_report.py` (read-only, stdlib-only): parses `cycles.jsonl` (+ rotated `.gz`), computes duplicate/genuinely-new rates, productive-spawn, gate-pass, integration rates, gate-fail reason breakdown, dedup-decision breakdown (heuristic quality signal), liveness (healthy/degraded/dead). Metrics whose inputs don't exist yet (`protected_surface_rejections`, `cost_per_integrated_change`, `harvestable_upstream_ratio`, `human_intervention_needed`) emit `null` + note per the #705 gap-visibility rule — no invented inputs. `--json` + human table + `--test`.

## Tests
`tests/test_loop_metrics_report.py` (fixture ledger → asserted metric values, liveness states, gz window, empty-ledger safety). Full suite **1304 passed, 0 failed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)