### PR TITLE
feat(runtime): benchmark-evidence gate — optimization claims require a before/after measurement (#813)

### DIFF
--- a/nanobot/runtime/benchmark_evidence.py
+++ b/nanobot/runtime/benchmark_evidence.py
@@ -1,0 +1,116 @@
+"""Benchmark-evidence gate — optimization claims require a before/after
+measurement (#813).
+
+The #761 usage-evidence layer proved a *behavior-preserving* change was
+exercised post-integration; it has no opinion on whether an *optimization*
+claim ("this is faster/cheaper/smaller") is actually true. A claim like that
+needs a measurement, not a harness-observed touch — the instance could
+otherwise declare `serves: "optimization latency"` on any ordinary change and
+ride the existing harness-signal confirmation path to a false "verified
+faster" credit.
+
+This module adds the missing measurement gate, enforced at CONFIRMATION time
+(the simplest integration point — no bridge/gate change needed):
+
+- :func:`is_optimization_claim` recognizes the EXPLICIT, structured signal —
+  a ``serves`` value normalized and checked with ``startswith("optimization")``
+  — never inferred from free-text rationale or summary prose. Steering the
+  proposer to actually emit this form is #815; this module only makes the
+  signal valid (``llm_proposer._SERVES_PREFIXES``) and enforced.
+- :func:`validate_benchmark` schema-checks a benchmark artifact: ``metric``
+  and ``method`` must be non-empty strings, ``baseline`` and ``new_value``
+  must be numbers. No trust of prose — every field is type-checked, nothing
+  is inferred from surrounding text.
+- :func:`has_valid_benchmark` is the fail-closed existence+validity check
+  ``usage_evidence.confirm_serves`` calls before ever confirming an
+  optimization-claim entry: a missing, corrupt, or schema-invalid artifact
+  means NO valid benchmark, full stop.
+
+Artifacts live at ``<state_dir>/benchmarks/<cycle_id>.json`` — a new
+sidecar this module is the sole writer/reader of; the runtime itself never
+writes into ``state/benchmarks/`` today (the scorecard only reads it), so
+this module owns exactly one new file per benchmarked cycle and nothing
+else.
+
+Everything here is deterministic (NO LLM call) and fail-closed on the
+existence check (:func:`has_valid_benchmark`) — an unreadable/missing file
+degrades to "no valid benchmark", never to a false pass. The schema check
+itself (:func:`validate_benchmark`) never raises; it always returns a list
+(empty means valid).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+BENCHMARK_SCHEMA = "benchmark-evidence-v1"
+
+_REQUIRED_STR_FIELDS = ("metric", "method")
+_REQUIRED_NUM_FIELDS = ("baseline", "new_value")
+
+
+def is_optimization_claim(serves: Any) -> bool:
+    """True iff ``serves`` declares an optimization claim — the explicit,
+    structured signal (#813): normalized (stripped, lower-cased) and checked
+    with ``startswith("optimization")``. Never inferred from rationale or
+    summary text. Fail-open to ``False`` on any unexpected input shape."""
+    try:
+        return str(serves or "").strip().lower().startswith("optimization")
+    except Exception:
+        return False
+
+
+def validate_benchmark(obj: Any) -> list[str]:
+    """Schema-validate a benchmark artifact; return a list of violations
+    (empty list == valid). Required fields, no trust of prose:
+
+    - ``metric``: non-empty string (what was measured)
+    - ``baseline``: number (the before value)
+    - ``new_value``: number (the after value)
+    - ``method``: non-empty string (how it was measured)
+
+    Never raises — an unexpected shape (e.g. ``obj`` not even a dict)
+    produces a violation list rather than an exception.
+    """
+    violations: list[str] = []
+    try:
+        if not isinstance(obj, dict):
+            return ["benchmark is not a JSON object"]
+        for field in _REQUIRED_STR_FIELDS:
+            value = obj.get(field)
+            if not isinstance(value, str) or not value.strip():
+                violations.append(f"{field} must be a non-empty string")
+        for field in _REQUIRED_NUM_FIELDS:
+            value = obj.get(field)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                violations.append(f"{field} must be a number")
+        return violations
+    except Exception:
+        return ["benchmark validation raised unexpectedly"]
+
+
+def benchmark_path(state_dir: Path, cycle_id: str) -> Path:
+    """Path of the benchmark artifact for ``cycle_id``:
+    ``<state_dir>/benchmarks/<cycle_id>.json``."""
+    return Path(state_dir) / "benchmarks" / f"{cycle_id}.json"
+
+
+def has_valid_benchmark(state_dir: Path, cycle_id: str) -> bool:
+    """True iff a schema-valid benchmark artifact exists for ``cycle_id``.
+
+    Fail-closed: an empty ``cycle_id``, a missing file, an unreadable/corrupt
+    file, or a file that fails :func:`validate_benchmark` all read as
+    ``False`` — an optimization claim gets no benefit of the doubt.
+    """
+    try:
+        cycle_id = str(cycle_id or "").strip()
+        if not cycle_id:
+            return False
+        path = benchmark_path(state_dir, cycle_id)
+        if not path.is_file():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return not validate_benchmark(data)
+    except Exception:
+        return False

--- a/nanobot/runtime/benchmark_evidence.py
+++ b/nanobot/runtime/benchmark_evidence.py
@@ -18,29 +18,55 @@ This module adds the missing measurement gate, enforced at CONFIRMATION time
   proposer to actually emit this form is #815; this module only makes the
   signal valid (``llm_proposer._SERVES_PREFIXES``) and enforced.
 - :func:`validate_benchmark` schema-checks a benchmark artifact: ``metric``
-  and ``method`` must be non-empty strings, ``baseline`` and ``new_value``
-  must be numbers. No trust of prose — every field is type-checked, nothing
+  and ``method`` must be non-empty strings; ``baseline``/``new_value`` must
+  be finite numbers (not bool, not NaN/inf); ``direction`` must be
+  ``"lower_is_better"`` or ``"higher_is_better"``; and the measurement must
+  show an ACTUAL improvement in the declared direction — ``new_value`` equal
+  to ``baseline`` (no change) or a regression against ``direction`` is
+  rejected. No trust of prose — every field is type/value-checked, nothing
   is inferred from surrounding text.
-- :func:`has_valid_benchmark` is the fail-closed existence+validity check
-  ``usage_evidence.confirm_serves`` calls before ever confirming an
-  optimization-claim entry: a missing, corrupt, or schema-invalid artifact
-  means NO valid benchmark, full stop.
+- :func:`benchmark_file_exists` / :func:`has_valid_benchmark` are the
+  fail-closed existence/validity checks ``usage_evidence.confirm_serves``
+  uses before ever confirming (or continuing to trust a prior confirmation
+  of) an optimization-claim entry.
 
 Artifacts live at ``<state_dir>/benchmarks/<cycle_id>.json`` — a new
-sidecar this module is the sole writer/reader of; the runtime itself never
-writes into ``state/benchmarks/`` today (the scorecard only reads it), so
-this module owns exactly one new file per benchmarked cycle and nothing
-else.
+sidecar this module is the sole reader of; the runtime itself never writes
+into ``state/benchmarks/`` today (the scorecard only reads it). ``cycle_id``
+is treated as untrusted input when building that path: a value containing a
+path separator (``/`` or ``\\``) or ``..`` is rejected before ever joining,
+so a crafted id can't be used to read an arbitrary on-disk JSON file
+(:func:`benchmark_path` still builds the naive path for callers that already
+trust their ``cycle_id``; :func:`has_valid_benchmark` and
+:func:`benchmark_file_exists` do the rejection themselves before touching
+disk).
 
-Everything here is deterministic (NO LLM call) and fail-closed on the
-existence check (:func:`has_valid_benchmark`) — an unreadable/missing file
-degrades to "no valid benchmark", never to a false pass. The schema check
-itself (:func:`validate_benchmark`) never raises; it always returns a list
-(empty means valid).
+PROVENANCE WARNING (#813, tracked for hardening in #819): a benchmark
+artifact under ``state/benchmarks/`` is a plain JSON file. ``state/`` is off
+the instance's COMMIT surface, but it IS writable at runtime by an
+instance-authored script (the same class of live reward-hack #789 already
+had to repair: a script hardcoding a sidecar path and writing a falsified
+field into it). :func:`validate_benchmark` checks *shape*, not *authorship*
+— it cannot tell a harness-executed measurement from a forged one. Until
+#819 lands real harness-verified provenance (re-execution or a signed/
+harness-authored artifact), this module ships FAIL-CLOSED: the
+``SELFEVO_BENCHMARK_TRUST`` env switch (default OFF) gates the entire
+affirmative path. With it off (the required posture pre-#819), any
+optimization claim is permanently unconfirmable, and a forged artifact is
+inert — a fully-shaped forged benchmark buys nothing. Do not flip this
+switch on until #819's provenance guarantee exists.
+
+Everything here is deterministic (NO LLM call) and fail-closed: an
+unreadable/missing file, a disabled trust switch, or an unexpected input
+shape all degrade to "no valid benchmark", never to a false pass. The
+schema check itself (:func:`validate_benchmark`) never raises; it always
+returns a list (empty means valid).
 """
 from __future__ import annotations
 
 import json
+import math
+import os
 from pathlib import Path
 from typing import Any
 
@@ -48,6 +74,25 @@ BENCHMARK_SCHEMA = "benchmark-evidence-v1"
 
 _REQUIRED_STR_FIELDS = ("metric", "method")
 _REQUIRED_NUM_FIELDS = ("baseline", "new_value")
+_VALID_DIRECTIONS = ("lower_is_better", "higher_is_better")
+
+# #813 HIGH-2: operator-owned trust switch, same SELFEVO_ / default-OFF
+# precedent as SELFEVO_DECAY_PROTECT (#809) and SELFEVO_RUNTIME_SLICE
+# (#812) — read from the environment, not a file in the instance repo,
+# so the instance cannot flip its own trust on. MUST stay OFF until #819
+# (harness-verified benchmark provenance) lands; see the module docstring.
+TRUST_ENV = "SELFEVO_BENCHMARK_TRUST"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def benchmark_trust_enabled() -> bool:
+    """True iff the operator has explicitly opted into trusting on-disk
+    benchmark artifacts (:data:`TRUST_ENV`, default OFF). Fail-closed on any
+    unexpected environment error."""
+    try:
+        return os.environ.get(TRUST_ENV, "0").strip().lower() in _TRUTHY
+    except Exception:
+        return False
 
 
 def is_optimization_claim(serves: Any) -> bool:
@@ -66,9 +111,15 @@ def validate_benchmark(obj: Any) -> list[str]:
     (empty list == valid). Required fields, no trust of prose:
 
     - ``metric``: non-empty string (what was measured)
-    - ``baseline``: number (the before value)
-    - ``new_value``: number (the after value)
+    - ``baseline``: finite number (the before value)
+    - ``new_value``: finite number (the after value)
     - ``method``: non-empty string (how it was measured)
+    - ``direction``: ``"lower_is_better"`` or ``"higher_is_better"``
+
+    Beyond shape, the measurement itself must show a genuine improvement:
+    ``new_value == baseline`` (no change) is rejected, and a regression
+    against the declared ``direction`` is rejected — a benchmark proving
+    "slower/equal" is not a valid optimization claim.
 
     Never raises — an unexpected shape (e.g. ``obj`` not even a dict)
     produces a violation list rather than an exception.
@@ -77,37 +128,108 @@ def validate_benchmark(obj: Any) -> list[str]:
     try:
         if not isinstance(obj, dict):
             return ["benchmark is not a JSON object"]
+
         for field in _REQUIRED_STR_FIELDS:
             value = obj.get(field)
             if not isinstance(value, str) or not value.strip():
                 violations.append(f"{field} must be a non-empty string")
+
+        direction_raw = obj.get("direction")
+        direction: str | None = None
+        if not isinstance(direction_raw, str) or direction_raw.strip() not in _VALID_DIRECTIONS:
+            violations.append(f"direction must be one of {_VALID_DIRECTIONS}")
+        else:
+            direction = direction_raw.strip()
+
+        numeric: dict[str, float] = {}
         for field in _REQUIRED_NUM_FIELDS:
             value = obj.get(field)
             if isinstance(value, bool) or not isinstance(value, (int, float)):
                 violations.append(f"{field} must be a number")
+                continue
+            if not math.isfinite(value):
+                violations.append(f"{field} must be a finite number (not NaN/inf)")
+                continue
+            numeric[field] = value
+
+        if "baseline" in numeric and "new_value" in numeric:
+            baseline = numeric["baseline"]
+            new_value = numeric["new_value"]
+            if new_value == baseline:
+                violations.append(
+                    "new_value must differ from baseline — a no-change "
+                    "measurement is not an optimization"
+                )
+            elif direction == "lower_is_better" and not (new_value < baseline):
+                violations.append(
+                    "new_value must be lower than baseline for "
+                    "direction=lower_is_better (regression, not an improvement)"
+                )
+            elif direction == "higher_is_better" and not (new_value > baseline):
+                violations.append(
+                    "new_value must be higher than baseline for "
+                    "direction=higher_is_better (regression, not an improvement)"
+                )
         return violations
     except Exception:
         return ["benchmark validation raised unexpectedly"]
 
 
+def _is_safe_cycle_id(cycle_id: Any) -> str:
+    """Normalize ``cycle_id`` and return it iff safe to join into a path;
+    ``""`` otherwise. #813 MED-2: a ``cycle_id`` containing a path separator
+    (``/`` or ``\\``) or ``..`` is rejected BEFORE ever being joined — a
+    crafted id must never let a caller escape ``<state_dir>/benchmarks/``."""
+    try:
+        c = str(cycle_id or "").strip()
+        if not c or "/" in c or "\\" in c or ".." in c:
+            return ""
+        return c
+    except Exception:
+        return ""
+
+
 def benchmark_path(state_dir: Path, cycle_id: str) -> Path:
     """Path of the benchmark artifact for ``cycle_id``:
-    ``<state_dir>/benchmarks/<cycle_id>.json``."""
+    ``<state_dir>/benchmarks/<cycle_id>.json``. Callers that have not
+    already validated ``cycle_id`` should prefer :func:`benchmark_file_exists`
+    / :func:`has_valid_benchmark`, which reject unsafe ids themselves."""
     return Path(state_dir) / "benchmarks" / f"{cycle_id}.json"
 
 
-def has_valid_benchmark(state_dir: Path, cycle_id: str) -> bool:
-    """True iff a schema-valid benchmark artifact exists for ``cycle_id``.
+def benchmark_file_exists(state_dir: Path, cycle_id: str) -> bool:
+    """True iff a benchmark artifact file exists for ``cycle_id`` —
+    regardless of trust/validity. Used by the ``confirm_serves`` gate
+    (#813) to choose between the ``benchmark_missing`` and
+    ``benchmark_untrusted`` reason codes. Rejects unsafe ``cycle_id`` values
+    the same way :func:`has_valid_benchmark` does (MED-2)."""
+    try:
+        safe_id = _is_safe_cycle_id(cycle_id)
+        if not safe_id:
+            return False
+        return benchmark_path(state_dir, safe_id).is_file()
+    except Exception:
+        return False
 
-    Fail-closed: an empty ``cycle_id``, a missing file, an unreadable/corrupt
-    file, or a file that fails :func:`validate_benchmark` all read as
-    ``False`` — an optimization claim gets no benefit of the doubt.
+
+def has_valid_benchmark(state_dir: Path, cycle_id: str) -> bool:
+    """True ONLY IF: the operator trust switch (:func:`benchmark_trust_enabled`)
+    is ON, AND a benchmark artifact file exists for ``cycle_id``, AND
+    :func:`validate_benchmark` finds it clean.
+
+    Fail-closed on every axis: an unsafe/empty ``cycle_id``, the trust
+    switch being off (the default — see the module docstring's PROVENANCE
+    WARNING), a missing file, an unreadable/corrupt file, or a file that
+    fails schema/measurement validation all read as ``False``. An
+    optimization claim gets no benefit of the doubt.
     """
     try:
-        cycle_id = str(cycle_id or "").strip()
-        if not cycle_id:
+        safe_id = _is_safe_cycle_id(cycle_id)
+        if not safe_id:
             return False
-        path = benchmark_path(state_dir, cycle_id)
+        if not benchmark_trust_enabled():
+            return False
+        path = benchmark_path(state_dir, safe_id)
         if not path.is_file():
             return False
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -904,11 +904,23 @@ def _fold_completed(state_dir: Path) -> set[str]:
     done-truth rotation-proof by construction: once folded, an entry
     survives the midnight ledger rotation that blinds every single-file
     ledger reader (the #771/#772 blind spot). Fail-open: an unreadable
-    ledger or sidecar degrades to whatever the sidecar already holds."""
+    ledger or sidecar degrades to whatever the sidecar already holds.
+
+    #813: each folded entry also carries the ``proposed`` row's own
+    ``serves`` value (``""`` if the row predates this field or carried
+    none) — the benchmark-evidence gate in
+    ``usage_evidence.confirm_serves`` reads it via
+    ``benchmark_evidence.is_optimization_claim`` to tell an optimization
+    claim from an ordinary entry without re-reading the ledger."""
     try:
         data = _load_completed(state_dir)
         entries: dict[str, Any] = data["entries"]
         demand_by_cycle: dict[str, str] = {}
+        # #813: the 'proposed' row's own ``serves`` value, folded alongside
+        # ``demand_id`` so the confirmation path (usage_evidence.confirm_serves)
+        # can later tell whether a completed entry is an optimization claim
+        # without re-reading the ledger.
+        serves_by_cycle: dict[str, str] = {}
         success_by_cycle: dict[str, dict[str, Any]] = {}
 
         def _consume(lines: list[str]) -> None:
@@ -930,6 +942,9 @@ def _fold_completed(state_dir: Path) -> set[str]:
                     demand_id = str(row.get("demand_id") or "").strip()
                     if demand_id:
                         demand_by_cycle[cycle_id] = demand_id
+                    serves = str(row.get("serves") or "").strip()
+                    if serves:
+                        serves_by_cycle[cycle_id] = serves
                 elif phase == "outcome":
                     if str(row.get("outcome") or "").strip().lower() == "success":
                         success_by_cycle[cycle_id] = row
@@ -966,6 +981,10 @@ def _fold_completed(state_dir: Path) -> set[str]:
                 "cycle_id": cycle_id,
                 "ts": str(success.get("ts") or ""),
                 "files_changed": files if isinstance(files, list) else [],
+                # #813: empty string when the proposed row carried no serves
+                # (or predates this field) — is_optimization_claim("") is
+                # False, so older/serves-less entries are unaffected.
+                "serves": serves_by_cycle.get(cycle_id, ""),
             }
             changed = True
         if changed:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -76,7 +76,13 @@ _JSON_OBJ_RE = re.compile(r"\{.*\}", re.DOTALL)
 # #760: 'demand ' is the primary form under demand-driven mode; the pre-#760
 # prefixes are kept as accepted legacy forms for one release so a model
 # replying in the old vocabulary is not hard-rejected during rollout.
-_SERVES_PREFIXES = ("demand ", "priority ", "vector 1", "vector 2", "hypothesis ")
+# #813: 'optimization' is the explicit, structured signal a cycle uses to
+# declare an optimization claim (e.g. 'optimization latency: p95 request
+# time') — matches nanobot.runtime.benchmark_evidence.is_optimization_claim's
+# check exactly, so a value valid here is recognized there too. Steering the
+# proposer to actually emit this form is #815; this change only makes the
+# signal schema-valid + enforceable at confirmation time.
+_SERVES_PREFIXES = ("demand ", "priority ", "vector 1", "vector 2", "hypothesis ", "optimization")
 _SERVES_DEMAND_RE = re.compile(r"^demand\s+(\S+)", re.IGNORECASE)
 
 _MAX_DEMAND_CHARS = 4000  # separately bounded, same precedent as _MAX_INVENTORY_CHARS

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -409,19 +409,37 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
     repair. The stripped entry then re-evaluates honestly from usage
     evidence like any unconfirmed entry.
 
-    Benchmark-evidence gate (#813): an entry whose ``serves`` (folded by
+    Benchmark-evidence gate (#813), checked BEFORE the "already confirmed"
+    fast path in the harness-confirm pass below (though AFTER tamper repair,
+    so a foreign signal is honestly stripped first — see the ordering note
+    in the implementation), so it can never be bypassed by an entry that is
+    already ``confirmed`` (HIGH-1 fix: a forged ``{"confirmed": true,
+    "signal": "pycache", "serves": "optimization ..."}`` entry has a
+    legitimate-looking harness signal and would otherwise sail past both
+    the tamper check — its signal IS in :data:`HARNESS_SIGNALS` — and the
+    old "confirmed is True: continue" short-circuit): an entry whose
+    ``serves`` (folded by
     ``demand._fold_completed``) is an optimization claim
-    (``benchmark_evidence.is_optimization_claim``) can NEVER be marked
-    confirmed without a schema-valid benchmark artifact at
-    ``<state_dir>/benchmarks/<cycle_id>.json``
-    (``benchmark_evidence.has_valid_benchmark``) — checked BEFORE the
-    harness-signal match below, so a harness usage signal alone is not
-    enough for this class of entry. A gated entry is forced
-    ``"confirmed": False`` with ``unconfirmed_reason: "benchmark_missing"``;
-    once a valid benchmark artifact appears, the entry confirms via the
-    normal harness-signal path on the next call, unchanged. A
-    non-optimization entry (``serves`` empty, missing, or any other prefix)
-    is completely unaffected by this gate.
+    (``benchmark_evidence.is_optimization_claim``) is evaluated against
+    ``benchmark_evidence.has_valid_benchmark`` REGARDLESS of its current
+    ``confirmed`` value. If no valid benchmark artifact is found, the entry
+    is forced (or, if already confirmed, REVOKED to)
+    ``"confirmed": False`` with an ``unconfirmed_reason`` of
+    ``"benchmark_missing"`` (no artifact file at all) or
+    ``"benchmark_untrusted"`` (a file exists but the operator trust switch
+    ``benchmark_evidence.TRUST_ENV`` is off, or the file fails schema/
+    measurement validation) — see that module's PROVENANCE WARNING for why
+    the switch defaults off pending #819. A gated entry never proceeds to
+    the harness-signal match below this call. Once a valid, trusted
+    benchmark artifact exists, the entry confirms via the normal
+    harness-signal path, unchanged. A non-optimization entry (``serves``
+    empty, missing, or any other prefix) is completely unaffected by this
+    gate and falls straight through to the pre-#813 logic below.
+
+    Returns the number of entries NEWLY confirmed this call only — a gated
+    or revoked entry still triggers a sidecar write (its ``confirmed``/
+    ``unconfirmed_reason`` fields changed) but is never counted in the
+    returned total; fail-open to ``0``.
     """
     try:
         state_dir = Path(state_dir)
@@ -435,6 +453,12 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
         repaired = 0
         gated = 0
         now_iso = _iso(datetime.now(timezone.utc))
+
+        # Pass 1 (#789, unchanged): tamper repair. Runs first so a foreign
+        # signal is stripped off an entry regardless of whether it also
+        # turns out to be an optimization claim below — the benchmark gate
+        # in Pass 2 must see the honestly-stripped state, not a
+        # non-harness-authored ``signal``.
         for entry_id, entry in completed["entries"].items():
             if not isinstance(entry, dict) or not entry.get("confirmed"):
                 continue
@@ -465,27 +489,52 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
                 )
             except Exception:
                 pass
+
+        # Pass 2 (#813 HIGH-1): benchmark-evidence gate, over EVERY entry
+        # (confirmed or not) — independent of, and before, Pass 3's
+        # "already confirmed" fast path, so an optimization claim can never
+        # ride an already-``confirmed: true`` state (forged, or legitimately
+        # harness-signalled before a benchmark requirement existed) past
+        # this check. Must run AFTER Pass 1 so a foreign-signal entry that
+        # also happens to be an optimization claim is evaluated on its
+        # post-repair (stripped) state.
+        for entry in completed["entries"].values():
+            if not isinstance(entry, dict):
+                continue
+            serves = entry.get("serves")
+            if not benchmark_evidence.is_optimization_claim(serves):
+                continue
+            cycle_id = entry.get("cycle_id")
+            if benchmark_evidence.has_valid_benchmark(state_dir, cycle_id):
+                # Valid, trusted benchmark: clear any stale gate marker from
+                # a prior call so Pass 3 can (re)confirm normally. Popping an
+                # absent key is a no-op; only count it as a change (for the
+                # write-gate) when something actually came off the entry.
+                if entry.pop("unconfirmed_reason", None) is not None:
+                    gated += 1
+                continue
+            reason = (
+                "benchmark_missing"
+                if not benchmark_evidence.benchmark_file_exists(state_dir, cycle_id)
+                else "benchmark_untrusted"
+            )
+            if entry.get("confirmed") is not False or entry.get("unconfirmed_reason") != reason:
+                entry["confirmed"] = False
+                entry["unconfirmed_reason"] = reason
+                gated += 1
+
+        # Pass 3 (pre-#813, extended): the ordinary harness-signal confirm.
         for entry in completed["entries"].values():
             if not isinstance(entry, dict) or entry.get("confirmed") is True:
                 continue
-            # #813: benchmark-evidence gate — checked BEFORE the harness-
-            # signal match below. An optimization claim with no schema-valid
-            # benchmark artifact can NEVER be confirmed by a harness usage
-            # signal alone; it is forced unconfirmed with a reason instead.
-            # A non-optimization entry (empty/other ``serves``) skips this
-            # branch entirely and falls through to the unchanged path below.
-            if benchmark_evidence.is_optimization_claim(
-                entry.get("serves")
-            ) and not benchmark_evidence.has_valid_benchmark(
-                state_dir, entry.get("cycle_id")
+            # #813: an optimization-claim entry that failed the benchmark
+            # gate above was just forced to confirmed=False with an
+            # unconfirmed_reason set — it must not be re-confirmed here via
+            # a harness usage signal alone.
+            if (
+                benchmark_evidence.is_optimization_claim(entry.get("serves"))
+                and entry.get("unconfirmed_reason") in ("benchmark_missing", "benchmark_untrusted")
             ):
-                if (
-                    entry.get("confirmed") is not False
-                    or entry.get("unconfirmed_reason") != "benchmark_missing"
-                ):
-                    entry["confirmed"] = False
-                    entry["unconfirmed_reason"] = "benchmark_missing"
-                    gated += 1
                 continue
             completed_ts = _parse_ts(entry.get("ts"))
             if completed_ts is None:

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -58,6 +58,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from nanobot.runtime import benchmark_evidence
+
 USAGE_SCHEMA = "usage-evidence-v1"
 
 # #789: the ONLY signal values this module itself ever writes into a
@@ -406,6 +408,20 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
     ``{"phase": "integrity", "reason": "sidecar_tamper"}`` is appended per
     repair. The stripped entry then re-evaluates honestly from usage
     evidence like any unconfirmed entry.
+
+    Benchmark-evidence gate (#813): an entry whose ``serves`` (folded by
+    ``demand._fold_completed``) is an optimization claim
+    (``benchmark_evidence.is_optimization_claim``) can NEVER be marked
+    confirmed without a schema-valid benchmark artifact at
+    ``<state_dir>/benchmarks/<cycle_id>.json``
+    (``benchmark_evidence.has_valid_benchmark``) — checked BEFORE the
+    harness-signal match below, so a harness usage signal alone is not
+    enough for this class of entry. A gated entry is forced
+    ``"confirmed": False`` with ``unconfirmed_reason: "benchmark_missing"``;
+    once a valid benchmark artifact appears, the entry confirms via the
+    normal harness-signal path on the next call, unchanged. A
+    non-optimization entry (``serves`` empty, missing, or any other prefix)
+    is completely unaffected by this gate.
     """
     try:
         state_dir = Path(state_dir)
@@ -417,6 +433,7 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
             return 0
         newly_confirmed = 0
         repaired = 0
+        gated = 0
         now_iso = _iso(datetime.now(timezone.utc))
         for entry_id, entry in completed["entries"].items():
             if not isinstance(entry, dict) or not entry.get("confirmed"):
@@ -451,6 +468,25 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
         for entry in completed["entries"].values():
             if not isinstance(entry, dict) or entry.get("confirmed") is True:
                 continue
+            # #813: benchmark-evidence gate — checked BEFORE the harness-
+            # signal match below. An optimization claim with no schema-valid
+            # benchmark artifact can NEVER be confirmed by a harness usage
+            # signal alone; it is forced unconfirmed with a reason instead.
+            # A non-optimization entry (empty/other ``serves``) skips this
+            # branch entirely and falls through to the unchanged path below.
+            if benchmark_evidence.is_optimization_claim(
+                entry.get("serves")
+            ) and not benchmark_evidence.has_valid_benchmark(
+                state_dir, entry.get("cycle_id")
+            ):
+                if (
+                    entry.get("confirmed") is not False
+                    or entry.get("unconfirmed_reason") != "benchmark_missing"
+                ):
+                    entry["confirmed"] = False
+                    entry["unconfirmed_reason"] = "benchmark_missing"
+                    gated += 1
+                continue
             completed_ts = _parse_ts(entry.get("ts"))
             if completed_ts is None:
                 continue
@@ -472,7 +508,7 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
                 entry["signal"] = str(usage_entry.get("signal") or "")
                 newly_confirmed += 1
                 break
-        if newly_confirmed or repaired:
+        if newly_confirmed or repaired or gated:
             _write_json(completed_path, completed)
         return newly_confirmed
     except Exception:

--- a/tests/test_benchmark_evidence.py
+++ b/tests/test_benchmark_evidence.py
@@ -1,12 +1,16 @@
 """Tests for #813: benchmark-evidence gate.
 
-Covers the schema validator (:func:`validate_benchmark`), the explicit
-structured optimization-claim signal (:func:`is_optimization_claim`), and
-the fail-closed existence+validity check (:func:`has_valid_benchmark`).
+Covers the schema+measurement validator (:func:`validate_benchmark`), the
+explicit structured optimization-claim signal (:func:`is_optimization_claim`),
+the operator trust switch (:func:`benchmark_trust_enabled`,
+``SELFEVO_BENCHMARK_TRUST``), the fail-closed existence/validity check
+(:func:`has_valid_benchmark`, :func:`benchmark_file_exists`), and the
+cycle_id path-traversal rejection.
 """
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 
 from nanobot.runtime import benchmark_evidence
@@ -17,6 +21,7 @@ _GOOD_BENCHMARK = {
     "baseline": 420,
     "new_value": 180,
     "method": "wrk -t2 -c50 -d30s against /health, median of 3 runs",
+    "direction": "lower_is_better",
 }
 
 
@@ -29,6 +34,10 @@ def _write_benchmark(state_dir: Path, cycle_id: str, payload: dict) -> None:
 class TestValidateBenchmark:
     def test_good_artifact_has_no_violations(self):
         assert benchmark_evidence.validate_benchmark(dict(_GOOD_BENCHMARK)) == []
+
+    def test_good_artifact_higher_is_better_has_no_violations(self):
+        obj = dict(_GOOD_BENCHMARK, baseline=100, new_value=250, direction="higher_is_better")
+        assert benchmark_evidence.validate_benchmark(obj) == []
 
     def test_not_a_dict_is_a_violation(self):
         assert benchmark_evidence.validate_benchmark("not a dict") != []
@@ -95,6 +104,61 @@ class TestValidateBenchmark:
         obj = dict(_GOOD_BENCHMARK, baseline=420.5, new_value=180.25)
         assert benchmark_evidence.validate_benchmark(obj) == []
 
+    # ─── MED-1: direction, nan/inf, no-change, regression ──────────────────
+
+    def test_missing_direction_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK)
+        del obj["direction"]
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("direction" in v for v in violations)
+
+    def test_invalid_direction_value_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, direction="sideways")
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("direction" in v for v in violations)
+
+    def test_nan_baseline_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, baseline=float("nan"))
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("baseline" in v and "finite" in v for v in violations)
+
+    def test_inf_new_value_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, new_value=float("inf"))
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("new_value" in v and "finite" in v for v in violations)
+
+    def test_neg_inf_baseline_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, baseline=float("-inf"))
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("baseline" in v and "finite" in v for v in violations)
+
+    def test_no_change_measurement_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, baseline=420, new_value=420)
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("differ" in v or "no-change" in v for v in violations)
+
+    def test_regression_lower_is_better_is_rejected(self):
+        """direction says lower is better, but new_value went UP."""
+        obj = dict(_GOOD_BENCHMARK, baseline=180, new_value=420, direction="lower_is_better")
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("regression" in v for v in violations)
+
+    def test_regression_higher_is_better_is_rejected(self):
+        """direction says higher is better, but new_value went DOWN."""
+        obj = dict(_GOOD_BENCHMARK, baseline=250, new_value=100, direction="higher_is_better")
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("regression" in v for v in violations)
+
+    def test_nan_short_circuits_direction_check(self):
+        """A non-finite value must not also spuriously fire the
+        equality/regression checks (which would produce confusing double
+        violations); it should raise exactly the finiteness violation for
+        that field, no direction/regression noise for it."""
+        obj = dict(_GOOD_BENCHMARK, baseline=float("nan"), new_value=180)
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("baseline" in v and "finite" in v for v in violations)
+        assert not any("regression" in v for v in violations)
+
 
 class TestIsOptimizationClaim:
     def test_bare_optimization_is_true(self):
