### PR TITLE
fix(runtime): decay farming guards — eligibility gate, churn split, double-dip block (#800)

### DIFF
--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -262,6 +262,7 @@ def _ledger_rows(state_dir: Path, now: datetime) -> list[dict[str, Any]]:
 
 def _loop_section(rows: list[dict[str, Any]]) -> dict[str, Any]:
     integrations = 0
+    decay_integrations = 0
     idle_rows = 0
     outcome_rows = 0
     proposals = 0
@@ -269,6 +270,18 @@ def _loop_section(rows: list[dict[str, Any]]) -> dict[str, Any]:
     self_dedup_rejects = 0
     duplicate_failure_skips = 0
     skips_by_class: dict[str, int] = {}
+    # #800 churn split: cycles whose proposed row served a decay demand
+    # (demand_id "decay-…", the #760 traceability field). A success outcome
+    # for such a cycle is an archival — bookkeeping churn, not new value —
+    # and the create→archive treadmill farmed one credit per archival. Those
+    # successes count as decay_integrations, never as integrations.
+    decay_cycles: set[str] = set()
+    for row in rows:
+        if row.get("phase") != "proposed":
+            continue
+        cycle_id = str(row.get("cycle_id") or "").strip()
+        if cycle_id and str(row.get("demand_id") or "").startswith("decay-"):
+            decay_cycles.add(cycle_id)
     for row in rows:
         phase = row.get("phase")
         if phase == "idle":
@@ -283,7 +296,10 @@ def _loop_section(rows: list[dict[str, Any]]) -> dict[str, Any]:
             outcome_rows += 1
             outcome = str(row.get("outcome") or "").strip().lower()
             if outcome == "success":
-                integrations += 1
+                if str(row.get("cycle_id") or "").strip() in decay_cycles:
+                    decay_integrations += 1
+                else:
+                    integrations += 1
             elif outcome.startswith("skipped"):
                 skips_by_class[outcome] = skips_by_class.get(outcome, 0) + 1
                 if str(row.get("reason") or "").strip() == "recent_duplicate_failure":
@@ -291,7 +307,12 @@ def _loop_section(rows: list[dict[str, Any]]) -> dict[str, Any]:
     cycleish = idle_rows + outcome_rows
     repeat_failures = duplicate_failure_skips + self_dedup_rejects
     return {
+        # Value-bearing integrations ONLY (#800) — the fitness numerator
+        # consumed by the _TARGETS gap analysis. Archival churn is reported
+        # separately; cost denominators use integrations_total (all work).
         "integrations": integrations,
+        "decay_integrations": decay_integrations,
+        "integrations_total": integrations + decay_integrations,
         "skips_by_class": skips_by_class,
         "proposals": proposals,
         "proposer_rejects": proposer_rejects,
@@ -766,7 +787,10 @@ def compute_scorecard(
             "computed_at_utc": _iso(now),
             "window_days": _WINDOW_DAYS,
             "loop": loop,
-            "cost": _cost_section(state_dir, now, loop["integrations"]),
+            # #800: cost per integration reflects ALL work (decay archivals
+            # included) — the denominator is integrations_total, explicitly,
+            # while the fitness numerator loop["integrations"] excludes them.
+            "cost": _cost_section(state_dir, now, loop["integrations_total"]),
             "quality": _quality_section(state_dir, selfevo_repo),
             "value": _value_section(state_dir, selfevo_repo, now),
             "heldout": _heldout_section(state_dir),

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -74,6 +74,17 @@ _RESCAN_HOURS = 6
 _HEADER_LINES = 50  # bounded output-path extraction window
 _MAX_RESULT_FILES = 50  # same bounded-read discipline as demand._MAX_RESULT_FILES
 
+# #800: decay-eligibility epoch — the #761 usage-evidence deployment date.
+# Scripts created BEFORE this date can be legitimately stale without ever
+# having harness evidence (the evidence system did not exist to observe
+# them); a script created AFTER it that has NEVER been used is the
+# instance's own never-exercised artifact and must not surface as decay
+# (the create→archive reward-farming vector the #800 audit found).
+_EVIDENCE_EPOCH = datetime(2026, 7, 16, tzinfo=timezone.utc)
+
+_ARCHIVE_MARKER_LINES = 5  # bounded archived-stub check window (#800)
+_ARCHIVE_MARKERS = ("DEPRECATED", "ARCHIVED")
+
 # Exact `state/...` or `docs/...` path strings only — nothing looser (the
 # bound exists so a script cannot "claim" usage via arbitrary prose; the
 # referenced file must actually exist and its mtime is the evidence).
@@ -450,6 +461,50 @@ def _git_last_commit_iso(selfevo_repo: Path, rel: str) -> str | None:
         return None
 
 
+def _git_creation_iso(selfevo_repo: Path, rel: str) -> str | None:
+    """Creation date of ``rel`` — the author date of the FIRST commit that
+    added it (last line of ``git log --diff-filter=A --follow``). ``None``
+    on any failure (fail-open toward not flagging)."""
+    try:
+        result = subprocess.run(
+            [
+                "git", "-C", str(selfevo_repo), "log",
+                "--diff-filter=A", "--follow", "--format=%aI", "--", rel,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+        if not lines:
+            return None
+        parsed = _parse_ts(lines[-1])
+        return _iso(parsed) if parsed is not None else None
+    except Exception:
+        return None
+
+
+def _is_archived_stub(script: Path) -> bool:
+    """True when one of :data:`_ARCHIVE_MARKERS` (``DEPRECATED`` /
+    ``ARCHIVED``) appears in the FIRST :data:`_ARCHIVE_MARKER_LINES` lines —
+    the stub shape a decay archival itself produces. Same bounded-read
+    discipline as the ``used:output`` header extraction. An unreadable
+    script reads as ``True`` (fail-open toward NOT flagging, #800)."""
+    try:
+        with open(script, encoding="utf-8", errors="replace") as fh:
+            for _ in range(_ARCHIVE_MARKER_LINES):
+                line = fh.readline()
+                if not line:
+                    break
+                if any(marker in line for marker in _ARCHIVE_MARKERS):
+                    return True
+        return False
+    except Exception:
+        return True
+
+
 def stale_artifacts(
     state_dir: Path,
     selfevo_repo: Path | None,
@@ -466,6 +521,16 @@ def stale_artifacts(
     is skipped (fail-open toward NOT flagging). Returns
     ``[{path, stale_since}]`` sorted oldest-first; the caller bounds the
     count. Only ``scripts/`` files are ever considered.
+
+    Decay-eligibility guard (#800 audit — decay reward farming): a script is
+    eligible ONLY if it EVER had a harness-observed ``last_used``, or its
+    git CREATION date predates :data:`_EVIDENCE_EPOCH` (pre-evidence scripts
+    can be legitimately stale unobserved). A never-used script created after
+    the epoch is the instance's own never-exercised artifact — mass-creating
+    scripts and archiving them 14 days later farmed one integration credit
+    per archival; such scripts never surface as decay. Scripts that are
+    already archived stubs (:func:`_is_archived_stub`) are also skipped —
+    re-archiving an archived stub was the double-dip vector.
     """
     try:
         if not selfevo_repo:
@@ -482,6 +547,8 @@ def stale_artifacts(
             rel = f"scripts/{script.name}"
             entry = entries.get(rel)
             entry = entry if isinstance(entry, dict) else {}
+            if _is_archived_stub(script):
+                continue  # already archived — never re-propose (#800 double-dip)
             last_used = _parse_ts(entry.get("last_used"))
             last_touched = _parse_ts(entry.get("last_touched"))
             if last_used is None and last_touched is None:
@@ -492,6 +559,12 @@ def stale_artifacts(
                 continue
             if last_touched is not None and last_touched >= cutoff:
                 continue
+            if last_used is None:
+                # #800 eligibility guard: never-used script — only decay-
+                # eligible when it predates the evidence system entirely.
+                created = _parse_ts(_git_creation_iso(repo, rel))
+                if created is None or created >= _EVIDENCE_EPOCH:
+                    continue  # own never-exercised artifact — not decay
             newest = max(ts for ts in (last_used, last_touched) if ts is not None)
             out.append({"path": rel, "stale_since": _iso(newest)})
         out.sort(key=lambda item: item["stale_since"])

--- a/tests/test_bridge_dedup_target_path.py
+++ b/tests/test_bridge_dedup_target_path.py
@@ -279,6 +279,55 @@ class TestDemandVettedRequestBypassesAlreadyDone:
         assert outcome_rows[0]["outcome"] == "skipped-duplicate"
 
 
+class TestSecondArchiveProposalIsBlocked:
+    def test_rearchive_of_already_archived_script_fires_dedup(self, tmp_path, monkeypatch):
+        """#800 double-dip vector: the decay lane archived scripts/foo_bar.py
+        (real commit touching that path); a second cycle proposing to archive
+        the SAME file again must be blocked by the git-scoped pre-spawn dedup
+        (_task_already_done_for_path) — each re-archival farmed another
+        integration credit."""
+        base = tmp_path
+        state_dir = _setup(base, monkeypatch)
+        _origin, work = _init_selfevo_repo(base)
+
+        target_path = "scripts/foo_bar.py"
+        (work / "scripts").mkdir(exist_ok=True)
+        (work / "scripts" / "foo_bar.py").write_text(
+            '"""DEPRECATED: archived stub."""\nraise SystemExit(1)\n'
+        )
+        _run(work, "add", target_path)
+        _run(
+            work, "commit", "-m",
+            "chore: archive scripts/foo_bar.py with deprecation warning",
+        )
+        _run(work, "push", "origin", "HEAD:main")
+
+        title = "Archive scripts/foo_bar.py by adding deprecation warning"
+        _seed_bridge_request(
+            state_dir, "req-rearchive", "cycle-rearchive",
+            task_title=f"Implement and commit: {title}",
+            task=f"Add a deprecation warning header.\n\nTarget path: {target_path}",
+            recommended_next_action=f"Implement and commit: {title} (target: {target_path})",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [
+            r for r in rows
+            if r.get("cycle_id") == "cycle-rearchive" and r["phase"] == "outcome"
+        ]
+        assert len(outcome_rows) == 1
+        assert outcome_rows[0]["outcome"] == "skipped-duplicate"
+        dedup_rows = [
+            r for r in rows
+            if r.get("cycle_id") == "cycle-rearchive" and r["phase"] == "dedup"
+        ]
+        assert len(dedup_rows) == 1
+        assert dedup_rows[0]["decision"] == "skipped_duplicate"
+
+
 class TestResultRecordsTargetPath:
     def test_result_file_records_request_target_path(self, tmp_path, monkeypatch):
         """#798: _write_bridge_completed_result stores the request's own

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -94,6 +94,34 @@ class TestLoopSection:
         assert loop["repeat_failures"] == 2
         assert loop["repeat_failure_rate"] == 1.0
 
+    def test_decay_successes_split_from_integrations(self, tmp_path):
+        """#800 churn split: a success whose proposed row served a decay
+        demand is an archival (bookkeeping churn) — it counts as
+        decay_integrations, never as integrations (the fitness numerator);
+        integrations_total reports all work and feeds the cost denominator."""
+        state_dir = tmp_path / "state"
+        _write_ledger(
+            state_dir,
+            [
+                {"phase": "proposed", "cycle_id": "c-decay", "demand_id": "decay-608215ed8a44", "ts": _iso(40)},
+                {"phase": "outcome", "cycle_id": "c-decay", "outcome": "success", "ts": _iso(39)},
+                {"phase": "proposed", "cycle_id": "c-goal", "demand_id": "priority-b7942f7bf37b", "ts": _iso(20)},
+                {"phase": "outcome", "cycle_id": "c-goal", "outcome": "success", "ts": _iso(19)},
+            ],
+        )
+        _write_telemetry(
+            state_dir,
+            NOW.strftime("%Y-%m-%d"),
+            [{"ts": _iso(5), "prompt_tokens": 800, "completion_tokens": 200}],
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        loop = snap["loop"]
+        assert loop["integrations"] == 1
+        assert loop["decay_integrations"] == 1
+        assert loop["integrations_total"] == 2
+        # Cost per integration reflects ALL work: 1000 tokens / 2 total.
+        assert snap["cost"]["tokens_per_integration"] == 500.0
+
     def test_bounded_archive_read(self, tmp_path):
         """Only the newest _MAX_GZ_FILES archives are read."""
         state_dir = tmp_path / "state"

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -435,9 +435,9 @@ class TestTamperRepair:
 # ─── decay demand kind ──────────────────────────────────────────────────────
 
 
-def _seed_old_repo_scripts(tmp_path: Path, names: list[str]) -> Path:
-    """Repo whose scripts have an OLD git commit date (via GIT_COMMITTER_DATE)
-    so the git fallback reads them as stale."""
+def _seed_repo_scripts_at(tmp_path: Path, names: list[str], commit_iso: str) -> Path:
+    """Repo whose scripts were all created (and last touched) by one commit
+    dated ``commit_iso`` (via GIT_COMMITTER_DATE/GIT_AUTHOR_DATE)."""
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
@@ -446,11 +446,20 @@ def _seed_old_repo_scripts(tmp_path: Path, names: list[str]) -> Path:
     (repo / "scripts").mkdir()
     for name in names:
         (repo / "scripts" / name).write_text("x = 1\n", encoding="utf-8")
-    old = _iso(datetime.now(timezone.utc) - timedelta(days=60))
-    env = dict(os.environ, GIT_COMMITTER_DATE=old, GIT_AUTHOR_DATE=old)
+    env = dict(os.environ, GIT_COMMITTER_DATE=commit_iso, GIT_AUTHOR_DATE=commit_iso)
     subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=repo, check=True, env=env)
     return repo
+
+
+def _seed_old_repo_scripts(tmp_path: Path, names: list[str]) -> Path:
+    """Repo whose scripts have an OLD git commit date so the git fallback
+    reads them as stale. Pinned BEFORE usage_evidence._EVIDENCE_EPOCH (not a
+    days-ago offset from the real clock, which would drift past the #800
+    eligibility epoch as time advances) — pre-epoch scripts stay
+    decay-eligible without ever having harness evidence."""
+    old = _iso(usage_evidence._EVIDENCE_EPOCH - timedelta(days=45))
+    return _seed_repo_scripts_at(tmp_path, names, old)
 
 
 class TestDecayDemand:
@@ -563,3 +572,82 @@ class TestDecayDemand:
         state_dir = _state_dir(tmp_path)
         assert usage_evidence.stale_artifacts(state_dir, None, older_than_days=14) == []
         assert usage_evidence.stale_artifacts(state_dir, tmp_path / "gone", older_than_days=14) == []
+
+
+# ─── #800: decay-eligibility guard (create→archive farming) ─────────────────
+
+
+class TestDecayEligibilityGuard:
+    def test_never_used_created_after_epoch_is_not_stale(self, tmp_path):
+        """The farming vector: a script the instance created AFTER the
+        usage-evidence epoch that was NEVER harness-observed as used must
+        not surface as decay — mass-create → wait 14d → archive-for-credit."""
+        state_dir = _state_dir(tmp_path)
+        post_epoch = _iso(usage_evidence._EVIDENCE_EPOCH + timedelta(days=1))
+        repo = _seed_repo_scripts_at(tmp_path, ["own_artifact.py"], post_epoch)
+        _write_usage_sidecar(state_dir, {})  # no evidence at all
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
+
+    def test_never_used_created_before_epoch_is_eligible(self, tmp_path):
+        """Pre-epoch scripts can be legitimately stale without ever having
+        evidence — the evidence system did not exist to observe them."""
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, ["legacy.py"])
+        _write_usage_sidecar(state_dir, {})
+        stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
+        assert [item["path"] for item in stale] == ["scripts/legacy.py"]
+
+    def test_used_then_stale_is_eligible_even_when_created_after_epoch(self, tmp_path):
+        """A script that EVER had harness-observed usage decays normally —
+        the guard gates never-used artifacts only."""
+        state_dir = _state_dir(tmp_path)
+        post_epoch = _iso(usage_evidence._EVIDENCE_EPOCH + timedelta(days=1))
+        repo = _seed_repo_scripts_at(tmp_path, ["was_used.py"], post_epoch)
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/was_used.py": {"last_used": _now_iso(days_ago=30),
+                                     "last_touched": _now_iso(days_ago=20),
+                                     "signal": "pycache"}},
+        )
+        stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
+        assert [item["path"] for item in stale] == ["scripts/was_used.py"]
+
+    def test_archived_stub_is_never_reproposed(self, tmp_path):
+        """Double-dip vector: an already-archived stub (DEPRECATED/ARCHIVED
+        marker in the first 5 lines) must never re-surface as decay — the
+        second archival of the same file farmed a second credit."""
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, ["stub_a.py", "stub_b.py"])
+        (repo / "scripts" / "stub_a.py").write_text(
+            '"""DEPRECATED: archived by decay lane."""\nraise SystemExit(1)\n',
+            encoding="utf-8",
+        )
+        (repo / "scripts" / "stub_b.py").write_text(
+            "# ARCHIVED 2026-07-30\nx = 1\n", encoding="utf-8",
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {
+                "scripts/stub_a.py": {"last_used": _now_iso(days_ago=30),
+                                      "last_touched": None, "signal": "pycache"},
+                "scripts/stub_b.py": {"last_used": _now_iso(days_ago=30),
+                                      "last_touched": None, "signal": "pycache"},
+            },
+        )
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
+
+    def test_marker_past_line_five_does_not_shield(self, tmp_path):
+        """The stub check is bounded to the FIRST 5 lines — a DEPRECATED
+        mention deeper in a real script does not exempt it from decay."""
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, ["deep_mention.py"])
+        (repo / "scripts" / "deep_mention.py").write_text(
+            "x = 1\n" * 6 + "# TODO: mark DEPRECATED someday\n", encoding="utf-8",
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/deep_mention.py": {"last_used": _now_iso(days_ago=30),
+                                         "last_touched": None, "signal": "pycache"}},
+        )
+        stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
+        assert [item["path"] for item in stale] == ["scripts/deep_mention.py"]


