### PR TITLE
feat(runtime): deterministic planner request-minting kill-switch, ships ON (#739)

### DIFF
--- a/docs/changes/739-planner-minting-kill-switch/proposal.md
+++ b/docs/changes/739-planner-minting-kill-switch/proposal.md
@@ -1,0 +1,88 @@
+# Implementation proposal: deterministic-planner minting kill-switch (#739)
+
+- **Issue:** #739
+- **story_id:** `docs/changes/archive/707-state-light-proposer` (named follow-up)
+- **Status:** implemented in this change (bounded first step — disable minting,
+  delete nothing).
+
+## Why
+
+#707 closed GO: the LLM proposer is permanently ON and sourced 12 autonomous
+integrations in 24h (`docs/changes/archive/707-state-light-proposer/results.md`).
+With the proposer live, the deterministic planner (coordinator
+feedback-decision lanes) is now pure noise: it re-mints the same duplicate
+`subagent-verify-materialized-improvement` request roughly every 10 minutes
+(~79 dup-skips/day against a fixed commit, `7dc70ea`), dominating ledger
+traffic and burning a dedup pass every bridge run for zero productive spawns.
+Planner retirement is the explicitly named follow-up in the #707 results doc;
+the planner's chronic fragility (5+ prior fixes across #656/#664/#690/#695/
+#697) is already long documented. Per proposer spec R28
+(`docs/specs/self-evolving-runtime/spec.md`), the proposer already fires
+whenever the queue is empty or every recent row was a duplicate-skip — so it
+is already positioned to be the sole request source once the planner's
+minting is turned off.
+
+## What
+
+A single kill-switch env var, `SELFEVO_DETERMINISTIC_PLANNER_ENABLED`,
+default `"1"` (any value other than the exact literal `"0"` — absent, `"1"`,
+or garbage — preserves today's behavior byte-for-byte). Read via a small
+helper in `nanobot/runtime/cycle_planning.py`,
+`_deterministic_planner_enabled() -> bool`, mirroring the style of
+`SELFEVO_LLM_PROPOSER_ENABLED` in `nanobot/runtime/llm_proposer.py` (#707) —
+one flag, no other new config surface.
+
+When the flag is `"0"`, exactly two call sites early-return `None` without
+any side effect (no directory creation, no file write), logging one INFO
+line each:
+
+1. `_write_subagent_request_artifact` (`cycle_planning.py`) — guard placed
+   before the function's first side effect (`request_dir.mkdir(...)`).
+2. `_ensure_verify_request_for_fresh_materialization` (`cycle_planning.py`,
+   called from `coordinator.py`'s #700 decouple guard around line 487) —
+   guard placed before it reads `state/improvements/`.
+
+Both call sites in `coordinator.py` (`_write_subagent_request_artifact` at
+~line 468, the decouple guard at ~line 487) already tolerate a `None` return
+— `subagent_request_path` falls back to the previously recorded plan value or
+stays `None`, and the decoupled-path branch is skipped entirely (`if
+decoupled_verify_request_path and not subagent_request_path`) — so the rest
+of the coordinator cycle (goal handling, reports, learning, HADI bookkeeping)
+completes unchanged whether the flag is on or off. No lane code, bridge code,
+or proposer code is touched.
+
+## Rollout
+
+1. **Ship default ON (`"1"` / unset).** Lands inert — behavior is
+   byte-identical to before this change, verified by the full existing test
+   suite passing unchanged plus new kill-switch-specific tests.
+2. **Canary (post-merge, operator-gated).** Operator sets
+   `SELFEVO_DETERMINISTIC_PLANNER_ENABLED=0` on the eeepc host (a runtime
+   env var, not a LiteLLM credential, so it does not touch
+   `/etc/eeepc-agent/litellm.env`). Observe the ledger: planner dup-skips
+   should stop and the proposer becomes the sole request source. Watched via
+   `scripts/loop_metrics_report.py` the same way #707's canary was.
+3. **Keep or revert.** If the proposer alone sustains healthy liveness and
+   productive spawns, leave the flag off and open a follow-up issue to
+   consider retiring the deterministic-planner lane code itself (explicitly
+   out of scope here). If it regresses, flip back to unset/`"1"` — no code
+   revert, no state cleanup, since the flag only gates two writes.
+
+## Rollback
+
+Set (or unset) `SELFEVO_DETERMINISTIC_PLANNER_ENABLED` back to `"1"` on the
+host. No migration, no state repair — the deterministic planner resumes
+minting exactly as before.
+
+## Non-goals
+
+- Deleting or restructuring the deterministic-planner lane code
+  (`_derive_feedback_decision`, `next_bounded_candidate`,
+  `_derive_generated_candidates`, etc.) — it stays intact and simply stops
+  being called to mint new requests when the flag is off.
+- Any change to the bridge (`nanobot/runtime/bridge.py`) or the LLM proposer
+  (`nanobot/runtime/llm_proposer.py`).
+- Any change to goal handling, reporting, learning, or HADI bookkeeping in
+  the coordinator cycle — these run identically regardless of the flag.
+- A live canary run — that is an operator-gated follow-up action after this
+  change merges, not part of this PR.

--- a/docs/specs/self-evolving-runtime/spec.md
+++ b/docs/specs/self-evolving-runtime/spec.md
@@ -147,6 +147,17 @@ an open-ended chat session. The learning signal is the HADI arc
   fixes the root cause of the accumulated stale-request pile: the normal
   handoff previously wrote a brand-new request file every cycle it re-landed
   on the verify task, even while an unresolved one was still in flight.
+- R34 (issue #739). Behind the `SELFEVO_DETERMINISTIC_PLANNER_ENABLED`
+  kill-switch (default `"1"`, i.e. unchanged behavior — any value other than
+  the literal `"0"` preserves current behavior), both request-minting call
+  sites named in R33 (`_write_subagent_request_artifact` and
+  `_ensure_verify_request_for_fresh_materialization`) SHALL return `None`
+  without writing a request file when the flag is `"0"`. This leaves the
+  subagent bridge's LLM proposer (`docs/specs/subagent-bridge/spec.md` R28)
+  as the sole request source; no other coordinator behavior (goals, reports,
+  learning, HADI bookkeeping) changes, and the planner's lane code itself is
+  not deleted or restructured by this flag — see
+  `docs/changes/739-planner-minting-kill-switch/proposal.md`.
 - R29 (issue #695). When `_synthesize_hypothesis_from_state` (R26) is
   exhausted — goal vectors and a state signal both exist, but every (signal,
   vector) combination it can compose is already done in git log — candidate

--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,6 +49,29 @@ from nanobot.runtime.cycle_observe import (
     _task_title_for_id,
 )
 from nanobot.runtime.subagent_materializer import _result_path_for
+
+_logger = logging.getLogger(__name__)
+
+# Issue #739: deterministic-planner minting kill-switch. Default "1" (unset
+# behaves identically) preserves today's behavior byte-for-byte — this ships
+# inert, same rollout pattern as SELFEVO_LLM_PROPOSER_ENABLED (#707). Setting
+# "0" stops the deterministic planner from minting NEW subagent-verify
+# requests at its two write call sites (_write_subagent_request_artifact and
+# _ensure_verify_request_for_fresh_materialization); everything else in the
+# coordinator cycle (goals, reports, learning, HADI bookkeeping) is
+# untouched, and callers already tolerate these functions returning None.
+DETERMINISTIC_PLANNER_ENABLED_ENV = "SELFEVO_DETERMINISTIC_PLANNER_ENABLED"
+
+
+def _deterministic_planner_enabled() -> bool:
+    """Return whether the deterministic planner may mint new requests.
+
+    Mirrors the style of ``SELFEVO_LLM_PROPOSER_ENABLED`` in
+    ``nanobot.runtime.llm_proposer``: a single small env-backed helper, no
+    other config surface. Any value other than the literal ``"0"`` (absent,
+    ``"1"``, or garbage) preserves current behavior.
+    """
+    return os.environ.get(DETERMINISTIC_PLANNER_ENABLED_ENV, "1").strip() != "0"
 
 
 def _productive_subagent_request_ids(state_root: Path) -> set[str]:
@@ -1176,6 +1201,12 @@ def _write_subagent_request_artifact(
     current_plan: dict[str, Any],
     workspace: Path | None = None,
 ) -> str | None:
+    if not _deterministic_planner_enabled():
+        _logger.info(
+            "deterministic planner minting disabled "
+            "(SELFEVO_DETERMINISTIC_PLANNER_ENABLED=0) — skipping request write"
+        )
+        return None
     if current_plan.get("current_task_id") != "subagent-verify-materialized-improvement":
         return None
     request_dir = state_root / "subagents" / "requests"
@@ -1300,6 +1331,12 @@ def _ensure_verify_request_for_fresh_materialization(
        terminal result (already_done/completed/no_commit/blocked) do not
        count as live and never block a fresh write.
     """
+    if not _deterministic_planner_enabled():
+        _logger.info(
+            "deterministic planner minting disabled "
+            "(SELFEVO_DETERMINISTIC_PLANNER_ENABLED=0) — skipping request write"
+        )
+        return None
     improvements_dir = state_root / "improvements"
     if not improvements_dir.exists():
         return None

--- a/tests/test_planner_minting_kill_switch.py
+++ b/tests/test_planner_minting_kill_switch.py
@@ -1,0 +1,168 @@
+"""Issue #739: deterministic-planner minting kill-switch.
+
+Post-#707-GO the LLM proposer is the reliable request source (#707); the
+deterministic planner (coordinator feedback-decision lanes) re-mints the
+SAME duplicate ``subagent-verify-materialized-improvement`` request every
+cycle it runs (~79 dup-skips/day against a fixed commit), pure ledger noise.
+``SELFEVO_DETERMINISTIC_PLANNER_ENABLED`` (default "1" = today's behavior,
+byte-identical) lets an operator flip the planner's two request-minting call
+sites off ("0") without deleting any lane code or touching the bridge/
+proposer — mirrors the ``SELFEVO_LLM_PROPOSER_ENABLED`` kill-switch style
+from #707 (nanobot/runtime/llm_proposer.py).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime.cycle_planning import (
+    DETERMINISTIC_PLANNER_ENABLED_ENV,
+    _deterministic_planner_enabled,
+    _ensure_verify_request_for_fresh_materialization,
+    _write_subagent_request_artifact,
+)
+
+
+def _write_materialized_artifact(improvements_dir: Path, *, name: str, title: str) -> Path:
+    improvements_dir.mkdir(parents=True, exist_ok=True)
+    path = improvements_dir / name
+    path.write_text(json.dumps({
+        "schema_version": "materialized-improvement-v1",
+        "task_id": "materialize-synthesized-improvement",
+        "next_bounded_candidate": {"title": title},
+        "derived_candidate": {"title": title},
+    }), encoding="utf-8")
+    return path
+
+
+def _bounded_execution_plan() -> dict:
+    return {
+        "current_task_id": "subagent-verify-materialized-improvement",
+        "tasks": [
+            {"task_id": "subagent-verify-materialized-improvement", "title": "verify"},
+        ],
+        "materialized_improvement_artifact_path": "/nonexistent/materialized-x.json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper truthiness table
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        (None, True),        # unset -> default "1" -> enabled
+        ("1", True),
+        ("0", False),
+        ("garbage", True),   # anything other than literal "0" preserves current behavior
+        ("", True),
+        ("  0  ", False),    # whitespace-tolerant
+        ("00", True),        # only the exact literal "0" disables
+    ],
+)
+def test_deterministic_planner_enabled_truthiness(
+    monkeypatch: pytest.MonkeyPatch, raw_value: str | None, expected: bool
+) -> None:
+    if raw_value is None:
+        monkeypatch.delenv(DETERMINISTIC_PLANNER_ENABLED_ENV, raising=False)
+    else:
+        monkeypatch.setenv(DETERMINISTIC_PLANNER_ENABLED_ENV, raw_value)
+    assert _deterministic_planner_enabled() is expected
+
+
+# ---------------------------------------------------------------------------
+# _write_subagent_request_artifact
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw_value", [None, "1", "garbage"])
+def test_write_subagent_request_artifact_unaffected_when_flag_not_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raw_value: str | None
+) -> None:
+    if raw_value is None:
+        monkeypatch.delenv(DETERMINISTIC_PLANNER_ENABLED_ENV, raising=False)
+    else:
+        monkeypatch.setenv(DETERMINISTIC_PLANNER_ENABLED_ENV, raw_value)
+
+    state_root = tmp_path / "state"
+    result_path = _write_subagent_request_artifact(
+        state_root=state_root,
+        cycle_id="cycle-1",
+        goal_id="goal-1",
+        current_plan=_bounded_execution_plan(),
+    )
+
+    assert result_path is not None
+    assert Path(result_path).exists()
+
+
+def test_write_subagent_request_artifact_returns_none_and_writes_nothing_when_flag_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(DETERMINISTIC_PLANNER_ENABLED_ENV, "0")
+
+    state_root = tmp_path / "state"
+    result_path = _write_subagent_request_artifact(
+        state_root=state_root,
+        cycle_id="cycle-1",
+        goal_id="goal-1",
+        current_plan=_bounded_execution_plan(),
+    )
+
+    assert result_path is None
+    requests_dir = state_root / "subagents" / "requests"
+    assert not requests_dir.exists() or list(requests_dir.glob("*.json")) == []
+
+
+# ---------------------------------------------------------------------------
+# _ensure_verify_request_for_fresh_materialization
+# ---------------------------------------------------------------------------
+
+def test_ensure_verify_request_for_fresh_materialization_returns_none_when_flag_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(DETERMINISTIC_PLANNER_ENABLED_ENV, "0")
+
+    state_root = tmp_path / "state"
+    improvements_dir = state_root / "improvements"
+    _write_materialized_artifact(
+        improvements_dir,
+        name="materialized-cycle-739.json",
+        title="Some fresh hypothesis title never seen in git log",
+    )
+
+    result_path = _ensure_verify_request_for_fresh_materialization(
+        state_root=state_root,
+        cycle_id="cycle-739",
+        goal_id="goal-bootstrap",
+    )
+
+    assert result_path is None
+    requests_dir = state_root / "subagents" / "requests"
+    assert not requests_dir.exists() or list(requests_dir.glob("*.json")) == []
+
+
+def test_ensure_verify_request_for_fresh_materialization_unaffected_when_flag_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(DETERMINISTIC_PLANNER_ENABLED_ENV, raising=False)
+
+    state_root = tmp_path / "state"
+    improvements_dir = state_root / "improvements"
+    fresh_artifact = _write_materialized_artifact(
+        improvements_dir,
+        name="materialized-cycle-739b.json",
+        title="Another fresh hypothesis title never seen in git log",
+    )
+
+    result_path = _ensure_verify_request_for_fresh_materialization(
+        state_root=state_root,
+        cycle_id="cycle-739b",
+        goal_id="goal-bootstrap",
+    )
+
+    assert result_path is not None
+    written = json.loads(Path(result_path).read_text(encoding="utf-8"))
+    assert written["source_artifact"] == str(fresh_artifact)


### PR DESCRIPTION
Closes #739.

Adds `SELFEVO_DETERMINISTIC_PLANNER_ENABLED` (default `"1"` — absent/garbage = unchanged, byte-identical; only literal `"0"` disables). When `"0"`, the coordinator's two request-minting call sites (`_write_subagent_request_artifact`, `_ensure_verify_request_for_fresh_materialization`) return None before any side effect, leaving the bridge's LLM proposer (spec R28) as the sole task source. Nothing else in the coordinator changes; lane code is not deleted (explicit non-goal). Same inert-rollout pattern as #707's flag.

Includes `docs/changes/739-planner-minting-kill-switch/proposal.md` (why/rollout/rollback) and spec R34 in `self-evolving-runtime` referencing the R33 call sites.

Tests: +13 (`tests/test_planner_minting_kill_switch.py`) — truthiness table, both call sites write-vs-skip. Suite 1387 passed; 2 pre-existing environment-dependent systemd failures (identical on stashed baseline). Ruff: 0 new findings.

Post-merge (separate, operator-gated): host canary flip to `"0"` → ledger should show proposer-only requests and the ~79/day duplicate-skips stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125qdhCSXD9qCxmmFvoK5uv