### PR TITLE
fix(runtime): pre-spawn dedup respects target_path — no more keyword false-positives (#736)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1392,7 +1392,39 @@ async def _main_impl():
         # WITHOUT changing _task_already_done itself or the bookkeeping identity
         # (backlog_title) used below.
         _dup_check_title = _duplicate_check_title(req, backlog_title)
-        if _dup_check_title and _task_already_done(_dup_check_title, _selfevo_repo_check):
+        # #736: LLM-proposed requests always carry a `Target path: <path>`
+        # line in their task text. The plain keyword heuristic above matches
+        # against the WHOLE 7-day git log, which becomes saturated with
+        # overlapping words as history accumulates (self-worsening false
+        # positives — see #736 live evidence). If the request names a target
+        # path and that file does NOT exist in the instance repo, the task
+        # cannot possibly be already done — skip the keyword heuristic
+        # entirely. If the target path exists, scope the keyword heuristic to
+        # commits that actually touched it (more precise than the whole log).
+        # Any extraction/lookup error falls open to the pre-#736 behavior
+        # (plain _task_already_done over the whole log).
+        _already_done = False
+        try:
+            _target_path = _extract_target_path(req)
+        except Exception:
+            _target_path = None
+        if _dup_check_title and _target_path:
+            try:
+                _target_exists = (_selfevo_repo_check / _target_path).exists()
+            except Exception:
+                _target_exists = None
+            if _target_exists is False:
+                _already_done = False
+            elif _target_exists is True:
+                _already_done = _task_already_done_for_path(
+                    _dup_check_title, _selfevo_repo_check, _target_path,
+                )
+            else:
+                # Fail-open: couldn't resolve target_exists — fall back.
+                _already_done = _task_already_done(_dup_check_title, _selfevo_repo_check)
+        elif _dup_check_title:
+            _already_done = _task_already_done(_dup_check_title, _selfevo_repo_check)
+        if _already_done:
             import subprocess as _sp_check
             _git_chk = ['git', '-c', f'safe.directory={_selfevo_repo_check}',
                         '-C', str(_selfevo_repo_check)]
@@ -2461,6 +2493,83 @@ def _task_already_done(backlog_title: str, repo_root: 'Path') -> bool:
             continue
         subject_lower = subject.lower()
         # Require at least 3 distinct keywords to match (was 2 — too many false positives)
+        matches = sum(1 for w in words if w in subject_lower)
+        if matches >= min(3, len(words)):
+            return True
+
+    return False
+
+
+def _extract_target_path(req: dict) -> 'str | None':
+    """Return the ``Target path: <path>`` value embedded in a request's task
+    text, or None if absent (#736).
+
+    LLM-proposed requests (:func:`nanobot.runtime.llm_proposer.write_request`)
+    always carry a target path as a literal ``Target path: <path>`` line in
+    the ``task`` field (and it is echoed in ``recommended_next_action`` as
+    ``(target: <path>)``, which this also tolerates as a fallback). This is
+    used by the pre-spawn dedup gate to distinguish "genuinely new proposal
+    whose target file doesn't exist yet" from "keyword-saturated git log
+    false positive" (#736 live evidence).
+
+    Fail-open: any exception (missing/malformed fields, regex issues) returns
+    None, which falls back to the pre-#736 keyword-only behavior.
+    """
+    try:
+        import re as _re
+
+        for field in ('task', 'recommended_next_action'):
+            text = req.get(field)
+            if not text or not isinstance(text, str):
+                continue
+            m = _re.search(r'Target path:\s*(\S+)', text)
+            if m:
+                return m.group(1).strip().rstrip(').,;')
+            m = _re.search(r'\(target:\s*(\S+?)\)', text)
+            if m:
+                return m.group(1).strip()
+        return None
+    except Exception:
+        return None
+
+
+def _task_already_done_for_path(
+    backlog_title: str, repo_root: 'Path', target_path: str,
+) -> bool:
+    """Same keyword heuristic as :func:`_task_already_done`, but the git log
+    is scoped to commits that touched ``target_path`` (#736).
+
+    When a request carries a target path that already exists in the repo,
+    the plain keyword heuristic over the WHOLE 7-day log is prone to false
+    positives once history accumulates enough overlapping words (e.g.
+    "memory"/"json"/"script"). Scoping the log to the specific path with
+    ``git log -- <target_path>`` makes a match mean the file that matters
+    was actually touched, not just that similar words appear somewhere in
+    unrelated commits.
+    """
+    if not backlog_title or not repo_root.is_dir() or not target_path:
+        return False
+
+    import re as _re
+    import subprocess as _sp2
+
+    _git = ['git', '-c', f'safe.directory={repo_root}', '-C', str(repo_root)]
+    result = _sp2.run(
+        _git + ['log', '--since=7 days ago', '--pretty=%H %s', '--', target_path],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return False
+
+    words = [w.lower() for w in _re.findall(r'[A-Za-z]{4,}', backlog_title)]
+    if not words:
+        return False
+
+    for line in result.stdout.strip().splitlines():
+        subject = line[41:].strip() if len(line) > 41 else line
+        if any(subject.lower().startswith(skip.lower()) for skip in _ALREADY_DONE_SKIP_PREFIXES):
+            continue
+        subject_lower = subject.lower()
         matches = sum(1 for w in words if w in subject_lower)
         if matches >= min(3, len(words)):
             return True

--- a/tests/test_bridge_dedup_target_path.py
+++ b/tests/test_bridge_dedup_target_path.py
@@ -1,0 +1,243 @@
+"""Tests for #736: pre-spawn dedup false-positives — the keyword heuristic in
+``_task_already_done`` was matching genuinely-new LLM proposals against a
+keyword-saturated 7-day git log even though the proposal's target file did
+not exist in the instance repo.
+
+LLM-proposed requests (``nanobot.runtime.llm_proposer.write_request``) always
+carry a ``Target path: <path>`` line in their ``task`` field. This is used to
+make the pre-spawn dedup gate target_path-aware:
+
+- target_path present, file missing -> keyword heuristic is bypassed entirely
+  (task cannot possibly be already done).
+- target_path present, file exists -> keyword heuristic runs, but scoped to
+  ``git log -- <target_path>`` instead of the whole log.
+- no target_path -> unchanged behavior (whole-log ``_task_already_done``).
+
+Reuses the bridge-integration harness from tests/test_cycle_ledger.py.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nanobot.runtime import bridge
+from tests.test_cycle_ledger import (
+    _FakeSubagentManager,
+    _init_selfevo_repo,
+    _read_ledger,
+    _run,
+    _seed_bridge_request,
+)
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
+
+
+# ─── _extract_target_path unit tests ──────────────────────────────────────────
+
+
+class TestExtractTargetPath:
+    def test_extracts_from_llm_proposer_shaped_request(self):
+        req = {
+            "task_title": "Implement and commit: Create a memory pressure checker",
+            "task": (
+                "Add a script that checks RAM and swap usage to detect memory "
+                "pressure.\n\nTarget path: scripts/check_memory_pressure.py"
+            ),
+            "recommended_next_action": (
+                "Implement and commit: Create a memory pressure checker "
+                "(target: scripts/check_memory_pressure.py)"
+            ),
+        }
+        assert bridge._extract_target_path(req) == "scripts/check_memory_pressure.py"
+
+    def test_falls_back_to_recommended_next_action(self):
+        req = {
+            "task": "no target path marker here at all",
+            "recommended_next_action": "Implement and commit: X (target: scripts/x.py)",
+        }
+        assert bridge._extract_target_path(req) == "scripts/x.py"
+
+    def test_returns_none_when_absent(self):
+        req = {"task": "just a plain task with no marker", "recommended_next_action": ""}
+        assert bridge._extract_target_path(req) is None
+
+    def test_returns_none_for_empty_request(self):
+        assert bridge._extract_target_path({}) is None
+
+    def test_fail_open_on_garbage_input(self):
+        class _Weird:
+            def get(self, *_a, **_k):
+                raise RuntimeError("boom")
+
+        # Must not raise — fail-open to None.
+        assert bridge._extract_target_path(_Weird()) is None
+
+
+# ─── pre-spawn dedup integration tests ────────────────────────────────────────
+
+
+TITLE = "Create a script to check memory pressure levels"
+TASK_TEXT_TEMPLATE = (
+    "Add a script that checks RAM and swap usage to detect memory "
+    "pressure.\n\nTarget path: {target_path}"
+)
+
+
+def _setup(base, monkeypatch):
+    state_dir = base / "state"
+    state_dir.mkdir()
+    monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+    monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+    monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+    monkeypatch.setattr(bridge, "SubagentManager", _FakeSubagentManager)
+    monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+    return state_dir
+
+
+class TestMissingTargetPathBypassesKeywordHeuristic:
+    def test_missing_target_file_not_skipped_despite_saturated_log(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _origin, work = _init_selfevo_repo(base)
+
+        # Saturate the 7-day git log with commits that share >=3 keywords with
+        # TITLE but never touch the (nonexistent) target path.
+        (work / "mod.py").write_text("def ok():\n    return True\n")
+        _run(work, "add", "mod.py")
+        _run(
+            work, "commit", "--allow-empty", "-m",
+            "chore: script to check memory pressure bookkeeping levels",
+        )
+        _run(work, "push", "origin", "HEAD:main")
+
+        target_path = "scripts/check_memory_pressure.py"  # does NOT exist in repo
+        _seed_bridge_request(
+            state_dir, "req-novel", "cycle-novel",
+            task_title=f"Implement and commit: {TITLE}",
+            task=TASK_TEXT_TEMPLATE.format(target_path=target_path),
+            recommended_next_action=f"Implement and commit: {TITLE} (target: {target_path})",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-novel" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        # Proceeded to spawn (success), NOT skipped as a false-positive duplicate.
+        assert outcome_rows[0]["outcome"] == "success"
+
+
+class TestExistingTargetPathScopesKeywordHeuristic:
+    def test_matching_commit_touching_path_fires_dedup(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _origin, work = _init_selfevo_repo(base)
+
+        target_path = "scripts/check_memory_pressure.py"
+        (work / "scripts").mkdir(exist_ok=True)
+        (work / "scripts" / "check_memory_pressure.py").write_text("def main():\n    pass\n")
+        _run(work, "add", "scripts/check_memory_pressure.py")
+        _run(
+            work, "commit", "-m",
+            "feat: add script to check memory pressure levels",
+        )
+        _run(work, "push", "origin", "HEAD:main")
+
+        _seed_bridge_request(
+            state_dir, "req-dup", "cycle-dup",
+            task_title=f"Implement and commit: {TITLE}",
+            task=TASK_TEXT_TEMPLATE.format(target_path=target_path),
+            recommended_next_action=f"Implement and commit: {TITLE} (target: {target_path})",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-dup" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "skipped-duplicate"
+
+    def test_keyword_matching_commits_not_touching_path_do_not_fire(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _origin, work = _init_selfevo_repo(base)
+
+        target_path = "scripts/check_memory_pressure.py"
+        # Target file exists, but was NOT touched by the keyword-matching commit.
+        (work / "scripts").mkdir(exist_ok=True)
+        (work / "scripts" / "check_memory_pressure.py").write_text("def main():\n    pass\n")
+        _run(work, "add", "scripts/check_memory_pressure.py")
+        _run(work, "commit", "-m", "feat: unrelated initial add")
+
+        (work / "mod.py").write_text("def ok():\n    return 1\n")
+        _run(work, "add", "mod.py")
+        _run(
+            work, "commit", "-m",
+            "feat: script to check memory pressure levels (unrelated file)",
+        )
+        _run(work, "push", "origin", "HEAD:main")
+
+        _seed_bridge_request(
+            state_dir, "req-novel2", "cycle-novel2",
+            task_title=f"Implement and commit: {TITLE}",
+            task=TASK_TEXT_TEMPLATE.format(target_path=target_path),
+            recommended_next_action=f"Implement and commit: {TITLE} (target: {target_path})",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-novel2" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "success"
+
+
+class TestNoTargetPathFallsBackUnchanged:
+    def test_request_without_target_path_uses_task_already_done(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _init_selfevo_repo(base)
+
+        monkeypatch.setattr(bridge, "_task_already_done", lambda *_a, **_k: True)
+
+        _seed_bridge_request(
+            state_dir, "req-plain", "cycle-plain",
+            task_title="Some deterministic planner task with no target path",
+            task="Just do the thing, no target path marker here.",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-plain" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "skipped-duplicate"
+
+    def test_request_without_target_path_proceeds_when_not_already_done(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _init_selfevo_repo(base)
+
+        monkeypatch.setattr(bridge, "_task_already_done", lambda *_a, **_k: False)
+
+        _seed_bridge_request(
+            state_dir, "req-plain2", "cycle-plain2",
+            task_title="Some deterministic planner task with no target path",
+            task="Just do the thing, no target path marker here.",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-plain2" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "success"


### PR DESCRIPTION
Closes #736.

## What

The pre-spawn dedup in `_main_impl` now uses the `Target path: <path>` that LLM-proposed requests always carry:

- target file **does not exist** in the instance repo → the task cannot be already done → keyword heuristic bypassed (tag-dedup and #716 failure-suppression untouched);
- target file **exists** → same ≥3-keyword heuristic, but scoped to `git log --since='7 days ago' -- <target_path>` (a match now means the file that matters was touched);
- request has **no target path** (deterministic planner) → behavior unchanged (`_task_already_done` over the whole log).

Fail-open at every step: extraction or FS/git error → pre-#736 behavior.

## Why

Live evidence 2026-07-13: two genuinely-new proposals (`check_memory_pressure.py` 18:03Z, `prune_memory.py` 18:56Z) were ledgered `skipped-duplicate/already_done` although neither target file exists — the whole-log keyword heuristic matched `validate_memory_json.py`/MEMORY.md commits (*memory/JSON/files* saturation). Liveness went DEGRADED for 2+ h. The false-positive rate is self-worsening as the loop integrates more.

## Tests

New `tests/test_bridge_dedup_target_path.py` (10 tests): extraction/fallback/fail-open, missing-target bypasses a keyword-saturated log, existing-target + path-touching commit skips, existing-target + non-path commits proceeds, no-target unchanged. Full suite: 1372 passed; 2 failures are pre-existing environment-dependent systemd tests (identical on stashed baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125qdhCSXD9qCxmmFvoK5uv