### PR TITLE
fix(runtime): confirmed_ratio goal-gap lever hint (#808)

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -127,7 +127,10 @@ _MAX_LEDGER_DEFECTS = 10
 _MAX_COMPILE_DEFECTS = 10
 _MAX_HELDOUT_DEFECTS = 5  # #780: bounded held-out failure demand
 _MAX_SUMMARY_CHARS = 160
-_MAX_EVIDENCE_CHARS = 240
+# #808: was 240; goal-gap items with a scorecard ``lever_hint`` append it
+# after the evidence sentence, and 240 truncated the hint mid-word before
+# reaching the "does NOT move it" instruction — the whole point of the hint.
+_MAX_EVIDENCE_CHARS = 420
 
 _DECAY_DAYS = 14
 _MAX_DECAY_ITEMS = 5
@@ -712,11 +715,18 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
                 continue  # FUTURE (or anything else) never generates demand
             detail = f"current {gap.get('current')} vs target {gap.get('target')}"
             gap_evidence = str(gap.get("evidence") or "").strip()
+            rationale = gap_evidence or detail
+            lever_hint = str(gap.get("lever_hint") or "").strip()
+            if lever_hint:
+                # #808: proposer-facing guidance only — the summary (and
+                # therefore the id) stays untouched so exhaustion/dedup
+                # identity (#778) is unaffected by this addition.
+                rationale = f"{rationale} | lever: {lever_hint}"
             items.append(
                 _make_item(
                     "goal-gap",
                     f"goal gap: {metric} ({vector})",
-                    gap_evidence or detail,
+                    rationale,
                 )
             )
         return items

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -133,6 +133,16 @@ _TARGETS: dict[str, dict[str, Any]] = {
         "denominator_metric": "completed_declared",
         "vector": "V2",
         "rank": 4,
+        # #808: this gap otherwise reads as "generic quality problem" to the
+        # proposer, which then edits an irrelevant reporting script that
+        # structurally cannot move the metric. Spell out the actual lever.
+        "lever_hint": (
+            "Rises only when a completed scripts/*.py artifact is actually "
+            "used after completion (harness pycache/output signal via "
+            "confirm_serves). Editing reporting/analysis scripts does NOT "
+            "move it — propose work that produces a script the loop will "
+            "exercise, or improves the confirm-serves usage evidence path."
+        ),
     },
     # #780: fraction of held-out-checked artifacts whose behavioral check
     # fails (failed / (passed+failed); skips excluded — a checker problem is
@@ -667,19 +677,21 @@ def _compute_gaps(
             if not breached:
                 continue
             rel = "above max" if direction == "max" else "below min"
-            gaps.append(
-                {
-                    "metric": metric,
-                    "vector": spec["vector"],
-                    "current": round(float(current), 4),
-                    "target": threshold,
-                    "evidence": (
-                        f"{metric}={round(float(current), 4)} is {rel} target "
-                        f"{threshold} over the last {_WINDOW_DAYS}d window "
-                        f"(goal vector {spec['vector']})"
-                    ),
-                }
-            )
+            gap_dict: dict[str, Any] = {
+                "metric": metric,
+                "vector": spec["vector"],
+                "current": round(float(current), 4),
+                "target": threshold,
+                "evidence": (
+                    f"{metric}={round(float(current), 4)} is {rel} target "
+                    f"{threshold} over the last {_WINDOW_DAYS}d window "
+                    f"(goal vector {spec['vector']})"
+                ),
+            }
+            lever_hint = spec.get("lever_hint")
+            if lever_hint:
+                gap_dict["lever_hint"] = lever_hint
+            gaps.append(gap_dict)
         except Exception:
             continue
     gaps.sort(key=lambda g: (0 if g["vector"] == "V1" else 1, _TARGETS.get(g["metric"], {}).get("rank", 99)))

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -451,6 +451,58 @@ class TestGoalGapDemand:
         assert "(V1)" in gap_items[0]["summary"]
         assert "(V2)" in gap_items[1]["summary"]
 
+    def test_gap_lever_hint_appended_to_evidence_id_unchanged(self, tmp_path):
+        """#808: when the scorecard gap carries a lever_hint, the demand
+        item's evidence gains it (so the proposer sees what actually moves
+        the metric) but the stable summary/id (#778 exhaustion identity) is
+        byte-unchanged versus a gap with no lever_hint."""
+        state_dir = _state_dir(tmp_path)
+        hint = "produce a script the loop will exercise"
+        _write_scorecard_gaps(
+            state_dir,
+            [
+                {
+                    "metric": "confirmed_ratio",
+                    "vector": "V2",
+                    "current": 0.39,
+                    "target": 0.5,
+                    "evidence": "confirmed_ratio=0.39 is below min target 0.5",
+                    "lever_hint": hint,
+                }
+            ],
+        )
+        gap_item = next(
+            i for i in demand.collect_demand(state_dir, None) if i["kind"] == "goal-gap"
+        )
+        assert hint in gap_item["evidence"]
+        expected_summary = "goal gap: confirmed_ratio (V2)"
+        assert gap_item["summary"] == expected_summary
+        assert gap_item["id"] == demand.item_id("goal-gap", expected_summary)
+
+    def test_real_confirmed_ratio_hint_tail_survives_evidence_cap(self, tmp_path):
+        """#808 sizing guard: the ACTUAL _TARGETS lever_hint must reach the
+        proposer un-truncated — its load-bearing tail is the instruction that
+        redirects the loop off the reporter. If the hint grows past
+        _MAX_EVIDENCE_CHARS (or the cap is lowered) the mid-instruction
+        truncation regression returns; this pins the last words present."""
+        from nanobot.runtime import scorecard
+        hint = scorecard._TARGETS["confirmed_ratio"]["lever_hint"]
+        state_dir = _state_dir(tmp_path)
+        _write_scorecard_gaps(
+            state_dir,
+            [{
+                "metric": "confirmed_ratio", "vector": "V2",
+                "current": 0.39, "target": 0.5,
+                "evidence": "confirmed_ratio=0.39 is below min target 0.5",
+                "lever_hint": hint,
+            }],
+        )
+        gap_item = next(
+            i for i in demand.collect_demand(state_dir, None) if i["kind"] == "goal-gap"
+        )
+        # last words of the real hint must be present (not sliced off by the cap)
+        assert hint[-40:] in gap_item["evidence"]
+
     def test_future_vector_generates_nothing(self, tmp_path):
         """The goal's FUTURE section maps to no metric: no target carries a
         FUTURE vector, and even a (hypothetically corrupted) gap entry with

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -512,6 +512,37 @@ class TestGoalGaps:
         assert "confirmed_ratio" in gaps
         assert gaps["confirmed_ratio"]["vector"] == "V2"
 
+    def test_confirmed_ratio_gap_carries_lever_hint(self, tmp_path):
+        """#808: confirmed_ratio's gap dict carries the scorecard's
+        lever_hint so the proposer sees what actually moves the metric,
+        instead of freely targeting an irrelevant reporting script."""
+        state_dir = tmp_path / "state"
+        (state_dir / "demand").mkdir(parents=True)
+        (state_dir / "demand" / "completed.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "demand-completed-v1",
+                    "entries": {f"id{i}": {"cycle_id": f"c{i}", "ts": _iso(50)} for i in range(3)},
+                }
+            ),
+            encoding="utf-8",
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        gaps = {g["metric"]: g for g in snap["gaps"]}
+        assert "confirmed_ratio" in gaps
+        assert gaps["confirmed_ratio"]["lever_hint"] == scorecard._TARGETS["confirmed_ratio"]["lever_hint"]
+
+    def test_gap_without_lever_hint_has_no_field(self, tmp_path):
+        """A metric whose target has no lever_hint (e.g. repeat_failure_rate)
+        must not crash and must not gain a fabricated lever_hint key."""
+        state_dir = tmp_path / "state"
+        _minimal_repeat_failure_ledger(state_dir)
+        assert "lever_hint" not in scorecard._TARGETS["repeat_failure_rate"]
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        gaps = {g["metric"]: g for g in snap["gaps"]}
+        assert "repeat_failure_rate" in gaps
+        assert "lever_hint" not in gaps["repeat_failure_rate"]
+
     def test_v1_gaps_ordered_before_v2(self, tmp_path):
         state_dir = tmp_path / "state"
         _minimal_repeat_failure_ledger(state_dir)


### PR DESCRIPTION
Closes #808.

The `confirmed_ratio` goal-gap demand fired every cycle and the live loop wasted cycles editing `scripts/check_confirmation_ratio.py` — a reporter that structurally cannot move the metric. `confirmed_ratio` rises only when completed `scripts/*.py` artifacts are actually USED after completion (harness pycache/output signal via `confirm_serves`); the goal-gap item carried no guidance, so the LLM proposer freely targeted an irrelevant script.

## Fix (minimal)
- `scorecard.py`: optional `lever_hint` on `_TARGETS["confirmed_ratio"]`, carried through `_compute_gaps` into the gap dict (only when defined — no crash for the other targets).
- `demand.py`: `_goal_gap_items` appends the hint to the item's rationale/evidence. Stable `summary`/`id` **byte-unchanged** → exhaustion/dedup identity (#778) preserved (Opus-reviewed, confirmed).
- `_MAX_EVIDENCE_CHARS` 240→420: at 240 the hint truncated mid-instruction before the load-bearing "does NOT move it" clause. Sizing-guard test pins the hint tail present.

No new suppression path added — existing exhaustion (2 rejects/24h) already bounds re-firing; a legitimately-open gap stays open.

## Review (Opus)
No blocking defects. Identity preservation verified rigorously (item_id hashes kind+summary only; hint touches evidence only). End-to-end reach confirmed: hint reaches the proposer prompt via `llm_proposer._demand_section`. 420-cap sizing correct (397-char hint, 23 headroom).

Tests: scorecard 24 + new demand identity/sizing guards; the 2 pre-existing Windows path failures in TestCompileDefects are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)