@@ -127,28 +191,101 @@ class TestIsOptimizationClaim:
         assert benchmark_evidence.is_optimization_claim("vector 1: optimization-adjacent") is False
 
 
+class TestBenchmarkTrustSwitch:
+    def test_default_is_off(self, monkeypatch):
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        assert benchmark_evidence.benchmark_trust_enabled() is False
+
+    def test_explicit_zero_is_off(self, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "0")
+        assert benchmark_evidence.benchmark_trust_enabled() is False
+
+    def test_truthy_values_turn_it_on(self, monkeypatch):
+        for value in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", value)
+            assert benchmark_evidence.benchmark_trust_enabled() is True
+
+    def test_garbage_value_is_off(self, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "sure why not")
+        assert benchmark_evidence.benchmark_trust_enabled() is False
+
+
 class TestHasValidBenchmark:
-    def test_true_for_schema_valid_file(self, tmp_path):
+    def test_false_by_default_even_for_schema_valid_file(self, tmp_path, monkeypatch):
+        """#813 HIGH-2: fail-closed default — a perfectly valid artifact is
+        still not trusted until the operator opts in."""
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        _write_benchmark(tmp_path, "cycle-abc123", _GOOD_BENCHMARK)
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123") is False
+
+    def test_true_for_schema_valid_file_when_trusted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         _write_benchmark(tmp_path, "cycle-abc123", _GOOD_BENCHMARK)
         assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123") is True
 
