### PR TITLE
fix(runtime): test-for subject stops at descriptive title tail (#757)

### DIFF
--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -475,8 +475,14 @@ _CONTENT_WORD_RE = re.compile(r"[A-Za-z]{4,}")
 # "Create test suite for approval truth normalization script" or
 # "Create unit tests for backlog_health script". The captured remainder is
 # the subject being tested.
+# The subject capture stops at " script" / " to ..." / punctuation — live
+# titles carry a descriptive tail ("... script to verify cycle summary
+# prepending") whose words ("verify", "cycle", ...) are NOT part of the
+# subject; capturing them let unrelated test suites share >=2 subject words
+# and re-created the recent-failure cascade #757 was meant to kill.
 _TEST_TITLE_RE = re.compile(
-    r"\b(?:unit\s+)?tests?(?:\s+suite|\s+coverage)?\s+for\s+(?:the\s+)?(.+)",
+    r"\b(?:unit\s+)?tests?(?:\s+suite|\s+coverage)?\s+for\s+(?:the\s+)?"
+    r"(.+?)(?:\s+script\b|\s+to\s+|[.,;:]|$)",
     re.IGNORECASE,
 )
 

--- a/tests/test_existence_index.py
+++ b/tests/test_existence_index.py
@@ -214,6 +214,27 @@ class TestDeriveIntent:
     def test_no_target_no_pattern_derives_none(self):
         assert ei.derive_intent("Improve loop metrics reporting") is None
 
+    def test_subject_stops_at_descriptive_tail(self):
+        # Post-deploy live evidence (2026-07-14 21:06-21:16Z): the tail after
+        # "script to verify ..." leaked into the subject, so unrelated test
+        # suites shared >=2 words ("cycle", "verify") and the recent-failure
+        # cascade survived the #757 fix.
+        a = ei.derive_intent(
+            "Create unit tests for cycle_logger script to verify cycle "
+            "summary prepending and history formatting")
+        b = ei.derive_intent(
+            "Create unit tests for analyze_cycle_duration script to verify "
+            "duration tracking and reporting")
+        c = ei.derive_intent(
+            "Create unit tests for analyze_pass_streak script to verify "
+            "streak counting")
+        assert a == ("test-for", frozenset({"cycle", "logger"}))
+        assert ei.intents_match(a, b) is False
+        assert ei.intents_match(b, c) is False
+        # A reworded retry of the SAME subject still matches.
+        assert ei.intents_match(
+            a, ei.derive_intent("Create test suite for cycle_logger script")) is True
+
     def test_intents_match_same_subject_and_different_subject(self):
         a = ei.derive_intent("Create test suite for approval truth normalization script")
         b = ei.derive_intent("Create unit tests for approval truth script")


### PR DESCRIPTION
Roll-out finding for #757 (do not close the issue — this is the follow-up precision fix).

## What happened live (post-#758 deploy, 2026-07-14 21:06–21:16Z)

The recent-failure cascade survived: `Create unit tests for cycle_logger script to verify cycle summary prepending…` and `…for analyze_pass_streak script to verify streak counting` were both suppressed by the historical `…for analyze_cycle_duration script to verify duration…`. (The truthful `matched_against` from #758 is what made this instantly visible in the ledger.)

Root cause: `_TEST_TITLE_RE` captured **everything** after "for", so the descriptive tail leaked into the subject word-set — unrelated suites shared ≥2 words ("cycle", "verify") and `intents_match()` treated them as the same target.

## Fix

Non-greedy subject capture terminated at ` script` / ` to …` / punctuation / end:
- `…for cycle_logger script to verify…` → subject `{cycle, logger}`
- `…for analyze_cycle_duration script to verify…` → `{analyze, cycle, duration}` — 1 shared word → not the same target.

Reworded retries of the SAME subject still match (subset rule unchanged).

## Tests

Regression test reproduces the three live titles; all 42 existence-index + recent-failure tests pass; full suite 1509 passed (+2 known systemd-environmental failures in test_cycle_health_summary.py). ruff clean.

Refs #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)