### PR TITLE
fix(runtime): birth-use does not count — tighten decay eligibility (#800 follow-up)

### DIFF
--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -85,6 +85,13 @@ _EVIDENCE_EPOCH = datetime(2026, 7, 16, tzinfo=timezone.utc)
 _ARCHIVE_MARKER_LINES = 5  # bounded archived-stub check window (#800)
 _ARCHIVE_MARKERS = ("DEPRECATED", "ARCHIVED")
 
+# #800 (tightened): a last_used within this window after the script's git
+# creation is the creation cycle's own self-test (the subagent executes the
+# script once right after writing it → __pycache__ → "used"), not evidence
+# anyone consumes it. Post-epoch scripts need a use OUTSIDE this window to
+# be decay-eligible.
+_BIRTH_USE_GRACE = timedelta(days=1)
+
 # Exact `state/...` or `docs/...` path strings only — nothing looser (the
 # bound exists so a script cannot "claim" usage via arbitrary prose; the
 # referenced file must actually exist and its mtime is the evidence).
@@ -522,15 +529,20 @@ def stale_artifacts(
     ``[{path, stale_since}]`` sorted oldest-first; the caller bounds the
     count. Only ``scripts/`` files are ever considered.
 
-    Decay-eligibility guard (#800 audit — decay reward farming): a script is
-    eligible ONLY if it EVER had a harness-observed ``last_used``, or its
-    git CREATION date predates :data:`_EVIDENCE_EPOCH` (pre-evidence scripts
-    can be legitimately stale unobserved). A never-used script created after
-    the epoch is the instance's own never-exercised artifact — mass-creating
-    scripts and archiving them 14 days later farmed one integration credit
-    per archival; such scripts never surface as decay. Scripts that are
-    already archived stubs (:func:`_is_archived_stub`) are also skipped —
-    re-archiving an archived stub was the double-dip vector.
+    Decay-eligibility guard (#800 audit — decay reward farming): a script
+    created after :data:`_EVIDENCE_EPOCH` is eligible ONLY if it has a
+    harness-observed ``last_used`` more than :data:`_BIRTH_USE_GRACE` after
+    its git creation date. Both halves matter: never-used post-epoch scripts
+    are the instance's own never-exercised artifacts (mass-creating scripts
+    and archiving them 14 days later farmed one integration credit per
+    archival), and a ``last_used`` INSIDE the grace window is just the
+    creation cycle's own self-test (the subagent executes a script once
+    right after writing it, which drops a ``__pycache__`` entry — live
+    dry-run showed 17 farmed scripts passing an ever-used check on exactly
+    that birth signal). Pre-epoch scripts are exempt (the evidence system
+    did not exist to observe them). Scripts that are already archived stubs
+    (:func:`_is_archived_stub`) are always skipped — re-archiving an
+    archived stub was the double-dip vector.
     """
     try:
         if not selfevo_repo:
@@ -559,12 +571,17 @@ def stale_artifacts(
                 continue
             if last_touched is not None and last_touched >= cutoff:
                 continue
-            if last_used is None:
-                # #800 eligibility guard: never-used script — only decay-
-                # eligible when it predates the evidence system entirely.
-                created = _parse_ts(_git_creation_iso(repo, rel))
-                if created is None or created >= _EVIDENCE_EPOCH:
-                    continue  # own never-exercised artifact — not decay
+            # #800 eligibility guard, tightened: for post-epoch scripts a
+            # last_used inside the birth-grace window is the creation
+            # cycle's own self-test, not consumption — treat it as never
+            # used. The git call only runs for otherwise-stale scripts.
+            created = _parse_ts(_git_creation_iso(repo, rel))
+            if created is None or created >= _EVIDENCE_EPOCH:
+                if last_used is None or (
+                    created is not None
+                    and last_used < created + _BIRTH_USE_GRACE
+                ):
+                    continue  # own never-/birth-only-exercised artifact
             newest = max(ts for ts in (last_used, last_touched) if ts is not None)
             out.append({"path": rel, "stale_since": _iso(newest)})
         out.sort(key=lambda item: item["stale_since"])

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -597,20 +597,44 @@ class TestDecayEligibilityGuard:
         stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
         assert [item["path"] for item in stale] == ["scripts/legacy.py"]
 
-    def test_used_then_stale_is_eligible_even_when_created_after_epoch(self, tmp_path):
-        """A script that EVER had harness-observed usage decays normally —
-        the guard gates never-used artifacts only."""
+    def test_used_after_birth_grace_then_stale_is_eligible(self, tmp_path):
+        """A post-epoch script with harness-observed usage OUTSIDE the
+        birth-grace window decays normally — the guard gates never-used and
+        birth-only-used artifacts, not genuinely consumed ones."""
         state_dir = _state_dir(tmp_path)
-        post_epoch = _iso(usage_evidence._EVIDENCE_EPOCH + timedelta(days=1))
+        epoch = usage_evidence._EVIDENCE_EPOCH
+        post_epoch = _iso(epoch + timedelta(days=1))
         repo = _seed_repo_scripts_at(tmp_path, ["was_used.py"], post_epoch)
+        # Used 10 days after creation — well past _BIRTH_USE_GRACE — and
+        # both timestamps are anchored to the fixed epoch, so they stay
+        # stale as the real clock advances.
         _write_usage_sidecar(
             state_dir,
-            {"scripts/was_used.py": {"last_used": _now_iso(days_ago=30),
-                                     "last_touched": _now_iso(days_ago=20),
+            {"scripts/was_used.py": {"last_used": _iso(epoch + timedelta(days=11)),
+                                     "last_touched": _iso(epoch + timedelta(days=12)),
                                      "signal": "pycache"}},
         )
         stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
         assert [item["path"] for item in stale] == ["scripts/was_used.py"]
+
+    def test_birth_only_use_created_after_epoch_is_not_stale(self, tmp_path):
+        """The tightened #800 vector: the creation cycle's own self-test
+        (subagent runs the script right after writing it → __pycache__ →
+        last_used == creation date) is not consumption. Live dry-run showed
+        17 farmed scripts passing an ever-used check on exactly that birth
+        signal — they must not surface as decay."""
+        state_dir = _state_dir(tmp_path)
+        epoch = usage_evidence._EVIDENCE_EPOCH
+        post_epoch = _iso(epoch + timedelta(days=1))
+        repo = _seed_repo_scripts_at(tmp_path, ["birth_tested.py"], post_epoch)
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/birth_tested.py": {
+                "last_used": _iso(epoch + timedelta(days=1, hours=2)),
+                "last_touched": _iso(epoch + timedelta(days=1, hours=2)),
+                "signal": "pycache"}},
+        )
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
 
     def test_archived_stub_is_never_reproposed(self, tmp_path):
         """Double-dip vector: an already-archived stub (DEPRECATED/ARCHIVED


### PR DESCRIPTION
Follow-up to #801 (refs #800).

## Problem found in live verification
Post-deploy dry-run on eeepc: **17 farmed scripts still decay-eligible.** The #801 ever-used gate is satisfied by the creation cycle's own self-test — the subagent executes a script once right after writing it, which drops `__pycache__` → `last_used` == creation date. Birth-only use passed as consumption.

## Fix
`stale_artifacts`: a post-epoch script is decay-eligible only when `last_used > git_creation + _BIRTH_USE_GRACE` (1 day). Use inside the grace window = the creation cycle testing itself. Pre-epoch scripts unaffected; fail-open directions unchanged.

Tests: birth-only-use → not eligible; use 10 days after creation → eligible (timestamps anchored to the fixed epoch so they don't drift with the real clock). 55 passed in usage-evidence + scorecard suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)