### PR DESCRIPTION
Closes #800.

## Problem (audit 2026-08-12)
The instance farms integration credit via a create→archive treadmill: mass-created scripts (Jul 13–14 burst), never exercised, archived ~23–25 days later via decay demand — one credit at each end, ~5 commits per archival. 54/68 completed demands are decay; 32/86 scripts already stubbed; a second cycle re-touched an archived stub for another credit. Full evidence in #800.

## Fixes (harness-side — the instance's `surfaces/` is self-mutable, so none of this is expressible there; see the immutability invariant in `scorecard.py`)

1. **Decay eligibility gate** (`usage_evidence.stale_artifacts`): a never-used script is decay-eligible only when its git creation predates `_EVIDENCE_EPOCH` (2026-07-16, the #761 usage-evidence deployment). A post-epoch never-used script is the instance's own never-exercised artifact — it never surfaces as archival credit.
2. **Archived-stub skip** (same function): scripts with DEPRECATED/ARCHIVED in the first 5 lines are never re-proposed — closes the observed double-dip.
3. **Churn split** (`scorecard._loop_section`): success outcomes in cycles serving `decay-*` demand count as `decay_integrations`; the fitness numerator `integrations` carries value-bearing work only; cost denominators use `integrations_total`.
4. **Double-dip dedup test**: a second archive-proposal for an already-archived script is blocked by the git-scoped pre-spawn dedup.

## Review notes
- `%aI` git format requires git ≥2.21 — host runs 2.39.5; failure direction is fail-open toward NOT flagging (safe).
- Loose DEPRECATED substring match can shield a legit script that mentions deprecation in its header — consequence is only "no auto-archival proposal", accepted for simplicity.
- No `_TARGETS` entry keys on `integrations`, and `loop_explorer`/`loop_metrics_report` consumers are backward-compatible.

Tests: 284 passed in combined focused suites (2 pre-existing Windows path failures in test_demand.py confirmed on pristine tree, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)