### PR TITLE
feat(runtime): goal-alignment 'serves' field, honest no-op, hypotheses→priorities reader (#751)

### DIFF
--- a/docs/changes/751-value-link/proposal.md
+++ b/docs/changes/751-value-link/proposal.md
@@ -1,0 +1,220 @@
+# Implementation proposal: goal-alignment 'serves' field, honest no-op, hypotheses reader (#751)
+
+- **Issue:** #751
+- **story_id:** `docs/specs/subagent-bridge/spec.md` (LLM proposer, R28-R33; this
+  change adds R36)
+- **Depends on:** #748 (evidence-based done-detection — the ground the value
+  judgment stands on). **Related:** #749 (SYSTEM_MAP inventory in proposer
+  context), #750 (FTS5 existence index).
+- **Status:** implemented in this change.
+
+## Problem
+
+Nothing in the #707 proposal schema (`task_title`, `rationale`, `target_path`)
+ties a proposed task to the project's actual goals. `rationale` is free text
+the LLM writes about its own proposal — it is not checked against anything.
+Confirmed consequence (night of 2026-07-14): 16 integrations landed overnight
+with declining value per cycle as the proposer circled a saturated theme
+space (memory/CPU monitoring scripts under successive new names), because
+nothing forced it to justify *why* a task mattered or let it admit that
+nothing did. Meanwhile `state/hypotheses/backlog.json`
+(`cycle_persist._build_hypothesis_backlog_snapshot`, written every cycle by
+the coordinator) and `state/research/hypotheses.json`
+(`cycle_planning._write_research_feed`, an append-only cycle-snapshot log)
+are both written every self-evolving cycle but read by **nothing** on the live
+path — the deterministic planner that used to consume them was retired in
+#739, and no replacement reader was ever wired up. The "hypothesis ->
+priority" chain exists only on paper.
+
+## Proposal
+
+Three additions to `nanobot/runtime/llm_proposer.py`, all schema-validated or
+fail-open, none introducing a new kill-switch (the existing
+`SELFEVO_LLM_PROPOSER_ENABLED` gate covers all of this — `serves` is simply
+part of the proposal contract from now on).
+
+### 1. `serves` field — schema-enforced goal alignment
+
+`_PROPOSER_SYSTEM_PROMPT` now requires a fourth JSON key, `serves`, naming
+what the proposed task serves:
+
+- `"priority <N>"` — a numbered `goal_text.json` "Current priority targets"
+  entry (e.g. `"priority 5"`);
+- `"vector 1"` / `"vector 2"` — goal_text's Vector 1 (self-optimization) /
+  Vector 2 (owner utility), optionally with a 3-8 word justification suffix
+  after a colon (e.g. `"vector 1: reduces cycle disk writes"`);
+- `"hypothesis <id-or-short-title>"` — an entry from the new Hypothesis
+  backlog context section (part 3, below), e.g. `"hypothesis h3"`.
+
+`validate_sizing` (extended, not renamed — see "Deviations" below) rejects a
+proposal whose `serves` is missing/empty, over 160 characters, or does not
+start (case-insensitively) with one of those four prefixes. This follows the
+exact same reject → retry-once-with-feedback → fail-closed path the other
+schema checks already use (R29); no proposal is written this cycle if
+`serves` still fails validation after the retry.
+
+`write_request`'s `append_event` call for the `proposed` ledger row (R31) now
+also carries the accepted `serves` string. It is **not** added to the written
+request JSON payload itself — that would break the R29
+request-schema-equality invariant with
+`cycle_planning._write_subagent_request_artifact` (verified unchanged by
+`TestWriteRequestSchemaEquality.test_same_keys_and_queued_status`). Rows
+written before this change (no `serves` key) read as class `"missing"` in
+the report below — never a crash.
+
+`scripts/loop_metrics_report.py` gains a **goal alignment** section:
+`_goal_alignment_breakdown` counts `proposed`-phase ledger rows per
+`serves`-class (`priority` / `vector 1` / `vector 2` / `hypothesis` /
+`missing` / `other`) over the report window, plus the count of honest no-op
+skips (part 2). Rendered as a new table section in `render_table` and a new
+`goal_alignment` key in the JSON report.
+
+### 2. Honest no-op
+
+The prompt now also allows: *"If nothing you could propose creates real
+value toward the goals — everything worthwhile is done, queued, or listed as
+existing — reply with exactly `{"no_valuable_task": true, "reason": "..."}`
+instead of inventing filler work."*
+
+When `maybe_propose` receives this reply (and the reply is currently
+"allowed" — see the cap below), it records a **`proposer_skip`** ledger event
+(`phase: "proposer_skip"`, `reason`, deliberately no `cycle_id` — no
+cycle/subagent request exists for a skipped cycle) and returns `None`
+immediately: no subagent request is minted this cycle. `proposer_skip` is a
+distinct phase from `proposed` — never a `proposed` row with a placeholder
+title — so it can never pollute R30's title-based dedup
+(`_recent_proposed_titles` only reads `phase == "proposed"`) or the
+goal-alignment counts above.
+
+**Kill-switch reuse + idle-loop bound.** No new enable flag: `serves` and the
+no-op reply are both part of the existing proposer's contract, gated by the
+same `SELFEVO_LLM_PROPOSER_ENABLED`. To stop a lazy model from replying
+`no_valuable_task` forever, `_consecutive_noop_streak` counts trailing
+`proposer_skip` rows among the ledger's own `proposed`/`proposer_skip`
+history (stopping at the most recent `proposed` row) — tracked via the
+ledger, not in-memory, so the cap survives a process restart. Once the streak
+reaches `_MAX_CONSECUTIVE_NOOP_SKIPS` (3), the next call is forced into
+normal mode: `build_context(..., force_proposal=True)` appends an explicit
+"you must propose a concrete task this cycle" note, and even if the model
+still replies `no_valuable_task` anyway, `maybe_propose` ignores it (does not
+treat it as an honored skip) and falls through to `validate_sizing`, which
+rejects it for a missing `task_title` — the same reject/retry/fail-closed
+path as any other invalid proposal (belt-and-suspenders: correct regardless
+of whether the model actually respects the forced-mode instruction).
+
+**Pacing.** `bridge.py` calls `maybe_propose` at most once per bridge cycle
+(the timer-paced ~10-minute cadence the surrounding R28 invocation policy
+already relies on) — this alone is sufficient to keep a run of honest skips
+from tight-looping; no additional rate limit was needed.
+
+### 3. Hypotheses reader (гипотеза -> приоритет chain)
+
+New module `nanobot/runtime/hypothesis_backlog.py`:
+
+- `_backlog_candidates` / `_research_candidates` read the two existing
+  cycle-writers' files (`hypotheses/backlog.json` primary,
+  `research/hypotheses.json` secondary) into a common
+  `{key, title, source}` shape. `key` prefers the backlog entry's own
+  `hypothesis_id`; otherwise a slug of the title (`research/hypotheses.json`
+  entries have no id).
+- `top_candidates` / `context_section` surface the top 5 still-`active`
+  candidates as a new, separately-bounded `## Hypothesis backlog (candidate
+  value sources)` section in `build_context` — one
+  `- [<key>] <title>` line each, omitted entirely when there is nothing to
+  show (same fail-open convention as the R34 inventory section).
+- **Lifecycle** (`active` -> `answered` / `stale`): `reconcile` scans recent
+  ledger rows for a `proposed` row whose `serves` names a hypothesis
+  (`hypothesis <ref>`) followed by a same-`cycle_id` `outcome` row with
+  `outcome == "success"` — that candidate is marked `answered` (with the
+  resolving `cycle_id` as evidence) and stops appearing in the context.
+  A candidate not referenced by any `serves: hypothesis ...` proposal for
+  `STALE_AFTER_UNTOUCHED_CYCLES` (50) reconciliation passes, or older than
+  `STALE_AFTER_DAYS` (14) since first observed, is demoted to `stale` and
+  also drops out of the context.
+
+## Deviations from the issue brief (and why)
+
+1. **Lifecycle status is NOT stored inside `backlog.json`'s own entries.**
+   The brief's most literal reading ("persist status IN the backlog.json
+   entries, additive keys, never drop unknown fields") assumes
+   read-modify-write semantics. In the actual code,
+   `cycle_persist._build_hypothesis_backlog_snapshot` writes a **fully
+   regenerated** snapshot every self-evolving cycle
+   (`hypothesis_backlog_path.write_text(json.dumps(hypothesis_backlog, ...))`
+   in `coordinator.py`, not a merge) — any status key this module added to an
+   entry would be silently wiped by the very next cycle's snapshot.
+   Persisting lifecycle status there would require invasive changes to the
+   coordinator's cycle-persistence path, well outside this change's scope.
+   Instead, `hypothesis_backlog.py` owns a small sidecar file,
+   `<state_dir>/hypotheses/lifecycle.json`, keyed by the stable candidate
+   key, read/written exclusively by this module — additive-only, never
+   dropping unknown fields (verified by
+   `test_unknown_fields_preserved_after_rewrite`), satisfying the same
+   intent (state survives across cycles) without fighting the existing
+   writer's overwrite semantics.
+2. **No dedicated cycle-outcome hook for answered-marking; lazy
+   reconciliation instead.** The brief allows this as a fallback ("if no
+   clean hook exists without invasive changes, implement the marking as part
+   of the NEXT `build_context` call"). Grepping for where cycle outcomes are
+   recorded (`cycle_ledger.record_cycle_outcome`, called from `bridge.py` at
+   the point a cycle's result is known) shows no existing seam that already
+   has both the `serves` value and the resolving cycle_id available together
+   without new plumbing through the bridge's cycle-result path. Reconciling
+   lazily inside `top_candidates`/`context_section` (called once per proposer
+   cycle via `build_context`) is simple and fail-open: a hypothesis's
+   `answered` status becomes visible in the context within one additional
+   proposer cycle of its resolving outcome landing, matching the loop's own
+   coarse (~10-minute) cadence — sufficient for this purpose.
+3. **`_MAX_CONSECUTIVE_NOOP_SKIPS` enforcement is a static text note in the
+   context plus a code-level ignore, not a variable system prompt.** Rather
+   than parameterizing `propose()`'s system-prompt argument per call (which
+   would require changing its call signature — and every existing test in
+   `tests/test_llm_proposer.py` monkeypatches `llm_proposer.propose` with a
+   fixed `(context, *, rejection_reason=None, timeout=120.0)` signature that
+   would break under a new required/optional kwarg mismatch with certain
+   mocks), the forced-mode signal is carried entirely in the **context**
+   string (`build_context(..., force_proposal=True)`) while `propose()`'s own
+   signature and the constant `_PROPOSER_SYSTEM_PROMPT` are both left
+   unchanged. This keeps 100% of the pre-#751 `propose()` call sites and
+   mocks working unmodified.
+
+## Test evidence
+
+- `tests/test_llm_proposer.py`: extended `TestValidateSizing`'s `_good()`
+  fixture with a `serves` default; new `TestValidateServes` (accepted forms:
+  `priority 11`, `vector 1: ...`, `vector 2`, `hypothesis h3`, case
+  variance; rejected: missing, empty, wrong prefix, over 160 chars, list
+  type); new `TestHonestNoOp` (skip records a `proposer_skip` row and mints
+  no request, default reason placeholder, the 3-consecutive cap forces
+  normal mode on the 4th call with the forced-note present in context, the
+  streak resets after a real proposal); new `TestBuildContextHypotheses`
+  (section present/bounded from `backlog.json`, corrupt file omitted,
+  absent when no hypothesis files exist). All previously-existing fake
+  `propose()` return dicts across the file were updated to include a valid
+  `serves` field so the suite stays green under the new mandatory field.
+- `tests/test_hypothesis_backlog.py` (new): primary/secondary source
+  reading, dedup-by-key, corrupt-file fail-open, answered-marking on a
+  success outcome with `serves: hypothesis ...`, staying active on a
+  non-success outcome, stale demotion by age and by untouched-cycle count,
+  unknown-field preservation across a lifecycle rewrite, fail-open on a
+  wholly missing state dir.
+- `scripts/loop_metrics_report.py`'s `--test` self-check: extended the fixture
+  ledger with 5 `proposed` rows (one per serves-class, one legacy row with no
+  `serves` at all) and 2 `proposer_skip` rows; asserts the new
+  `goal_alignment` breakdown counts each class correctly and that the
+  pre-existing metrics/liveness assertions are unaffected.
+
+## Acceptance (from the issue)
+
+- Every ledger `proposed` row carries a non-empty `serves` (schema-enforced,
+  fail-closed on violation) — the report shows the distribution.
+- A live cycle demonstrably picks a hypothesis from the backlog and marks it
+  Answered with commit evidence — verified logically here via
+  `test_answered_marking_on_success_outcome_with_serves_hypothesis`; live
+  verification on the eeepc host follows after deploy (this PR does not
+  close #751 — see PR body).
+- A saturated-theme scenario ends in `no_valuable_task` (ledger-visible)
+  rather than a near-duplicate integration — covered by `TestHonestNoOp`;
+  live confirmation follows after deploy.
+- Fail-closed on schema violation (reject + one retry, then no proposal this
+  cycle) — unchanged path, now also covering `serves`.

--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -1,8 +1,11 @@
 # Subagent Bridge — spec
 
-_Status: current. Last updated: 2026-07-14 (#749: added R34, the deterministic
-SYSTEM_MAP inventory fed into the LLM proposer's context so it stops shipping
-near-duplicate scripts under new names — see
+_Status: current. Last updated: 2026-07-14 (#751: added R36, the 'serves'
+goal-alignment field, the honest `no_valuable_task` no-op reply, and the
+hypothesis-backlog reader/lifecycle — see
+`docs/changes/751-value-link/proposal.md`). Previous entry: 2026-07-14 (#749:
+added R34, the deterministic SYSTEM_MAP inventory fed into the LLM proposer's
+context so it stops shipping near-duplicate scripts under new names — see
 `docs/changes/749-system-map/proposal.md`; #750: added R35, the FTS5
 existence-index semantic dedup gate — see
 `docs/changes/750-existence-index/proposal.md`). Previous entry: 2026-07-08 (#703:
@@ -159,6 +162,71 @@ next bounded task from an LLM instead of idling. Design + go/no-go evidence:
   (default ON); fail-open on any internal error (missing/corrupt index,
   missing source directories) — degrades to R32/R33-only behavior, never
   blocks a proposal it failed to evaluate.
+- R36 (issue #751). Every proposal SHALL name what goal it serves, and the
+  proposer MAY honestly decline to propose when nothing serves a goal, so
+  goal-alignment is queryable and a saturated theme space produces a
+  recorded skip instead of invented filler work:
+  - **`serves` field.** The proposal schema (`_PROPOSER_SYSTEM_PROMPT`)
+    SHALL require a fourth key, `serves`, naming what the task serves:
+    `"priority <N>"` (a numbered `goal_text.json` priority), `"vector 1"` /
+    `"vector 2"` (Vector 1 = self-optimization, Vector 2 = owner utility;
+    optionally suffixed with a 3-8 word justification after a colon), or
+    `"hypothesis <id-or-short-title>"` naming an entry surfaced by the
+    hypothesis-backlog section below. `validate_sizing` SHALL reject a
+    missing/empty `serves`, one over 160 characters, or one not starting
+    (case-insensitively) with one of those four prefixes — the same
+    reject/retry-once/fail-closed path as the other schema checks (R29).
+    Every `proposed` ledger row (R31) SHALL carry the accepted `serves`
+    value (recorded in the ledger event only, not in the written request
+    payload, to preserve the R29 request-schema-equality invariant);
+    pre-#751 rows without `serves` read as class `"missing"`, never a
+    crash. `scripts/loop_metrics_report.py` reports a goal-alignment
+    section: a count of `proposed` rows per `serves`-class
+    (`priority`/`vector 1`/`vector 2`/`hypothesis`/`missing`/`other`) over
+    the report window, plus the count of honest no-op skips (below).
+  - **Honest no-op.** The proposer prompt SHALL allow the LLM to reply
+    `{"no_valuable_task": true, "reason": "<short>"}` instead of a proposal
+    when nothing it could propose creates real value toward the goals
+    (everything worthwhile is done, queued, or already listed). Accepting
+    this reply SHALL append a distinct `proposer_skip` ledger event
+    (`reason`, no `cycle_id` — no cycle/subagent request exists for a
+    skipped cycle) and return with NO subagent request minted — deliberately
+    a different phase than `proposed`, so it never pollutes R30's
+    title-based dedup or the goal-alignment counts above. To bound this
+    against a lazy model idling the loop indefinitely, the reply is only
+    honored while `_consecutive_noop_streak` (counted from trailing
+    `proposed`/`proposer_skip` ledger rows, not in-memory, so it survives a
+    process restart) is under `_MAX_CONSECUTIVE_NOOP_SKIPS` (3); the next
+    call is forced into normal proposal mode (the built context carries an
+    explicit "you must propose" note), and even a model that still replies
+    `no_valuable_task` in that state has the reply ignored and is treated as
+    an ordinary schema violation (missing `task_title`), following the same
+    reject/retry/fail-closed path as any other invalid proposal. `bridge.py`
+    already invokes `maybe_propose` at most once per bridge cycle
+    (timer-paced, ~10 min per R28's surrounding cadence) — sufficient
+    pacing on its own; no additional rate limit was needed for this path.
+  - **Hypothesis-backlog reader.** `nanobot/runtime/hypothesis_backlog.py`
+    gives the proposer context a bounded `## Hypothesis backlog (candidate
+    value sources)` section (top 5, one `- [<key>] <title>` line each) read
+    from `<state_dir>/hypotheses/backlog.json` (primary) and
+    `<state_dir>/research/hypotheses.json` (secondary) — both written every
+    self-evolving cycle but, with the deterministic planner retired (#739),
+    read by nothing else on the live path until this change. Candidates
+    have a small lifecycle — `active` -> `answered` (evidenced by the
+    resolving `cycle_id`) once a `serves: hypothesis <ref>` proposal's cycle
+    reaches a `success` outcome, or `active` -> `stale` (dropped from the
+    context) once untouched by any such proposal for 50 reconciliation
+    passes or 14 days, whichever comes first — persisted in a sidecar
+    `<state_dir>/hypotheses/lifecycle.json` this module owns exclusively
+    (additive-only; never drops unknown keys), rather than inside
+    `backlog.json` itself, which is fully regenerated every cycle by the
+    coordinator and so cannot hold cross-cycle status without a
+    read-modify-write change to that writer (out of this change's scope).
+    Reconciliation is lazy — it runs as a side effect of every
+    `build_context` call (once per proposer cycle) rather than at a
+    dedicated cycle-outcome hook, since no such hook exists without
+    invasive coordinator changes. Fail-open throughout: a missing/corrupt
+    file degrades to an omitted section, never blocks a proposal.
 
 ### Executor model
 - R4. The bridge SHALL run the bounded subagent on the mandatory local executor

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -1,0 +1,336 @@
+"""Hypotheses -> priorities reader (#751).
+
+The deterministic planner (retired in #739) used to be the only reader of
+``state_dir/hypotheses/backlog.json`` (written every self-evolving cycle by
+``nanobot.runtime.coordinator``/``cycle_persist._build_hypothesis_backlog_snapshot``)
+and ``state_dir/research/hypotheses.json`` (an append-only cycle-snapshot log
+written by ``cycle_planning._write_research_feed``). With the planner off,
+nothing on the live path read either file — the "hypothesis -> priority"
+chain existed only on paper. This module gives the LLM proposer
+(``nanobot.runtime.llm_proposer``) a bounded, fail-open read of both files as
+candidate ``serves: hypothesis <id>`` targets, plus a small lifecycle
+(active -> answered/stale) so the context doesn't re-offer resolved or
+abandoned candidates forever.
+
+Design note — why lifecycle state is NOT stored inside ``backlog.json``
+itself (a deviation from the most literal reading of #751's brief): that
+file is fully REGENERATED every self-evolving cycle by
+``cycle_persist._build_hypothesis_backlog_snapshot`` (a plain
+``path.write_text(json.dumps(...))``, not a read-modify-write) — any status
+key this module added to an entry would be silently wiped by the very next
+cycle's snapshot. Persisting lifecycle status in that file would therefore
+require invasive changes to the coordinator's cycle-persistence path, well
+outside this change's scope. Instead, this module owns a small sidecar file,
+``state_dir/hypotheses/lifecycle.json``, keyed by a stable candidate key
+(the snapshot's own ``hypothesis_id`` when present, else a slug of the
+title) that it reads/writes exclusively — additive-only, never dropping
+unknown fields, satisfying the same spirit (state survives across cycles)
+without fighting the existing writer's overwrite semantics.
+
+Everything here is fail-open: a missing/corrupt file, or any unexpected
+shape, degrades to "no candidates" / "no lifecycle change" rather than
+raising. Nothing here ever touches ``backlog.json`` or
+``research/hypotheses.json`` themselves — both remain owned by their
+existing writers.
+"""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+TOP_N = 5
+MAX_SECTION_CHARS = 1200
+STALE_AFTER_DAYS = 14
+STALE_AFTER_UNTOUCHED_CYCLES = 50
+
+_HYPOTHESIS_SERVES_RE = re.compile(r"^hypothesis\s+(.+)$", re.IGNORECASE)
+
+
+def _read_json(path: Path, default: Any) -> Any:
+    try:
+        if not path.is_file():
+            return default
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def _write_json(path: Path, data: Any) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _load_ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
+    path = Path(state_dir) / "ledger" / "cycles.jsonl"
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(rec, dict):
+            rows.append(rec)
+    return rows
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")[:60]
+
+
+def _candidate_key(entry: dict[str, Any]) -> str:
+    hid = str(entry.get("hypothesis_id") or "").strip()
+    if hid:
+        return hid
+    title = str(entry.get("task_title") or entry.get("title") or "").strip()
+    return f"slug-{_slug(title)}" if title else ""
+
+
+def _backlog_candidates(state_dir: Path) -> list[dict[str, str]]:
+    """Primary source: ``hypotheses/backlog.json``'s ``entries`` list
+    (``cycle_persist._build_hypothesis_backlog_snapshot``'s shape)."""
+    data = _read_json(Path(state_dir) / "hypotheses" / "backlog.json", None)
+    if not isinstance(data, dict):
+        return []
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        return []
+    out: list[dict[str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        key = _candidate_key(entry)
+        title = str(entry.get("task_title") or entry.get("title") or "").strip()
+        if not key or not title:
+            continue
+        out.append({"key": key, "title": title, "source": "backlog"})
+    return out
+
+
+def _research_candidates(state_dir: Path) -> list[dict[str, str]]:
+    """Secondary source: ``research/hypotheses.json`` — an append-only list
+    of cycle snapshots (``cycle_planning._write_research_feed``'s shape),
+    each with a ``candidates`` list of ``{title, hypothesis, acceptance}``."""
+    data = _read_json(Path(state_dir) / "research" / "hypotheses.json", None)
+    if not isinstance(data, list):
+        return []
+    out: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for snapshot in data:
+        if not isinstance(snapshot, dict):
+            continue
+        candidates = snapshot.get("candidates")
+        if not isinstance(candidates, list):
+            continue
+        for cand in candidates:
+            if not isinstance(cand, dict):
+                continue
+            title = str(cand.get("title") or cand.get("hypothesis") or "").strip()
+            if not title:
+                continue
+            key = f"slug-{_slug(title)}"
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({"key": key, "title": title, "source": "research"})
+    return out
+
+
+def _all_candidates(state_dir: Path) -> list[dict[str, str]]:
+    seen: set[str] = set()
+    out: list[dict[str, str]] = []
+    for cand in _backlog_candidates(state_dir) + _research_candidates(state_dir):
+        if cand["key"] in seen:
+            continue
+        seen.add(cand["key"])
+        out.append(cand)
+    return out
+
+
+def _load_lifecycle(state_dir: Path) -> dict[str, Any]:
+    data = _read_json(Path(state_dir) / "hypotheses" / "lifecycle.json", None)
+    if not isinstance(data, dict) or not isinstance(data.get("entries"), dict):
+        return {"schema_version": "hypothesis-lifecycle-v1", "entries": {}}
+    return data
+
+
+def _save_lifecycle(state_dir: Path, data: dict[str, Any]) -> None:
+    _write_json(Path(state_dir) / "hypotheses" / "lifecycle.json", data)
+
+
+def _serves_hypothesis_ref(serves: str) -> str | None:
+    match = _HYPOTHESIS_SERVES_RE.match((serves or "").strip())
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _ref_matches_candidate(ref: str, cand: dict[str, str]) -> bool:
+    ref_low = ref.lower().strip()
+    if not ref_low:
+        return False
+    key_low = cand["key"].lower()
+    title_low = cand["title"].lower()
+    return ref_low == key_low or ref_low in key_low or ref_low in title_low
+
+
+def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
+    """Lazy lifecycle reconciliation (#751 design choice — no invasive hook
+    into where cycle outcomes are recorded; this runs instead as a side
+    effect of every :func:`top_candidates`/:func:`context_section` call, i.e.
+    once per proposer cycle via ``llm_proposer.build_context``).
+
+    Marks a candidate ``answered`` (with the resolving ``cycle_id`` as
+    evidence) the first time a ledger ``'proposed'`` row whose ``serves``
+    names it (``hypothesis <ref>``) is later followed by a same-``cycle_id``
+    ``'outcome'`` row with ``outcome == "success"``. Demotes any still-
+    ``active`` candidate to ``stale`` once it has gone unreferenced by any
+    ``serves: hypothesis ...`` proposal for :data:`STALE_AFTER_UNTOUCHED_CYCLES`
+    reconciliation passes, or :data:`STALE_AFTER_DAYS` days have elapsed
+    since it was first observed — whichever comes first. Fail-open: never
+    raises; a partial/corrupt read degrades to "no reconciliation this
+    pass" rather than crashing the caller.
+    """
+    try:
+        state_dir = Path(state_dir)
+        now = now or datetime.now(timezone.utc)
+        candidates = _all_candidates(state_dir)
+        if not candidates:
+            return
+
+        lifecycle = _load_lifecycle(state_dir)
+        entries: dict[str, Any] = lifecycle.setdefault("entries", {})
+
+        rows = _load_ledger_rows(state_dir)
+        proposed_by_cycle: dict[str, dict[str, Any]] = {}
+        outcome_by_cycle: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            cid = row.get("cycle_id")
+            if not cid:
+                continue
+            phase = row.get("phase")
+            if phase == "proposed":
+                proposed_by_cycle[cid] = row
+            elif phase == "outcome":
+                outcome_by_cycle[cid] = row
+
+        touched_keys: set[str] = set()
+        answered_keys: dict[str, str] = {}
+        for cid, prow in proposed_by_cycle.items():
+            ref = _serves_hypothesis_ref(str(prow.get("serves") or ""))
+            if not ref:
+                continue
+            for cand in candidates:
+                if not _ref_matches_candidate(ref, cand):
+                    continue
+                touched_keys.add(cand["key"])
+                outcome_row = outcome_by_cycle.get(cid)
+                if outcome_row and outcome_row.get("outcome") == "success":
+                    answered_keys[cand["key"]] = str(cid)
+
+        now_iso = now.isoformat().replace("+00:00", "Z")
+        for cand in candidates:
+            key = cand["key"]
+            entry = entries.get(key)
+            if not isinstance(entry, dict):
+                entry = {}
+            entry.setdefault("status", "active")
+            entry.setdefault("first_seen", now_iso)
+            entry.setdefault("cycles_untouched", 0)
+
+            if key in answered_keys and entry.get("status") != "answered":
+                entry["status"] = "answered"
+                entry["answered_evidence"] = answered_keys[key]
+                entry["answered_at"] = now_iso
+
+            if entry.get("status") == "active":
+                if key in touched_keys:
+                    entry["cycles_untouched"] = 0
+                    entry["last_touched"] = now_iso
+                else:
+                    entry["cycles_untouched"] = int(entry.get("cycles_untouched") or 0) + 1
+
+                first_seen = _parse_ts(entry.get("first_seen")) or now
+                age_days = (now - first_seen).total_seconds() / 86400.0
+                if (
+                    age_days >= STALE_AFTER_DAYS
+                    or entry["cycles_untouched"] >= STALE_AFTER_UNTOUCHED_CYCLES
+                ):
+                    entry["status"] = "stale"
+                    entry["stale_at"] = now_iso
+
+            entries[key] = entry
+
+        lifecycle["entries"] = entries
+        _save_lifecycle(state_dir, lifecycle)
+    except Exception:
+        pass
+
+
+def top_candidates(state_dir: Path, n: int = TOP_N) -> list[dict[str, str]]:
+    """Top ``n`` still-``active`` candidates, backlog-order then research-
+    order, reconciling lifecycle state first. Fail-open: returns ``[]`` on
+    any error."""
+    try:
+        state_dir = Path(state_dir)
+        reconcile(state_dir)
+        candidates = _all_candidates(state_dir)
+        if not candidates:
+            return []
+        lifecycle = _load_lifecycle(state_dir)
+        entries = lifecycle.get("entries", {})
+        out: list[dict[str, str]] = []
+        for cand in candidates:
+            status = "active"
+            stored = entries.get(cand["key"])
+            if isinstance(stored, dict):
+                status = str(stored.get("status") or "active")
+            if status != "active":
+                continue
+            out.append(cand)
+            if len(out) >= n:
+                break
+        return out
+    except Exception:
+        return []
+
+
+def context_section(state_dir: Path) -> str:
+    """Bounded ``## Hypothesis backlog (candidate value sources)`` body (no
+    heading — the caller adds it), one ``- [<key>] <title>`` line per
+    candidate. Fail-open: returns ``""`` on any error or when there are no
+    active candidates, so the caller can omit the section entirely."""
+    try:
+        candidates = top_candidates(state_dir, TOP_N)
+        if not candidates:
+            return ""
+        lines = [f"- [{cand['key']}] {cand['title']}" for cand in candidates]
+        section = "\n".join(lines)
+        if len(section) > MAX_SECTION_CHARS:
+            section = section[:MAX_SECTION_CHARS]
+        return section
+    except Exception:
+        return ""

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -29,7 +29,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from nanobot.runtime import system_map
+from nanobot.runtime import hypothesis_backlog, system_map
 from nanobot.runtime.cycle_ledger import append_event
 from nanobot.runtime.cycle_planning import (
     _recent_git_log,
@@ -55,6 +55,8 @@ _DUP_STREAK_K = 3
 _MAX_TITLE_CHARS = 120
 _RECENT_PROPOSED_TITLES_N = 10
 _MAX_LLM_CALLS = 3
+_MAX_CONSECUTIVE_NOOP_SKIPS = 3
+_MAX_SERVES_CHARS = 160
 
 _PRIORITY_PATTERN = re.compile(
     r"\([A-Za-z]\)\s*Priority\s+(\d+)\s*[—-]\s*(.+?):\s*(.+?)(?=\n\([A-Za-z]\)|\Z)",
@@ -62,23 +64,42 @@ _PRIORITY_PATTERN = re.compile(
 )
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 _JSON_OBJ_RE = re.compile(r"\{.*\}", re.DOTALL)
+_SERVES_PREFIXES = ("priority ", "vector 1", "vector 2", "hypothesis ")
 
 _PROPOSER_SYSTEM_PROMPT = (
     "You are proposing exactly ONE small, bounded engineering improvement for a "
     "self-evolving codebase. Reply with ONLY a JSON object with keys "
-    "task_title, rationale, target_path — no prose, no markdown code fences. "
-    "task_title must be non-empty and at most 120 characters, describing a "
-    "single behavior/bug (not a bundle). target_path must name exactly ONE "
-    "path (file or directory) under one of these mutable surfaces: "
-    "surfaces/, scripts/, memory/, lessons/, docs/, tests/ — no other path is "
-    "acceptable. rationale must briefly justify the change and must NOT "
-    "repeat any already-done or recently-failed work described in the "
-    "context below. If the goal text lists numbered 'Current priority "
-    "targets', propose EXACTLY one of them (the first not yet done) "
-    "VERBATIM as the task; only invent a new task when no numbered "
-    "priorities remain. The context lists existing scripts; do NOT propose a "
-    "script that duplicates one (same purpose under a different name) — "
-    "extend the existing file or pick a different task instead."
+    "task_title, rationale, target_path, serves — no prose, no markdown code "
+    "fences. task_title must be non-empty and at most 120 characters, "
+    "describing a single behavior/bug (not a bundle). target_path must name "
+    "exactly ONE path (file or directory) under one of these mutable "
+    "surfaces: surfaces/, scripts/, memory/, lessons/, docs/, tests/ — no "
+    "other path is acceptable. serves must name what goal this task serves — "
+    "non-empty, at most 160 characters, starting with one of: 'priority <N>' "
+    "(a numbered goal_text priority, e.g. 'priority 5'), 'vector 1' or "
+    "'vector 2' (optionally followed by a colon and a short 3-8 word "
+    "justification, e.g. 'vector 1: reduces cycle disk writes'), or "
+    "'hypothesis <id-or-short-title>' naming an entry from the Hypothesis "
+    "backlog section below (e.g. 'hypothesis h3'). rationale must briefly "
+    "justify the change and must NOT repeat any already-done or recently-"
+    "failed work described in the context below. If the goal text lists "
+    "numbered 'Current priority targets', propose EXACTLY one of them (the "
+    "first not yet done) VERBATIM as the task, with serves naming that "
+    "priority number; only invent a new task when no numbered priorities "
+    "remain. The context lists existing scripts; do NOT propose a script "
+    "that duplicates one (same purpose under a different name) — extend the "
+    "existing file or pick a different task instead. If nothing you could "
+    "propose creates real value toward the goals — everything worthwhile is "
+    "done, queued, or listed as existing — you MAY instead reply with ONLY "
+    '{"no_valuable_task": true, "reason": "<short reason>"} instead of '
+    "inventing filler work."
+)
+
+_FORCE_PROPOSAL_NOTE = (
+    "IMPORTANT: you have already replied no_valuable_task for "
+    f"{_MAX_CONSECUTIVE_NOOP_SKIPS} consecutive cycles. Do NOT reply "
+    "no_valuable_task this cycle — you MUST propose a concrete, valid task "
+    "using the schema above, choosing the least-wasteful available option."
 )
 
 
@@ -421,8 +442,10 @@ def _system_map_inventory_section(selfevo_repo: Path | None) -> str:
         return ""
 
 
-def build_context(state_dir: Path, selfevo_repo: Path | None) -> str:
-    """Compact, bounded proposer context (#707 C3; extended by #749).
+def build_context(
+    state_dir: Path, selfevo_repo: Path | None, *, force_proposal: bool = False
+) -> str:
+    """Compact, bounded proposer context (#707 C3; extended by #749, #751).
 
     Two read-only base inputs, kept separate: the filtered (done-items
     stripped) goal_text, and a bounded digest of the last N terminal ledger
@@ -433,7 +456,17 @@ def build_context(state_dir: Path, selfevo_repo: Path | None) -> str:
     near-duplicate scripts under new names (the confirmed
     ``track_memory.py``/``monitor_memory.py`` failure) — omitted entirely
     when there is nothing to show, rather than truncating the base context
-    to make room. Fail-open: returns an empty string on any error.
+    to make room. A fourth, separately-bounded section (#751) lists the top
+    active hypothesis-backlog candidates (see
+    ``nanobot.runtime.hypothesis_backlog``) as ``serves: hypothesis <id>``
+    targets — also omitted entirely when there is nothing to show.
+
+    ``force_proposal`` (#751): when the proposer's consecutive
+    ``no_valuable_task`` skip streak has hit its cap, the caller
+    (``maybe_propose``) sets this so the appended note tells the model it
+    must propose a concrete task this cycle rather than skip again.
+
+    Fail-open: returns an empty string on any error.
     """
     try:
         state_dir = Path(state_dir)
@@ -469,6 +502,20 @@ def build_context(state_dir: Path, selfevo_repo: Path | None) -> str:
                 "\n\n## Existing scripts (do not duplicate — extend or skip instead)\n"
                 + inventory_section
             )
+
+        try:
+            hypothesis_section = hypothesis_backlog.context_section(state_dir)
+        except Exception:
+            hypothesis_section = ""
+        if hypothesis_section:
+            context += (
+                "\n\n## Hypothesis backlog (candidate value sources)\n"
+                + hypothesis_section
+            )
+
+        if force_proposal:
+            context += "\n\n" + _FORCE_PROPOSAL_NOTE
+
         return context
     except Exception:
         return ""
@@ -538,8 +585,34 @@ def propose(context: str, *, rejection_reason: str | None = None, timeout: float
     return _extract_json_object(reply)
 
 
+def _validate_serves(proposal: dict[str, Any]) -> tuple[bool, str]:
+    """#751: goal-alignment field validation, same reject/retry path as the
+    other schema checks in :func:`validate_sizing`. ``serves`` must be a
+    non-empty string, at most :data:`_MAX_SERVES_CHARS` (160) characters,
+    starting (case-insensitively) with one of :data:`_SERVES_PREFIXES` —
+    ``'priority '``, ``'vector 1'``, ``'vector 2'``, or ``'hypothesis '``.
+    ``'vector 1'``/``'vector 2'`` alone are accepted (the optional
+    justification suffix, e.g. ``': reduces cycle disk writes'``, is not
+    separately validated beyond the length cap)."""
+    serves = proposal.get("serves")
+    if isinstance(serves, (list, tuple, dict)):
+        return False, "serves must be a single string, not a list/object"
+    serves = str(serves or "").strip()
+    if not serves:
+        return False, "serves is missing"
+    if len(serves) > _MAX_SERVES_CHARS:
+        return False, f"serves exceeds {_MAX_SERVES_CHARS} chars"
+    if not serves.lower().startswith(_SERVES_PREFIXES):
+        return False, (
+            "serves must start with one of "
+            f"{_SERVES_PREFIXES} (goal alignment): got {serves!r}"
+        )
+    return True, ""
+
+
 def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
-    """Pre-spawn checkable sizing (#707 C2). Returns ``(ok, reason)``."""
+    """Pre-spawn checkable sizing (#707 C2; extended by #751's ``serves``
+    goal-alignment field). Returns ``(ok, reason)``."""
     if not isinstance(proposal, dict):
         return False, "proposal is not a JSON object"
 
@@ -563,6 +636,10 @@ def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
         return False, "target_path must name exactly one path"
     if not any(target_path.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES):
         return False, f"target_path outside allowed surfaces {_ALLOWED_PATH_PREFIXES}: {target_path}"
+
+    ok, reason = _validate_serves(proposal)
+    if not ok:
+        return False, reason
 
     return True, ""
 
@@ -624,6 +701,44 @@ def _display_title(task_title: str) -> str:
     return f"Implement and commit: {task_title}" if task_title else task_title
 
 
+def _consecutive_noop_streak(state_dir: Path) -> int:
+    """#751 kill-switch bound: count trailing ``no_valuable_task`` skip
+    events among this module's own proposer-decision ledger rows
+    (``'proposed'`` and ``'proposer_skip'`` phases only), most-recent-first,
+    stopping at the first ``'proposed'`` row or the start of the ledger.
+    Tracked via the ledger (not in-memory) so the cap survives process
+    restarts. Fail-open: any error reads as ``0`` (no streak), which only
+    ever makes the caller MORE willing to allow another no-op — never less
+    safe than the ledger being unreadable."""
+    try:
+        rows = _load_ledger_rows(state_dir)
+        relevant = [r for r in rows if r.get("phase") in ("proposed", "proposer_skip")]
+        count = 0
+        for row in reversed(relevant):
+            if row.get("phase") == "proposer_skip":
+                count += 1
+            else:
+                break
+        return count
+    except Exception:
+        return 0
+
+
+def _record_noop_skip(state_dir: Path, reason: str) -> None:
+    """#751 honest no-op: a distinct ``'proposer_skip'`` ledger phase (NOT a
+    ``'proposed'`` row with a placeholder title) so this event never pollutes
+    title-based dedup (``_recent_proposed_titles``) or the ``'proposed'``-row
+    goal-alignment counts in ``scripts/loop_metrics_report.py``. No
+    ``cycle_id`` — no cycle/subagent request exists for a skipped cycle."""
+    append_event(
+        state_dir,
+        {
+            "phase": "proposer_skip",
+            "reason": (reason or "").strip()[:200] or "(no reason given)",
+        },
+    )
+
+
 def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
     """Write the request JSON in the IDENTICAL shape
     ``_write_subagent_request_artifact`` (nanobot.runtime.cycle_planning)
@@ -641,7 +756,12 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
 
     Also appends a ``'proposed'`` ledger row so proposer cycles are
     distinguishable from planner cycles in
-    ``scripts/loop_metrics_report.py``.
+    ``scripts/loop_metrics_report.py``. #751: that row also carries
+    ``serves`` (the goal-alignment field, already schema-validated by
+    :func:`validate_sizing` before this is ever called) so the report can
+    compute a per-serves-class distribution; deliberately NOT added to the
+    request ``payload`` itself, to keep the C1 request-schema-equality
+    invariant with ``cycle_planning._write_subagent_request_artifact``.
     """
     state_dir = Path(state_dir)
     cycle_id = f"cycle-{uuid.uuid4().hex[:12]}"
@@ -649,6 +769,7 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
     task_title = str(proposal.get("task_title") or "").strip()
     rationale = str(proposal.get("rationale") or "").strip()
     target_path = str(proposal.get("target_path") or "").strip()
+    serves = str(proposal.get("serves") or "").strip()
 
     improvements_dir = state_dir / "improvements"
     improvements_dir.mkdir(parents=True, exist_ok=True)
@@ -700,6 +821,7 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
             "request_id": request_id,
             "task_title": task_title,
             "target_path": target_path,
+            "serves": serves,
             "source_artifact": "llm_proposer",
         },
     )
@@ -719,6 +841,14 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
     than stacking additively, so a proposal that fails sizing twice never
     also gets a dedup retry, and a proposal that fails dedup after a sizing
     retry gets exactly one more try.
+
+    #751: an honest ``{"no_valuable_task": true, "reason": ...}`` reply (only
+    honored while :func:`_consecutive_noop_streak` is under
+    :data:`_MAX_CONSECUTIVE_NOOP_SKIPS`) records a ``'proposer_skip'`` ledger
+    event and returns ``None`` immediately — no subagent request is minted.
+    ``should_propose`` firing at most once per bridge cycle (timer-paced,
+    ~10 min) is itself sufficient pacing for this path; no extra guard is
+    needed to keep a run of skips from tight-looping.
 
     Returns the just-written request's ``task_title`` (the same string
     ``write_request`` persists) iff a request was written this call, else
@@ -750,7 +880,16 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if not should_propose(state_dir, selfevo_repo):
             return None
 
-        context = build_context(state_dir, selfevo_repo)
+        # #751: an LLM that has honestly skipped 3 cycles in a row (no
+        # valuable task) must not be allowed to idle the loop forever — the
+        # 4th call is forced into normal proposal mode (the no-op reply is
+        # not offered in the context, and even if the model replies with one
+        # anyway it is ignored below and treated as a schema violation,
+        # belt-and-suspenders). Tracked via trailing ledger rows, not
+        # in-memory, so the cap survives process restarts.
+        allow_no_op = _consecutive_noop_streak(state_dir) < _MAX_CONSECUTIVE_NOOP_SKIPS
+
+        context = build_context(state_dir, selfevo_repo, force_proposal=not allow_no_op)
         if not context:
             return None
 
@@ -758,10 +897,18 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
 
         proposal = propose(context)
         calls_made += 1
+
+        if allow_no_op and isinstance(proposal, dict) and proposal.get("no_valuable_task") is True:
+            _record_noop_skip(state_dir, str(proposal.get("reason") or ""))
+            return None
+
         ok, reason = validate_sizing(proposal)
         if not ok and calls_made < _MAX_LLM_CALLS:
             proposal = propose(context, rejection_reason=reason)
             calls_made += 1
+            if allow_no_op and isinstance(proposal, dict) and proposal.get("no_valuable_task") is True:
+                _record_noop_skip(state_dir, str(proposal.get("reason") or ""))
+                return None
             ok, reason = validate_sizing(proposal)
         if not ok:
             return None

--- a/scripts/loop_metrics_report.py
+++ b/scripts/loop_metrics_report.py
@@ -311,6 +311,47 @@ def _dedup_breakdown(cycles: dict[str, dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+_SERVES_CLASSES = ("priority", "vector 1", "vector 2", "hypothesis")
+
+
+def _serves_class(serves: Any) -> str:
+    """#751 goal-alignment classification of a ``'proposed'`` ledger row's
+    ``serves`` field. ``"missing"`` covers both pre-#751 rows (no ``serves``
+    key at all) and any row whose value doesn't parse — never a crash, per
+    this script's own gap-visibility convention. ``"other"`` would mean a
+    row wrote a ``serves`` value that ``llm_proposer.validate_sizing``
+    should have rejected before write (defensive only; not expected to ever
+    accumulate in a report driven by real writes)."""
+    text = str(serves or "").strip()
+    if not text:
+        return "missing"
+    low = text.lower()
+    if low.startswith("priority "):
+        return "priority"
+    if low.startswith("vector 1"):
+        return "vector 1"
+    if low.startswith("vector 2"):
+        return "vector 2"
+    if low.startswith("hypothesis "):
+        return "hypothesis"
+    return "other"
+
+
+def _goal_alignment_breakdown(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """#751: distribution of ``serves``-classes across ``'proposed'`` ledger
+    rows in the window, plus the count of honest ``'proposer_skip'``
+    (``no_valuable_task``) events. Rows written before #751 (no ``serves``
+    key) count under ``"missing"`` rather than breaking the report."""
+    proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+    class_counts: Counter[str] = Counter(_serves_class(r.get("serves")) for r in proposed_rows)
+    skip_rows = [r for r in rows if r.get("phase") == "proposer_skip"]
+    return {
+        "proposed_total": len(proposed_rows),
+        "by_serves_class": {name: class_counts.get(name, 0) for name in (*_SERVES_CLASSES, "missing", "other")},
+        "no_valuable_task_skips": len(skip_rows),
+    }
+
+
 def _median_gap_seconds(timestamps: list[datetime]) -> float | None:
     """Median gap (seconds) between consecutive, time-sorted timestamps.
 
@@ -409,6 +450,7 @@ def build_report(state_dir: Path, days: int) -> dict[str, Any]:
     cycles = group_by_cycle(rows)
     computed = compute_metrics(cycles)
     liveness = compute_liveness(cycles, rows, computed["metrics"]["duplicate_rate"]["value"], now=now)
+    goal_alignment = _goal_alignment_breakdown(rows)
 
     window_start = (now - timedelta(days=days)).isoformat().replace("+00:00", "Z")
     window_end = now.isoformat().replace("+00:00", "Z")
@@ -429,6 +471,7 @@ def build_report(state_dir: Path, days: int) -> dict[str, Any]:
         "metrics": computed["metrics"],
         "gate_fail_breakdown": computed["gate_fail_breakdown"],
         "dedup_breakdown": computed["dedup_breakdown"],
+        "goal_alignment": goal_alignment,
     }
 
 
@@ -508,6 +551,21 @@ def render_table(report: dict[str, Any]) -> str:
     lines.append("Metrics pending upstream inputs (null, per #705 gap-visibility rule):")
     for name in ("protected_surface_rejections", "cost_per_integrated_change", "harvestable_upstream_ratio", "human_intervention_needed"):
         lines.append(f"  {name}: n/a — {m[name]['note']}")
+    lines.append("")
+
+    goal_alignment = report["goal_alignment"]
+    lines.append(
+        f"Goal alignment (#751 — 'serves' distribution over "
+        f"{goal_alignment['proposed_total']} proposed rows; "
+        f"{goal_alignment['no_valuable_task_skips']} no_valuable_task skips in window):"
+    )
+    by_class = goal_alignment["by_serves_class"]
+    if goal_alignment["proposed_total"] or any(by_class.values()):
+        for name, count in sorted(by_class.items(), key=lambda kv: -kv[1]):
+            if count:
+                lines.append(f"  {name:<12} {count}")
+    else:
+        lines.append("  (no proposed rows in window)")
 
     return "\n".join(lines)
 
@@ -547,6 +605,18 @@ def _self_test() -> None:
             {"phase": "started", "cycle_id": "c4", "ts": ts(20)},
             {"phase": "dedup", "cycle_id": "c4", "decision": "proceeded", "matched_against": None, "ts": ts(19)},
             {"phase": "outcome", "cycle_id": "c4", "outcome": "failed", "reason": "no_commit", "ts": ts(18)},
+            # #751: goal-alignment rows — mix of serves-classes, one legacy
+            # row with no serves at all, and two honest no-op skips. Reuse
+            # the existing c1..c5 cycle_ids (a 'proposed' row for a cycle
+            # that also has started/gate/outcome rows is the normal shape) so
+            # these don't inflate n_cycles with extra incomplete buckets.
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "t1", "serves": "priority 5", "ts": ts(50)},
+            {"phase": "proposed", "cycle_id": "c2", "task_title": "t2", "serves": "vector 1: reduces disk writes", "ts": ts(40)},
+            {"phase": "proposed", "cycle_id": "c3", "task_title": "t3", "serves": "vector 2", "ts": ts(30)},
+            {"phase": "proposed", "cycle_id": "c4", "task_title": "t4", "serves": "hypothesis h3", "ts": ts(20)},
+            {"phase": "proposed", "cycle_id": "c5", "task_title": "t5", "ts": ts(10)},
+            {"phase": "proposer_skip", "reason": "nothing valuable this cycle", "ts": ts(4)},
+            {"phase": "proposer_skip", "reason": "still nothing", "ts": ts(3)},
         ]
         with open(ledger_dir / "cycles.jsonl", "w", encoding="utf-8") as fh:
             for row in rows:
@@ -604,6 +674,16 @@ def _self_test() -> None:
         assert dedup["by_decision"]["proceeded"] == 4
         assert dedup["by_decision"]["skipped_duplicate"] == 1
         assert dedup["top_matched_against"][0]["matched_against"] == "done:title-x"
+
+        goal_alignment = report["goal_alignment"]
+        assert goal_alignment["proposed_total"] == 5
+        assert goal_alignment["by_serves_class"]["priority"] == 1
+        assert goal_alignment["by_serves_class"]["vector 1"] == 1
+        assert goal_alignment["by_serves_class"]["vector 2"] == 1
+        assert goal_alignment["by_serves_class"]["hypothesis"] == 1
+        assert goal_alignment["by_serves_class"]["missing"] == 1
+        assert goal_alignment["by_serves_class"]["other"] == 0
+        assert goal_alignment["no_valuable_task_skips"] == 2
 
         assert report["liveness"]["state"] == "healthy"
 

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -1,0 +1,246 @@
+"""Tests for #751: the hypotheses -> priorities reader.
+
+Covers reading candidates from the primary source
+(``hypotheses/backlog.json``, ``cycle_persist._build_hypothesis_backlog_snapshot``'s
+shape) and the secondary source (``research/hypotheses.json``,
+``cycle_planning._write_research_feed``'s append-only shape), the bounded
+``context_section`` rendering, and the lifecycle reconciliation
+(active -> answered/stale), including that unknown fields in a lifecycle
+entry survive a rewrite.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime import cycle_ledger, hypothesis_backlog
+
+
+def _state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    return state_dir
+
+
+def _write_backlog(state_dir: Path, entries: list[dict]) -> None:
+    backlog_dir = state_dir / "hypotheses"
+    backlog_dir.mkdir(parents=True, exist_ok=True)
+    (backlog_dir / "backlog.json").write_text(
+        json.dumps({"entries": entries}), encoding="utf-8"
+    )
+
+
+def _write_research(state_dir: Path, snapshots: list[dict]) -> None:
+    research_dir = state_dir / "research"
+    research_dir.mkdir(parents=True, exist_ok=True)
+    (research_dir / "hypotheses.json").write_text(json.dumps(snapshots), encoding="utf-8")
+
+
+def _write_lifecycle(state_dir: Path, entries: dict) -> None:
+    backlog_dir = state_dir / "hypotheses"
+    backlog_dir.mkdir(parents=True, exist_ok=True)
+    (backlog_dir / "lifecycle.json").write_text(
+        json.dumps({"schema_version": "hypothesis-lifecycle-v1", "entries": entries}),
+        encoding="utf-8",
+    )
+
+
+def _read_lifecycle(state_dir: Path) -> dict:
+    path = state_dir / "hypotheses" / "lifecycle.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestPrimarySource:
+    def test_top_candidates_reads_backlog_primary_source(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        entries = [
+            {"hypothesis_id": f"hypothesis-h{i}", "task_title": f"Title {i}"} for i in range(7)
+        ]
+        _write_backlog(state_dir, entries)
+
+        candidates = hypothesis_backlog.top_candidates(state_dir)
+
+        assert len(candidates) == hypothesis_backlog.TOP_N
+        assert candidates[0] == {"key": "hypothesis-h0", "title": "Title 0", "source": "backlog"}
+
+    def test_context_section_format(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(
+            state_dir,
+            [{"hypothesis_id": "hypothesis-h1", "task_title": "Investigate flaky test X"}],
+        )
+
+        section = hypothesis_backlog.context_section(state_dir)
+        assert section == "- [hypothesis-h1] Investigate flaky test X"
+
+    def test_corrupt_backlog_file_is_omitted(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        backlog_dir = state_dir / "hypotheses"
+        backlog_dir.mkdir(parents=True)
+        (backlog_dir / "backlog.json").write_text("not json {{{", encoding="utf-8")
+
+        assert hypothesis_backlog.top_candidates(state_dir) == []
+        assert hypothesis_backlog.context_section(state_dir) == ""
+
+    def test_missing_files_are_fail_open(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        assert hypothesis_backlog.top_candidates(state_dir) == []
+        assert hypothesis_backlog.context_section(state_dir) == ""
+
+    def test_entries_without_title_or_id_are_skipped(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(
+            state_dir,
+            [
+                {"hypothesis_id": "", "task_title": ""},
+                {"hypothesis_id": "hypothesis-h1", "task_title": "Valid title"},
+                "not a dict",
+            ],
+        )
+        candidates = hypothesis_backlog.top_candidates(state_dir)
+        assert candidates == [{"key": "hypothesis-h1", "title": "Valid title", "source": "backlog"}]
+
+
+class TestSecondarySource:
+    def test_research_hypotheses_used_when_no_backlog(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_research(
+            state_dir,
+            [
+                {
+                    "date": "2026-07-01",
+                    "cycle_id": "cycle-a",
+                    "candidates": [{"title": "Research candidate one", "acceptance": "..."}],
+                }
+            ],
+        )
+
+        candidates = hypothesis_backlog.top_candidates(state_dir)
+        assert len(candidates) == 1
+        assert candidates[0]["title"] == "Research candidate one"
+        assert candidates[0]["key"].startswith("slug-")
+        assert candidates[0]["source"] == "research"
+
+    def test_backlog_takes_precedence_and_dedups_by_key(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Primary title"}])
+        _write_research(
+            state_dir,
+            [{"date": "2026-07-01", "cycle_id": "cycle-a", "candidates": [{"title": "Secondary title"}]}],
+        )
+
+        candidates = hypothesis_backlog.top_candidates(state_dir)
+        titles = [c["title"] for c in candidates]
+        assert "Primary title" in titles
+        assert "Secondary title" in titles
+        assert titles[0] == "Primary title"
+
+    def test_corrupt_research_file_is_omitted(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        research_dir = state_dir / "research"
+        research_dir.mkdir(parents=True)
+        (research_dir / "hypotheses.json").write_text("not json", encoding="utf-8")
+        assert hypothesis_backlog.top_candidates(state_dir) == []
+
+
+class TestLifecycleReconciliation:
+    def test_answered_marking_on_success_outcome_with_serves_hypothesis(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        lifecycle = _read_lifecycle(state_dir)
+        entry = lifecycle["entries"]["hypothesis-h1"]
+        assert entry["status"] == "answered"
+        assert entry["answered_evidence"] == "c1"
+
+        # Answered candidates no longer surface as context candidates.
+        assert hypothesis_backlog.top_candidates(state_dir) == []
+        assert hypothesis_backlog.context_section(state_dir) == ""
+
+    def test_referenced_but_not_yet_successful_stays_active(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "failed"}
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        lifecycle = _read_lifecycle(state_dir)
+        assert lifecycle["entries"]["hypothesis-h1"]["status"] == "active"
+        assert len(hypothesis_backlog.top_candidates(state_dir)) == 1
+
+    def test_stale_demotion_by_age_excluded_from_context(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Old idea"}])
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat().replace("+00:00", "Z")
+        _write_lifecycle(
+            state_dir,
+            {"hypothesis-h1": {"status": "active", "first_seen": old_ts, "cycles_untouched": 0}},
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        lifecycle = _read_lifecycle(state_dir)
+        assert lifecycle["entries"]["hypothesis-h1"]["status"] == "stale"
+        assert hypothesis_backlog.top_candidates(state_dir) == []
+
+    def test_stale_demotion_by_untouched_cycles_excluded_from_context(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Old idea"}])
+        recent_ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        _write_lifecycle(
+            state_dir,
+            {
+                "hypothesis-h1": {
+                    "status": "active",
+                    "first_seen": recent_ts,
+                    "cycles_untouched": hypothesis_backlog.STALE_AFTER_UNTOUCHED_CYCLES - 1,
+                }
+            },
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        lifecycle = _read_lifecycle(state_dir)
+        assert lifecycle["entries"]["hypothesis-h1"]["status"] == "stale"
+        assert hypothesis_backlog.top_candidates(state_dir) == []
+
+    def test_unknown_fields_preserved_after_rewrite(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        recent_ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        _write_lifecycle(
+            state_dir,
+            {
+                "hypothesis-h1": {
+                    "status": "active",
+                    "first_seen": recent_ts,
+                    "cycles_untouched": 0,
+                    "custom_note": "operator annotation — keep me",
+                }
+            },
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        lifecycle = _read_lifecycle(state_dir)
+        assert lifecycle["entries"]["hypothesis-h1"]["custom_note"] == "operator annotation — keep me"
+
+    def test_reconcile_is_fail_open_on_unreadable_state(self, tmp_path):
+        # No exception even when nothing exists at all.
+        hypothesis_backlog.reconcile(tmp_path / "does-not-exist")

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -53,6 +53,10 @@ def _append_outcome(state_dir: Path, cycle_id: str, outcome: str) -> None:
     )
 
 
+def _append_skip(state_dir: Path, reason: str = "nothing valuable") -> None:
+    cycle_ledger.append_event(state_dir, {"phase": "proposer_skip", "reason": reason})
+
+
 # ─── kill-switch ───────────────────────────────────────────────────────────
 
 
@@ -242,6 +246,7 @@ class TestShouldPropose:
                 "task_title": "Fix a typo in docs/README-ish file",
                 "rationale": "Corrects a small doc mistake.",
                 "target_path": "docs/foo.md",
+                "serves": "priority 1",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -494,6 +499,7 @@ class TestValidateSizing:
             "task_title": "Add a docstring example to scripts/loop_metrics_report.py",
             "rationale": "Improves discoverability of the report script's CLI usage.",
             "target_path": "scripts/loop_metrics_report.py",
+            "serves": "priority 3",
         }
         proposal.update(overrides)
         return proposal
@@ -543,6 +549,72 @@ class TestValidateSizing:
         assert "one path" in reason
 
 
+# ─── #751: 'serves' goal-alignment field validation ────────────────────────
+
+
+class TestValidateServes:
+    def _good(self, **overrides):
+        proposal = {
+            "task_title": "Add a docstring example to scripts/loop_metrics_report.py",
+            "rationale": "Improves discoverability of the report script's CLI usage.",
+            "target_path": "scripts/loop_metrics_report.py",
+            "serves": "priority 3",
+        }
+        proposal.update(overrides)
+        return proposal
+
+    def test_accepts_priority_form(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves="priority 11"))
+        assert ok is True, reason
+
+    def test_accepts_vector_1_with_justification(self):
+        ok, reason = llm_proposer.validate_sizing(
+            self._good(serves="vector 1: reduces cycle disk writes")
+        )
+        assert ok is True, reason
+
+    def test_accepts_vector_2_alone(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves="vector 2"))
+        assert ok is True, reason
+
+    def test_accepts_hypothesis_form(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves="hypothesis h3"))
+        assert ok is True, reason
+
+    def test_accepts_case_insensitively(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves="PRIORITY 2"))
+        assert ok is True, reason
+
+    def test_rejects_missing_serves(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves=""))
+        assert ok is False
+        assert "serves" in reason
+
+    def test_rejects_serves_key_absent_entirely(self):
+        proposal = self._good()
+        del proposal["serves"]
+        ok, reason = llm_proposer.validate_sizing(proposal)
+        assert ok is False
+        assert "serves" in reason
+
+    def test_rejects_wrong_prefix(self):
+        ok, reason = llm_proposer.validate_sizing(
+            self._good(serves="because it seemed useful")
+        )
+        assert ok is False
+        assert "serves" in reason
+
+    def test_rejects_serves_over_160_chars(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves="priority 1 " + "x" * 160))
+        assert ok is False
+        assert "160" in reason
+
+    def test_rejects_serves_as_list(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(serves=["priority 1"]))
+        assert ok is False
+        assert "serves" in reason
+
+
 class TestProposeRetryOnce(object):
     def test_retries_exactly_once_on_rejection(self, tmp_path, monkeypatch):
         monkeypatch.setenv(ENV_VAR, "1")
@@ -554,11 +626,12 @@ class TestProposeRetryOnce(object):
         def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
             calls.append(rejection_reason)
             if rejection_reason is None:
-                return {"task_title": "", "rationale": "", "target_path": ""}  # invalid
+                return {"task_title": "", "rationale": "", "target_path": "", "serves": ""}  # invalid
             return {
                 "task_title": "Fix a typo in docs/README-ish file",
                 "rationale": "Corrects a small doc mistake.",
                 "target_path": "docs/foo.md",
+                "serves": "priority 1",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -577,7 +650,7 @@ class TestProposeRetryOnce(object):
 
         def _always_bad(context, *, rejection_reason=None, timeout=120.0):
             calls.append(rejection_reason)
-            return {"task_title": "", "rationale": "", "target_path": ""}
+            return {"task_title": "", "rationale": "", "target_path": "", "serves": ""}
 
         monkeypatch.setattr(llm_proposer, "propose", _always_bad)
         result = llm_proposer.maybe_propose(state_dir, None)
@@ -615,11 +688,13 @@ class TestSelfDedup:
                     "task_title": "Implement lightweight memory and CPU profiling script",
                     "rationale": "Tracks resource usage.",
                     "target_path": "scripts/profile.py",
+                    "serves": "priority 2",
                 }
             return {
                 "task_title": "Add a smoke test for the loop metrics report",
                 "rationale": "Closes an unrelated coverage gap.",
                 "target_path": "tests/test_loop_metrics_extra.py",
+                "serves": "priority 2",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -656,11 +731,13 @@ class TestSelfDedup:
                     "task_title": "Implement lightweight memory usage tracker",
                     "rationale": "Tracks memory usage.",
                     "target_path": "scripts/mem.py",
+                    "serves": "priority 4",
                 }
             return {
                 "task_title": "Document the release checklist",
                 "rationale": "Fills a documentation gap.",
                 "target_path": "docs/release.md",
+                "serves": "priority 4",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -687,6 +764,7 @@ class TestSelfDedup:
                 "task_title": "Implement lightweight memory and CPU profiling script",
                 "rationale": "Tracks resource usage.",
                 "target_path": "scripts/profile.py",
+                "serves": "priority 2",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _always_clone)
@@ -850,10 +928,15 @@ class TestWriteRequestSchemaEquality:
             "task_title": "Document the ledger digest helper",
             "rationale": "Improves maintainer onboarding.",
             "target_path": "docs/proposer-notes.md",
+            "serves": "priority 1",
         }
         path = llm_proposer.write_request(state_dir, proposal)
         written = json.loads(Path(path).read_text(encoding="utf-8"))
 
+        # #751: 'serves' is recorded in the ledger row only (see
+        # test_ledger_proposed_row_appended), deliberately NOT added to the
+        # written request payload, so this C1 schema-equality invariant is
+        # unaffected by the new field.
         assert set(written.keys()) == set(fixture.keys())
         assert written["request_status"] == "queued" == fixture["request_status"]
 
@@ -866,6 +949,7 @@ class TestWriteRequestSchemaEquality:
             "task_title": "Add a helper doc",
             "rationale": "helps operators",
             "target_path": "docs/helper.md",
+            "serves": "priority 1",
         }
         written_path = llm_proposer.write_request(state_dir, proposal)
 
@@ -880,6 +964,7 @@ class TestWriteRequestSchemaEquality:
             "task_title": "Add a helper doc",
             "rationale": "helps operators",
             "target_path": "docs/helper.md",
+            "serves": "priority 7",
         }
         llm_proposer.write_request(state_dir, proposal)
 
@@ -889,7 +974,25 @@ class TestWriteRequestSchemaEquality:
         assert len(proposed_rows) == 1
         assert proposed_rows[0]["task_title"] == "Add a helper doc"
         assert proposed_rows[0]["target_path"] == "docs/helper.md"
+        assert proposed_rows[0]["serves"] == "priority 7"
         assert proposed_rows[0]["source_artifact"] == "llm_proposer"
+
+    def test_ledger_row_serves_defaults_to_empty_string_when_absent(self, tmp_path):
+        """Old-shaped callers (or a proposal dict missing 'serves' entirely)
+        must not crash write_request; the row simply carries an empty
+        string, which loop_metrics_report classifies as 'missing'."""
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+        }
+        llm_proposer.write_request(state_dir, proposal)
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert proposed_rows[0]["serves"] == ""
 
 
 # ─── integration: maybe_propose -> bridge.find_pending_request handoff ─────
@@ -960,6 +1063,7 @@ class TestIntegrationHandoff:
                 "task_title": "Add a smoke test for the loop metrics report",
                 "rationale": "Closes a coverage gap surfaced by the ledger digest.",
                 "target_path": "tests/test_loop_metrics_extra.py",
+                "serves": "priority 1",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -996,6 +1100,7 @@ class TestJournalLineUsesOwnReturnValue:
                 "task_title": "Add a docstring to the ledger digest helper",
                 "rationale": "Improves maintainer onboarding.",
                 "target_path": "docs/proposer-notes.md",
+                "serves": "priority 1",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -1048,6 +1153,7 @@ class TestJournalLineUsesOwnReturnValue:
                 "task_title": "Add a smoke test for the loop metrics report",
                 "rationale": "Closes a coverage gap.",
                 "target_path": "tests/test_loop_metrics_extra.py",
+                "serves": "priority 1",
             }
 
         monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
@@ -1065,3 +1171,145 @@ class TestJournalLineUsesOwnReturnValue:
         found_path, found_req = bridge.find_pending_request()
         assert found_path == stale_path
         assert found_req.get("task_title") == "STALE OLDEST TITLE — should never be logged"
+
+
+# ─── #751: honest no-op (no_valuable_task) ─────────────────────────────────
+
+
+class TestHonestNoOp:
+    @pytest.fixture(autouse=True)
+    def _enable(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "1")
+
+    def test_no_valuable_task_reply_skips_without_minting_request(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            return {"no_valuable_task": True, "reason": "everything worthwhile is already queued"}
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+
+        assert result is None
+        assert not (state_dir / "subagents" / "requests").exists()
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        skip_rows = [r for r in rows if r.get("phase") == "proposer_skip"]
+        assert len(skip_rows) == 1
+        assert skip_rows[0]["reason"] == "everything worthwhile is already queued"
+        # Must never be a 'proposed' row (would pollute title-based dedup /
+        # the #751 goal-alignment counts in loop_metrics_report.py).
+        assert not [r for r in rows if r.get("phase") == "proposed"]
+
+    def test_reason_defaults_when_absent(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            return {"no_valuable_task": True}
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        assert llm_proposer.maybe_propose(state_dir, None) is None
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        skip_rows = [r for r in rows if r.get("phase") == "proposer_skip"]
+        assert len(skip_rows) == 1
+        assert skip_rows[0]["reason"]  # non-empty placeholder, never blank
+
+    def test_consecutive_cap_forces_normal_mode_on_fourth_call(self, tmp_path, monkeypatch):
+        """#751 kill-switch bound: after _MAX_CONSECUTIVE_NOOP_SKIPS (3)
+        trailing skips, the 4th call is forced into normal proposal mode —
+        the context carries the forced-proposal note, and even if the model
+        still tries no_valuable_task on its first reply, that reply is
+        ignored (treated as an ordinary schema violation: missing
+        task_title) rather than honored."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        for i in range(llm_proposer._MAX_CONSECUTIVE_NOOP_SKIPS):
+            _append_skip(state_dir, reason=f"skip {i}")
+
+        assert llm_proposer._consecutive_noop_streak(state_dir) == llm_proposer._MAX_CONSECUTIVE_NOOP_SKIPS
+
+        captured_contexts = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            captured_contexts.append(context)
+            if rejection_reason is None:
+                return {"no_valuable_task": True, "reason": "still nothing, honestly"}
+            return {
+                "task_title": "Least-wasteful available option",
+                "rationale": "Forced proposal after the no-op cap.",
+                "target_path": "docs/forced.md",
+                "serves": "priority 1",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+
+        assert result == "Implement and commit: Least-wasteful available option"
+        assert len(captured_contexts) == 2
+        assert llm_proposer._FORCE_PROPOSAL_NOTE in captured_contexts[0]
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        # No additional proposer_skip row was recorded — the forced call
+        # produced a real proposal instead of another honored skip.
+        assert len([r for r in rows if r.get("phase") == "proposer_skip"]) == llm_proposer._MAX_CONSECUTIVE_NOOP_SKIPS
+
+    def test_streak_counts_only_trailing_skips_after_last_proposal(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "Some earlier proposal")
+        _append_skip(state_dir, "skip 1")
+        _append_skip(state_dir, "skip 2")
+        assert llm_proposer._consecutive_noop_streak(state_dir) == 2
+
+        _append_proposed(state_dir, "c2", "A newer proposal resets the streak")
+        assert llm_proposer._consecutive_noop_streak(state_dir) == 0
+
+
+# ─── #751: hypothesis-backlog context section ──────────────────────────────
+
+
+class TestBuildContextHypotheses:
+    def test_includes_hypothesis_section_from_backlog_json(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        backlog_dir = state_dir / "hypotheses"
+        backlog_dir.mkdir(parents=True)
+        (backlog_dir / "backlog.json").write_text(
+            json.dumps(
+                {
+                    "entries": [
+                        {"hypothesis_id": "hypothesis-h1", "task_title": "Investigate flaky test X"},
+                        {"hypothesis_id": "hypothesis-h2", "task_title": "Reduce cycle disk writes"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        context = llm_proposer.build_context(state_dir, None)
+
+        assert "## Hypothesis backlog (candidate value sources)" in context
+        assert "- [hypothesis-h1] Investigate flaky test X" in context
+        assert "- [hypothesis-h2] Reduce cycle disk writes" in context
+
+    def test_corrupt_backlog_file_omits_section(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        backlog_dir = state_dir / "hypotheses"
+        backlog_dir.mkdir(parents=True)
+        (backlog_dir / "backlog.json").write_text("not valid json {{{", encoding="utf-8")
+
+        context = llm_proposer.build_context(state_dir, None)
+        assert "Hypothesis backlog" not in context
+
+    def test_absent_when_no_hypothesis_files(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        context = llm_proposer.build_context(state_dir, None)
+        assert "Hypothesis backlog" not in context


### PR DESCRIPTION
## What / why

The #707 LLM proposer's schema (`task_title`, `rationale`, `target_path`) never tied a proposal to an actual goal — `rationale` is free text the model writes about its own idea, checked against nothing. Confirmed consequence (2026-07-14): 16 integrations landed overnight with declining value as the proposer circled a saturated theme space. Meanwhile `state/hypotheses/backlog.json` and `state/research/hypotheses.json` are written every cycle but read by nothing on the live path since the deterministic planner that consumed them was retired in #739.

Three additions to `nanobot/runtime/llm_proposer.py`, gated by the existing `SELFEVO_LLM_PROPOSER_ENABLED` kill-switch (no new switch):

1. **`serves` field** — every proposal must now name what it serves: `priority <N>`, `vector 1`/`vector 2` (optional justification suffix), or `hypothesis <id>`. Schema-validated in `validate_sizing` (same reject → retry-once → fail-closed path as the other checks), recorded in the `proposed` ledger row (not the request payload, to preserve the R29 schema-equality invariant). `scripts/loop_metrics_report.py` gains a goal-alignment breakdown by serves-class.
2. **Honest no-op** — the model may reply `{"no_valuable_task": true, "reason": "..."}` instead of inventing filler work. Recorded as a distinct `proposer_skip` ledger event (not `proposed`, so it can't pollute title-dedup or the goal-alignment counts); no subagent request is minted. Bounded: after 3 consecutive skips (counted from the ledger, not in-memory), the next call is forced into normal-proposal mode.
3. **Hypotheses reader** — new `nanobot/runtime/hypothesis_backlog.py` surfaces the top 5 active entries from `hypotheses/backlog.json` (primary) and `research/hypotheses.json` (secondary) as a bounded context section, with an active → answered/stale lifecycle (answered on a successful `serves: hypothesis ...` cycle; stale after 50 untouched reconciliation passes or 14 days) persisted in a sidecar `hypotheses/lifecycle.json` this module owns exclusively — `backlog.json` itself is fully regenerated every cycle by the coordinator, so it can't hold cross-cycle status without invasive changes (documented deviation, see proposal.md).

Substantial change: `docs/changes/751-value-link/proposal.md` (includes a "Deviations from the issue brief" section), spec delta in `docs/specs/subagent-bridge/spec.md` (new R36; R28-R35 unchanged).

## Test evidence

- `tests/test_llm_proposer.py`: extended with `TestValidateServes` (accepted/rejected `serves` forms), `TestHonestNoOp` (skip records event + mints no request, 3-consecutive cap forces normal mode with the forced-note visible in context, streak resets after a real proposal), `TestBuildContextHypotheses` (section present/bounded, corrupt file omitted, absent when no files). All pre-existing fake `propose()` fixtures updated to carry a valid `serves` field.
- `tests/test_hypothesis_backlog.py` (new): primary/secondary source reads, corrupt-file fail-open, answered-marking on success outcome, stale demotion by age and by untouched-cycle count, unknown-field preservation across a lifecycle rewrite.
- `scripts/loop_metrics_report.py --test`: extended fixture with serves-classed `proposed` rows + `proposer_skip` rows; asserts the new goal-alignment breakdown.
- `.venv/bin/python -m pytest tests/ -q`: **1485 passed**, 2 failed — both are the pre-existing environmental failures in `test_cycle_health_summary.py` noted in the task brief (unrelated to this change; confirmed present on `main` too).
- `ruff check nanobot/ tests/ scripts/`: 331 pre-existing errors, identical before and after this branch (verified via `git stash`) — **zero new issues**. The specific files this PR touches (`llm_proposer.py`, `hypothesis_backlog.py`, `loop_metrics_report.py`, both test files) are individually clean.

## Key design choices

- **`proposer_skip` is a new ledger phase**, not a `proposed` row with a placeholder title — keeps it out of title-based dedup and the new goal-alignment counts.
- **Lazy reconciliation**, not a cycle-outcome hook — no existing seam had both `serves` and the resolving `cycle_id` available together without invasive bridge/coordinator plumbing; reconciliation runs instead as a side effect of every `build_context` call (once per proposer cycle).
- **Lifecycle state lives in a new sidecar file** (`hypotheses/lifecycle.json`), not inside `backlog.json` — that file is fully regenerated (not read-modify-write) every cycle by the coordinator, so any status key added there would be wiped by the next snapshot.
- **No new `propose()` parameter** for forced-proposal mode — the forced note is carried in the `build_context` output instead, since every existing test monkeypatches `propose()` with a fixed narrow signature that a new keyword arg would break.

Part of #751 (live verification follows after deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)