### PR TITLE
fix(runtime): bulk-skip no longer wedges on marker-mismatched requests (#733)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -149,7 +149,12 @@ def find_pending_request() -> tuple[Path | None, dict]:
         if status not in ('queued', 'pending'):
             continue
         rid = req.get('request_id') or req.get('verification_task_id') or str(path)
-        if rid in real_handled or str(path) in real_handled:
+        # Bridge handled markers are filed under the SANITIZED id (see
+        # `safe_id = request_id.replace('/', '_')[:120]` below); compare that
+        # form too, or a raw id containing sanitized characters (e.g. '/')
+        # slips this filter and gets returned forever (#733 wedge).
+        safe_rid = rid.replace('/', '_')[:120]
+        if rid in real_handled or safe_rid in real_handled or str(path) in real_handled:
             continue
         return path, req
     return None, {}
@@ -1187,8 +1192,22 @@ async def _main_impl():
     # skipped request, since no skip branch touches the cycle-branch/repo
     # state it guards against.
     _precondition_checked = False
+    # #733 follow-up: a request whose handled marker exists under the
+    # SANITIZED request_id can still slip find_pending_request's real_handled
+    # filter (which compares the RAW request_id/marker stem) and keep being
+    # returned every iteration — wedging the bulk-skip loop at one skip per
+    # run. Track paths already returned this run; if the same path comes back
+    # we cannot make progress, so end the run cleanly instead of looping
+    # forever (defense-in-depth alongside turning the marker-exists branch
+    # below into a `continue`).
+    _seen_req_paths: set[str] = set()
     while True:
         req_path, req = find_pending_request()
+        if req_path is not None:
+            if str(req_path) in _seen_req_paths:
+                print('bridge: find_pending_request returned the same request twice this run; ending run')
+                return 0
+            _seen_req_paths.add(str(req_path))
         if not req_path:
             # #707: state-light LLM proposer — only fires on proven novelty
             # exhaustion (see llm_proposer.should_propose), behind the
@@ -1215,7 +1234,11 @@ async def _main_impl():
         handled_marker = BRIDGE_STATE_DIR / f'handled_{safe_id}.txt'
         if handled_marker.exists():
             print('already_handled')
-            return 0
+            # #733 follow-up: don't cap the whole run on one already-marked
+            # request — the _seen_req_paths guard above now protects against
+            # find_pending_request re-returning the same request forever, so
+            # it's safe to step over this one and keep bulk-skipping.
+            continue
 
         # #720: cycle_id resolved once, up front, so every ledger row for this
         # cycle (write-ahead start, dedup, gate, terminal outcome) joins on the

--- a/tests/test_bridge_bulk_skip.py
+++ b/tests/test_bridge_bulk_skip.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 
 import pytest
 
@@ -203,3 +204,196 @@ class TestMaxSkipsEnvParsing:
             assert self._reload_with_env(monkeypatch, "3") == 3
         finally:
             importlib.reload(bridge)
+
+
+class TestMarkerWedgeDoesNotCapRunAtOneSkip:
+    """Live-found #733 follow-up: find_pending_request can return a request
+    whose handled marker exists under the SANITIZED request_id (the marker
+    filename uses ``safe_id = request_id.replace('/', '_')``) while its own
+    filter compares the RAW request_id/marker stem — so a request whose raw
+    id contains sanitized characters slips the filter and is returned again
+    and again. The old marker-exists branch did ``return 0``, so one wedged
+    request near the queue head capped the whole run at one skip.
+    """
+
+    def test_wedged_request_stepped_over_via_continue(self, tmp_path, monkeypatch):
+        """queue = [dup, wedged (marker exists, but find_pending_request still
+        returns it), dup, novel] processed in ONE run: both dups skipped, the
+        wedged request is stepped over via `continue` (not `return 0`), and
+        the novel request spawns — matching the live-found bulk-skip
+        expectation of at most one spawn per run.
+
+        find_pending_request itself is stubbed here (not exercised) so this
+        test isolates the loop's OWN defense-in-depth (the marker-exists
+        `continue`) from the find_pending_request filter fix covered by
+        TestFindPendingRequestSanitizedMarkerFilter below.
+        """
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        _init_selfevo_repo(base)
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        bridge_state_dir = state_dir / "subagent_bridge"
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", bridge_state_dir)
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "SubagentManager", _FakeSubagentManager)
+        monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+        monkeypatch.setattr(
+            bridge, "_task_already_done",
+            lambda title, _repo: title.startswith("dup"),
+        )
+
+        spawn_calls = []
+        real_spawn = _FakeSubagentManager.spawn
+
+        async def _counting_spawn(self, **kwargs):
+            spawn_calls.append(1)
+            return await real_spawn(self, **kwargs)
+
+        monkeypatch.setattr(_FakeSubagentManager, "spawn", _counting_spawn)
+
+        _seed_bridge_request(state_dir, "req-dup-1", "cycle-dup-1", task_title="dup task alpha")
+        # Wedged request: raw request_id contains '/', its handled marker was
+        # filed (by a hypothetical prior run) under the SANITIZED id — but a
+        # future sanitization edge case could make find_pending_request return
+        # it anyway. Content isn't relevant here since find_pending_request is
+        # stubbed; the marker file existing is what the loop must catch.
+        wedged_req_id = "wedge/task/one"
+        wedged_cycle_id = "cycle-wedge-1"
+        wedged_path = state_dir / "subagents" / "requests" / "request-wedge.json"
+        wedged_path.parent.mkdir(parents=True, exist_ok=True)
+        wedged_req = {
+            "request_id": wedged_req_id,
+            "cycle_id": wedged_cycle_id,
+            "task_title": "mismatched marker task",
+        }
+        wedged_path.write_text(json.dumps(wedged_req), encoding="utf-8")
+        bridge_state_dir.mkdir(parents=True, exist_ok=True)
+        safe_wedged_id = wedged_req_id.replace("/", "_")[:120]
+        (bridge_state_dir / f"handled_{safe_wedged_id}.txt").write_text(
+            str(wedged_path), encoding="utf-8",
+        )
+
+        _seed_bridge_request(state_dir, "req-dup-2", "cycle-dup-2", task_title="dup task beta")
+        _seed_bridge_request(state_dir, "req-novel", "cycle-novel", task_title="totally novel feature widget")
+
+        dup1_path = state_dir / "subagents" / "requests" / "req-dup-1.json"
+        dup2_path = state_dir / "subagents" / "requests" / "req-dup-2.json"
+        novel_path = state_dir / "subagents" / "requests" / "req-novel.json"
+
+        _sequence = [dup1_path, wedged_path, dup2_path, novel_path]
+        _calls = {"n": 0}
+
+        def _fake_find_pending_request():
+            idx = _calls["n"]
+            _calls["n"] += 1
+            if idx >= len(_sequence):
+                return None, {}
+            path = _sequence[idx]
+            req = json.loads(path.read_text(encoding="utf-8"))
+            return path, req
+
+        monkeypatch.setattr(bridge, "find_pending_request", _fake_find_pending_request)
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        # Exactly one spawn for the whole run (S6 invariant), for the novel request.
+        assert len(spawn_calls) == 1
+
+        rows = _read_ledger(state_dir)
+        for cid in ("cycle-dup-1", "cycle-dup-2"):
+            crows = _rows_for_cycle(rows, cid)
+            assert crows[-1]["outcome"] == "skipped-duplicate"
+
+        # The wedged request was stepped over (continue), not treated as a
+        # run-ending event — no ledger row was written for it at all (the
+        # marker-exists branch just prints and continues, same as before #733).
+        wedged_rows = _rows_for_cycle(rows, wedged_cycle_id)
+        assert wedged_rows == []
+
+        novel_rows = _rows_for_cycle(rows, "cycle-novel")
+        assert novel_rows[-1]["outcome"] == "success"
+
+
+class TestSamePathReturnedTwiceEndsRunCleanly:
+    def test_same_path_repeated_breaks_loop(self, tmp_path, monkeypatch):
+        """If find_pending_request keeps returning the SAME request path
+        (e.g. a future sanitization edge case the marker-exists branch alone
+        doesn't catch), the loop must not spin forever — it ends the run
+        cleanly the second time the same path comes back.
+        """
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        _init_selfevo_repo(base)
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(
+            bridge, "_task_already_done",
+            lambda title, _repo: title.startswith("dup"),
+        )
+
+        _seed_bridge_request(state_dir, "req-dup-1", "cycle-dup-1", task_title="dup task alpha")
+        dup1_path = state_dir / "subagents" / "requests" / "req-dup-1.json"
+        dup1_req = json.loads(dup1_path.read_text(encoding="utf-8"))
+
+        _calls = {"n": 0}
+
+        def _fake_find_pending_request():
+            _calls["n"] += 1
+            return dup1_path, dup1_req
+
+        monkeypatch.setattr(bridge, "find_pending_request", _fake_find_pending_request)
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        # find_pending_request was called exactly twice: once to get the
+        # request, once more to discover it's the same path again — at which
+        # point the run ends instead of looping forever.
+        assert _calls["n"] == 2
+
+        rows = _read_ledger(state_dir)
+        crows = _rows_for_cycle(rows, "cycle-dup-1")
+        assert crows[-1]["outcome"] == "skipped-duplicate"
+
+        markers = list((state_dir / "subagent_bridge").glob("handled_*.txt"))
+        assert len(markers) == 1
+
+
+class TestFindPendingRequestSanitizedMarkerFilter:
+    """Root-cause hardening: find_pending_request's real_handled filter now
+    also compares the SANITIZED form of each candidate's request_id, matching
+    how the bridge names its handled markers (``safe_id =
+    request_id.replace('/', '_')[:120]``). A request whose marker exists
+    under the sanitized id must not be returned at all, independent of the
+    loop-level defenses above.
+    """
+
+    def test_marker_under_sanitized_id_filters_out_raw_id_request(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        bridge_state_dir = state_dir / "subagent_bridge"
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", bridge_state_dir)
+
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        raw_request_id = "task/with/slash"
+        req_path = req_dir / "request-x.json"
+        req_path.write_text(
+            json.dumps({"request_id": raw_request_id, "cycle_id": "cycle-x", "status": "queued"}),
+            encoding="utf-8",
+        )
+
+        bridge_state_dir.mkdir(parents=True)
+        safe_id = raw_request_id.replace("/", "_")[:120]
+        (bridge_state_dir / f"handled_{safe_id}.txt").write_text(str(req_path), encoding="utf-8")
+
+        result_path, result_req = bridge.find_pending_request()
+        assert result_path is None
+        assert result_req == {}


### PR DESCRIPTION
Live acceptance of #733 found the bulk loop capped at ONE skip per run: a queued request whose handled marker exists under the SANITIZED id (while find_pending_request filtered by the raw id) kept being returned, and the marker-exists branch returned instead of continuing — wedging the queue while the planner mints ~1 dup/10min. Refs #733.

## Fix
1. **Root cause** (find_pending_request, 5 lines): the filter now also matches the sanitized form of the candidate's request_id against real_handled — marker-mismatched requests are no longer returned at all.
2. **Defense in depth**: per-run `_seen_req_paths` set — the same path returned twice ends the run cleanly (no infinite loop possible).
3. Marker-exists branch: `return 0` → `continue` (safe under the seen-set guard).

## Tests
+3 (wedge scenario stepped over with one spawn; same-path-twice clean break; sanitized-marker request not returned). Full suite **1364 passed, 0 failed**; zero new ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)