### PR TITLE
fix(runtime): proposer diversity — self-dedup, rejected-themes digest, prefer numbered priorities (#707)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -30,7 +30,11 @@ from pathlib import Path
 from typing import Any
 
 from nanobot.runtime.cycle_ledger import append_event
-from nanobot.runtime.cycle_planning import filter_completed_priorities_from_goal_text
+from nanobot.runtime.cycle_planning import (
+    _recent_git_log,
+    _title_already_done_in_git_log,
+    filter_completed_priorities_from_goal_text,
+)
 
 ENABLED_ENV = "SELFEVO_LLM_PROPOSER_ENABLED"
 _TRUTHY = {"1", "true", "yes", "on"}
@@ -46,6 +50,8 @@ _MAX_CONTEXT_CHARS = 4000
 _LEDGER_DIGEST_ROWS = 15
 _DUP_STREAK_K = 3
 _MAX_TITLE_CHARS = 120
+_RECENT_PROPOSED_TITLES_N = 10
+_MAX_LLM_CALLS = 3
 
 _PRIORITY_PATTERN = re.compile(
     r"\([A-Za-z]\)\s*Priority\s+(\d+)\s*[—-]\s*(.+?):\s*(.+?)(?=\n\([A-Za-z]\)|\Z)",
@@ -64,7 +70,10 @@ _PROPOSER_SYSTEM_PROMPT = (
     "surfaces/, scripts/, memory/, lessons/, docs/, tests/ — no other path is "
     "acceptable. rationale must briefly justify the change and must NOT "
     "repeat any already-done or recently-failed work described in the "
-    "context below."
+    "context below. If the goal text lists numbered 'Current priority "
+    "targets', propose EXACTLY one of them (the first not yet done) "
+    "VERBATIM as the task; only invent a new task when no numbered "
+    "priorities remain."
 )
 
 
@@ -168,6 +177,26 @@ def _terminal_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [r for r in rows if r.get("phase") == "outcome"]
 
 
+def _proposed_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [r for r in rows if r.get("phase") == "proposed"]
+
+
+def _recent_proposed_titles(rows: list[dict[str, Any]], n: int = _RECENT_PROPOSED_TITLES_N) -> list[str]:
+    """Titles from the last ``n`` 'proposed' ledger rows (this module's own
+    write_request appends one per proposal, whether or not it was later
+    consumed/rejected by the bridge). Unlike ``'outcome'`` rows, ``'proposed'``
+    rows always carry ``task_title`` — this is the only ledger phase that can
+    reconstruct "what did the proposer already suggest" for #707 canary
+    novelty-collapse detection (rejected-as-duplicate proposals never reach
+    git log, since no commit is ever made for them)."""
+    titles: list[str] = []
+    for row in _proposed_rows(rows)[-n:]:
+        title = str(row.get("task_title") or "").strip()
+        if title:
+            titles.append(title)
+    return titles
+
+
 def _last_k_all_duplicate(state_dir: Path, k: int = _DUP_STREAK_K) -> bool:
     terminal = _terminal_rows(_load_ledger_rows(state_dir))
     if len(terminal) < k:
@@ -235,7 +264,9 @@ def build_context(state_dir: Path, selfevo_repo: Path | None) -> str:
         state_dir = Path(state_dir)
         raw_goal_text = _load_goal_text(state_dir)
         filtered_goal = filter_completed_priorities_from_goal_text(raw_goal_text, selfevo_repo)
-        digest_lines = _digest_ledger(_load_ledger_rows(state_dir))
+        ledger_rows = _load_ledger_rows(state_dir)
+        digest_lines = _digest_ledger(ledger_rows)
+        recent_proposed_titles = _recent_proposed_titles(ledger_rows)
         surface_rule = (
             "Mutable surface rule: target_path MUST be a single path under "
             "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + " — no other "
@@ -247,6 +278,9 @@ def build_context(state_dir: Path, selfevo_repo: Path | None) -> str:
             "",
             "## Recent cycle outcomes (most recent last — do not repeat done/failed work)",
             "\n".join(f"- {line}" for line in digest_lines) or "(no ledger history yet)",
+            "",
+            "## Recently proposed (rejected as duplicates — do NOT propose these themes again)",
+            "\n".join(f"- {title}" for title in recent_proposed_titles) or "(none yet)",
             "",
             surface_rule,
         ]
@@ -351,6 +385,41 @@ def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
     return True, ""
 
 
+def _is_duplicate_proposal(
+    state_dir: Path, selfevo_repo: Path | None, proposal: dict[str, Any]
+) -> tuple[bool, str]:
+    """Pre-write self-dedup (#707 canary novelty collapse).
+
+    Reuses the SAME per-line proportional word-overlap heuristic the bridge
+    and deterministic planner already use for "is this title already done"
+    (``cycle_planning._title_already_done_in_git_log``), fed with two sources
+    concatenated: the recent git log (already-DONE work) and this proposer's
+    own recent ``'proposed'`` ledger titles (already-REJECTED-as-duplicate
+    work, which never reaches git log since no commit is ever made for it).
+    Either source matching is sufficient to flag a duplicate.
+
+    Returns ``(True, feedback_text)`` on a match — ``feedback_text`` is meant
+    to be passed as ``propose()``'s ``rejection_reason`` on retry. Fail-open:
+    any error is treated as "not a duplicate".
+    """
+    try:
+        title = str(proposal.get("task_title") or "").strip()
+        if not title:
+            return False, ""
+        git_log = _recent_git_log(Path(selfevo_repo)) if selfevo_repo else ""
+        recent_titles = _recent_proposed_titles(_load_ledger_rows(state_dir))
+        combined_log = "\n".join([git_log] + recent_titles) if (git_log or recent_titles) else ""
+        if combined_log and _title_already_done_in_git_log(title, combined_log):
+            return True, (
+                f"your proposal '{title}' duplicates already-done or "
+                "recently-rejected work; propose something from a DIFFERENT "
+                "area, preferring the numbered Current priority targets"
+            )
+        return False, ""
+    except Exception:
+        return False, ""
+
+
 def _active_goal_id(state_dir: Path) -> str:
     try:
         path = Path(state_dir) / "goals" / "registry.json"
@@ -448,8 +517,17 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
 
 
 def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
-    """Single public entrypoint (#707): build context, propose, validate
-    (with one retry on rejection), and write the request if valid.
+    """Single public entrypoint (#707, hardened for the canary novelty-
+    collapse defect): build context, propose, validate sizing (with one
+    retry on rejection), self-dedup (with one retry-with-feedback), and
+    write the request if valid.
+
+    At most :data:`_MAX_LLM_CALLS` (3) chat completions are made per call:
+    an initial proposal, an optional sizing-rejection retry, and an optional
+    dedup-rejection retry — the two retry budgets share this one cap rather
+    than stacking additively, so a proposal that fails sizing twice never
+    also gets a dedup retry, and a proposal that fails dedup after a sizing
+    retry gets exactly one more try.
 
     Returns ``True`` iff a request was written this call. Never raises —
     every step is individually fail-open, and the whole function is wrapped
@@ -464,12 +542,27 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
         if not context:
             return False
 
+        calls_made = 0
+
         proposal = propose(context)
+        calls_made += 1
         ok, reason = validate_sizing(proposal)
-        if not ok:
+        if not ok and calls_made < _MAX_LLM_CALLS:
             proposal = propose(context, rejection_reason=reason)
+            calls_made += 1
             ok, reason = validate_sizing(proposal)
         if not ok:
+            return False
+
+        dup, dup_reason = _is_duplicate_proposal(state_dir, selfevo_repo, proposal)
+        if dup and calls_made < _MAX_LLM_CALLS:
+            proposal = propose(context, rejection_reason=dup_reason)
+            calls_made += 1
+            ok, reason = validate_sizing(proposal)
+            if not ok:
+                return False
+            dup, dup_reason = _is_duplicate_proposal(state_dir, selfevo_repo, proposal)
+        if dup:
             return False
 
         write_request(state_dir, proposal)

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -35,6 +35,18 @@ def _write_goal_text(state_dir: Path, text: str) -> None:
     )
 
 
+def _append_proposed(state_dir: Path, cycle_id: str, task_title: str) -> None:
+    cycle_ledger.append_event(
+        state_dir,
+        {
+            "phase": "proposed",
+            "cycle_id": cycle_id,
+            "task_title": task_title,
+            "source_artifact": "llm_proposer",
+        },
+    )
+
+
 def _append_outcome(state_dir: Path, cycle_id: str, outcome: str) -> None:
     cycle_ledger.append_event(
         state_dir, {"phase": "outcome", "cycle_id": cycle_id, "outcome": outcome}
@@ -228,6 +240,29 @@ class TestBuildContext:
         context = llm_proposer.build_context(state_dir, None)
         assert "no ledger history yet" in context
 
+    def test_recent_proposed_titles_appear_under_rejected_block(self, tmp_path):
+        """#707 canary fix: proposer-written 'proposed' ledger rows (which
+        DO carry task_title, unlike 'outcome' rows) surface under a clearly
+        labeled do-not-repeat block, so the model sees its own recent
+        (rejected-as-duplicate) proposals."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        _append_proposed(state_dir, "c1", "Implement lightweight memory usage tracker")
+        _append_proposed(state_dir, "c2", "Implement lightweight resource usage monitor")
+
+        context = llm_proposer.build_context(state_dir, None)
+        assert "Recently proposed" in context
+        assert "do NOT propose these themes again" in context
+        assert "Implement lightweight memory usage tracker" in context
+        assert "Implement lightweight resource usage monitor" in context
+        assert len(context) <= llm_proposer._MAX_CONTEXT_CHARS
+
+    def test_no_proposed_rows_shows_none_yet(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        context = llm_proposer.build_context(state_dir, None)
+        assert "(none yet)" in context
+
 
 # ─── validate_sizing ─────────────────────────────────────────────────────────
 
@@ -328,6 +363,157 @@ class TestProposeRetryOnce(object):
         assert result is False
         assert len(calls) == 2
         assert not (state_dir / "subagents" / "requests").exists()
+
+
+# ─── #707 canary: pre-write self-dedup + retry-with-feedback ──────────────
+
+
+class TestSelfDedup:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+
+    def test_duplicate_via_git_log_retries_then_writes_novel_title(self, tmp_path, monkeypatch):
+        """A proposal whose title matches an already-committed piece of work
+        (the #575 heuristic, via the temp git repo) is rejected pre-write;
+        the retry prompt carries explicit duplicate feedback, and a novel
+        retry title is written."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        repo = _make_git_repo_with_commit(
+            tmp_path,
+            "feat: implement lightweight memory and cpu profiling script for eeepc host",
+        )
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            if rejection_reason is None:
+                return {
+                    "task_title": "Implement lightweight memory and CPU profiling script",
+                    "rationale": "Tracks resource usage.",
+                    "target_path": "scripts/profile.py",
+                }
+            return {
+                "task_title": "Add a smoke test for the loop metrics report",
+                "rationale": "Closes an unrelated coverage gap.",
+                "target_path": "tests/test_loop_metrics_extra.py",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, repo)
+
+        assert result is True
+        assert len(calls) == 2
+        assert calls[0] is None
+        assert "duplicates already-done" in calls[1]
+        assert "DIFFERENT area" in calls[1]
+
+        req_dir = state_dir / "subagents" / "requests"
+        written = [json.loads(p.read_text(encoding="utf-8")) for p in req_dir.glob("*.json")]
+        assert len(written) == 1
+        assert "loop metrics report" in written[0]["task_title"]
+
+    def test_duplicate_via_recent_proposed_titles_rejected(self, tmp_path, monkeypatch):
+        """A title never committed to git (no selfevo repo at all here) but
+        matching a recent 'proposed' ledger row is still caught — this is
+        the case the canary hit: 6 clones in a row, each correctly bridge-
+        skipped as a duplicate, so no commit for any of them ever landed."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        _append_proposed(state_dir, "c-old", "Implement lightweight memory usage monitor for eeepc")
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            if rejection_reason is None:
+                return {
+                    "task_title": "Implement lightweight memory usage tracker",
+                    "rationale": "Tracks memory usage.",
+                    "target_path": "scripts/mem.py",
+                }
+            return {
+                "task_title": "Document the release checklist",
+                "rationale": "Fills a documentation gap.",
+                "target_path": "docs/release.md",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+
+        assert result is True
+        assert len(calls) == 2
+        assert calls[1] is not None
+
+    def test_both_duplicate_gives_up_without_writing(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        repo = _make_git_repo_with_commit(
+            tmp_path,
+            "feat: implement lightweight memory and cpu profiling script for eeepc host",
+        )
+
+        calls = []
+
+        def _always_clone(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            return {
+                "task_title": "Implement lightweight memory and CPU profiling script",
+                "rationale": "Tracks resource usage.",
+                "target_path": "scripts/profile.py",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _always_clone)
+        result = llm_proposer.maybe_propose(state_dir, repo)
+
+        assert result is False
+        assert len(calls) <= 3
+        assert len(calls) == 2  # sizing passes both times; only the dedup retry is spent
+        assert not (state_dir / "subagents" / "requests").exists()
+
+
+# ─── prompt: prefer numbered "Current priority targets" ────────────────────
+
+
+class TestPromptPrioritiesPreference:
+    def test_system_prompt_prefers_numbered_priorities(self, monkeypatch):
+        captured: dict = {}
+
+        class _CapturingCompletions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeResponse(
+                    json.dumps(
+                        {
+                            "task_title": "x",
+                            "rationale": "y",
+                            "target_path": "docs/z.md",
+                        }
+                    )
+                )
+
+        class _CapturingChat:
+            def __init__(self):
+                self.completions = _CapturingCompletions()
+
+        class _CapturingClient:
+            def __init__(self, *args, **kwargs):
+                self.chat = _CapturingChat()
+
+        import openai
+
+        monkeypatch.setattr(openai, "OpenAI", lambda *a, **kw: _CapturingClient())
+        monkeypatch.setenv("LITELLM_BASE_URL", "http://fake-gateway.local")
+        monkeypatch.setenv("LITELLM_API_KEY", "sk-fake")
+
+        llm_proposer.propose("some context")
+
+        messages = captured["messages"]
+        system_msg = next(m["content"] for m in messages if m["role"] == "system")
+        assert "Current priority targets" in system_msg
+        assert "VERBATIM" in system_msg
 
 
 # ─── propose() — mocked OpenAI client, no network ──────────────────────────


### PR DESCRIPTION
Canary iteration 2 for #707. Six hours live showed proposer novelty collapse: 6/6 follow-up proposals were semantic clones of the first integrated task (each correctly pre-spawn skipped; genuinely_new 1/7 vs the 0.60 go/no-go bar). Refs #707.

## Fix (llm_proposer.py only)
1. **Pre-write self-dedup**: proposal title checked via the same #575 heuristic (`cycle_planning` helpers — no bridge import) against git log AND the last 10 'proposed' ledger titles; one retry with explicit duplicate feedback; hard cap 3 LLM calls/invocation (sizing+dedup retries share the budget).
2. **Do-not-repeat context block**: `build_context` includes the last ~10 proposer titles from ledger 'proposed' rows (outcome rows carry no titles) under a labeled rejected-themes block, within the 4k cap.
3. **Prefer numbered priorities**: prompt now instructs proposing the first not-yet-done "Current priority target" VERBATIM before inventing anything (P11/P12 sat unused while the model anchored on vector prose).

## Tests
+6 (self-dedup git-log/proposed-title/give-up paths, prompt instruction, context block). Full suite **1353 passed, 0 failed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)