-    def test_false_when_file_missing(self, tmp_path):
+    def test_false_when_file_missing_even_if_trusted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-nope") is False
 
-    def test_false_when_file_schema_invalid(self, tmp_path):
+    def test_false_when_file_schema_invalid_even_if_trusted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         _write_benchmark(tmp_path, "cycle-bad", {"metric": "x"})  # missing fields
         assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-bad") is False
 
-    def test_false_when_file_corrupt_json(self, tmp_path):
+    def test_false_when_file_corrupt_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         path = benchmark_evidence.benchmark_path(tmp_path, "cycle-corrupt")
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("{not json", encoding="utf-8")
         assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-corrupt") is False
 
-    def test_false_for_empty_cycle_id(self, tmp_path):
+    def test_false_for_empty_cycle_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         assert benchmark_evidence.has_valid_benchmark(tmp_path, "") is False
         assert benchmark_evidence.has_valid_benchmark(tmp_path, None) is False
 
     def test_benchmark_path_shape(self, tmp_path):
         path = benchmark_evidence.benchmark_path(tmp_path, "cycle-xyz")
         assert path == tmp_path / "benchmarks" / "cycle-xyz.json"
+
+    # ─── MED-2: cycle_id path traversal ──────────────────────────────────
+
+    def test_path_traversal_cycle_id_never_valid(self, tmp_path, monkeypatch):
+        """A crafted cycle_id must never let has_valid_benchmark escape
+        <state_dir>/benchmarks/ to read an arbitrary on-disk JSON file."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        # Plant a valid-looking benchmark OUTSIDE the benchmarks/ dir that a
+        # traversal payload might target.
+        outside = tmp_path / "secret.json"
+        outside.write_text(json.dumps(_GOOD_BENCHMARK), encoding="utf-8")
+        for payload in ("../secret", "..\\secret", "../../secret", "a/b", "a\\b", ".."):
+            assert benchmark_evidence.has_valid_benchmark(tmp_path, payload) is False
+
+    def test_path_traversal_cycle_id_benchmark_file_exists_is_false(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        outside = tmp_path / "secret.json"
+        outside.write_text(json.dumps(_GOOD_BENCHMARK), encoding="utf-8")
+        assert benchmark_evidence.benchmark_file_exists(tmp_path, "../secret") is False
+        assert benchmark_evidence.benchmark_file_exists(tmp_path, "..") is False
+
+    def test_ordinary_cycle_id_with_dots_but_no_traversal_is_fine(self, tmp_path, monkeypatch):
+        """A cycle_id merely containing a single dot (e.g. as part of a
+        uuid-like id) is not a traversal attempt and must still resolve —
+        only an actual '..' sequence, or a path separator, is rejected."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cycle.abc123", _GOOD_BENCHMARK)
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle.abc123") is True
+
+
+class TestBenchmarkFileExists:
+    def test_true_when_present_regardless_of_validity_or_trust(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        _write_benchmark(tmp_path, "cycle-1", {"metric": "x"})  # schema-invalid
+        assert benchmark_evidence.benchmark_file_exists(tmp_path, "cycle-1") is True
+
+    def test_false_when_absent(self, tmp_path):
+        assert benchmark_evidence.benchmark_file_exists(tmp_path, "cycle-none") is False
+
+    def test_false_for_empty_or_none_cycle_id(self, tmp_path):
+        assert benchmark_evidence.benchmark_file_exists(tmp_path, "") is False
+        assert benchmark_evidence.benchmark_file_exists(tmp_path, None) is False

--- a/tests/test_benchmark_evidence.py
+++ b/tests/test_benchmark_evidence.py
@@ -1,0 +1,154 @@
+"""Tests for #813: benchmark-evidence gate.
+
+Covers the schema validator (:func:`validate_benchmark`), the explicit
+structured optimization-claim signal (:func:`is_optimization_claim`), and
+the fail-closed existence+validity check (:func:`has_valid_benchmark`).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime import benchmark_evidence
+
+
+_GOOD_BENCHMARK = {
+    "metric": "p95_latency_ms",
+    "baseline": 420,
+    "new_value": 180,
+    "method": "wrk -t2 -c50 -d30s against /health, median of 3 runs",
+}
+
+
+def _write_benchmark(state_dir: Path, cycle_id: str, payload: dict) -> None:
+    path = benchmark_evidence.benchmark_path(state_dir, cycle_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestValidateBenchmark:
+    def test_good_artifact_has_no_violations(self):
+        assert benchmark_evidence.validate_benchmark(dict(_GOOD_BENCHMARK)) == []
+
+    def test_not_a_dict_is_a_violation(self):
+        assert benchmark_evidence.validate_benchmark("not a dict") != []
+        assert benchmark_evidence.validate_benchmark(None) != []
+        assert benchmark_evidence.validate_benchmark([1, 2, 3]) != []
+
+    def test_missing_metric_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK)
+        del obj["metric"]
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("metric" in v for v in violations)
+
+    def test_empty_metric_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, metric="   ")
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("metric" in v for v in violations)
+
+    def test_non_string_metric_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, metric=123)
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("metric" in v for v in violations)
+
+    def test_missing_method_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK)
+        del obj["method"]
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("method" in v for v in violations)
+
+    def test_empty_method_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, method="")
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("method" in v for v in violations)
+
+    def test_missing_baseline_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK)
+        del obj["baseline"]
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("baseline" in v for v in violations)
+
+    def test_non_numeric_baseline_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, baseline="420ms")
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("baseline" in v for v in violations)
+
+    def test_bool_baseline_is_rejected(self):
+        """bool is technically an int subclass in Python — must not slip
+        through the numeric check."""
+        obj = dict(_GOOD_BENCHMARK, baseline=True)
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("baseline" in v for v in violations)
+
+    def test_missing_new_value_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK)
+        del obj["new_value"]
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("new_value" in v for v in violations)
+
+    def test_non_numeric_new_value_is_rejected(self):
+        obj = dict(_GOOD_BENCHMARK, new_value=None)
+        violations = benchmark_evidence.validate_benchmark(obj)
+        assert any("new_value" in v for v in violations)
+
+    def test_float_values_are_accepted(self):
+        obj = dict(_GOOD_BENCHMARK, baseline=420.5, new_value=180.25)
+        assert benchmark_evidence.validate_benchmark(obj) == []
+
+
+class TestIsOptimizationClaim:
+    def test_bare_optimization_is_true(self):
+        assert benchmark_evidence.is_optimization_claim("optimization") is True
+
+    def test_optimization_with_metric_is_true(self):
+        assert benchmark_evidence.is_optimization_claim("optimization latency") is True
+
+    def test_case_insensitive(self):
+        assert benchmark_evidence.is_optimization_claim("OPTIMIZATION latency") is True
+        assert benchmark_evidence.is_optimization_claim("Optimization: p95") is True
+
+    def test_leading_whitespace_is_stripped(self):
+        assert benchmark_evidence.is_optimization_claim("  optimization latency") is True
+
+    def test_priority_serves_is_false(self):
+        assert benchmark_evidence.is_optimization_claim("priority 5") is False
+
+    def test_demand_serves_is_false(self):
+        assert benchmark_evidence.is_optimization_claim("demand defect-1a2b3c4d5e6f") is False
+
+    def test_hypothesis_serves_is_false(self):
+        assert benchmark_evidence.is_optimization_claim("hypothesis h3") is False
+
+    def test_empty_and_none_are_false(self):
+        assert benchmark_evidence.is_optimization_claim("") is False
+        assert benchmark_evidence.is_optimization_claim(None) is False
+
+    def test_word_containing_optimization_but_not_prefixed_is_false(self):
+        assert benchmark_evidence.is_optimization_claim("vector 1: optimization-adjacent") is False
+
+
+class TestHasValidBenchmark:
+    def test_true_for_schema_valid_file(self, tmp_path):
+        _write_benchmark(tmp_path, "cycle-abc123", _GOOD_BENCHMARK)
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123") is True
+
+    def test_false_when_file_missing(self, tmp_path):
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-nope") is False
+
+    def test_false_when_file_schema_invalid(self, tmp_path):
+        _write_benchmark(tmp_path, "cycle-bad", {"metric": "x"})  # missing fields
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-bad") is False
+
+    def test_false_when_file_corrupt_json(self, tmp_path):
+        path = benchmark_evidence.benchmark_path(tmp_path, "cycle-corrupt")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-corrupt") is False
+
+    def test_false_for_empty_cycle_id(self, tmp_path):
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "") is False
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, None) is False
+
+    def test_benchmark_path_shape(self, tmp_path):
+        path = benchmark_evidence.benchmark_path(tmp_path, "cycle-xyz")
+        assert path == tmp_path / "benchmarks" / "cycle-xyz.json"

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -846,7 +846,9 @@ class TestFailOpen:
 # ─── completed sidecar: ledger-chain done-truth (#773) ──────────────────────
 
 
-def _append_proposed(state_dir: Path, cycle_id: str, demand_id: str, ts: str | None = None) -> None:
+def _append_proposed(
+    state_dir: Path, cycle_id: str, demand_id: str, ts: str | None = None, serves: str | None = None
+) -> None:
     event = {
         "phase": "proposed",
         "cycle_id": cycle_id,
@@ -855,6 +857,8 @@ def _append_proposed(state_dir: Path, cycle_id: str, demand_id: str, ts: str | N
     }
     if ts:
         event["ts"] = ts
+    if serves:
+        event["serves"] = serves
     cycle_ledger.append_event(state_dir, event)
 
 
@@ -892,6 +896,35 @@ class TestCompletedSidecar:
         assert entry["cycle_id"] == "c1"
         assert entry["files_changed"] == ["scripts/eeebot_dashboard.py"]
         assert entry["ts"]
+
+    def test_fold_persists_serves_from_proposed_row(self, tmp_path):
+        """#813: the completed entry carries the proposed row's own
+        ``serves`` value, so the benchmark-evidence gate can later tell an
+        optimization claim from an ordinary entry without re-reading the
+        ledger."""
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(
+            state_dir, "c1", "defect-optxxxxxxxxxx", ts=_now_iso(20),
+            serves="optimization latency",
+        )
+        _append_outcome(
+            state_dir, "c1", "success", ts=_now_iso(10),
+            files_changed=["scripts/foo.py"],
+        )
+        demand._fold_completed(state_dir)
+        entry = _completed_sidecar(state_dir)["entries"]["defect-optxxxxxxxxxx"]
+        assert entry["serves"] == "optimization latency"
+
+    def test_fold_defaults_serves_to_empty_when_absent(self, tmp_path):
+        """A proposed row with no ``serves`` (pre-#813 shape) folds to an
+        empty string, not a missing key — is_optimization_claim("") is
+        False, so this reads as an ordinary entry."""
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "priority-abcabcabcabc", ts=_now_iso(20))
+        _append_outcome(state_dir, "c1", "success", ts=_now_iso(10), files_changed=["a.py"])
+        demand._fold_completed(state_dir)
+        entry = _completed_sidecar(state_dir)["entries"]["priority-abcabcabcabc"]
+        assert entry["serves"] == ""
 
     def test_proposed_without_success_is_not_folded(self, tmp_path):
         state_dir = _state_dir(tmp_path)

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -324,6 +324,7 @@ _GOOD_BENCHMARK = {
     "baseline": 420,
     "new_value": 180,
     "method": "wrk -t2 -c50 -d30s against /health, median of 3 runs",
+    "direction": "lower_is_better",
 }
 
 
@@ -333,22 +334,50 @@ def _write_benchmark(state_dir: Path, cycle_id: str, payload: dict) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-class TestBenchmarkEvidenceGate:
-    def test_optimization_claim_without_benchmark_never_confirms(self, tmp_path):
-        """The harness signal is present (a real pycache usage), but the
-        entry declares an optimization claim with no benchmark artifact at
-        all — it must stay unconfirmed with the reason recorded, never
-        confirmed via the ordinary harness-signal path."""
+def _completed_optimization_entry(
+    state_dir: Path,
+    entry_id: str,
+    cycle_id: str,
+    *,
+    confirmed: bool | None = None,
+    signal: str | None = None,
+) -> None:
+    entry: dict = {
+        "cycle_id": cycle_id,
+        "ts": _now_iso(days_ago=2),
+        "files_changed": ["scripts/used_tool.py"],
+        "serves": "optimization latency",
+    }
+    if confirmed is not None:
+        entry["confirmed"] = confirmed
+    if signal is not None:
+        entry["signal"] = signal
+    _write_completed(state_dir, {entry_id: entry})
+
+
+class TestBenchmarkEvidenceGateTrustOff:
+    """SELFEVO_BENCHMARK_TRUST unset/off (the default, required posture
+    pending #819): the affirmative path stays fully dormant."""
+
+    def test_valid_benchmark_still_does_not_confirm(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
         state_dir = _state_dir(tmp_path)
-        _write_completed(
+        _completed_optimization_entry(state_dir, "defect-opt3", "cycle-opt-3")
+        _write_benchmark(state_dir, "cycle-opt-3", dict(_GOOD_BENCHMARK))
+        _write_usage_sidecar(
             state_dir,
-            {"defect-opt": {
-                "cycle_id": "cycle-opt-1",
-                "ts": _now_iso(days_ago=2),
-                "files_changed": ["scripts/used_tool.py"],
-                "serves": "optimization latency",
-            }},
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
         )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt3"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+
+    def test_no_benchmark_at_all_is_benchmark_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt", "cycle-opt-1")
         _write_usage_sidecar(
             state_dir,
             {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
@@ -359,58 +388,8 @@ class TestBenchmarkEvidenceGate:
         assert entry["confirmed"] is False
         assert entry["unconfirmed_reason"] == "benchmark_missing"
 
-    def test_optimization_claim_with_invalid_benchmark_never_confirms(self, tmp_path):
-        """A benchmark artifact exists but fails schema validation (e.g.
-        missing method) — still gated, same as no artifact at all."""
-        state_dir = _state_dir(tmp_path)
-        _write_completed(
-            state_dir,
-            {"defect-opt2": {
-                "cycle_id": "cycle-opt-2",
-                "ts": _now_iso(days_ago=2),
-                "files_changed": ["scripts/used_tool.py"],
-                "serves": "optimization latency",
-            }},
-        )
-        _write_benchmark(state_dir, "cycle-opt-2", {"metric": "latency"})  # incomplete
-        _write_usage_sidecar(
-            state_dir,
-            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
-                                      "last_touched": None, "signal": "pycache"}},
-        )
-        assert usage_evidence.confirm_serves(state_dir, None) == 0
-        entry = _read_completed(state_dir)["entries"]["defect-opt2"]
-        assert entry["confirmed"] is False
-        assert entry["unconfirmed_reason"] == "benchmark_missing"
-
-    def test_optimization_claim_with_valid_benchmark_confirms_normally(self, tmp_path):
-        """With a schema-valid benchmark artifact present, the entry
-        confirms through the ordinary harness-signal path, unchanged."""
-        state_dir = _state_dir(tmp_path)
-        _write_completed(
-            state_dir,
-            {"defect-opt3": {
-                "cycle_id": "cycle-opt-3",
-                "ts": _now_iso(days_ago=2),
-                "files_changed": ["scripts/used_tool.py"],
-                "serves": "optimization latency",
-            }},
-        )
-        _write_benchmark(state_dir, "cycle-opt-3", dict(_GOOD_BENCHMARK))
-        _write_usage_sidecar(
-            state_dir,
-            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
-                                      "last_touched": None, "signal": "pycache"}},
-        )
-        assert usage_evidence.confirm_serves(state_dir, None) == 1
-        entry = _read_completed(state_dir)["entries"]["defect-opt3"]
-        assert entry["confirmed"] is True
-        assert entry["signal"] == "pycache"
-        assert "unconfirmed_reason" not in entry
-
-    def test_non_optimization_entry_unaffected_by_gate(self, tmp_path):
-        """A normal (non-optimization) entry confirms exactly as before —
-        the gate never even looks at it."""
+    def test_non_optimization_entry_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
         state_dir = _state_dir(tmp_path)
         _write_completed(
             state_dir,
@@ -431,9 +410,10 @@ class TestBenchmarkEvidenceGate:
         assert entry["confirmed"] is True
         assert "unconfirmed_reason" not in entry
 
-    def test_entry_without_serves_field_unaffected(self, tmp_path):
+    def test_entry_without_serves_field_unaffected(self, tmp_path, monkeypatch):
         """Entries folded before #813 (no ``serves`` key at all) behave
         exactly as before — is_optimization_claim(None) is False."""
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
         state_dir = _state_dir(tmp_path)
         _write_completed(
             state_dir,
@@ -452,24 +432,188 @@ class TestBenchmarkEvidenceGate:
         entry = _read_completed(state_dir)["entries"]["priority-legacy"]
         assert entry["confirmed"] is True
 
-    def test_gated_entry_write_is_idempotent(self, tmp_path):
+    def test_invalid_benchmark_is_benchmark_untrusted_not_missing(self, tmp_path, monkeypatch):
+        """A schema-invalid artifact IS present on disk — the reason must
+        distinguish this from no-file-at-all."""
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt2", "cycle-opt-2")
+        _write_benchmark(state_dir, "cycle-opt-2", {"metric": "latency"})  # incomplete
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt2"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+
+    def test_gated_entry_write_is_idempotent(self, tmp_path, monkeypatch):
         """A second pass over an already-gated entry changes nothing further
         and does not re-increment any counter."""
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
         state_dir = _state_dir(tmp_path)
-        _write_completed(
-            state_dir,
-            {"defect-opt4": {
-                "cycle_id": "cycle-opt-4",
-                "ts": _now_iso(days_ago=2),
-                "files_changed": ["scripts/used_tool.py"],
-                "serves": "optimization throughput",
-            }},
-        )
+        _completed_optimization_entry(state_dir, "defect-opt4", "cycle-opt-4")
         _write_usage_sidecar(state_dir, {})
         usage_evidence.confirm_serves(state_dir, None)
         first = _read_completed(state_dir)
         usage_evidence.confirm_serves(state_dir, None)
         assert _read_completed(state_dir) == first
+
+
+class TestBenchmarkEvidenceGateTrustOn:
+    """SELFEVO_BENCHMARK_TRUST=1 (explicit operator opt-in): the affirmative
+    path is live."""
+
+    def test_valid_benchmark_confirms_on_harness_signal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt3", "cycle-opt-3")
+        _write_benchmark(state_dir, "cycle-opt-3", dict(_GOOD_BENCHMARK))
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["defect-opt3"]
+        assert entry["confirmed"] is True
+        assert entry["signal"] == "pycache"
+        assert "unconfirmed_reason" not in entry
+
+    def test_no_benchmark_never_confirms(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt", "cycle-opt-1")
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_missing"
+
+    def test_invalid_benchmark_never_confirms(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt2", "cycle-opt-2")
+        _write_benchmark(state_dir, "cycle-opt-2", {"metric": "latency"})  # incomplete
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt2"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+
+    def test_regression_benchmark_never_confirms(self, tmp_path, monkeypatch):
+        """A benchmark file exists and is well-typed but proves a
+        regression (fails validate_benchmark's improvement check) — still
+        gated as untrusted, never confirms."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt5", "cycle-opt-5")
+        _write_benchmark(
+            state_dir, "cycle-opt-5",
+            dict(_GOOD_BENCHMARK, baseline=180, new_value=420),  # got SLOWER
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt5"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+
+    def test_non_optimization_entry_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"priority-normal": {
+                "cycle_id": "cycle-normal",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "priority 5",
+            }},
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["priority-normal"]
+        assert entry["confirmed"] is True
+
+    # ─── HIGH-1: revocation of a pre-confirmed optimization entry ─────────
+
+    def test_preconfirmed_entry_with_no_benchmark_is_revoked(self, tmp_path, monkeypatch):
+        """The exact bypass shape: confirmed=True with a legitimate-looking
+        harness signal AND an optimization claim, but no valid benchmark.
+        Must be REVOKED to confirmed=False, not left alone."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-forged", "cycle-forged",
+            confirmed=True, signal="pycache",
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-forged"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_missing"
+
+    def test_preconfirmed_entry_revoked_even_when_trust_off(self, tmp_path, monkeypatch):
+        """The bypass must be closed regardless of the trust switch state —
+        with it off, a claim with a valid-looking benchmark is STILL
+        revoked (untrusted), not merely a fresh one blocked from
+        confirming."""
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-forged2", "cycle-forged2",
+            confirmed=True, signal="pycache",
+        )
+        _write_benchmark(state_dir, "cycle-forged2", dict(_GOOD_BENCHMARK))
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-forged2"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+
+    def test_preconfirmed_entry_with_valid_trusted_benchmark_stays_confirmed(self, tmp_path, monkeypatch):
+        """Not every pre-confirmed optimization entry is revoked — one that
+        already has a valid, trusted benchmark artifact is left confirmed."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-legit", "cycle-legit",
+            confirmed=True, signal="pycache",
+        )
+        _write_benchmark(state_dir, "cycle-legit", dict(_GOOD_BENCHMARK))
+        assert usage_evidence.confirm_serves(state_dir, None) == 0  # already confirmed, not "newly"
+        entry = _read_completed(state_dir)["entries"]["defect-legit"]
+        assert entry["confirmed"] is True
+        assert "unconfirmed_reason" not in entry
+
+    def test_foreign_signal_optimization_entry_is_repaired_then_gated(self, tmp_path, monkeypatch):
+        """A confirmed entry with BOTH a foreign (non-harness) signal and an
+        optimization claim with no benchmark: the #789 tamper repair must
+        still fire (foreign signal stripped, tamper markers recorded) AND
+        the benchmark gate must still land on confirmed=False afterward."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-both", "cycle-both",
+            confirmed=True, signal="operator-confirmed",
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-both"]
+        assert entry["tamper_repaired_at"]
+        assert entry["tamper_signal"] == "operator-confirmed"
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_missing"
 
 
 # ─── #789: tamper repair (trust only harness signals) ───────────────────────

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -16,7 +16,7 @@ import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from nanobot.runtime import demand, usage_evidence
+from nanobot.runtime import benchmark_evidence, demand, usage_evidence
 
 
 def _iso(dt: datetime) -> str:
@@ -314,6 +314,162 @@ class TestConfirmServes:
     def test_fail_open_on_missing_sidecars(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         assert usage_evidence.confirm_serves(state_dir, None) == 0
+
+
+# ─── #813: benchmark-evidence gate ──────────────────────────────────────────
+
+
+_GOOD_BENCHMARK = {
+    "metric": "p95_latency_ms",
+    "baseline": 420,
+    "new_value": 180,
+    "method": "wrk -t2 -c50 -d30s against /health, median of 3 runs",
+}
+
+
+def _write_benchmark(state_dir: Path, cycle_id: str, payload: dict) -> None:
+    path = benchmark_evidence.benchmark_path(state_dir, cycle_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestBenchmarkEvidenceGate:
+    def test_optimization_claim_without_benchmark_never_confirms(self, tmp_path):
+        """The harness signal is present (a real pycache usage), but the
+        entry declares an optimization claim with no benchmark artifact at
+        all — it must stay unconfirmed with the reason recorded, never
+        confirmed via the ordinary harness-signal path."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"defect-opt": {
+                "cycle_id": "cycle-opt-1",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "optimization latency",
+            }},
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_missing"
+
+    def test_optimization_claim_with_invalid_benchmark_never_confirms(self, tmp_path):
+        """A benchmark artifact exists but fails schema validation (e.g.
+        missing method) — still gated, same as no artifact at all."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"defect-opt2": {
+                "cycle_id": "cycle-opt-2",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "optimization latency",
+            }},
+        )
+        _write_benchmark(state_dir, "cycle-opt-2", {"metric": "latency"})  # incomplete
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt2"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_missing"
+
+    def test_optimization_claim_with_valid_benchmark_confirms_normally(self, tmp_path):
+        """With a schema-valid benchmark artifact present, the entry
+        confirms through the ordinary harness-signal path, unchanged."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"defect-opt3": {
+                "cycle_id": "cycle-opt-3",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "optimization latency",
+            }},
+        )
+        _write_benchmark(state_dir, "cycle-opt-3", dict(_GOOD_BENCHMARK))
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["defect-opt3"]
+        assert entry["confirmed"] is True
+        assert entry["signal"] == "pycache"
+        assert "unconfirmed_reason" not in entry
+
+    def test_non_optimization_entry_unaffected_by_gate(self, tmp_path):
+        """A normal (non-optimization) entry confirms exactly as before —
+        the gate never even looks at it."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"priority-normal": {
+                "cycle_id": "cycle-normal",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "priority 5",
+            }},
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["priority-normal"]
+        assert entry["confirmed"] is True
+        assert "unconfirmed_reason" not in entry
+
+    def test_entry_without_serves_field_unaffected(self, tmp_path):
+        """Entries folded before #813 (no ``serves`` key at all) behave
+        exactly as before — is_optimization_claim(None) is False."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"priority-legacy": {
+                "cycle_id": "cycle-legacy",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+            }},
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["priority-legacy"]
+        assert entry["confirmed"] is True
+
+    def test_gated_entry_write_is_idempotent(self, tmp_path):
+        """A second pass over an already-gated entry changes nothing further
+        and does not re-increment any counter."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"defect-opt4": {
+                "cycle_id": "cycle-opt-4",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "optimization throughput",
+            }},
+        )
+        _write_usage_sidecar(state_dir, {})
+        usage_evidence.confirm_serves(state_dir, None)
+        first = _read_completed(state_dir)
+        usage_evidence.confirm_serves(state_dir, None)
+        assert _read_completed(state_dir) == first
 
 
 # ─── #789: tamper repair (trust only harness signals) ───────────────────────


