### PR TITLE
fix(runtime): marker-aware proposer anti-stacking + queue-empty firing clause (#745)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -85,6 +85,41 @@ def _requests_dir(state_dir: Path) -> Path:
     return Path(state_dir) / "subagents" / "requests"
 
 
+def _bridge_state_dir(state_dir: Path) -> Path:
+    """Mirrors ``nanobot.runtime.bridge``'s ``BRIDGE_STATE_DIR`` (bridge.py:52
+    ``os.environ.get('SUBAGENT_BRIDGE_STATE_DIR', str(STATE_DIR /
+    'subagent_bridge'))``), rooted at THIS call's own ``state_dir`` argument
+    instead of the bridge's module-level ``STATE_DIR`` global — this module
+    cannot import bridge.py (circular import, see the ``_ALLOWED_PATH_PREFIXES``
+    comment above), so the relation is duplicated as a small literal rather
+    than a shared constant. The bridge always calls this module with its own
+    ``STATE_DIR`` as ``state_dir``, so the two resolve to the identical path
+    in production; tests that use a temp ``state_dir`` get the matching temp
+    ``subagent_bridge`` subdirectory.
+    """
+    return Path(os.environ.get("SUBAGENT_BRIDGE_STATE_DIR", str(Path(state_dir) / "subagent_bridge")))
+
+
+def _request_id_of(req: dict[str, Any], path: Path) -> str:
+    """Same fallback chain the bridge uses to name a request for marker
+    purposes (bridge.py:1225, mirrored from ``find_pending_request``'s
+    ``rid`` at bridge.py:151): ``request_id``, else ``verification_task_id``,
+    else the request file's own path."""
+    return str(req.get("request_id") or req.get("verification_task_id") or str(path))
+
+
+def _is_request_handled(state_dir: Path, req: dict[str, Any], path: Path) -> bool:
+    """True iff the bridge already wrote a ``handled_<safe_rid>.txt`` marker
+    for this request (bridge.py:1231-1233, 1276 etc.) — the ONLY source of
+    handledness; the request file's own ``request_status`` is never rewritten
+    (#745). Mirrors the bridge's exact sanitization: ``rid.replace('/',
+    '_')[:120]``."""
+    rid = _request_id_of(req, path)
+    safe_rid = rid.replace("/", "_")[:120]
+    marker = _bridge_state_dir(state_dir) / f"handled_{safe_rid}.txt"
+    return marker.exists()
+
+
 def _is_proposer_request(req: dict[str, Any]) -> bool:
     """True iff ``req`` is a request this module itself wrote (``write_request``).
 
@@ -102,7 +137,8 @@ def _is_proposer_request(req: dict[str, Any]) -> bool:
 
 
 def _has_queued_proposer_request(state_dir: Path) -> bool:
-    """Anti-stacking guard: is there already a queued proposer-written request?
+    """Anti-stacking guard: is there already a queued, NOT-YET-HANDLED
+    proposer-written request?
 
     Deliberately narrower than "any queued request" (#707 canary finding):
     in production the deterministic planner mints stale duplicate requests
@@ -112,6 +148,16 @@ def _has_queued_proposer_request(state_dir: Path) -> bool:
     stay silent. Only a request this module already queued blocks a new one,
     preventing unbounded proposer stacking while still firing on planner-only
     queues.
+
+    #745: a request's ``request_status`` field is never rewritten once
+    written — handledness is marker-file based only (bridge.py's
+    ``handled_<safe_rid>.txt``, see ``_is_request_handled``). Before this fix,
+    a proposer request the bridge had already executed kept reading as
+    "queued" in its own file and blocked every subsequent proposal until the
+    hourly archiver deleted it — the loop's cadence was accidentally
+    archiver-paced instead of timer-paced. A request whose handled marker
+    already exists no longer counts as blocking, regardless of its stale
+    ``request_status``.
     """
     req_dir = _requests_dir(state_dir)
     if not req_dir.is_dir():
@@ -124,9 +170,57 @@ def _has_queued_proposer_request(state_dir: Path) -> bool:
         if not isinstance(req, dict):
             continue
         status = str(req.get("request_status") or req.get("status") or "").strip().lower()
-        if status in ("queued", "pending") and _is_proposer_request(req):
-            return True
+        if status not in ("queued", "pending") or not _is_proposer_request(req):
+            continue
+        try:
+            if _is_request_handled(state_dir, req, path):
+                continue
+        except Exception:
+            pass
+        return True
     return False
+
+
+def _queue_effectively_empty(state_dir: Path) -> bool:
+    """#745: is the requests dir free of ANY unhandled queued/pending
+    request, regardless of who wrote it (planner, operator, or this module)?
+
+    This is the "fresh-priorities deadlock" fix: spec R28 (subagent-bridge)
+    says the proposer fires "when the queue is empty", but the #731 rework
+    lost that clause — ``should_propose`` fired only on priorities-empty or a
+    last-3-outcomes duplicate streak. With the deterministic planner off,
+    dup streaks stop occurring; if an operator seeds fresh ``goal_text.json``
+    priorities that the #712 filter says still remain (nothing done yet),
+    the proposer went permanently silent even though there was nothing at
+    all queued to work through.
+
+    A request counts as "pending" iff its status is queued/pending AND its
+    handled marker does NOT exist (same handledness check as
+    ``_has_queued_proposer_request``); an unreadable/malformed request file
+    counts as NOT pending — fail-open, consistent with the rest of this
+    module. Returns ``True`` iff no request in the dir counts as pending
+    (including when the dir does not exist at all).
+    """
+    req_dir = _requests_dir(state_dir)
+    if not req_dir.is_dir():
+        return True
+    for path in req_dir.glob("*.json"):
+        try:
+            req = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(req, dict):
+            continue
+        status = str(req.get("request_status") or req.get("status") or "").strip().lower()
+        if status not in ("queued", "pending"):
+            continue
+        try:
+            if _is_request_handled(state_dir, req, path):
+                continue
+        except Exception:
+            pass
+        return False
+    return True
 
 
 def _load_goal_text(state_dir: Path) -> str:
@@ -206,15 +300,36 @@ def _last_k_all_duplicate(state_dir: Path, k: int = _DUP_STREAK_K) -> bool:
 
 
 def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
-    """Invocation policy (#707): fires only on proven novelty exhaustion.
+    """Invocation policy (#707, extended by #745): fires on proven novelty
+    exhaustion OR an effectively empty request queue.
 
-    ``(no queued proposer request) AND (filtered goal_text has no remaining
-    "Current priority targets" entries OR the last K=3 terminal ledger
-    outcome rows are all "skipped-duplicate")``. The queue clause is an
-    anti-stacking guard on the proposer's OWN requests only (see
-    ``_has_queued_proposer_request``) — a queued planner request no longer
-    blocks proposing, since a queue full of stale planner duplicates is
-    itself the novelty-exhaustion signal this function exists to catch.
+    ``(no queued, unhandled proposer request) AND ((the request queue has NO
+    unhandled queued/pending request at all) OR (filtered goal_text has no
+    remaining "Current priority targets" entries) OR (the last K=3 terminal
+    ledger outcome rows are all "skipped-duplicate"))``.
+
+    The first clause is an anti-stacking guard on the proposer's OWN
+    requests only (see ``_has_queued_proposer_request``) — a queued planner
+    request no longer blocks proposing, since a queue full of stale planner
+    duplicates is itself a novelty-exhaustion signal this function exists to
+    catch. Both this guard and the queue-empty clause below check the
+    bridge's marker-file handledness (``_is_request_handled``), not the
+    request file's own (never-rewritten) ``request_status`` — otherwise an
+    already-executed request keeps blocking until the hourly archiver
+    deletes it, making the loop's cadence archiver-paced instead of
+    timer-paced (#745).
+
+    The queue-empty clause (spec R28, subagent-bridge) fires regardless of
+    who wrote the pending request (any author, not just the proposer): with
+    the deterministic planner off, dup streaks stop occurring, so if an
+    operator seeds fresh ``goal_text.json`` priorities that still remain
+    (nothing done yet) and nothing is queued, the proposer must still fire
+    or the loop idles forever (the "fresh-priorities deadlock", #745). The
+    priorities-empty and last-3-duplicate-streak clauses are unchanged
+    fallbacks for when the queue is non-empty (e.g. still holds an unhandled
+    planner request) — they cover the case a re-enabled planner mints stale
+    duplicates faster than the bridge consumes them.
+
     Fail-closed: any error, or a completely missing/unreadable state
     directory, returns ``False``. Always ``False`` when the kill switch
     (``SELFEVO_LLM_PROPOSER_ENABLED``) is off.
@@ -230,6 +345,8 @@ def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
         goal_text_path = state_dir / "goals" / "goal_text.json"
         if not goal_text_path.is_file():
             return False
+        if _queue_effectively_empty(state_dir):
+            return True
         raw_goal_text = _load_goal_text(state_dir)
         filtered = filter_completed_priorities_from_goal_text(raw_goal_text, selfevo_repo)
         if not _priorities_remain(filtered):

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -133,11 +133,32 @@ class TestShouldPropose:
         )
         assert llm_proposer.should_propose(state_dir, None) is False
 
-    def test_priorities_remain_and_not_all_dup_returns_false(self, tmp_path):
+    def test_priorities_remain_no_dup_streak_but_empty_queue_returns_true(self, tmp_path):
+        """#745: changed expectation. Previously (no queue-empty clause) this
+        returned False — priorities remain and there's no dup streak. Now the
+        requests dir has never even been created (nothing queued at all), so
+        the new queue-empty clause (spec R28) fires regardless of the
+        priorities/dup-streak state — this IS the fresh-priorities-deadlock
+        case the fix targets."""
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, GOAL_TEXT_JSON and json.loads(GOAL_TEXT_JSON)["text"])
         # No selfevo repo -> filter is a no-op -> priorities remain.
         # Fewer than 3 terminal rows, so the duplicate-streak branch is False too.
+        _append_outcome(state_dir, "c1", "success")
+        assert llm_proposer.should_propose(state_dir, None) is True
+
+    def test_priorities_remain_no_dup_streak_but_queue_nonempty_returns_false(self, tmp_path):
+        """Unchanged behavior: an unhandled non-proposer (e.g. planner)
+        request is still queued, so the queue is NOT empty — falls through
+        to the unchanged priorities/dup-streak fallback clauses, both False."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, GOAL_TEXT_JSON and json.loads(GOAL_TEXT_JSON)["text"])
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-planner.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": "cycle-planner-1"}),
+            encoding="utf-8",
+        )
         _append_outcome(state_dir, "c1", "success")
         assert llm_proposer.should_propose(state_dir, None) is False
 
@@ -147,15 +168,34 @@ class TestShouldPropose:
         assert llm_proposer.should_propose(state_dir, None) is True
 
     def test_last_three_all_skipped_duplicate_returns_true(self, tmp_path):
+        """#745: an unhandled non-proposer request is kept queued so the
+        queue-empty clause does NOT fire — this isolates the dup-streak
+        fallback clause the test name is actually about."""
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-planner.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": "cycle-planner-1"}),
+            encoding="utf-8",
+        )
         for i in range(3):
             _append_outcome(state_dir, f"c{i}", "skipped-duplicate")
         assert llm_proposer.should_propose(state_dir, None) is True
 
     def test_last_three_not_all_duplicate_returns_false(self, tmp_path):
+        """#745: an unhandled non-proposer request is kept queued so the
+        queue-empty clause does NOT fire — otherwise an empty queue would
+        make this True regardless of the dup-streak state, defeating the
+        point of this test (isolating the dup-streak fallback clause)."""
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-planner.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": "cycle-planner-1"}),
+            encoding="utf-8",
+        )
         _append_outcome(state_dir, "c1", "skipped-duplicate")
         _append_outcome(state_dir, "c2", "skipped-duplicate")
         _append_outcome(state_dir, "c3", "success")
@@ -207,6 +247,103 @@ class TestShouldPropose:
         result = llm_proposer.maybe_propose(state_dir, None)
         assert result == "Implement and commit: Fix a typo in docs/README-ish file"
         assert llm_proposer.should_propose(state_dir, None) is False
+
+
+# ─── #745: marker-based handledness (archiver-paced cadence bug) ──────────
+# ─── and the queue-empty clause (fresh-priorities deadlock)             ───
+
+
+def _write_handled_marker(state_dir: Path, request_id: str) -> None:
+    """Writes the marker the SAME way the bridge does (bridge.py:1231-1232,
+    1276): ``handled_<safe_rid>.txt`` under ``<state_dir>/subagent_bridge``,
+    with ``safe_rid = request_id.replace('/', '_')[:120]``."""
+    bridge_state_dir = state_dir / "subagent_bridge"
+    bridge_state_dir.mkdir(parents=True, exist_ok=True)
+    safe_rid = request_id.replace("/", "_")[:120]
+    (bridge_state_dir / f"handled_{safe_rid}.txt").write_text("marker", encoding="utf-8")
+
+
+class TestHandledMarker:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+
+    def test_handled_marker_present_no_longer_blocks_anti_stacking(self, tmp_path):
+        """#745 core fix: a proposer request the bridge already executed
+        (handled marker written) no longer counts as 'queued' for the
+        anti-stacking guard, even though its own request_status field still
+        says 'queued' (that field is never rewritten) — this was the
+        archiver-paced cadence bug."""
+        state_dir = _state_dir(tmp_path)
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        request_id = "llm-proposer-cycle-abc123"
+        (req_dir / "request-handled.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": request_id}),
+            encoding="utf-8",
+        )
+        _write_handled_marker(state_dir, request_id)
+        assert llm_proposer._has_queued_proposer_request(state_dir) is False
+
+    def test_no_marker_still_blocks_anti_stacking(self, tmp_path):
+        """Companion negative case: same request, no marker written -> still
+        blocks (anti-stacking preserved)."""
+        state_dir = _state_dir(tmp_path)
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        request_id = "llm-proposer-cycle-abc123"
+        (req_dir / "request-unhandled.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": request_id}),
+            encoding="utf-8",
+        )
+        assert llm_proposer._has_queued_proposer_request(state_dir) is True
+
+    def test_queue_effectively_empty_true_when_only_request_is_handled(self, tmp_path):
+        """A non-proposer (e.g. planner) request queued but handled-marker'd,
+        and nothing else in the dir -> the queue counts as effectively
+        empty."""
+        state_dir = _state_dir(tmp_path)
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        request_id = "cycle-planner-handled-1"
+        (req_dir / "request-planner-handled.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": request_id}),
+            encoding="utf-8",
+        )
+        _write_handled_marker(state_dir, request_id)
+        assert llm_proposer._queue_effectively_empty(state_dir) is True
+
+    def test_queue_effectively_empty_false_when_unhandled_request_present(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        (req_dir / "request-planner.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": "cycle-planner-2"}),
+            encoding="utf-8",
+        )
+        assert llm_proposer._queue_effectively_empty(state_dir) is False
+
+    def test_queue_effectively_empty_true_when_dir_missing(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        assert llm_proposer._queue_effectively_empty(state_dir) is True
+
+    def test_should_propose_true_when_only_queued_request_is_handled(self, tmp_path):
+        """End-to-end: a handled-marker'd proposer request sitting in the
+        queue with a stale 'queued' request_status must NOT block a new
+        proposal, and with the queue thus effectively empty, should_propose
+        fires even though priorities remain and there's no dup streak."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        req_dir = state_dir / "subagents" / "requests"
+        req_dir.mkdir(parents=True)
+        request_id = "llm-proposer-cycle-done1"
+        (req_dir / "request-done.json").write_text(
+            json.dumps({"request_status": "queued", "request_id": request_id}),
+            encoding="utf-8",
+        )
+        _write_handled_marker(state_dir, request_id)
+        _append_outcome(state_dir, "c1", "success")
+        assert llm_proposer.should_propose(state_dir, None) is True
 
 
 # ─── build_context ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #745. Follow-up of the #739 canary evaluation.

Two gaps in `llm_proposer.py` now that the proposer is the sole task source:

1. **Archiver-paced cadence** — `_has_queued_proposer_request` read the request FILE's `request_status`, which is never rewritten; handledness lives only in the bridge's `handled_<safe_rid>.txt` markers. An already-executed proposer request kept blocking the next proposal for 1–2 h until the archiver deleted the file. Now a marker'd request no longer blocks (`_is_request_handled` mirrors the bridge's exact sanitization; `_bridge_state_dir` mirrors bridge.py:52, documented why it can't be imported).
2. **Fresh-priorities deadlock** — spec R28 says the proposer fires "when the queue is empty", but the #731 rework lost that clause; with the planner off, dup-streaks never occur, so fresh goal_text priorities would silence the loop forever. New `_queue_effectively_empty` (no unhandled queued/pending request from ANY author) is now the third firing clause in `should_propose`; the existing two clauses are unchanged fallbacks.

Expected live effect: timer-paced rhythm (~1 proposal per 2 bridge runs) and priorities picked up verbatim by the proposer (R30). No new env knobs; fail-open/fail-closed contracts preserved. Spec R28 already matches — no spec edit.

Tests: module 40→49 (handled-marker unblocks, no-marker still blocks, deadlock case now proposes, unhandled planner request still gates, dir-missing = empty); 3 existing assertions updated with justification. Full suite 1399 passed; only the 2 known pre-existing systemd flakes (identical on stashed baseline). Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125qdhCSXD9qCxmmFvoK5uv