### PR TITLE
docs(804): actualize architecture docs — CURRENT_ARCHITECTURE.md + supersede banners

### DIFF
--- a/docs/CURRENT_ARCHITECTURE.md
+++ b/docs/CURRENT_ARCHITECTURE.md
@@ -1,0 +1,115 @@
+# Current Architecture
+
+_Status: current. Last updated: 2026-08-12._
+
+The authoritative, one-page map of how eeebot's self-evolving runtime works
+**today** — the state-light proposer loop adopted by #702–#708 (June–July 2026),
+replacing the retired lane/HADI/reward control-plane machinery. Depth lives in
+`docs/specs/` and `docs/changes/`; this page is the index that ties them
+together. Every claim below traces to a module docstring or a linked change doc.
+
+## Three-repo model
+
+- **`ozand/eeebot`** — the **product**: the runtime code (`nanobot/`), specs,
+  the host deploy tooling, and the harness that owns fitness. Canonical source
+  (`docs/specs/promotion-and-release/spec.md` R1).
+- **`eeebot-self-evolving`** — the **instance**: the mutable workspace the loop
+  edits (`scripts/`, `surfaces/`, `tests/`, `memory/`, `docs/`). Checked out on
+  the host beside the state root; the loop integrates onto its `main`
+  (`docs/specs/subagent-bridge/spec.md`).
+- **`ozand/eeebot-ops-dashboard`** — the ops **dashboard** (WSGI), extracted in
+  #617 and canonical there since 2026-07-05 (`docs/specs/migration/spec.md`).
+
+The fitness function (scorecard, targets, sidecars, held-out checkers) lives in
+the **product** runtime and the harness-owned state dir — never in the instance
+workspace, so the instance cannot redefine how its own value is measured
+(#603 invariant; `docs/specs/self-evolving-runtime/spec.md` R26).
+
+## The live loop, end to end
+
+One timer-paced process invocation = one bridge cycle
+(`nanobot/runtime/bridge.py`). State is operational/artifact truth (ledgers,
+result files, telemetry) — not a control graph (#702 decision).
+
+1. **Propose (sole task source).** The LLM proposer
+   (`nanobot/runtime/llm_proposer.py`) is the only source of new tasks: since
+   #739's deterministic-planner kill-switch (`SELFEVO_DETERMINISTIC_PLANNER_ENABLED="0"`)
+   the coordinator mints no requests, and the #707 replacement went GO on
+   2026-07-13. Behind `SELFEVO_DEMAND_DRIVEN_ENABLED` (default ON, #760), the
+   proposer works **only when there is demand**: the LLM *selects and refines*
+   one presented demand item and never invents from a bare inventory. No demand
+   ⇒ **zero LLM calls** and one `{phase: "idle", reason: "no_demand"}` ledger row.
+2. **Dedup chain (pre-spawn).** A proposal passes the bridge's dedup sequence
+   before any subagent spawns: **already-done** (`_task_already_done`, git-log /
+   done-ledger keyword overlap), **recent-failure** suppression
+   (`_recent_failure_match`, structured-intent keyed, R37/#757), and the
+   **existence index** (`nanobot/runtime/existence_index.py`, FTS5 over script
+   filenames/docstrings + past titles, R35/#750) that catches intent duplicates
+   whose wording differs.
+3. **Bounded gate.** Exactly one fresh-context subagent runs, commits on a cycle
+   branch (`selfevo/cycle-<id>`), then the **bounded smoke gate** (#686): import
+   `py_compile` of changed files + the tests they affect + a small fixed core
+   set — NOT the full suite (sized to the host per-cycle budget). A
+   **mutation-surface** violation is a hard block (R12a). The gate **fails safe**
+   — any error/timeout/missing-pytest is treated as failure.
+4. **Integrate on green.** Only on a clean gate does the bridge merge the cycle
+   branch into the instance repo's `main` (`_integrate_cycle_to_main`, merge
+   `--no-ff`). `origin/main` never advances on red — the git-verifiable rollback
+   guarantee `main_sha_before == main_sha_after` when not integrated (#653/#678).
+5. **Cycle ledger.** Every phase (start, dedup decision, gate decision, terminal
+   outcome) appends to a single flat file `state/ledger/cycles.jsonl`
+   (`nanobot/runtime/cycle_ledger.py`, #720 — the minimal form of #704),
+   rotated daily to `cycles-YYYY-MM-DD.jsonl.gz`.
+6. **Scorecard (fitness).** `nanobot/runtime/scorecard.py` (#765) computes a
+   deterministic, LLM-free 7-day snapshot — loop/cost/quality/value/heldout/
+   integrity metrics — to `state/scorecard/latest.json` + `history.jsonl`,
+   30-minute watermarked. It reads across ledger rotation. Post-integration
+   consumption is verified by harness-observed usage evidence only
+   (`nanobot/runtime/usage_evidence.py`, #761) — never self-reported claims.
+7. **Demand feeds the next proposal.** `nanobot/runtime/demand.py` (#760)
+   deterministically scans state and yields demand items in trust order:
+   **priority** > **defect** > **goal-gap** > **hypothesis** > **decay**
+   (goal-gap from scorecard target breaches #765; defect includes held-out
+   check failures #780). This demand is what step 1 presents to the LLM next
+   cycle — closing the loop.
+
+Held-out verification (#780, `nanobot/runtime/heldout/`) runs product-side
+sandboxed behavioral checkers against instance artifacts on the scorecard
+recompute path; failures become `defect` demand carrying the checker's evidence
+without the instance ever seeing the checker.
+
+## Host layout & deploy
+
+- Release symlink: `/opt/eeepc-agent/runtimes/self-evolving-agent/current` →
+  the active timestamped release under `.../releases/`.
+- State root: `/var/lib/eeepc-agent/self-evolving-agent/state` (goal_text,
+  ledgers, scorecard, sidecars, telemetry).
+- Deploy path (`host/eeepc/scripts/deploy_release.sh`): `git archive` HEAD →
+  `scp` to host → extract into `releases/` → flip the `current` symlink →
+  `systemctl restart eeepc-self-evolving-agent.service`. Since #601 the bridge
+  unit runs `-m nanobot.runtime.bridge` straight from the release (no file
+  copy). See `docs/specs/host-runtime/spec.md`.
+
+## Recent hardening (2026-08)
+
+- **#798/#799** — dedup cascade: skips are not failures; cross-target precision
+  in the recent-failure/dedup path.
+- **#800/#801/#802** — decay-farming guards: a decay eligibility gate, a
+  churn split in the scorecard, a double-dip block, and the birth-use rule
+  (birth-use does not count toward decay eligibility).
+
+## Read next (depth)
+
+- `docs/changes/702-ledger-loop-architecture-decision/decision.md` — why the
+  state-light loop replaced the control-plane state machine.
+- `docs/changes/704-ledger-artifact-memory/design.md` — the ledger/artifact
+  memory schema (the loop's only durable state).
+- `docs/changes/760-demand-driven-proposer/proposal.md` — the supply→demand
+  inversion and demand kinds.
+- `docs/changes/765-scorecard/proposal.md` — the fitness function and goal-gap
+  demand.
+- `docs/changes/780-heldout-pack/proposal.md` — the private held-out
+  evaluation split.
+- `docs/specs/self-evolving-runtime/spec.md`, `docs/specs/subagent-bridge/spec.md`,
+  `docs/specs/host-runtime/spec.md`, `docs/specs/promotion-and-release/spec.md`
+  — the normative capability specs.

--- a/docs/EEEBOT_BUDGET_AND_REWARD_MODEL.md
+++ b/docs/EEEBOT_BUDGET_AND_REWARD_MODEL.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED (2026-08-12):** describes the pre-July-2026 lane/HADI architecture, replaced by the state-light proposer loop (#702–#708). Current: [CURRENT_ARCHITECTURE.md](CURRENT_ARCHITECTURE.md).
+
 # eeebot Budget and Reward Model
 
 Last updated: 2026-04-21 UTC

--- a/docs/EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md
+++ b/docs/EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED (2026-08-12):** describes the pre-July-2026 lane/HADI architecture, replaced by the state-light proposer loop (#702–#708). Current: [CURRENT_ARCHITECTURE.md](CURRENT_ARCHITECTURE.md).
+
 # eeebot Experiment and Outcome Contract
 
 Last updated: 2026-04-21 UTC

--- a/docs/EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md
+++ b/docs/EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED (2026-08-12):** describes the pre-July-2026 lane/HADI architecture, replaced by the state-light proposer loop (#702–#708). Current: [CURRENT_ARCHITECTURE.md](CURRENT_ARCHITECTURE.md).
+
 # Closing the Insight → Hypothesis arc (HADI loop)
 
 Status: proposal / design-note

--- a/docs/EEEBOT_OPERATOR_WORKFLOW.md
+++ b/docs/EEEBOT_OPERATOR_WORKFLOW.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED (2026-08-12):** describes the pre-July-2026 lane/HADI architecture, replaced by the state-light proposer loop (#702–#708). Current: [CURRENT_ARCHITECTURE.md](CURRENT_ARCHITECTURE.md).
+
 # eeebot Operator Workflow
 
 Last updated: 2026-04-21 UTC

--- a/docs/EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md
+++ b/docs/EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED (2026-08-12):** describes the pre-July-2026 lane/HADI architecture, replaced by the state-light proposer loop (#702–#708). Current: [CURRENT_ARCHITECTURE.md](CURRENT_ARCHITECTURE.md).
+
 # eeebot Self-Improving Runtime Operating Contract
 
 Last updated: 2026-04-21 UTC

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,29 @@ Two principles govern this set: **simplicity** (smallest accurate model) and
 [`CONSTITUTION.md`](../CONSTITUTION.md).
 
 How the docs are organized:
+- [`CURRENT_ARCHITECTURE.md`](CURRENT_ARCHITECTURE.md) — **start here**: the
+  one-page map of the live state-light proposer loop (#702–#708).
 - [`specs/`](specs/README.md) — **current product truth**, one normative spec per capability.
 - [`changes/`](changes/README.md) — **changes in flight** (proposal/design), archived on merge.
 - **reference docs** (below) — explanation and runbooks, not contract.
+- **historical / superseded** (bottom) — pre-July-2026 lane/HADI architecture docs, kept for history.
 - `.legacy/` (archived/superseded docs) was removed 2026-07-05 (#613); recoverable
   via `git log -- .legacy`.
 
-## Capability specs (start here)
+## Start here (current architecture)
+
+Read these first, in order, for what is true **now**:
+
+1. [`CURRENT_ARCHITECTURE.md`](CURRENT_ARCHITECTURE.md) — the live loop end to end.
+2. Current source docs behind it:
+   [`changes/702-ledger-loop-architecture-decision`](changes/702-ledger-loop-architecture-decision/decision.md) (why the loop was redesigned),
+   [`changes/704-ledger-artifact-memory`](changes/704-ledger-artifact-memory/design.md) (ledger memory),
+   [`changes/760-demand-driven-proposer`](changes/760-demand-driven-proposer/proposal.md) (demand-driven proposer),
+   [`changes/765-scorecard`](changes/765-scorecard/proposal.md) (fitness scorecard),
+   [`changes/780-heldout-pack`](changes/780-heldout-pack/proposal.md) (held-out verification).
+3. The normative capability specs in [`specs/`](specs/README.md).
+
+## Capability specs
 
 The contract layer — what is true now, per capability:
 
@@ -33,14 +49,13 @@ Detailed walkthroughs behind the specs:
 - [OBSERVABILITY.md](OBSERVABILITY.md) — how to see what the system is doing.
 - [ARCHITECTURE.md](ARCHITECTURE.md) — high-level map.
 - [ACTIVE_GOAL.md](ACTIVE_GOAL.md) — current goal and progress criteria.
-- Self-evolving detail: [EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md](EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md), [EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md](EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md), [EEEBOT_BUDGET_AND_REWARD_MODEL.md](EEEBOT_BUDGET_AND_REWARD_MODEL.md), [EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md](EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md).
+- Self-evolving detail: [CURRENT_ARCHITECTURE.md](CURRENT_ARCHITECTURE.md) and the current source docs listed under "Start here" above. (The older EEEBOT_SELF_IMPROVING_* / _BUDGET_AND_REWARD_ / _EXPERIMENT_AND_OUTCOME_ / _INSIGHT_HYPOTHESIS_ contract docs are superseded — see "Historical / superseded" below.)
 
 ## Runbooks (operational how-to)
 
 - [EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md](EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md) — safe deploy/verify/rollback steps.
 - [EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md](EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md) — opening the apply approval window.
 - [CHANNEL_PLUGIN_GUIDE.md](CHANNEL_PLUGIN_GUIDE.md) — how to add a chat-channel plugin.
-- [EEEBOT_OPERATOR_WORKFLOW.md](EEEBOT_OPERATOR_WORKFLOW.md) — operator responsibilities.
 
 ## Charter, roadmap & process
 
@@ -51,8 +66,22 @@ Detailed walkthroughs behind the specs:
 
 ## Reading order for a new operator
 
-1. `specs/self-evolving-runtime/spec.md` → `specs/subagent-bridge/spec.md`
-2. `SYSTEM_OPERATION_REFERENCE.md` · `OBSERVABILITY.md`
-3. `specs/host-runtime/spec.md` · `EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md`
+1. [`CURRENT_ARCHITECTURE.md`](CURRENT_ARCHITECTURE.md) — the live loop in one page.
+2. `specs/self-evolving-runtime/spec.md` → `specs/subagent-bridge/spec.md`
+3. `SYSTEM_OPERATION_REFERENCE.md` · `OBSERVABILITY.md`
+4. `specs/host-runtime/spec.md` · `EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md`
 
 > Tasks/backlog are in GitHub Issues + status labels, not in this repo. See [`AGENTS.md`](../AGENTS.md).
+
+## Historical / superseded
+
+These docs describe the **pre-July-2026 lane/HADI/reward architecture**, replaced
+by the state-light proposer loop (#702–#708). Kept for history — each now carries
+a SUPERSEDED banner pointing at [`CURRENT_ARCHITECTURE.md`](CURRENT_ARCHITECTURE.md).
+Do not treat them as current contract.
+
+- [EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md](EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md)
+- [EEEBOT_BUDGET_AND_REWARD_MODEL.md](EEEBOT_BUDGET_AND_REWARD_MODEL.md)
+- [EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md](EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md)
+- [EEEBOT_OPERATOR_WORKFLOW.md](EEEBOT_OPERATOR_WORKFLOW.md)
+- [EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md](EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md)


### PR DESCRIPTION
Closes #804.

The repo's April-2026 operating docs describe the retired lane/HADI/WSJF/reward architecture; the state-light proposer loop (#702–#708) replaced it in June–July 2026. This aligns the docs index without rewriting history.

## Changes
- **NEW** `docs/CURRENT_ARCHITECTURE.md` (115 lines) — one-page live-loop map: three-repo model, proposer→dedup→gate→integrate→ledger→scorecard→demand, host layout + `deploy_release.sh` path, recent hardening (#798/#800–#802). Links to `docs/changes/*` and `docs/specs/*` for depth; every claim traced to a module docstring or change doc.
- **`docs/README.md`** — new "Start here" section leading with CURRENT_ARCHITECTURE.md + current sources; superseded docs moved to a labeled Historical section.
- **SUPERSEDED banner** (+2 lines, rest byte-identical) on: `EEEBOT_SELF_IMPROVING_RUNTIME_OPERATING_CONTRACT.md`, `EEEBOT_BUDGET_AND_REWARD_MODEL.md`, `EEEBOT_EXPERIMENT_AND_OUTCOME_CONTRACT.md`, `EEEBOT_OPERATOR_WORKFLOW.md`, `EEEBOT_INSIGHT_HYPOTHESIS_LOOP_CLOSURE.md`.

## Notes
- No contradictions found between module docstrings and docs/changes. One self-documented deviation: `cycle_ledger.py` (#720) ships #704's memory design in minimal single-file form (`cycles.jsonl`) vs the proposed done/failure split — described as-shipped.
- Possible follow-up (out of scope here): `docs/specs/self-evolving-runtime/spec.md` still frames itself around the HADI arc / retired-planner R-numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)