### PR TITLE
fix(runtime): bridge trusts demand-vetted requests; honor no-op on dedup retry (#760)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1407,7 +1407,21 @@ async def _main_impl():
             _target_path = _extract_target_path(req)
         except Exception:
             _target_path = None
-        if _dup_check_title and _target_path:
+        # #760 follow-up (live 2026-07-15 20:42Z): demand-vetted requests
+        # ('serves: demand <id>') were already judged not-done by the demand
+        # collector's strong filter (#748/#769 label evidence + extend
+        # carve-out); the word heuristics below are strictly weaker and
+        # falsely killed the P14 proposal (its title shared 4 words with a
+        # P11 commit touching the same dashboard file). Single source of
+        # done-truth: skip already_done entirely for such requests — the
+        # existence-index and recent-failure gates below still apply.
+        try:
+            _serves_demand = _request_serves_demand(req)
+        except Exception:
+            _serves_demand = False
+        if _serves_demand:
+            pass
+        elif _dup_check_title and _target_path:
             try:
                 _target_exists = (_selfevo_repo_check / _target_path).exists()
             except Exception:
@@ -2561,6 +2575,27 @@ def _task_already_done(backlog_title: str, repo_root: 'Path') -> bool:
             return True
 
     return False
+
+
+def _request_serves_demand(req: dict) -> bool:
+    """True iff the request's task text carries a ``Serves: demand <id>``
+    marker line (#760 follow-up) — written by
+    :func:`nanobot.runtime.llm_proposer.write_request` via the same
+    task-text marker mechanism as ``Target path:`` (#736), because the C1
+    schema-equality invariant keeps ``serves`` out of the payload keys.
+
+    Fail-open: any error reads as False, falling back to the pre-existing
+    already-done heuristics."""
+    try:
+        import re as _re
+
+        text = req.get('task')
+        if not text or not isinstance(text, str):
+            return False
+        m = _re.search(r'^Serves:\s*(.+)$', text, _re.MULTILINE)
+        return bool(m) and m.group(1).strip().lower().startswith('demand ')
+    except Exception:
+        return False
 
 
 def _extract_target_path(req: dict) -> 'str | None':

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1070,7 +1070,17 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
         "verification_task_id": request_id,
         "verification_role": "materialized_improvement_implementation",
         "task_title": _display_title(task_title),
-        "task": f"{rationale}\n\nTarget path: {target_path}".strip(),
+        # #760 follow-up: the 'Serves: <serves>' marker line (same task-text
+        # marker mechanism as '#736 Target path:') lets the bridge recognize
+        # demand-vetted requests ('Serves: demand <id>') — the demand
+        # collector already applied the strong done-filter (#748/#769), so
+        # the bridge must not second-guess with its weaker word heuristic
+        # (live false kill of the P14 proposal, 2026-07-15 20:42Z). Kept out
+        # of the payload keys to preserve the C1 schema-equality invariant.
+        "task": (
+            f"{rationale}\n\nTarget path: {target_path}"
+            + (f"\nServes: {serves}" if serves else "")
+        ).strip(),
         "recommended_next_action": f"Implement and commit: {task_title} (target: {target_path})",
         "request_status": "queued",
         "profile": "bounded_execution",
@@ -1248,6 +1258,14 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if dup and calls_made < _MAX_LLM_CALLS:
             proposal = _call_propose(rejection_reason=dup_reason)
             calls_made += 1
+            # #760 follow-up (live 2026-07-15 20:42-21:02Z): a model told
+            # "your proposal duplicates X" may honestly answer
+            # no_valuable_task — this path lacked the no-op check, so three
+            # honest refusals were recorded as sizing_rejected instead of
+            # proposer_skip.
+            if allow_no_op and _is_noop_reply(proposal):
+                _record_noop_skip(state_dir, str(proposal.get("reason") or ""))
+                return None
             ok, reason = validate_sizing(proposal)
             if not ok:
                 # #762: the dedup retry came back mis-sized — still a sizing

--- a/tests/test_bridge_dedup_target_path.py
+++ b/tests/test_bridge_dedup_target_path.py
@@ -199,6 +199,85 @@ class TestExistingTargetPathScopesKeywordHeuristic:
         assert outcome_rows[0]["outcome"] == "success"
 
 
+class TestDemandVettedRequestBypassesAlreadyDone:
+    def test_demand_serves_request_not_killed_by_word_overlap(self, tmp_path, monkeypatch):
+        """#760 follow-up, fired live 2026-07-15 20:42Z: the P14 proposal
+        ('Extend eeebot_dashboard.py with demand and idle visibility
+        section', serves 'demand priority-…') was killed by
+        _task_already_done_for_path — its title shares 4 words with a P11
+        commit touching the same dashboard file. Demand-vetted requests were
+        already judged not-done by the demand collector's strong filter
+        (#748/#769); the bridge must not second-guess with the weaker word
+        heuristic."""
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _origin, work = _init_selfevo_repo(base)
+
+        target_path = "scripts/eeebot_dashboard.py"
+        (work / "scripts").mkdir(exist_ok=True)
+        (work / "scripts" / "eeebot_dashboard.py").write_text("def main():\n    pass\n")
+        _run(work, "add", target_path)
+        # A P11-style commit touching the SAME file, word-overlapping the
+        # new proposal's title (extend/dashboard/section/...).
+        _run(
+            work, "commit", "-m",
+            "feat: extend eeebot_dashboard.py with loop health section",
+        )
+        _run(work, "push", "origin", "HEAD:main")
+
+        title = "Extend eeebot_dashboard.py with demand and idle visibility section"
+        _seed_bridge_request(
+            state_dir, "req-demand", "cycle-demand",
+            task_title=f"Implement and commit: {title}",
+            task=(
+                f"Add the demand section.\n\nTarget path: {target_path}\n"
+                "Serves: demand priority-b7942f7bf37b"
+            ),
+            recommended_next_action=f"Implement and commit: {title} (target: {target_path})",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-demand" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "success"
+
+    def test_same_request_without_serves_still_deduped(self, tmp_path, monkeypatch):
+        """Belt: absent the demand marker, the word heuristic behaves as
+        before — the bypass is scoped strictly to demand-vetted requests."""
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _origin, work = _init_selfevo_repo(base)
+
+        target_path = "scripts/eeebot_dashboard.py"
+        (work / "scripts").mkdir(exist_ok=True)
+        (work / "scripts" / "eeebot_dashboard.py").write_text("def main():\n    pass\n")
+        _run(work, "add", target_path)
+        _run(
+            work, "commit", "-m",
+            "feat: extend eeebot_dashboard.py with demand and idle visibility section",
+        )
+        _run(work, "push", "origin", "HEAD:main")
+
+        title = "Extend eeebot_dashboard.py with demand and idle visibility section"
+        _seed_bridge_request(
+            state_dir, "req-legacy", "cycle-legacy",
+            task_title=f"Implement and commit: {title}",
+            task=f"Add the demand section.\n\nTarget path: {target_path}",
+            recommended_next_action=f"Implement and commit: {title} (target: {target_path})",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r.get("cycle_id") == "cycle-legacy" and r["phase"] == "outcome"]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "skipped-duplicate"
+
+
 class TestNoTargetPathFallsBackUnchanged:
     def test_request_without_target_path_uses_task_already_done(self, tmp_path, monkeypatch):
         base = tmp_path

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1284,6 +1284,37 @@ class TestHonestNoOp:
         assert "reply=" in (rejects[0].get("detail") or "")
         assert "no_valuable_task" in (rejects[0].get("detail") or "")
 
+    def test_noop_reply_on_dedup_retry_is_honored(self, tmp_path, monkeypatch):
+        """#760 follow-up, fired live 2026-07-15 20:42-21:02Z: a model told
+        'your proposal duplicates X' honestly answered no_valuable_task, but
+        the dedup-retry path lacked the no-op check — three honest refusals
+        were recorded as sizing_rejected instead of proposer_skip."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+
+        replies = [
+            {"task_title": "Create duplicate thing", "rationale": "r",
+             "target_path": "scripts/dup_thing.py", "serves": "vector 1: x"},
+            {"no_valuable_task": True, "reason": "the only candidate is a duplicate"},
+        ]
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0, **kw):
+            return replies.pop(0)
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        monkeypatch.setattr(
+            llm_proposer, "_is_duplicate_proposal",
+            lambda *_a, **_k: (True, "duplicates existing work", "scripts/existing.py"),
+        )
+
+        assert llm_proposer.maybe_propose(state_dir, None) is None
+
+        rows = [json.loads(line) for line in (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+        skips = [r for r in rows if r.get("phase") == "proposer_skip"]
+        assert len(skips) == 1
+        assert skips[0]["reason"] == "the only candidate is a duplicate"
+        assert not [r for r in rows if r.get("phase") == "proposer_reject"]
+
     def test_reason_defaults_when_absent(self, tmp_path, monkeypatch):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, "no priority section, so should_propose is True")


### PR DESCRIPTION
Second roll-out follow-up from #760's R30 wake-up verification (live 2026-07-15 20:32–21:23Z).

## What the ledger showed

The wake-up chain worked up to the bridge: P14 survived the filter (#769) → demand item → `PROPOSED … | demand: priority-b7942f7bf37b` (20:32Z). Then:
1. **20:42Z `skipped_duplicate / already_done`** — `_task_already_done_for_path`'s word-bag (4 shared words with a P11 commit touching the same `eeebot_dashboard.py`) killed the legitimate proposal. Third site of the lexical-dedup disease (#736 → #757 → here).
2. **20:42–21:02Z ×3 `sizing_rejected` with `reply={"no_valuable_task": true…}`** — the dedup-retry path had no no-op check, so honest refusals burned as rejects.

## Fixes

- **Single source of done-truth**: `write_request` embeds `Serves: <serves>` as a task-text marker line (same mechanism as `Target path:` #736 — keeps the C1 schema-equality invariant; payload keys unchanged). The bridge's new `_request_serves_demand()` detects `Serves: demand <id>` and skips the already_done word heuristics for such requests — the demand collector already applied the strictly stronger #748/#769 filter. Existence-index and recent-failure gates still apply. Non-demand requests: behavior unchanged (pinned by test).
- **No-op on dedup retry**: the retry reply now gets `_is_noop_reply` handling → `proposer_skip`, not `sizing_rejected`.

## Tests

- Bridge integration: live P14 case reproduced (word-overlapping commit on shared target + `Serves: demand …` → success; same request without the marker → still deduped).
- Proposer: no_valuable_task on dedup retry → single `proposer_skip`, zero rejects.
- Full suite 1578 passed (2 known systemd-environmental failures), ruff clean on touched files.

Refs #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)