### PR TITLE
fix(runtime): proposer fires on duplicate-skip cycles — queue full of dups is exhaustion (#707)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -527,6 +527,27 @@ def _tag_cycle_pre(repo_root: 'Path', cycle_id: str, main_sha: str) -> None:
         pass
 
 
+def _maybe_propose_after_skip(selfevo_repo: 'Path') -> None:
+    """Invoke the #707 LLM proposer after a pre-spawn duplicate skip.
+
+    First canary finding: the deterministic planner mints stale duplicate
+    requests faster than the bridge consumes them, so the queue never empties
+    and the no-pending-request hook in ``_main_impl`` (near the top, guarded
+    by ``if not req_path``) never runs — a queue full of duplicates IS
+    novelty exhaustion. Called from the ``already_done`` and
+    ``_recent_failure_match`` pre-spawn skip branches, after their terminal
+    ledger/result bookkeeping, right before their ``return 0``. Fails open
+    (``maybe_propose`` never raises), so this is safe to call unconditionally.
+    The written request (if any) queues behind whatever stale requests remain
+    and is picked up oldest-first over the next few cycles as the queue
+    drains — no reordering logic needed.
+    """
+    if llm_proposer.maybe_propose(STATE_DIR, selfevo_repo):
+        _proposer_req_path, _proposer_req = find_pending_request()
+        _proposer_title = (_proposer_req or {}).get('task_title') or '(untitled)'
+        print(f'llm-proposer: queued {_proposer_title}')
+
+
 def _tag_cycle_post(repo_root: 'Path', cycle_id: str, outcome: str, sha: str | None = None) -> None:
     """Tag ``cycle-<id>-<outcome>`` at the terminal HEAD — the post half of the #721 bracket.
 
@@ -1367,6 +1388,9 @@ async def _main_impl():
         record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done', [], None)
         # #721: no cycle branch on this path — tag at current HEAD.
         _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
+        # #707: a queue full of stale duplicates is novelty exhaustion too —
+        # give the proposer a chance to fire here, not just on an empty queue.
+        _maybe_propose_after_skip(_selfevo_repo_check)
         return 0
     # #716: _task_already_done above only catches proposals that already landed
     # as a real git commit. A proposal that was blocked/rolled-back/produced no
@@ -1408,6 +1432,9 @@ async def _main_impl():
         record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'recent_duplicate_failure', [], None)
         # #721: no cycle branch on this path — tag at current HEAD.
         _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
+        # #707: a queue full of stale duplicates is novelty exhaustion too —
+        # give the proposer a chance to fire here, not just on an empty queue.
+        _maybe_propose_after_skip(_selfevo_repo_check)
         return 0
 
     else:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -76,7 +76,34 @@ def _requests_dir(state_dir: Path) -> Path:
     return Path(state_dir) / "subagents" / "requests"
 
 
-def _has_queued_request(state_dir: Path) -> bool:
+def _is_proposer_request(req: dict[str, Any]) -> bool:
+    """True iff ``req`` is a request this module itself wrote (``write_request``).
+
+    Matches on the same markers ``write_request`` sets: a ``request_id``
+    prefixed ``llm-proposer-``, or a ``source_artifact`` whose filename is
+    prefixed ``llm-proposed-`` (the companion artifact this module writes
+    under ``improvements/``). Either alone is sufficient — a request forged
+    or replayed with only one of the two markers is still ours.
+    """
+    request_id = str(req.get("request_id") or "")
+    if request_id.startswith("llm-proposer-"):
+        return True
+    source_artifact = str(req.get("source_artifact") or "")
+    return Path(source_artifact).name.startswith("llm-proposed-")
+
+
+def _has_queued_proposer_request(state_dir: Path) -> bool:
+    """Anti-stacking guard: is there already a queued proposer-written request?
+
+    Deliberately narrower than "any queued request" (#707 canary finding):
+    in production the deterministic planner mints stale duplicate requests
+    faster than the bridge consumes them, so the queue never empties and a
+    "no queued request at all" clause meant the proposer could never fire —
+    a queue full of planner duplicates IS novelty exhaustion, not a reason to
+    stay silent. Only a request this module already queued blocks a new one,
+    preventing unbounded proposer stacking while still firing on planner-only
+    queues.
+    """
     req_dir = _requests_dir(state_dir)
     if not req_dir.is_dir():
         return False
@@ -88,7 +115,7 @@ def _has_queued_request(state_dir: Path) -> bool:
         if not isinstance(req, dict):
             continue
         status = str(req.get("request_status") or req.get("status") or "").strip().lower()
-        if status in ("queued", "pending"):
+        if status in ("queued", "pending") and _is_proposer_request(req):
             return True
     return False
 
@@ -152,11 +179,16 @@ def _last_k_all_duplicate(state_dir: Path, k: int = _DUP_STREAK_K) -> bool:
 def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
     """Invocation policy (#707): fires only on proven novelty exhaustion.
 
-    ``(no queued request) AND (filtered goal_text has no remaining "Current
-    priority targets" entries OR the last K=3 terminal ledger outcome rows
-    are all "skipped-duplicate")``. Fail-closed: any error, or a completely
-    missing/unreadable state directory, returns ``False``. Always ``False``
-    when the kill switch (``SELFEVO_LLM_PROPOSER_ENABLED``) is off.
+    ``(no queued proposer request) AND (filtered goal_text has no remaining
+    "Current priority targets" entries OR the last K=3 terminal ledger
+    outcome rows are all "skipped-duplicate")``. The queue clause is an
+    anti-stacking guard on the proposer's OWN requests only (see
+    ``_has_queued_proposer_request``) — a queued planner request no longer
+    blocks proposing, since a queue full of stale planner duplicates is
+    itself the novelty-exhaustion signal this function exists to catch.
+    Fail-closed: any error, or a completely missing/unreadable state
+    directory, returns ``False``. Always ``False`` when the kill switch
+    (``SELFEVO_LLM_PROPOSER_ENABLED``) is off.
     """
     if not _enabled():
         return False
@@ -164,7 +196,7 @@ def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
         state_dir = Path(state_dir)
         if not state_dir.is_dir():
             return False
-        if _has_queued_request(state_dir):
+        if _has_queued_proposer_request(state_dir):
             return False
         goal_text_path = state_dir / "goals" / "goal_text.json"
         if not goal_text_path.is_file():

--- a/tests/test_cycle_ledger.py
+++ b/tests/test_cycle_ledger.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from nanobot.runtime import bridge, cycle_ledger
+from nanobot.runtime import bridge, cycle_ledger, llm_proposer
 
 
 def _read_ledger(state_dir: Path) -> list[dict]:
@@ -324,3 +324,30 @@ class TestBridgeIntegrationLedgerRows:
         assert phases == ["started", "dedup", "outcome"]
         assert rows[1]["decision"] == "skipped_duplicate"
         assert rows[2]["outcome"] == "skipped-duplicate"
+
+    def test_already_done_skip_invokes_llm_proposer(self, tmp_path, monkeypatch):
+        """#707 canary fix: the already_done pre-spawn skip must also give the
+        LLM proposer a chance to fire (a queue full of stale duplicates is
+        novelty exhaustion too) — not just the no-pending-request path."""
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "_task_already_done", lambda *_a, **_k: True)
+
+        calls = []
+        monkeypatch.setattr(
+            llm_proposer, "maybe_propose", lambda *a, **k: calls.append((a, k)) or False
+        )
+
+        _seed_bridge_request(
+            state_dir, "req-dup2", "cycle-dup2", task_title="implement thing xyz already done",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+        assert len(calls) == 1
+        assert calls[0][0][0] == state_dir

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -74,13 +74,50 @@ class TestShouldPropose:
     def test_missing_state_dir_returns_false(self, tmp_path):
         assert llm_proposer.should_propose(tmp_path / "does-not-exist", None) is False
 
-    def test_queued_request_present_returns_false(self, tmp_path):
+    def test_queued_planner_request_no_longer_blocks(self, tmp_path):
+        """#707 canary fix: a stale PLANNER-written request queued does NOT
+        block the proposer — a queue full of planner duplicates is itself
+        the novelty-exhaustion signal should_propose exists to catch."""
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, "no priority section")
         req_dir = state_dir / "subagents" / "requests"
         req_dir.mkdir(parents=True)
         (req_dir / "request-x.json").write_text(
-            json.dumps({"request_status": "queued"}), encoding="utf-8"
+            json.dumps({"request_status": "queued", "request_id": "cycle-abc123"}),
+            encoding="utf-8",
+        )
+        assert llm_proposer.should_propose(state_dir, None) is True
+
+    def test_queued_proposer_request_blocks_anti_stacking(self, tmp_path):
+        """A queued request the proposer itself already wrote DOES block a
+        second proposal (anti-stacking guard)."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section")
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-y.json").write_text(
+            json.dumps(
+                {"request_status": "queued", "request_id": "llm-proposer-cycle-abc123"}
+            ),
+            encoding="utf-8",
+        )
+        assert llm_proposer.should_propose(state_dir, None) is False
+
+    def test_queued_proposer_request_by_source_artifact_blocks(self, tmp_path):
+        """The anti-stacking guard also matches on source_artifact filename
+        (llm-proposed-*) alone, for a request missing the request_id marker."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section")
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-z.json").write_text(
+            json.dumps(
+                {
+                    "request_status": "queued",
+                    "source_artifact": "/some/path/llm-proposed-cycle-abc123.json",
+                }
+            ),
+            encoding="utf-8",
         )
         assert llm_proposer.should_propose(state_dir, None) is False
 
@@ -124,6 +161,39 @@ class TestShouldPropose:
             "feat: write scripts/smoke_test_loop.py — confirmed done for cycle-1000",
         )
         assert llm_proposer.should_propose(state_dir, repo) is True
+
+    def test_stale_planner_request_plus_dup_streak_fires_then_self_blocks(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end #707 canary scenario: a stale PLANNER request sits
+        queued (never consumed) while the last 3 terminal outcomes are all
+        skipped-duplicate. should_propose must be True despite the queued
+        request. After one successful maybe_propose call writes its own
+        (proposer) request, a second should_propose call is False — the
+        anti-stacking guard now sees ITS OWN queued request."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        for i in range(3):
+            _append_outcome(state_dir, f"c{i}", "skipped-duplicate")
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-stale.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": "cycle-stale123"}),
+            encoding="utf-8",
+        )
+
+        assert llm_proposer.should_propose(state_dir, None) is True
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            return {
+                "task_title": "Fix a typo in docs/README-ish file",
+                "rationale": "Corrects a small doc mistake.",
+                "target_path": "docs/foo.md",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        assert llm_proposer.maybe_propose(state_dir, None) is True
+        assert llm_proposer.should_propose(state_dir, None) is False
 
 
 # ─── build_context ──────────────────────────────────────────────────────────


### PR DESCRIPTION
First #707 canary finding (live): the planner mints stale duplicate requests faster than the bridge consumes them, so the queue never empties and the no-request proposer hook never ran (0 'proposed' ledger rows in production). Refs #707.

## Fix (minimal)
- `should_propose`: queue-empty clause → **anti-stacking guard** (`_has_queued_proposer_request` — only the proposer's own queued request blocks; a stale planner request no longer suppresses proposing).
- Bridge: `_maybe_propose_after_skip()` helper invoked from both pre-spawn skip branches (already_done + recent-failure) — a queue full of duplicates IS novelty exhaustion. Original no-request hook untouched. Proposals drain behind remaining stale requests within a few cycles (oldest-first; no reordering logic).

## Tests
+4 (anti-stacking by request_id and source_artifact; stale-planner-request + dup-streak fires then self-blocks; already_done-skip invokes maybe_propose in the _main_impl harness). Full suite **1347 passed, 0 failed**; zero new ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)