### PR TITLE
feat(runtime): state-light LLM proposer behind a kill-switch, ships OFF (#707)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -35,6 +35,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.cli.commands import _make_provider
 from nanobot.config.loader import load_config, set_config_path
 from nanobot.observability.llm_telemetry import set_call_context
+from nanobot.runtime import llm_proposer
 from nanobot.runtime.cycle_ledger import (
     VALID_OUTCOMES,
     record_cycle_outcome,
@@ -1141,6 +1142,18 @@ async def _main_impl():
 
     req_path, req = find_pending_request()
     if not req_path:
+        # #707: state-light LLM proposer — only fires on proven novelty
+        # exhaustion (see llm_proposer.should_propose), behind the
+        # SELFEVO_LLM_PROPOSER_ENABLED kill-switch (default OFF). Fails open
+        # (never raises), so this is safe to call unconditionally here. If it
+        # writes a request, the NEXT bridge invocation (next timer cycle)
+        # picks it up through the normal find_pending_request/dedup/gate path
+        # above — untouched by this change.
+        _selfevo_repo_for_proposer = STATE_DIR.parent / 'eeebot-self-evolving'
+        if llm_proposer.maybe_propose(STATE_DIR, _selfevo_repo_for_proposer):
+            _proposer_req_path, _proposer_req = find_pending_request()
+            _proposer_title = (_proposer_req or {}).get('task_title') or '(untitled)'
+            print(f'llm-proposer: queued {_proposer_title}')
         print('already_handled')
         return 0
 

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1,0 +1,446 @@
+"""State-light LLM proposer (#707).
+
+Fills the gap left when the deterministic generator in
+``nanobot.runtime.cycle_planning`` (``next_bounded_candidate`` /
+``_derive_generated_candidates``) has run out of hand-maintained
+``goal_text.json`` priorities to propose. Reuses the same downstream
+machinery — the queued-request JSON the bridge already consumes via
+``find_pending_request`` — so from the bridge's point of view a
+proposer-written request is indistinguishable from a planner-written one
+(C1, see ``docs/changes/707-state-light-proposer/proposal.md`` and
+``docs/changes/702-ledger-loop-architecture-decision/design-constraints.md``).
+
+Kill switch: ``SELFEVO_LLM_PROPOSER_ENABLED`` (env, default unset/off).
+When off, :func:`should_propose` always returns ``False`` and this module
+never makes an LLM call or writes any file — this is the entire rollout
+control surface, no other config.
+
+Everything here is fail-open/fail-closed by design, never raises: a broken
+environment, a network error, or a malformed LLM reply degrades to "nothing
+proposed this cycle" — identical to today's idle-safe behavior when the
+deterministic generator has nothing to offer.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+from nanobot.runtime.cycle_ledger import append_event
+from nanobot.runtime.cycle_planning import filter_completed_priorities_from_goal_text
+
+ENABLED_ENV = "SELFEVO_LLM_PROPOSER_ENABLED"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Mirrors nanobot.runtime.bridge._ALLOWED_PATH_PREFIXES exactly (#707 C2 —
+# checkable sizing). Not imported from bridge.py to avoid a circular import
+# (bridge.py imports this module for the invocation hook); duplicated as a
+# small literal instead of a shared constant, per the "minimal wiring, no new
+# config surface" scope of this change.
+_ALLOWED_PATH_PREFIXES = ("surfaces/", "scripts/", "memory/", "lessons/", "docs/", "tests/")
+
+_MAX_CONTEXT_CHARS = 4000
+_LEDGER_DIGEST_ROWS = 15
+_DUP_STREAK_K = 3
+_MAX_TITLE_CHARS = 120
+
+_PRIORITY_PATTERN = re.compile(
+    r"\([A-Za-z]\)\s*Priority\s+(\d+)\s*[—-]\s*(.+?):\s*(.+?)(?=\n\([A-Za-z]\)|\Z)",
+    re.DOTALL,
+)
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+_JSON_OBJ_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+_PROPOSER_SYSTEM_PROMPT = (
+    "You are proposing exactly ONE small, bounded engineering improvement for a "
+    "self-evolving codebase. Reply with ONLY a JSON object with keys "
+    "task_title, rationale, target_path — no prose, no markdown code fences. "
+    "task_title must be non-empty and at most 120 characters, describing a "
+    "single behavior/bug (not a bundle). target_path must name exactly ONE "
+    "path (file or directory) under one of these mutable surfaces: "
+    "surfaces/, scripts/, memory/, lessons/, docs/, tests/ — no other path is "
+    "acceptable. rationale must briefly justify the change and must NOT "
+    "repeat any already-done or recently-failed work described in the "
+    "context below."
+)
+
+
+def _enabled() -> bool:
+    return os.environ.get(ENABLED_ENV, "0").strip().lower() in _TRUTHY
+
+
+def _requests_dir(state_dir: Path) -> Path:
+    return Path(state_dir) / "subagents" / "requests"
+
+
+def _has_queued_request(state_dir: Path) -> bool:
+    req_dir = _requests_dir(state_dir)
+    if not req_dir.is_dir():
+        return False
+    for path in req_dir.glob("*.json"):
+        try:
+            req = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(req, dict):
+            continue
+        status = str(req.get("request_status") or req.get("status") or "").strip().lower()
+        if status in ("queued", "pending"):
+            return True
+    return False
+
+
+def _load_goal_text(state_dir: Path) -> str:
+    path = Path(state_dir) / "goals" / "goal_text.json"
+    if not path.is_file():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    return str(data.get("text") or "")
+
+
+def _priorities_remain(filtered_goal_text: str) -> bool:
+    marker = "Current priority targets:"
+    idx = filtered_goal_text.find(marker)
+    if idx == -1:
+        return False
+    section = filtered_goal_text[idx + len(marker):]
+    return bool(_PRIORITY_PATTERN.search(section))
+
+
+def _load_ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
+    path = Path(state_dir) / "ledger" / "cycles.jsonl"
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(rec, dict):
+            rows.append(rec)
+    return rows
+
+
+def _terminal_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [r for r in rows if r.get("phase") == "outcome"]
+
+
+def _last_k_all_duplicate(state_dir: Path, k: int = _DUP_STREAK_K) -> bool:
+    terminal = _terminal_rows(_load_ledger_rows(state_dir))
+    if len(terminal) < k:
+        return False
+    last_k = terminal[-k:]
+    return all(r.get("outcome") == "skipped-duplicate" for r in last_k)
+
+
+def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
+    """Invocation policy (#707): fires only on proven novelty exhaustion.
+
+    ``(no queued request) AND (filtered goal_text has no remaining "Current
+    priority targets" entries OR the last K=3 terminal ledger outcome rows
+    are all "skipped-duplicate")``. Fail-closed: any error, or a completely
+    missing/unreadable state directory, returns ``False``. Always ``False``
+    when the kill switch (``SELFEVO_LLM_PROPOSER_ENABLED``) is off.
+    """
+    if not _enabled():
+        return False
+    try:
+        state_dir = Path(state_dir)
+        if not state_dir.is_dir():
+            return False
+        if _has_queued_request(state_dir):
+            return False
+        goal_text_path = state_dir / "goals" / "goal_text.json"
+        if not goal_text_path.is_file():
+            return False
+        raw_goal_text = _load_goal_text(state_dir)
+        filtered = filter_completed_priorities_from_goal_text(raw_goal_text, selfevo_repo)
+        if not _priorities_remain(filtered):
+            return True
+        return _last_k_all_duplicate(state_dir)
+    except Exception:
+        return False
+
+
+def _digest_ledger(rows: list[dict[str, Any]], n: int = _LEDGER_DIGEST_ROWS) -> list[str]:
+    tail = _terminal_rows(rows)[-n:]
+    lines: list[str] = []
+    for row in tail:
+        outcome = str(row.get("outcome") or "unknown")
+        reason = str(row.get("reason") or "").strip()
+        branch = str(row.get("branch") or row.get("cycle_id") or "").strip()
+        one_liner = f"{outcome}: {reason or branch or '(no detail)'}"
+        lines.append(one_liner[:160])
+    return lines
+
+
+def build_context(state_dir: Path, selfevo_repo: Path | None) -> str:
+    """Compact, bounded proposer context (#707 C3).
+
+    Exactly two read-only inputs, kept separate: the filtered (done-items
+    stripped) goal_text, and a bounded digest of the last N terminal ledger
+    rows (done/failure signal, so the LLM does not re-propose already-
+    handled work). Hard-capped to ~4000 chars total. Fail-open: returns an
+    empty string on any error.
+    """
+    try:
+        state_dir = Path(state_dir)
+        raw_goal_text = _load_goal_text(state_dir)
+        filtered_goal = filter_completed_priorities_from_goal_text(raw_goal_text, selfevo_repo)
+        digest_lines = _digest_ledger(_load_ledger_rows(state_dir))
+        surface_rule = (
+            "Mutable surface rule: target_path MUST be a single path under "
+            "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + " — no other "
+            "path is acceptable."
+        )
+        parts = [
+            "## Goal (filtered — already-completed priorities removed)",
+            filtered_goal.strip() or "(no goal text available)",
+            "",
+            "## Recent cycle outcomes (most recent last — do not repeat done/failed work)",
+            "\n".join(f"- {line}" for line in digest_lines) or "(no ledger history yet)",
+            "",
+            surface_rule,
+        ]
+        context = "\n".join(parts)
+        if len(context) > _MAX_CONTEXT_CHARS:
+            context = context[:_MAX_CONTEXT_CHARS]
+        return context
+    except Exception:
+        return ""
+
+
+def _model_name() -> str:
+    raw = os.environ.get("SUBAGENT_BRIDGE_MODEL", "cl/gemini-3.5-flash-low").strip()
+    raw = raw or "cl/gemini-3.5-flash-low"
+    if raw.startswith("openai/"):
+        raw = raw[len("openai/"):]
+    return raw
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    if not text:
+        return None
+    stripped = text.strip()
+    fence_match = _JSON_FENCE_RE.search(stripped)
+    candidate = fence_match.group(1) if fence_match else None
+    if candidate is None:
+        obj_match = _JSON_OBJ_RE.search(stripped)
+        candidate = obj_match.group(0) if obj_match else None
+    if candidate is None:
+        return None
+    try:
+        parsed = json.loads(candidate)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def propose(context: str, *, rejection_reason: str | None = None, timeout: float = 120.0) -> dict[str, Any] | None:
+    """One chat completion via the same LiteLLM gateway the bridge uses.
+
+    Fails open (returns ``None``) on any missing config, network error, or
+    unparseable reply — never raises.
+    """
+    try:
+        from openai import OpenAI
+    except Exception:
+        return None
+    base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
+    api_key = os.environ.get("LITELLM_API_KEY", "").strip()
+    if not base_url or not api_key:
+        return None
+    user_content = context
+    if rejection_reason:
+        user_content = (
+            f"{context}\n\n"
+            f"Your previous proposal was rejected: {rejection_reason}. "
+            "Propose a different, valid one that fixes this problem."
+        )
+    try:
+        client = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+        response = client.chat.completions.create(
+            model=_model_name(),
+            messages=[
+                {"role": "system", "content": _PROPOSER_SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            max_tokens=400,
+            temperature=0.4,
+        )
+        reply = response.choices[0].message.content or ""
+    except Exception:
+        return None
+    return _extract_json_object(reply)
+
+
+def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
+    """Pre-spawn checkable sizing (#707 C2). Returns ``(ok, reason)``."""
+    if not isinstance(proposal, dict):
+        return False, "proposal is not a JSON object"
+
+    title = str(proposal.get("task_title") or "").strip()
+    if not title:
+        return False, "task_title is empty"
+    if len(title) > _MAX_TITLE_CHARS:
+        return False, f"task_title exceeds {_MAX_TITLE_CHARS} chars"
+
+    rationale = str(proposal.get("rationale") or "").strip()
+    if not rationale:
+        return False, "rationale is missing"
+
+    target_path = proposal.get("target_path")
+    if isinstance(target_path, (list, tuple)):
+        return False, "target_path must be exactly one path, not a list"
+    target_path = str(target_path or "").strip()
+    if not target_path:
+        return False, "target_path is missing"
+    if "," in target_path or ";" in target_path or "\n" in target_path:
+        return False, "target_path must name exactly one path"
+    if not any(target_path.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES):
+        return False, f"target_path outside allowed surfaces {_ALLOWED_PATH_PREFIXES}: {target_path}"
+
+    return True, ""
+
+
+def _active_goal_id(state_dir: Path) -> str:
+    try:
+        path = Path(state_dir) / "goals" / "registry.json"
+        if not path.is_file():
+            return ""
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return str(data.get("active_goal_id") or "")
+    except Exception:
+        pass
+    return ""
+
+
+def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
+    """Write the request JSON in the IDENTICAL shape
+    ``_write_subagent_request_artifact`` (nanobot.runtime.cycle_planning)
+    writes (#707 C1) — same keys, ``request_status: "queued"``. From the
+    bridge's ``find_pending_request`` point of view this file is
+    indistinguishable from a planner-written one.
+
+    ``target_path``/``rationale`` are carried WITHOUT changing the request
+    schema: they are embedded in a small companion artifact (the same
+    ``next_bounded_candidate`` shape the deterministic planner's own
+    materialized-improvement artifacts use, under a distinct
+    ``llm-proposed-*`` filename so it is never mistaken for a planner
+    materialization) and ``source_artifact`` points at it — an existing,
+    already-optional field the bridge already dereferences.
+
+    Also appends a ``'proposed'`` ledger row so proposer cycles are
+    distinguishable from planner cycles in
+    ``scripts/loop_metrics_report.py``.
+    """
+    state_dir = Path(state_dir)
+    cycle_id = f"cycle-{uuid.uuid4().hex[:12]}"
+    goal_id = _active_goal_id(state_dir)
+    task_title = str(proposal.get("task_title") or "").strip()
+    rationale = str(proposal.get("rationale") or "").strip()
+    target_path = str(proposal.get("target_path") or "").strip()
+
+    improvements_dir = state_dir / "improvements"
+    improvements_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = improvements_dir / f"llm-proposed-{cycle_id}.json"
+    artifact_payload = {
+        "schema_version": "llm-proposed-improvement-v1",
+        "source_artifact": "llm_proposer",
+        "next_bounded_candidate": {
+            "title": task_title,
+            "backlog_instructions": (
+                f"{rationale}\n\nTarget path: {target_path}" if rationale else f"Target path: {target_path}"
+            ),
+            "backlog_priority": None,
+        },
+        "recommended_next_action": f"Implement and commit: {task_title} (target: {target_path})",
+    }
+    artifact_path.write_text(json.dumps(artifact_payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    request_id = f"llm-proposer-{cycle_id}"
+    request_dir = _requests_dir(state_dir)
+    request_dir.mkdir(parents=True, exist_ok=True)
+    request_path = request_dir / f"request-{cycle_id}.json"
+    payload = {
+        "schema_version": "subagent-request-v1",
+        "cycle_id": cycle_id,
+        "goal_id": goal_id,
+        "task_id": "llm-proposed-improvement",
+        "semantic_task_id": "llm-proposed-improvement",
+        "request_id": request_id,
+        "verification_task_id": request_id,
+        "verification_role": "materialized_improvement_implementation",
+        "task_title": f"Implement and commit: {task_title}" if task_title else task_title,
+        "task": f"{rationale}\n\nTarget path: {target_path}".strip(),
+        "recommended_next_action": f"Implement and commit: {task_title} (target: {target_path})",
+        "request_status": "queued",
+        "profile": "bounded_execution",
+        "budget": "standard",
+        "source_artifact": str(artifact_path),
+        "feedback_decision": None,
+        "lessons_context": {},
+    }
+    request_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    append_event(
+        state_dir,
+        {
+            "phase": "proposed",
+            "cycle_id": cycle_id,
+            "request_id": request_id,
+            "task_title": task_title,
+            "target_path": target_path,
+            "source_artifact": "llm_proposer",
+        },
+    )
+
+    return str(request_path)
+
+
+def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
+    """Single public entrypoint (#707): build context, propose, validate
+    (with one retry on rejection), and write the request if valid.
+
+    Returns ``True`` iff a request was written this call. Never raises —
+    every step is individually fail-open, and the whole function is wrapped
+    in a final safety net so a bug here can never break the bridge cycle
+    that calls it.
+    """
+    try:
+        if not should_propose(state_dir, selfevo_repo):
+            return False
+
+        context = build_context(state_dir, selfevo_repo)
+        if not context:
+            return False
+
+        proposal = propose(context)
+        ok, reason = validate_sizing(proposal)
+        if not ok:
+            proposal = propose(context, rejection_reason=reason)
+            ok, reason = validate_sizing(proposal)
+        if not ok:
+            return False
+
+        write_request(state_dir, proposal)
+        return True
+    except Exception:
+        return False

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1,0 +1,444 @@
+"""Tests for #707: the state-light LLM proposer.
+
+Covers the kill-switch (default OFF), the invocation policy
+(``should_propose``), the bounded context builder (``build_context``), the
+pre-spawn sizing gate (``validate_sizing``), the C1 request-schema
+equality invariant (``write_request`` vs
+``nanobot.runtime.cycle_planning._write_subagent_request_artifact``), the
+mocked-LLM ``propose`` parsing, and an end-to-end check that a
+proposer-written request is picked up by the bridge's real
+``find_pending_request`` exactly like a planner-written one.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import bridge, cycle_ledger, llm_proposer
+from nanobot.runtime.cycle_planning import _write_subagent_request_artifact
+from tests.test_goal_backlog_routing import GOAL_TEXT_JSON, _make_git_repo_with_commit
+
+ENV_VAR = llm_proposer.ENABLED_ENV
+
+
+def _state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    (state_dir / "goals").mkdir(parents=True)
+    return state_dir
+
+
+def _write_goal_text(state_dir: Path, text: str) -> None:
+    (state_dir / "goals" / "goal_text.json").write_text(
+        json.dumps({"text": text}), encoding="utf-8"
+    )
+
+
+def _append_outcome(state_dir: Path, cycle_id: str, outcome: str) -> None:
+    cycle_ledger.append_event(
+        state_dir, {"phase": "outcome", "cycle_id": cycle_id, "outcome": outcome}
+    )
+
+
+# ─── kill-switch ───────────────────────────────────────────────────────────
+
+
+class TestKillSwitch:
+    def test_default_is_off(self, monkeypatch):
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        assert llm_proposer._enabled() is False
+
+    def test_should_propose_false_when_off_even_with_favorable_conditions(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priorities section here at all")
+        assert llm_proposer.should_propose(state_dir, None) is False
+
+    def test_maybe_propose_noop_when_off(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priorities section here at all")
+        assert llm_proposer.maybe_propose(state_dir, None) is False
+        assert not (state_dir / "subagents" / "requests").exists()
+
+
+# ─── should_propose branches (flag ON) ─────────────────────────────────────
+
+
+class TestShouldPropose:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+
+    def test_missing_state_dir_returns_false(self, tmp_path):
+        assert llm_proposer.should_propose(tmp_path / "does-not-exist", None) is False
+
+    def test_queued_request_present_returns_false(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section")
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-x.json").write_text(
+            json.dumps({"request_status": "queued"}), encoding="utf-8"
+        )
+        assert llm_proposer.should_propose(state_dir, None) is False
+
+    def test_priorities_remain_and_not_all_dup_returns_false(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, GOAL_TEXT_JSON and json.loads(GOAL_TEXT_JSON)["text"])
+        # No selfevo repo -> filter is a no-op -> priorities remain.
+        # Fewer than 3 terminal rows, so the duplicate-streak branch is False too.
+        _append_outcome(state_dir, "c1", "success")
+        assert llm_proposer.should_propose(state_dir, None) is False
+
+    def test_priorities_empty_returns_true(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "eeebot mission text with no priority-targets section.")
+        assert llm_proposer.should_propose(state_dir, None) is True
+
+    def test_last_three_all_skipped_duplicate_returns_true(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        for i in range(3):
+            _append_outcome(state_dir, f"c{i}", "skipped-duplicate")
+        assert llm_proposer.should_propose(state_dir, None) is True
+
+    def test_last_three_not_all_duplicate_returns_false(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        _append_outcome(state_dir, "c1", "skipped-duplicate")
+        _append_outcome(state_dir, "c2", "skipped-duplicate")
+        _append_outcome(state_dir, "c3", "success")
+        assert llm_proposer.should_propose(state_dir, None) is False
+
+    def test_priorities_done_via_git_log_returns_true(self, tmp_path):
+        """When a selfevo repo is supplied and its git log shows every listed
+        priority already done, the #712 filter empties "Current priority
+        targets:" -> should_propose fires even without a duplicate streak."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        repo = _make_git_repo_with_commit(
+            tmp_path,
+            "feat: write scripts/cycle_logger.py — confirmed done for cycle-999",
+            "feat: write scripts/smoke_test_loop.py — confirmed done for cycle-1000",
+        )
+        assert llm_proposer.should_propose(state_dir, repo) is True
+
+
+# ─── build_context ──────────────────────────────────────────────────────────
+
+
+class TestBuildContext:
+    def test_bounded_and_includes_goal_and_digest(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        goal_text = json.loads(GOAL_TEXT_JSON)["text"]
+        _write_goal_text(state_dir, goal_text)
+        _append_outcome(state_dir, "c1", "success")
+        _append_outcome(state_dir, "c2", "skipped-duplicate")
+
+        context = llm_proposer.build_context(state_dir, None)
+        assert len(context) <= llm_proposer._MAX_CONTEXT_CHARS
+        assert "Priority 5" in context
+        assert "success" in context
+        assert "skipped-duplicate" in context
+        assert "Mutable surface rule" in context
+
+    def test_hard_cap_enforced_with_huge_ledger(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "x" * 5000)
+        for i in range(200):
+            _append_outcome(state_dir, f"c{i}", "failed")
+        context = llm_proposer.build_context(state_dir, None)
+        assert len(context) <= llm_proposer._MAX_CONTEXT_CHARS
+
+    def test_missing_ledger_is_fail_open(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some goal text")
+        context = llm_proposer.build_context(state_dir, None)
+        assert "no ledger history yet" in context
+
+
+# ─── validate_sizing ─────────────────────────────────────────────────────────
+
+
+class TestValidateSizing:
+    def _good(self, **overrides):
+        proposal = {
+            "task_title": "Add a docstring example to scripts/loop_metrics_report.py",
+            "rationale": "Improves discoverability of the report script's CLI usage.",
+            "target_path": "scripts/loop_metrics_report.py",
+        }
+        proposal.update(overrides)
+        return proposal
+
+    def test_accepts_well_formed_proposal(self):
+        ok, reason = llm_proposer.validate_sizing(self._good())
+        assert ok is True
+        assert reason == ""
+
+    def test_rejects_none(self):
+        ok, reason = llm_proposer.validate_sizing(None)
+        assert ok is False
+        assert reason
+
+    def test_rejects_empty_title(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(task_title=""))
+        assert ok is False
+        assert "task_title" in reason
+
+    def test_rejects_long_title(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(task_title="x" * 200))
+        assert ok is False
+        assert "120" in reason
+
+    def test_rejects_missing_rationale(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(rationale=""))
+        assert ok is False
+        assert "rationale" in reason
+
+    def test_rejects_out_of_surface_path(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(target_path="nanobot/runtime/bridge.py"))
+        assert ok is False
+        assert "outside allowed surfaces" in reason
+
+    def test_rejects_multiple_paths_as_list(self):
+        ok, reason = llm_proposer.validate_sizing(
+            self._good(target_path=["scripts/a.py", "scripts/b.py"])
+        )
+        assert ok is False
+        assert "one path" in reason
+
+    def test_rejects_multiple_paths_as_string(self):
+        ok, reason = llm_proposer.validate_sizing(
+            self._good(target_path="scripts/a.py, scripts/b.py")
+        )
+        assert ok is False
+        assert "one path" in reason
+
+
+class TestProposeRetryOnce(object):
+    def test_retries_exactly_once_on_rejection(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            if rejection_reason is None:
+                return {"task_title": "", "rationale": "", "target_path": ""}  # invalid
+            return {
+                "task_title": "Fix a typo in docs/README-ish file",
+                "rationale": "Corrects a small doc mistake.",
+                "target_path": "docs/foo.md",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+        assert result is True
+        assert len(calls) == 2
+        assert calls[0] is None
+        assert calls[1] is not None
+
+    def test_gives_up_after_one_retry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        calls = []
+
+        def _always_bad(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            return {"task_title": "", "rationale": "", "target_path": ""}
+
+        monkeypatch.setattr(llm_proposer, "propose", _always_bad)
+        result = llm_proposer.maybe_propose(state_dir, None)
+        assert result is False
+        assert len(calls) == 2
+        assert not (state_dir / "subagents" / "requests").exists()
+
+
+# ─── propose() — mocked OpenAI client, no network ──────────────────────────
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self, content):
+        self._content = content
+
+    def create(self, **kwargs):
+        return _FakeResponse(self._content)
+
+
+class _FakeChat:
+    def __init__(self, content):
+        self.completions = _FakeCompletions(content)
+
+
+class _FakeClient:
+    def __init__(self, *args, content="{}", **kwargs):
+        self.chat = _FakeChat(content)
+
+
+class TestProposeMockedClient:
+    def _patch_client(self, monkeypatch, content):
+        def _factory(*args, **kwargs):
+            return _FakeClient(content=content)
+
+        import openai
+
+        monkeypatch.setattr(openai, "OpenAI", _factory)
+        monkeypatch.setenv("LITELLM_BASE_URL", "http://fake-gateway.local")
+        monkeypatch.setenv("LITELLM_API_KEY", "sk-fake")
+
+    def test_happy_path_json(self, monkeypatch):
+        self._patch_client(
+            monkeypatch,
+            json.dumps({
+                "task_title": "Add a test",
+                "rationale": "closes a gap",
+                "target_path": "tests/test_x.py",
+            }),
+        )
+        result = llm_proposer.propose("some context")
+        assert result == {
+            "task_title": "Add a test",
+            "rationale": "closes a gap",
+            "target_path": "tests/test_x.py",
+        }
+
+    def test_fenced_json(self, monkeypatch):
+        payload = {
+            "task_title": "Add a test",
+            "rationale": "closes a gap",
+            "target_path": "tests/test_x.py",
+        }
+        self._patch_client(monkeypatch, f"Sure!\n```json\n{json.dumps(payload)}\n```\n")
+        result = llm_proposer.propose("some context")
+        assert result == payload
+
+    def test_garbage_reply_returns_none(self, monkeypatch):
+        self._patch_client(monkeypatch, "not json at all, sorry")
+        assert llm_proposer.propose("some context") is None
+
+    def test_missing_gateway_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("LITELLM_BASE_URL", raising=False)
+        monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+        assert llm_proposer.propose("some context") is None
+
+
+# ─── write_request — C1 schema equality ────────────────────────────────────
+
+
+class TestWriteRequestSchemaEquality:
+    def _fixture_request(self, tmp_path) -> dict:
+        state_root = tmp_path / "fixture_state"
+        state_root.mkdir()
+        path = _write_subagent_request_artifact(
+            state_root=state_root,
+            cycle_id="cycle-fixture",
+            goal_id="goal-bootstrap",
+            current_plan={
+                "current_task_id": "subagent-verify-materialized-improvement",
+                "tasks": [],
+                "selected_task_title": "Do the thing",
+            },
+        )
+        assert path is not None
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+
+    def test_same_keys_and_queued_status(self, tmp_path):
+        fixture = self._fixture_request(tmp_path)
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Document the ledger digest helper",
+            "rationale": "Improves maintainer onboarding.",
+            "target_path": "docs/proposer-notes.md",
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+
+        assert set(written.keys()) == set(fixture.keys())
+        assert written["request_status"] == "queued" == fixture["request_status"]
+
+    def test_bridge_find_pending_request_accepts_it(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+        }
+        written_path = llm_proposer.write_request(state_dir, proposal)
+
+        found_path, found_req = bridge.find_pending_request()
+        assert found_path is not None
+        assert str(found_path) == written_path
+        assert found_req.get("request_status") == "queued"
+
+    def test_ledger_proposed_row_appended(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+        }
+        llm_proposer.write_request(state_dir, proposal)
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert len(proposed_rows) == 1
+        assert proposed_rows[0]["task_title"] == "Add a helper doc"
+        assert proposed_rows[0]["target_path"] == "docs/helper.md"
+        assert proposed_rows[0]["source_artifact"] == "llm_proposer"
+
+
+# ─── integration: maybe_propose -> bridge.find_pending_request handoff ─────
+
+
+class TestIntegrationHandoff:
+    def test_maybe_propose_writes_request_bridge_then_finds(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+
+        # Novelty-exhaustion condition: last 3 terminal rows all skipped-duplicate.
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        for i in range(3):
+            _append_outcome(state_dir, f"c{i}", "skipped-duplicate")
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            return {
+                "task_title": "Add a smoke test for the loop metrics report",
+                "rationale": "Closes a coverage gap surfaced by the ledger digest.",
+                "target_path": "tests/test_loop_metrics_extra.py",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+
+        assert llm_proposer.maybe_propose(state_dir, None) is True
+
+        found_path, found_req = bridge.find_pending_request()
+        assert found_path is not None
+        assert found_req.get("task_title", "").endswith("loop metrics report")
+        assert found_req.get("request_status") == "queued"


### PR DESCRIPTION
Implements `docs/changes/707-state-light-proposer/proposal.md` honoring the C1-C4 constraints. Refs #707, #702, #720, #710, #714.

## What
- **`nanobot/runtime/llm_proposer.py`** (446 lines): fires ONLY on novelty exhaustion (`should_propose`: flag ON ∧ no queued request ∧ (filtered goal_text has no current priorities ∨ last-3 terminal ledger outcomes all skipped-duplicate); fail-closed). Compact C3 context (filtered goal_text + bounded 15-row ledger digest, ≤4k chars) → ONE gateway call (reuses `SUBAGENT_BRIDGE_MODEL`/litellm env, no new config surface) → C2 sizing validation (single in-surface target, title bounds, retry once) → writes the **identical request JSON** the deterministic planner writes (C1; schema-equality tested), `source_artifact` → a companion `llm-proposed-*` improvement artifact carrying target/rationale in the planner's own `next_bounded_candidate` shape (build_task dereferences it transparently — zero schema change). Ledger `proposed` row for go/no-go isolation.
- **Bridge wiring: +13 lines** in the no-pending-request branch — `maybe_propose` then return; the NEXT timer cycle processes the queued proposal through the normal pre-spawn dedup → gate path (downstream untouched).
- **Kill-switch `SELFEVO_LLM_PROPOSER_ENABLED` — defaults OFF.** This PR is behaviorally inert until the operator flips the env on the host (the gated canary decision per the plan). No planner deletion.

## Tests
31 new (`tests/test_llm_proposer.py`): kill-switch, all should_propose branches, context bounds, sizing accept/6-rejects + retry-once, mocked-client propose (happy/fenced/garbage/no-env), C1 schema-equality vs a real planner request, ledger row, end-to-end `maybe_propose` → `bridge.find_pending_request` handoff. Full suite **1343 passed, 0 failed**; zero new ruff.

## Live context
The invocation condition is already true in production (planner recycling a stale hypothesis; every cycle = skipped-duplicate since P9/P10 completed) — the proposer is the structural fix, ready to canary by env flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)