### PR TITLE
fix(runtime): extend-priorities need verbatim label evidence, not shared-target existence (#748/#760)

### DIFF
--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -108,6 +108,26 @@ def _productive_subagent_request_ids(state_root: Path) -> set[str]:
 
 _TARGET_FILE_PATTERN = r"(?:scripts|surfaces|memory|lessons|docs|tests)/[A-Za-z0-9_./-]+\.\w+"
 
+_PRIORITY_LABEL_PATTERN = r"Priority\s+\d+\s*[—–-]\s*[^:.(]{1,40}"
+
+
+def _priority_label_prefix(entry_text: str) -> str | None:
+    """Extract the verbatim ``Priority N — <title prefix>`` label (#748
+    follow-up, live 2026-07-15): integrated cycles auto-commit with the
+    proposal title verbatim ("selfevo: auto-commit ... — Priority 11 — Loop
+    health in dashboard: ..."), so this label appearing in the recent git
+    log is the strongest available done-evidence — number AND title words
+    must both match, immune to the shared-target-file blind spot in
+    ``_priority_done_by_artifact``. Returns None when the entry carries no
+    such label or the captured prefix is too short to be distinctive."""
+    import re as _re
+
+    m = _re.search(_PRIORITY_LABEL_PATTERN, entry_text)
+    if not m:
+        return None
+    prefix = _re.sub(r"\s+", " ", m.group(0)).strip()
+    return prefix if len(prefix) >= 18 else None
+
 
 def _priority_target_file(entry_text: str) -> str | None:
     """Extract the first repo-relative target file path named in a priority entry.
@@ -154,17 +174,19 @@ def _priority_done_by_artifact(
         existing convention — a false "done" actively tells the LLM not to do
         real outstanding work, which is the exact bug this issue fixes).
 
-    This one rule intentionally covers both "create a new file" and "extend
-    an existing file" priorities: distinguishing the two lexically is brittle,
-    and the loop's real commit convention already names the file it touches
-    ("feat: create generate_changelog.py to ...", "chore: update HISTORY.md
-    with loop_health_report.py"), so exact-basename matching fits the actual
-    vocabulary either way. Residual false-positive risk: an "extend" priority
-    whose target file pre-exists and whose basename happens to appear in an
-    OLDER, unrelated commit within the 14-day ``_recent_git_log`` window would
-    still read as done. The 14-day window and the requirement for an EXACT
-    basename match (not a word-overlap heuristic) bound this risk; it is not
-    eliminated.
+    Evidence, strongest first (#748 follow-up, live 2026-07-15):
+
+    1. The entry's verbatim ``Priority N — <title prefix>`` label appears in
+       the recent git log (integrated cycles auto-commit the proposal title
+       verbatim) → ``True`` regardless of anything else.
+    2. Target file existence + exact-basename-in-log — but ONLY for
+       creation-type entries. For "extend"-type entries this evidence is
+       structurally blind: the residual risk documented in earlier revisions
+       fired live on 2026-07-15 (Priority 14 "extend scripts/
+       eeebot_dashboard.py" read as done because the file pre-existed from
+       Priority 7 and its basename appeared in Priority 11's commits —
+       the R30 wake-up never happened). An extend entry with no label
+       evidence is NOT done.
     """
     try:
         target = _priority_target_file(entry_text)
@@ -172,6 +194,9 @@ def _priority_done_by_artifact(
             return None
         if selfevo_repo_root is None or not selfevo_repo_root.is_dir():
             return None
+        label = _priority_label_prefix(entry_text)
+        if label and git_log and label.lower() in git_log.lower():
+            return True
         basename = target.rsplit("/", 1)[-1]
         if not basename:
             return None
@@ -180,7 +205,16 @@ def _priority_done_by_artifact(
             return False
         if not git_log:
             return False
-        return basename.lower() in git_log.lower()
+        if basename.lower() not in git_log.lower():
+            return False
+        # Basename evidence is conclusive only when this entry CREATED the
+        # file; an "extend" entry's target pre-exists by definition, so its
+        # existence proves nothing about THIS entry's work (#748 follow-up).
+        import re as _re
+
+        if _re.search(r"\bextend\b", entry_text, _re.IGNORECASE):
+            return False
+        return True
     except Exception:
         return False
 

--- a/tests/test_goal_text_priority_filter.py
+++ b/tests/test_goal_text_priority_filter.py
@@ -213,6 +213,63 @@ def test_artifact_positive_match_filters_into_completed(tmp_path: Path):
     assert "Priority 21" in current_targets_text
 
 
+def test_extend_priority_not_done_by_shared_target_file(tmp_path: Path):
+    """#748 follow-up, fired live 2026-07-15 (R30 wake-up never happened):
+    P14 'extend scripts/eeebot_dashboard.py' was read as done because the
+    file pre-existed (P7) and its basename appeared in P11's commits. An
+    extend-type entry with no verbatim 'Priority N — ...' label evidence in
+    the git log must stay a live priority."""
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        "selfevo: auto-commit uncommitted subagent work — Priority 11 — Loop "
+        "health in dashboard: extend scripts/eeebot_dashboard.py with a "
+        "compact loop-health section",
+        create_files=("scripts/eeebot_dashboard.py",),
+    )
+    text = (
+        "mission statement\n\n"
+        "Current priority targets:\n"
+        "(A) Priority 14 — Demand and idle visibility in dashboard: extend "
+        "scripts/eeebot_dashboard.py with a compact demand-status section."
+    )
+
+    rewritten = filter_completed_priorities_from_goal_text(text, repo)
+
+    assert rewritten == text
+    targets_section = rewritten.split("Current priority targets:", 1)[1]
+    assert "Priority 14" in targets_section
+
+
+def test_extend_priority_done_by_verbatim_label_in_log(tmp_path: Path):
+    """The same extend entry IS done once the git log carries its verbatim
+    'Priority N — <title>' label (integrated cycles auto-commit the proposal
+    title) — P11 keeps reading as done after the extend carve-out."""
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        "selfevo: auto-commit uncommitted subagent work — Priority 11 — Loop "
+        "health in dashboard: extend scripts/eeebot_dashboard.py with a "
+        "compact loop-health section",
+        create_files=("scripts/eeebot_dashboard.py",),
+    )
+    text = (
+        "mission statement\n\n"
+        "Current priority targets:\n"
+        "(A) Priority 11 — Loop health in dashboard: extend "
+        "scripts/eeebot_dashboard.py with a compact loop-health section "
+        "that reads state/ledger/cycles.jsonl.\n"
+        "(B) Priority 14 — Demand and idle visibility in dashboard: extend "
+        "scripts/eeebot_dashboard.py with a compact demand-status section."
+    )
+
+    rewritten = filter_completed_priorities_from_goal_text(text, repo)
+
+    targets_section = rewritten.split("Current priority targets:", 1)[1]
+    current = targets_section.split("Completed (do not repeat):")[0]
+    assert "Priority 11" not in current
+    assert "Priority 14" in current
+    assert "Loop health in dashboard" in rewritten.split("Completed (do not repeat):", 1)[1]
+
+
 def test_no_target_file_falls_back_to_word_heuristic(tmp_path: Path):
     """A priority entry naming NO target file path has no artifact signal, so
     `_priority_done_by_artifact` returns None and the old word-overlap

--- a/tests/test_state_synthesized_hypothesis.py
+++ b/tests/test_state_synthesized_hypothesis.py
@@ -34,9 +34,13 @@ GOAL_TEXT_JSON = """\
 }
 """
 
-# Both priority 7 and 8 titles' distinctive words appear together on one commit line each.
+# Integrated cycles auto-commit the proposal title verbatim, and R30 proposals
+# quote the goal_text entry verbatim — so done-evidence carries the
+# "Priority N — <title>" label (#748 follow-up: for extend-type entries like
+# P7 this label is REQUIRED; bare basename mentions no longer read as done).
 DONE_GIT_LOG_MESSAGES = (
-    "feat: wire host metrics into the dashboard via eeebot_dashboard.py (#700)",
+    "selfevo: auto-commit uncommitted subagent work — Priority 7 — Wire host "
+    "metrics into the dashboard: extend scripts/eeebot_dashboard.py (#700)",
     "feat: correlate cycle outcomes with host resources in cycle_resource_correlation.py (#701)",
 )
 


### PR DESCRIPTION
Roll-out finding from #760's R30 wake-up verification (live, 2026-07-15 19:20–20:01Z): seeded P14 ("extend scripts/eeebot_dashboard.py …") never woke the loop — 4 cycles of `idle/no_demand`. Diagnosis on host: `filter_completed_priorities_from_goal_text` marked P14 **Completed** — the documented residual risk of #748's artifact rule fired: the target file pre-existed (P7) and its basename appears in P11's commits.

## Fix (evidence hierarchy)

1. **Verbatim label**: `Priority N — <title prefix>` present in the recent git log → done. Integrated cycles auto-commit the proposal title verbatim and R30 proposals quote goal_text verbatim, so this is the loop's actual strongest evidence (number AND title words must match).
2. **Artifact + basename** stays conclusive **only for creation-type entries**; for `extend`-type entries the target's existence proves nothing about *this* entry's work → without label evidence they stay live.

## Tests

- Live-case regression: P14-style extend entry with shared target + P11 commits → stays live.
- P11 itself still reads done via its verbatim label after the carve-out.
- Synthesized-hypothesis fixture updated to realistic auto-commit done-evidence (its old messages predate R30).
- Full suite 1575 passed (2 known systemd-environmental failures). Ruff: only the pre-existing F821 on main (cycle_planning.py:1176), untouched.

After merge+deploy the P14 wake-up test resumes: the filter should keep P14 live → demand kind `priority` → proposal → integration.

Refs #748, #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)