### PR DESCRIPTION
## Summary
- Closes #813. Enforces the benchmark-evidence gate at CONFIRMATION time (the simpler AC option) — no bridge/gate decision-block change, so this stays clear of #814's territory (scorecard.py/scorer.py/score_weights.json untouched).
- NEW `nanobot/runtime/benchmark_evidence.py`: `validate_benchmark` (schema check — `metric`/`method` non-empty strings, `baseline`/`new_value` numbers, no trust of prose), `benchmark_path` (`state/benchmarks/<cycle_id>.json`), `has_valid_benchmark` (fail-closed existence+validity), `is_optimization_claim` (explicit structured signal — `serves` normalized `startswith("optimization")`).
- `llm_proposer._SERVES_PREFIXES` gains `'optimization'` so a cycle may legitimately declare `serves: "optimization <metric>"`. Steering the proposer to actually emit it is a separate issue (#815) — this PR only makes the signal schema-valid + enforced.
- `demand._fold_completed` now persists the `proposed` row's own `serves` value onto each folded `demand/completed.json` entry (alongside the already-present `cycle_id`), so the confirmation path can tell an optimization claim from an ordinary entry without re-reading the ledger.
- `usage_evidence.confirm_serves`: the benchmark gate is checked BEFORE the harness-signal match — an optimization-claim entry with no valid benchmark artifact is forced `confirmed=False` with `unconfirmed_reason="benchmark_missing"`, even when a harness usage signal is present; with a valid benchmark it confirms via the unchanged harness-signal path. Non-optimization entries and the existing #789 tamper-repair path are untouched.

## Test plan
- [x] `tests/test_benchmark_evidence.py` (new): `validate_benchmark` accepts a good artifact and rejects each missing/empty/wrong-typed field (including a `bool` baseline, since `bool` is an `int` subclass); `is_optimization_claim` true/false across serves forms; `has_valid_benchmark` true only for a schema-valid file, false for missing/corrupt/invalid/empty-cycle-id.
- [x] `tests/test_usage_evidence.py`: an optimization-claim entry WITHOUT a valid benchmark never confirms (even with a harness usage signal present) and records `unconfirmed_reason="benchmark_missing"`; WITH an invalid (schema-failing) benchmark, same gated result; WITH a valid benchmark it confirms normally on the harness signal; a non-optimization entry and a legacy entry with no `serves` field at all are both unaffected; gate write is idempotent across repeated calls.
- [x] `tests/test_demand.py`: `_fold_completed` persists `serves` from the proposed row onto the completed entry; defaults to `""` when the row carries none (pre-#813 shape).
- [x] `python -m py_compile nanobot/runtime/benchmark_evidence.py nanobot/runtime/usage_evidence.py nanobot/runtime/demand.py nanobot/runtime/llm_proposer.py` — clean.
- [x] `python -m pytest tests/test_usage_evidence.py tests/test_demand.py tests/test_benchmark_evidence.py -q` — 149 passed. 2 pre-existing, unrelated failures reproduce byte-identically on unmodified `origin/main` (`TestCompileDefects::test_broken_script_is_demand` / `test_watermark_no_ops_on_unchanged_head` — a Windows path-separator bug in `demand._compile_defects`, nothing to do with #813).

🤖 Generated with [Claude Code](https://claude.com/claude-code)