### PR TITLE
fix(runtime): dedup bookkeeping is not demand; tolerate weak-model no-op forms (#760)

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -252,15 +252,56 @@ def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
         return items
 
 
+def _skipped_cycle_ids(state_dir: Path, now: datetime) -> set[str]:
+    """Cycle ids whose terminal ledger outcome is ``skipped-*`` in the defect
+    window. Their result files are dedup bookkeeping, not defects (#760
+    roll-out fix: a blocked-by-dedup result masqueraded as demand and kept
+    the loop calling the LLM). Fail-open: errors yield an empty set — worst
+    case a bookkeeping result is presented as demand again, never a crash."""
+    skipped: set[str] = set()
+    try:
+        path = Path(state_dir) / "ledger" / "cycles.jsonl"
+        if not path.is_file():
+            return skipped
+        cutoff = now - timedelta(hours=_DEFECT_WINDOW_HOURS)
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if not isinstance(row, dict) or row.get("phase") != "outcome":
+                continue
+            if not str(row.get("outcome") or "").strip().lower().startswith("skipped"):
+                continue
+            ts = _parse_ts(row.get("ts"))
+            if ts is not None and ts < cutoff:
+                continue
+            cycle_id = str(row.get("cycle_id") or "").strip()
+            if cycle_id:
+                skipped.add(cycle_id)
+        return skipped
+    except Exception:
+        return skipped
+
+
 def _result_file_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
     """Failed/blocked subagent result files with error text — bounded to the
-    :data:`_MAX_RESULT_FILES` most recently modified files."""
+    :data:`_MAX_RESULT_FILES` most recently modified files.
+
+    Two exclusions keep dedup bookkeeping out of demand (#760 roll-out fix):
+    results whose cycle terminally ``skipped-*`` in the ledger, and
+    ``blocked`` results carrying no error text at all (the bridge writes
+    such placeholder results for every pre-spawn skip)."""
     items: list[dict[str, str]] = []
     try:
         results_dir = Path(state_dir) / "subagents" / "results"
         if not results_dir.is_dir():
             return []
         cutoff_ts = (now - timedelta(hours=_DEFECT_WINDOW_HOURS)).timestamp()
+        skipped_cycles = _skipped_cycle_ids(state_dir, now)
         entries = [p for p in results_dir.glob("*.json") if p.is_file()]
         try:
             entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
@@ -278,11 +319,15 @@ def _result_file_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]
             status = str(data.get("status") or "").strip().lower()
             if status not in ("failed", "blocked", "error"):
                 continue
+            if str(data.get("cycle_id") or "").strip() in skipped_cycles:
+                continue  # dedup bookkeeping, not a defect (#760 roll-out fix)
             blocker = data.get("blocker")
             blocker_reason = blocker.get("reason", "") if isinstance(blocker, dict) else ""
             error_text = str(
                 data.get("error") or data.get("error_text") or blocker_reason or ""
             ).strip()
+            if status == "blocked" and not error_text:
+                continue  # placeholder blocked result with no error signal
             title = str(data.get("backlog_title") or data.get("task_title") or entry.stem).strip()
             summary = f"subagent result {status}: {title}"
             items.append(

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1192,12 +1192,24 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         def _proposal_demand_id(p: Any) -> str:
             return _demand_id_from_serves(p.get("serves")) if isinstance(p, dict) else ""
 
+        def _is_noop_reply(p: Any) -> bool:
+            # #760 roll-out fix: the weak host model emits no_valuable_task
+            # as the string "true" (or 1) rather than a JSON boolean; such a
+            # reply then fell through to validate_sizing and burned a retry
+            # call on "task_title is empty". Accept the common truthy forms.
+            if not isinstance(p, dict):
+                return False
+            v = p.get("no_valuable_task")
+            if v is True or v == 1:
+                return True
+            return isinstance(v, str) and v.strip().lower() in ("true", "yes", "1")
+
         calls_made = 0
 
         proposal = _call_propose()
         calls_made += 1
 
-        if allow_no_op and isinstance(proposal, dict) and proposal.get("no_valuable_task") is True:
+        if allow_no_op and _is_noop_reply(proposal):
             _record_noop_skip(state_dir, str(proposal.get("reason") or ""))
             return None
 
@@ -1205,10 +1217,21 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if not ok and calls_made < _MAX_LLM_CALLS:
             proposal = _call_propose(rejection_reason=reason)
             calls_made += 1
-            if allow_no_op and isinstance(proposal, dict) and proposal.get("no_valuable_task") is True:
+            if allow_no_op and _is_noop_reply(proposal):
                 _record_noop_skip(state_dir, str(proposal.get("reason") or ""))
                 return None
             ok, reason = validate_sizing(proposal)
+        def _sizing_detail(reason_text: str, p: Any) -> str:
+            # #760 roll-out fix: "task_title is empty" alone was
+            # undiagnosable — include a snippet of the raw reply so the
+            # ledger shows WHAT the model actually sent (capped by the
+            # recorder's own detail limit).
+            try:
+                snippet = json.dumps(p, ensure_ascii=False)[:120] if isinstance(p, dict) else repr(p)[:120]
+            except Exception:
+                snippet = "<unserializable>"
+            return f"{reason_text}; reply={snippet}"
+
         if not ok:
             # #762: double sizing failure — record what was rejected and why.
             _record_proposer_reject(
@@ -1216,7 +1239,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
                 "sizing_rejected",
                 task_title=str((proposal or {}).get("task_title") or "") if isinstance(proposal, dict) else "",
                 target_path=str((proposal or {}).get("target_path") or "") if isinstance(proposal, dict) else "",
-                detail=reason,
+                detail=_sizing_detail(reason, proposal),
                 demand_id=_proposal_demand_id(proposal),
             )
             return None
@@ -1234,7 +1257,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
                     "sizing_rejected",
                     task_title=str((proposal or {}).get("task_title") or "") if isinstance(proposal, dict) else "",
                     target_path=str((proposal or {}).get("target_path") or "") if isinstance(proposal, dict) else "",
-                    detail=reason,
+                    detail=_sizing_detail(reason, proposal),
                     demand_id=_proposal_demand_id(proposal),
                 )
                 return None

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -177,6 +177,50 @@ class TestResultFileDefects:
         self._write_result(state_dir, "result-1.json", {"status": "completed", "task_title": "Done thing"})
         assert demand.collect_demand(state_dir, None) == []
 
+    def test_dedup_skipped_cycle_result_is_not_demand(self, tmp_path):
+        """#760 roll-out fix (live 2026-07-15 18:29Z): the bridge writes a
+        placeholder 'blocked' result for every pre-spawn dedup skip; the one
+        such result inside the window masqueraded as a defect demand item and
+        kept the loop calling the LLM instead of idling."""
+        state_dir = _state_dir(tmp_path)
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "outcome", "cycle_id": "cycle-50358aae8761", "outcome": "skipped-duplicate", "reason": "existence_index_duplicate", "ts": _now_iso(10)},
+        )
+        self._write_result(
+            state_dir,
+            "result-llm-proposer-cycle-50358aae8761.json",
+            {
+                "status": "blocked",
+                "cycle_id": "cycle-50358aae8761",
+                "task_title": "Create unit tests for backlog_health.py",
+                "error": "matched an existing artifact",
+            },
+        )
+        assert demand.collect_demand(state_dir, None) == []
+
+    def test_blocked_result_without_error_text_is_not_demand(self, tmp_path):
+        """Placeholder blocked results carry no error signal — bookkeeping,
+        not a defect (#760 roll-out fix, belt to the ledger cross-check)."""
+        state_dir = _state_dir(tmp_path)
+        self._write_result(
+            state_dir,
+            "result-1.json",
+            {"status": "blocked", "cycle_id": "cycle-nolederrow", "task_title": "Some skipped thing"},
+        )
+        assert demand.collect_demand(state_dir, None) == []
+
+    def test_blocked_result_with_real_error_still_demand(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        self._write_result(
+            state_dir,
+            "result-1.json",
+            {"status": "blocked", "cycle_id": "cycle-real", "task_title": "Genuinely stuck task", "error": "PermissionError: /some/path"},
+        )
+        defects = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "defect"]
+        assert len(defects) == 1
+        assert "PermissionError" in defects[0]["evidence"]
+
     def test_read_is_bounded_to_max_result_files(self, tmp_path, monkeypatch):
         """Only the _MAX_RESULT_FILES most recently modified result files are
         even opened (existence_index._MAX_LEDGER_RESULTS discipline)."""

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1244,6 +1244,46 @@ class TestHonestNoOp:
         # the #751 goal-alignment counts in loop_metrics_report.py).
         assert not [r for r in rows if r.get("phase") == "proposed"]
 
+    def test_string_true_noop_reply_is_honored(self, tmp_path, monkeypatch):
+        """#760 roll-out fix (live 2026-07-15 18:29Z): the weak host model
+        emits no_valuable_task as the STRING "true"; that reply fell through
+        to validate_sizing and burned a retry call on 'task_title is empty'.
+        Truthy string/int forms must be honored as an honest no-op."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0, **kw):
+            calls.append(1)
+            return {"no_valuable_task": "true", "reason": "nothing addressable"}
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        assert llm_proposer.maybe_propose(state_dir, None) is None
+        assert len(calls) == 1  # no burned sizing-retry call
+
+        rows = [json.loads(line) for line in (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert [r for r in rows if r.get("phase") == "proposer_skip"]
+        assert not [r for r in rows if r.get("phase") == "proposer_reject"]
+
+    def test_sizing_reject_detail_includes_reply_snippet(self, tmp_path, monkeypatch):
+        """#760 roll-out fix: 'task_title is empty' alone was undiagnosable —
+        the reject row's detail must show what the model actually sent."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0, **kw):
+            return {"no_valuable_task": "maybe", "task_title": ""}
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        assert llm_proposer.maybe_propose(state_dir, None) is None
+
+        rows = [json.loads(line) for line in (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+        rejects = [r for r in rows if r.get("phase") == "proposer_reject"]
+        assert rejects and rejects[0]["reason"] == "sizing_rejected"
+        assert "reply=" in (rejects[0].get("detail") or "")
+        assert "no_valuable_task" in (rejects[0].get("detail") or "")
+
     def test_reason_defaults_when_absent(self, tmp_path, monkeypatch):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, "no priority section, so should_propose is True")


### PR DESCRIPTION
Roll-out follow-up for #760 (same pattern as #759 for #757 — live findings within hours of deploy).

## What happened live (release 380745b, 18:23–18:41Z)

Expected first honest idle; instead the ledger showed `sizing_rejected` with `task_title is empty` every cycle. Diagnosis on host:

1. `collect_demand` returned **one** defect item: `result-llm-proposer-cycle-50358aae8761.json`, `status=blocked` — the placeholder result the bridge writes for every **pre-spawn dedup skip**. Bookkeeping, not a defect → false demand kept the loop calling the LLM.
2. Fed that pseudo-demand, the weak host model replied `no_valuable_task` in a non-boolean form (empty-title / string `"true"`) → fell through to `validate_sizing`, burning a retry per cycle.

## Fixes

- `demand.py`: `_result_file_defects` excludes results whose cycle terminally `skipped-*` in the ledger (new `_skipped_cycle_ids` helper, fail-open) and `blocked` results with no error text (placeholder shape). A blocked result with real error text remains demand.
- `llm_proposer.py`: `_is_noop_reply` honors truthy no-op forms (`True`, `1`, `"true"/"yes"/"1"`) → `proposer_skip` instead of a burned sizing retry; `sizing_rejected` detail now embeds a snippet of the raw reply (`reply={...}`) so the ledger alone diagnoses the next such case.

## Tests

5 new tests (live-case reproductions: skipped-cycle result, no-error blocked placeholder, real-error blocked kept; string-true no-op with single LLM call; detail snippet). Full suite 1575 passed, ruff clean.

Refs #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)