### PR TITLE
fix(runtime): modify-verb carve-out covers 'add ... to' and 'update' (#769/#748)

### DIFF
--- a/nanobot/runtime/cycle_planning.py
+++ b/nanobot/runtime/cycle_planning.py
@@ -208,11 +208,17 @@ def _priority_done_by_artifact(
         if basename.lower() not in git_log.lower():
             return False
         # Basename evidence is conclusive only when this entry CREATED the
-        # file; an "extend" entry's target pre-exists by definition, so its
-        # existence proves nothing about THIS entry's work (#748 follow-up).
+        # file; a modify-existing entry's target pre-exists by definition, so
+        # its existence proves nothing about THIS entry's work (#748
+        # follow-up). Modify verbs beyond "extend": live evidence 2026-07-18
+        # — P16 phrased "add ONE function ... to scripts/eeebot_dashboard.py"
+        # slipped past the extend-only check and was falsely filtered as
+        # done (its R30 wake-up never fired).
         import re as _re
 
-        if _re.search(r"\bextend\b", entry_text, _re.IGNORECASE):
+        if _re.search(
+            r"\bextend\b|\bupdate\b|\badd\b[^.]{0,80}?\bto\b", entry_text, _re.IGNORECASE
+        ):
             return False
         return True
     except Exception:

--- a/tests/test_goal_text_priority_filter.py
+++ b/tests/test_goal_text_priority_filter.py
@@ -240,6 +240,35 @@ def test_extend_priority_not_done_by_shared_target_file(tmp_path: Path):
     assert "Priority 14" in targets_section
 
 
+def test_add_to_priority_not_done_by_shared_target_file(tmp_path: Path):
+    """#769 follow-up, fired live 2026-07-18: P16 phrased 'add ONE function
+    render_cycle_strip(...) to scripts/eeebot_dashboard.py' slipped past the
+    extend-only carve-out — the file pre-existed and its basename appeared
+    in recent commits, so P16 was falsely filtered as done and its R30
+    wake-up never fired. 'add ... to <existing file>' (and 'update') are
+    modify verbs too."""
+    repo = _make_git_repo_with_commit(
+        tmp_path,
+        "selfevo: auto-commit uncommitted subagent work — Priority 11 — Loop "
+        "health in dashboard: extend scripts/eeebot_dashboard.py with a "
+        "compact loop-health section",
+        create_files=("scripts/eeebot_dashboard.py",),
+    )
+    text = (
+        "mission statement\n\n"
+        "Current priority targets:\n"
+        "(A) Priority 16 — Cycle strip line in dashboard: add ONE function "
+        "render_cycle_strip(ledger_path) to scripts/eeebot_dashboard.py and "
+        "call it from the main render."
+    )
+
+    rewritten = filter_completed_priorities_from_goal_text(text, repo)
+
+    assert rewritten == text
+    targets_section = rewritten.split("Current priority targets:", 1)[1]
+    assert "Priority 16" in targets_section
+
+
 def test_extend_priority_done_by_verbatim_label_in_log(tmp_path: Path):
     """The same extend entry IS done once the git log carries its verbatim
     'Priority N — <title>' label (integrated cycles auto-commit the proposal


### PR DESCRIPTION
Live 2026-07-18: seeded P16 ("add ONE function … to scripts/eeebot_dashboard.py") never woke the loop — the #769 carve-out matches only the literal word "extend", so target-existence + basename-in-log falsely marked it done. One hour of idle with a live priority.

Fix: modify-verb set now `extend | update | add … to`. Regression test reproduces the live P16 phrasing. Full suite 1699 passed, ruff clean (pre-existing F821 untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)