### PR TITLE
fix(runtime): proposer journal line logs its own title, not the oldest queued (#741)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -558,9 +558,8 @@ def _maybe_propose_after_skip(selfevo_repo: 'Path') -> None:
     and is picked up oldest-first over the next few cycles as the queue
     drains — no reordering logic needed.
     """
-    if llm_proposer.maybe_propose(STATE_DIR, selfevo_repo):
-        _proposer_req_path, _proposer_req = find_pending_request()
-        _proposer_title = (_proposer_req or {}).get('task_title') or '(untitled)'
+    _proposer_title = llm_proposer.maybe_propose(STATE_DIR, selfevo_repo)
+    if _proposer_title:
         print(f'llm-proposer: queued {_proposer_title}')
 
 
@@ -1217,9 +1216,8 @@ async def _main_impl():
             # picks it up through the normal find_pending_request/dedup/gate path
             # above — untouched by this change.
             _selfevo_repo_for_proposer = STATE_DIR.parent / 'eeebot-self-evolving'
-            if llm_proposer.maybe_propose(STATE_DIR, _selfevo_repo_for_proposer):
-                _proposer_req_path, _proposer_req = find_pending_request()
-                _proposer_title = (_proposer_req or {}).get('task_title') or '(untitled)'
+            _proposer_title = llm_proposer.maybe_propose(STATE_DIR, _selfevo_repo_for_proposer)
+            if _proposer_title:
                 print(f'llm-proposer: queued {_proposer_title}')
             print('already_handled')
             return 0

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -433,6 +433,15 @@ def _active_goal_id(state_dir: Path) -> str:
     return ""
 
 
+def _display_title(task_title: str) -> str:
+    """Format a proposal's ``task_title`` the way it is stored in the
+    written request's own ``task_title`` field (``write_request``) — the
+    single formatting rule shared by the persisted request and the
+    ``maybe_propose`` return value, so the two can never drift (#741)."""
+    task_title = task_title.strip()
+    return f"Implement and commit: {task_title}" if task_title else task_title
+
+
 def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
     """Write the request JSON in the IDENTICAL shape
     ``_write_subagent_request_artifact`` (nanobot.runtime.cycle_planning)
@@ -489,7 +498,7 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
         "request_id": request_id,
         "verification_task_id": request_id,
         "verification_role": "materialized_improvement_implementation",
-        "task_title": f"Implement and commit: {task_title}" if task_title else task_title,
+        "task_title": _display_title(task_title),
         "task": f"{rationale}\n\nTarget path: {target_path}".strip(),
         "recommended_next_action": f"Implement and commit: {task_title} (target: {target_path})",
         "request_status": "queued",
@@ -516,7 +525,7 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
     return str(request_path)
 
 
-def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
+def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
     """Single public entrypoint (#707, hardened for the canary novelty-
     collapse defect): build context, propose, validate sizing (with one
     retry on rejection), self-dedup (with one retry-with-feedback), and
@@ -529,18 +538,25 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
     also gets a dedup retry, and a proposal that fails dedup after a sizing
     retry gets exactly one more try.
 
-    Returns ``True`` iff a request was written this call. Never raises —
-    every step is individually fail-open, and the whole function is wrapped
-    in a final safety net so a bug here can never break the bridge cycle
-    that calls it.
+    Returns the just-written request's ``task_title`` (the same string
+    ``write_request`` persists) iff a request was written this call, else
+    ``None``. #741: the caller must log THIS return value, not a post-write
+    ``find_pending_request`` lookup — the queue is oldest-first, so a lookup
+    after this write can return a stale, unrelated request's title whenever
+    older requests are still pending. The return value is still truthy iff
+    a request was written (a written title is never empty — ``validate_sizing``
+    rejects an empty ``task_title``), so existing ``if maybe_propose(...)``
+    call sites keep working unchanged. Never raises — every step is
+    individually fail-open, and the whole function is wrapped in a final
+    safety net so a bug here can never break the bridge cycle that calls it.
     """
     try:
         if not should_propose(state_dir, selfevo_repo):
-            return False
+            return None
 
         context = build_context(state_dir, selfevo_repo)
         if not context:
-            return False
+            return None
 
         calls_made = 0
 
@@ -552,7 +568,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
             calls_made += 1
             ok, reason = validate_sizing(proposal)
         if not ok:
-            return False
+            return None
 
         dup, dup_reason = _is_duplicate_proposal(state_dir, selfevo_repo, proposal)
         if dup and calls_made < _MAX_LLM_CALLS:
@@ -560,12 +576,12 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
             calls_made += 1
             ok, reason = validate_sizing(proposal)
             if not ok:
-                return False
+                return None
             dup, dup_reason = _is_duplicate_proposal(state_dir, selfevo_repo, proposal)
         if dup:
-            return False
+            return None
 
         write_request(state_dir, proposal)
-        return True
+        return _display_title(str(proposal.get("task_title") or ""))
     except Exception:
-        return False
+        return None

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -71,7 +71,7 @@ class TestKillSwitch:
         monkeypatch.delenv(ENV_VAR, raising=False)
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, "no priorities section here at all")
-        assert llm_proposer.maybe_propose(state_dir, None) is False
+        assert llm_proposer.maybe_propose(state_dir, None) is None
         assert not (state_dir / "subagents" / "requests").exists()
 
 
@@ -204,7 +204,8 @@ class TestShouldPropose:
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
-        assert llm_proposer.maybe_propose(state_dir, None) is True
+        result = llm_proposer.maybe_propose(state_dir, None)
+        assert result == "Implement and commit: Fix a typo in docs/README-ish file"
         assert llm_proposer.should_propose(state_dir, None) is False
 
 
@@ -342,7 +343,7 @@ class TestProposeRetryOnce(object):
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
         result = llm_proposer.maybe_propose(state_dir, None)
-        assert result is True
+        assert result == "Implement and commit: Fix a typo in docs/README-ish file"
         assert len(calls) == 2
         assert calls[0] is None
         assert calls[1] is not None
@@ -360,7 +361,7 @@ class TestProposeRetryOnce(object):
 
         monkeypatch.setattr(llm_proposer, "propose", _always_bad)
         result = llm_proposer.maybe_propose(state_dir, None)
-        assert result is False
+        assert result is None
         assert len(calls) == 2
         assert not (state_dir / "subagents" / "requests").exists()
 
@@ -404,7 +405,8 @@ class TestSelfDedup:
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
         result = llm_proposer.maybe_propose(state_dir, repo)
 
-        assert result is True
+        assert result is not None
+        assert "loop metrics report" in result
         assert len(calls) == 2
         assert calls[0] is None
         assert "duplicates already-done" in calls[1]
@@ -414,6 +416,7 @@ class TestSelfDedup:
         written = [json.loads(p.read_text(encoding="utf-8")) for p in req_dir.glob("*.json")]
         assert len(written) == 1
         assert "loop metrics report" in written[0]["task_title"]
+        assert result == written[0]["task_title"]
 
     def test_duplicate_via_recent_proposed_titles_rejected(self, tmp_path, monkeypatch):
         """A title never committed to git (no selfevo repo at all here) but
@@ -443,7 +446,8 @@ class TestSelfDedup:
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
         result = llm_proposer.maybe_propose(state_dir, None)
 
-        assert result is True
+        assert result is not None
+        assert "release checklist" in result
         assert len(calls) == 2
         assert calls[1] is not None
 
@@ -468,7 +472,7 @@ class TestSelfDedup:
         monkeypatch.setattr(llm_proposer, "propose", _always_clone)
         result = llm_proposer.maybe_propose(state_dir, repo)
 
-        assert result is False
+        assert result is None
         assert len(calls) <= 3
         assert len(calls) == 2  # sizing passes both times; only the dedup retry is spent
         assert not (state_dir / "subagents" / "requests").exists()
@@ -692,9 +696,104 @@ class TestIntegrationHandoff:
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
 
-        assert llm_proposer.maybe_propose(state_dir, None) is True
+        result = llm_proposer.maybe_propose(state_dir, None)
+        assert result is not None
+        assert result.endswith("loop metrics report")
 
         found_path, found_req = bridge.find_pending_request()
         assert found_path is not None
         assert found_req.get("task_title", "").endswith("loop metrics report")
         assert found_req.get("request_status") == "queued"
+        assert found_req.get("task_title") == result
+
+
+# ─── #741: bridge must log maybe_propose's own return value, not a stale ───
+# ─── post-write find_pending_request lookup                              ───
+
+
+class TestJournalLineUsesOwnReturnValue:
+    def test_maybe_propose_return_value_contract(self, tmp_path, monkeypatch):
+        """The new contract: ``maybe_propose`` returns the exact
+        ``task_title`` string it just persisted (never a stale/unrelated
+        one) when it writes a request, and ``None`` — never ``False`` — when
+        it does not. The return value stays truthy iff a request was
+        written, so existing ``if maybe_propose(...):`` call sites keep
+        working unchanged."""
+        monkeypatch.setenv(ENV_VAR, "1")
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            return {
+                "task_title": "Add a docstring to the ledger digest helper",
+                "rationale": "Improves maintainer onboarding.",
+                "target_path": "docs/proposer-notes.md",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+        assert isinstance(result, str)
+        assert result == "Implement and commit: Add a docstring to the ledger digest helper"
+        assert bool(result) is True
+
+        # A second call is blocked by the anti-stacking guard (a proposer
+        # request is now queued) -> must return exactly None, not False.
+        result2 = llm_proposer.maybe_propose(state_dir, None)
+        assert result2 is None
+
+    def test_bridge_after_skip_logs_own_title_not_stale_queue_tail(self, tmp_path, monkeypatch, capsys):
+        """#741 regression: seed an OLDER stale request that stays queued
+        (unhandled) after the bulk-skip loop's cap ends the run — exactly
+        the ``test_cap_enforced_remainder_stays_queued`` scenario — then
+        drive ``_maybe_propose_after_skip`` directly with a mocked LLM reply.
+        Before the fix, the bridge re-derived the logged title via a
+        post-write ``find_pending_request()`` call, which is oldest-first
+        and so returned the STALE request's title (mtime-sorted ahead of the
+        proposer's brand-new file). The fix logs ``maybe_propose``'s own
+        return value instead.
+        """
+        monkeypatch.setenv(ENV_VAR, "1")
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        # An older, still-queued (never handled) stale request — sorted first
+        # by find_pending_request's oldest-first (mtime) ordering.
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        stale_path = req_dir / "request-stale.json"
+        stale_path.write_text(
+            json.dumps(
+                {
+                    "request_status": "queued",
+                    "request_id": "cycle-stale-old",
+                    "task_title": "STALE OLDEST TITLE — should never be logged",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            return {
+                "task_title": "Add a smoke test for the loop metrics report",
+                "rationale": "Closes a coverage gap.",
+                "target_path": "tests/test_loop_metrics_extra.py",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+
+        bridge._maybe_propose_after_skip(None)
+
+        captured = capsys.readouterr()
+        assert "llm-proposer: queued" in captured.out
+        assert "STALE OLDEST TITLE" not in captured.out
+        assert "loop metrics report" in captured.out
+
+        # Confirm the stale request is indeed still the oldest queued
+        # candidate find_pending_request would return — proving this test
+        # actually exercises the bug's precondition, not a no-op.
+        found_path, found_req = bridge.find_pending_request()
+        assert found_path == stale_path
+        assert found_req.get("task_title") == "STALE OLDEST TITLE — should never be logged"


### PR DESCRIPTION
Closes #741.

`maybe_propose` now returns the just-written request's `task_title` (str, same string persisted via a shared `_display_title` helper) instead of bool — `None` on every no-write path, so truthiness-based call sites keep working. Both bridge call sites (no-pending-request branch and `_maybe_propose_after_skip`) log that return value directly; the post-write `find_pending_request` title lookup (oldest-first → stale title) is removed. No changes to request JSON, ledger rows, dedup, or queue semantics.

Tests: +2 (return-value contract; bug repro — stale older request in queue, asserts the logged line carries the proposer's own title AND that `find_pending_request` would have returned the stale one), 8 assertions updated to the new contract. `test_llm_proposer.py`: 42 passed; full suite 1376 passed with the 2 known pre-existing systemd flakes only. Ruff: no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125qdhCSXD9qCxmmFvoK5uv