### PR TITLE
fix(runtime): harness-verified benchmark provenance — non-forgeable confirmation (#819)

### DIFF
--- a/nanobot/runtime/benchmark_evidence.py
+++ b/nanobot/runtime/benchmark_evidence.py
@@ -53,20 +53,36 @@ a harness-executed measurement from a forged one, and the artifact's own
 #819 closes that gap WITHOUT re-execution or a signing scheme: instead of
 trusting the artifact's numbers, :func:`verify_benchmark` corroborates the
 claimed improvement against the harness's OWN scorecard history
-(``state/scorecard/history.jsonl`` — a ``FITNESS_SIDECARS``-protected sidecar
-the scorecard module itself writes every recompute). Only a small allowlist
-of harness-observed V1 metrics (:data:`_HARNESS_METRICS`) is even eligible;
-for one of those, the artifact is a mere pointer ("this cycle claims metric
-X improved") and the harness's before/after snapshots around the
-integration timestamp decide whether that is true. An instance can still
-write a fully-shaped, internally-consistent forged artifact, but it buys
-nothing: the harness history either shows the named metric improved or it
-doesn't, and the instance cannot rewrite its own scorecard history (that
-would itself trip the #789 spawn-boundary tamper detector). This makes it
-SAFE for an operator to enable the ``SELFEVO_BENCHMARK_TRUST`` switch — the
-switch still defaults OFF (enabling it remains an explicit operator step,
-not something #819 flips on its own), and with it off the entire affirmative
-path stays dormant exactly as before.
+(``state/scorecard/history.jsonl`` — a ``scorecard.FITNESS_SIDECARS``-protected
+sidecar the scorecard module itself writes every recompute, in the SAME
+``compute_scorecard`` call that overwrites ``scorecard/latest.json``, so it
+is hashed by the #789 spawn-boundary check exactly like every other fitness
+sidecar). Only a small allowlist of harness-observed V1 metrics
+(:data:`_HARNESS_METRICS`) is even eligible; for one of those, the artifact
+is a mere pointer ("this cycle claims metric X improved") and the harness's
+own before/after snapshots decide whether that is true. An instance can
+still write a fully-shaped, internally-consistent forged artifact, but it
+buys nothing: the harness history either shows the named metric improved or
+it doesn't, and the instance cannot rewrite its own scorecard history
+un-noticed (that IS now a #789 spawn-boundary write on a protected sidecar —
+note #789 DETECTS and records the incident, it does not roll the file back,
+same as every other fitness sidecar).
+
+HONEST RESIDUAL (read before relying on this for anything causal): the V1
+scorecard metrics this module can verify are 7-day WINDOWED AGGREGATES
+(``scorecard._WINDOW_DAYS``), not a single-cycle before/after measurement.
+Corroboration here proves the named metric moved in the harness's own data
+in the cycle's own window — it does NOT prove THIS cycle's change caused
+that movement (an unrelated concurrent change moving the same aggregate in
+the same window would also corroborate). That is why this is a conservative
+SOFT signal, not a causal one, and why ``SELFEVO_BENCHMARK_TRUST`` stays OFF
+by default even after #819: true causal attribution (the harness itself
+re-executing a defined before/after measurement around a single cycle) is a
+documented follow-up, not something this module claims to provide. #819's
+guarantee is narrower and still real: a fabricated artifact with invented
+numbers cannot confirm on its own — only genuine, harness-observed movement
+of a registered metric can, in the artifact's claimed direction, in the
+artifact's claimed window.
 
 Everything here is deterministic (NO LLM call) and fail-closed: an
 unreadable/missing file, a disabled trust switch, an unregistered/mismatched
@@ -348,11 +364,16 @@ def verify_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any) -> boo
     5. the harness's OWN scorecard history
        (:func:`_history_snapshots`, ``state/scorecard/history.jsonl``) shows
        the SAME metric actually moved in the canonical improvement
-       direction, beyond a small tolerance, between the snapshot at-or-before
-       ``integration_ts`` (the "before") and the LATEST snapshot in history
-       (the "after") — and that "after" snapshot must itself be newer than
-       ``integration_ts`` (otherwise nothing has been observed since the
-       claimed change landed yet).
+       direction, beyond a small tolerance, between the CYCLE'S OWN
+       immediate before/after snapshots: "before" is the LATEST snapshot
+       with ``computed_at_utc <= integration_ts`` (the immediate
+       pre-integration state), and "after" is the EARLIEST snapshot with
+       ``computed_at_utc > integration_ts`` (the cycle's own immediate
+       post-integration recompute) — NOT the global-latest snapshot.
+       Narrowing to this specific window (rather than "any later snapshot")
+       keeps an unrelated LATER cycle's improvement, or a straddled/cherry-
+       picked window, from corroborating a claim it has nothing to do with.
+       Both a before and an after snapshot must exist, or this fails closed.
 
     The artifact's own ``baseline``/``new_value`` numbers are NEVER read
     here beyond :func:`validate_benchmark`'s shape check — they are not part
@@ -365,12 +386,22 @@ def verify_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any) -> boo
     EVERY optimization-claim entry regardless of stored state) always
     re-derives the verdict from the harness's own history.
 
+    HONEST RESIDUAL (see the module docstring's HONEST RESIDUAL section for
+    the full explanation): the corroborated metrics are 7-day windowed
+    aggregates, not single-cycle measurements — a narrow before/after window
+    around ``integration_ts`` reduces, but cannot eliminate, the chance that
+    an unrelated concurrent change moved the same aggregate. This is by
+    design a conservative SOFT signal, not causal proof; that is part of why
+    ``SELFEVO_BENCHMARK_TRUST`` stays off by default even with this check in
+    place.
+
     Fail-closed on every axis: an unsafe/empty ``cycle_id``, the trust
     switch being off, a missing/unreadable/corrupt/schema-invalid artifact,
     an unregistered or direction-mismatched metric, an unparseable
     ``integration_ts``, missing/unreadable history, no snapshot at-or-before
-    ``integration_ts``, no snapshot after it yet, or no corroborated
-    improvement all read as ``False``. Never raises.
+    ``integration_ts``, no snapshot strictly after it, or no corroborated
+    improvement between those two specific snapshots all read as ``False``.
+    Never raises.
     """
     try:
         safe_id = _is_safe_cycle_id(cycle_id)
@@ -406,6 +437,12 @@ def verify_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any) -> boo
         if not history:
             return False
 
+        # #819 HIGH follow-up: "before" is the LATEST snapshot at-or-before
+        # ts (the immediate pre-integration state); "after" is the
+        # EARLIEST snapshot strictly after ts (the cycle's own immediate
+        # post-integration recompute) — deliberately NOT the global-latest
+        # snapshot, so an unrelated later cycle's movement (or a
+        # straddled/cherry-picked window) cannot corroborate this claim.
         before = before_ts = after = after_ts = None
         for snapshot in history:
             if not isinstance(snapshot, dict):
@@ -416,15 +453,15 @@ def verify_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any) -> boo
             value = _snapshot_metric(snapshot, section, metric)
             if value is None:
                 continue
-            if snap_ts <= ts and (before_ts is None or snap_ts > before_ts):
-                before, before_ts = value, snap_ts
-            if after_ts is None or snap_ts > after_ts:
-                after, after_ts = value, snap_ts
+            if snap_ts <= ts:
+                if before_ts is None or snap_ts > before_ts:
+                    before, before_ts = value, snap_ts
+            else:
+                if after_ts is None or snap_ts < after_ts:
+                    after, after_ts = value, snap_ts
 
         if before is None or after is None:
-            return False  # no corroborating before and/or after snapshot
-        if after_ts <= ts:
-            return False  # nothing observed since the claimed change landed
+            return False  # no corroborating before and/or immediate-after snapshot
 
         return _harness_improved(before, after, canonical_direction)
     except Exception:

--- a/nanobot/runtime/benchmark_evidence.py
+++ b/nanobot/runtime/benchmark_evidence.py
@@ -41,32 +41,46 @@ trust their ``cycle_id``; :func:`has_valid_benchmark` and
 :func:`benchmark_file_exists` do the rejection themselves before touching
 disk).
 
-PROVENANCE WARNING (#813, tracked for hardening in #819): a benchmark
-artifact under ``state/benchmarks/`` is a plain JSON file. ``state/`` is off
-the instance's COMMIT surface, but it IS writable at runtime by an
-instance-authored script (the same class of live reward-hack #789 already
-had to repair: a script hardcoding a sidecar path and writing a falsified
-field into it). :func:`validate_benchmark` checks *shape*, not *authorship*
-— it cannot tell a harness-executed measurement from a forged one. Until
-#819 lands real harness-verified provenance (re-execution or a signed/
-harness-authored artifact), this module ships FAIL-CLOSED: the
-``SELFEVO_BENCHMARK_TRUST`` env switch (default OFF) gates the entire
-affirmative path. With it off (the required posture pre-#819), any
-optimization claim is permanently unconfirmable, and a forged artifact is
-inert — a fully-shaped forged benchmark buys nothing. Do not flip this
-switch on until #819's provenance guarantee exists.
+PROVENANCE WARNING (#813) / #819 UPDATE: a benchmark artifact under
+``state/benchmarks/`` is a plain JSON file. ``state/`` is off the instance's
+COMMIT surface, but it IS writable at runtime by an instance-authored script
+(the same class of live reward-hack #789 already had to repair: a script
+hardcoding a sidecar path and writing a falsified field into it).
+:func:`validate_benchmark` checks *shape*, not *authorship* — it cannot tell
+a harness-executed measurement from a forged one, and the artifact's own
+``baseline``/``new_value`` numbers are, on their own, worthless as proof.
+
+#819 closes that gap WITHOUT re-execution or a signing scheme: instead of
+trusting the artifact's numbers, :func:`verify_benchmark` corroborates the
+claimed improvement against the harness's OWN scorecard history
+(``state/scorecard/history.jsonl`` — a ``FITNESS_SIDECARS``-protected sidecar
+the scorecard module itself writes every recompute). Only a small allowlist
+of harness-observed V1 metrics (:data:`_HARNESS_METRICS`) is even eligible;
+for one of those, the artifact is a mere pointer ("this cycle claims metric
+X improved") and the harness's before/after snapshots around the
+integration timestamp decide whether that is true. An instance can still
+write a fully-shaped, internally-consistent forged artifact, but it buys
+nothing: the harness history either shows the named metric improved or it
+doesn't, and the instance cannot rewrite its own scorecard history (that
+would itself trip the #789 spawn-boundary tamper detector). This makes it
+SAFE for an operator to enable the ``SELFEVO_BENCHMARK_TRUST`` switch — the
+switch still defaults OFF (enabling it remains an explicit operator step,
+not something #819 flips on its own), and with it off the entire affirmative
+path stays dormant exactly as before.
 
 Everything here is deterministic (NO LLM call) and fail-closed: an
-unreadable/missing file, a disabled trust switch, or an unexpected input
-shape all degrade to "no valid benchmark", never to a false pass. The
-schema check itself (:func:`validate_benchmark`) never raises; it always
-returns a list (empty means valid).
+unreadable/missing file, a disabled trust switch, an unregistered/mismatched
+metric, missing or uncorroborating history, or an unexpected input shape
+all degrade to "not verified", never to a false pass. The schema check
+itself (:func:`validate_benchmark`) never raises; it always returns a list
+(empty means valid).
 """
 from __future__ import annotations
 
 import json
 import math
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -75,6 +89,39 @@ BENCHMARK_SCHEMA = "benchmark-evidence-v1"
 _REQUIRED_STR_FIELDS = ("metric", "method")
 _REQUIRED_NUM_FIELDS = ("baseline", "new_value")
 _VALID_DIRECTIONS = ("lower_is_better", "higher_is_better")
+
+# #819: the ONLY metric names a benchmark artifact can ever verify against —
+# each maps to (scorecard snapshot section, canonical improvement direction).
+# A benchmark whose ``metric`` is not a key here can NEVER verify, no matter
+# how well-formed the artifact: the instance cannot invent a new metric name
+# and have it trusted. Values are read straight off a scorecard history
+# snapshot as ``snapshot[section][metric]`` (scorecard.py's
+# ``_metric_value`` does the same lookup, scorecard.py:774-778). Where each
+# is actually computed: ``tokens_per_integration`` — scorecard.py:482-523
+# (``_cost_section``); ``compile_clean_ratio`` — scorecard.py:553-606
+# (``_quality_section``); ``repeat_failure_rate`` — scorecard.py:361-476
+# (``_loop_section``); ``heldout_gap`` — scorecard.py:710-744
+# (``_heldout_section``). Directions mirror scorecard._TARGETS
+# (scorecard.py:116-201) for the same metrics.
+_HARNESS_METRICS: dict[str, tuple[str, str]] = {
+    "tokens_per_integration": ("cost", "lower_is_better"),
+    "compile_clean_ratio": ("quality", "higher_is_better"),
+    "repeat_failure_rate": ("loop", "lower_is_better"),
+    "heldout_gap": ("heldout", "lower_is_better"),
+}
+
+# Corroboration tolerance: the harness-observed before/after must differ by
+# more than this — relative to the "before" magnitude, floored by a small
+# absolute epsilon for near-zero values — in the claimed-improving direction.
+# Guards against float noise/rounding being read as a genuine improvement.
+_IMPROVEMENT_REL_TOL = 0.01  # 1%
+_IMPROVEMENT_ABS_TOL = 1e-6
+
+# Bounded read of the harness's own scorecard history (larger than
+# scorecard.py's own 400-line trend window, #814/#767's _MAX_HISTORY_LINES,
+# because an optimization claim may need to look back further than 7 days
+# to find its pre-integration snapshot).
+_MAX_HISTORY_LINES = 3000
 
 # #813 HIGH-2: operator-owned trust switch, same SELFEVO_ / default-OFF
 # precedent as SELFEVO_DECAY_PROTECT (#809) and SELFEVO_RUNTIME_SLICE
@@ -199,10 +246,11 @@ def benchmark_path(state_dir: Path, cycle_id: str) -> Path:
 
 def benchmark_file_exists(state_dir: Path, cycle_id: str) -> bool:
     """True iff a benchmark artifact file exists for ``cycle_id`` —
-    regardless of trust/validity. Used by the ``confirm_serves`` gate
-    (#813) to choose between the ``benchmark_missing`` and
-    ``benchmark_untrusted`` reason codes. Rejects unsafe ``cycle_id`` values
-    the same way :func:`has_valid_benchmark` does (MED-2)."""
+    regardless of trust/validity/verification. Used by the
+    ``confirm_serves`` gate (#813, extended #819) to choose between the
+    ``benchmark_missing``, ``benchmark_untrusted``, and ``benchmark_unverified``
+    reason codes. Rejects unsafe ``cycle_id`` values the same way
+    :func:`has_valid_benchmark` does (MED-2)."""
     try:
         safe_id = _is_safe_cycle_id(cycle_id)
         if not safe_id:
@@ -212,16 +260,117 @@ def benchmark_file_exists(state_dir: Path, cycle_id: str) -> bool:
         return False
 
 
-def has_valid_benchmark(state_dir: Path, cycle_id: str) -> bool:
-    """True ONLY IF: the operator trust switch (:func:`benchmark_trust_enabled`)
-    is ON, AND a benchmark artifact file exists for ``cycle_id``, AND
-    :func:`validate_benchmark` finds it clean.
+def _parse_ts(value: Any) -> "datetime | None":
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except Exception:
+        return None
+
+
+def _history_snapshots(state_dir: Path) -> list[dict[str, Any]]:
+    """Bounded read of the harness's own scorecard history
+    (``<state_dir>/scorecard/history.jsonl``) — the TRUST ROOT
+    :func:`verify_benchmark` corroborates a claimed improvement against,
+    never the artifact's own numbers. Written exclusively by
+    ``scorecard.compute_scorecard`` (one JSON line per recompute); each line
+    is a full snapshot dict with a top-level ``computed_at_utc`` and
+    per-section metric values (``snapshot[section][metric]``). Bounded to
+    the newest :data:`_MAX_HISTORY_LINES` lines. Fail-open to ``[]`` on any
+    error — a missing/unreadable file or corrupt individual lines (skipped,
+    not fatal) never raise into the caller."""
+    out: list[dict[str, Any]] = []
+    try:
+        path = Path(state_dir) / "scorecard" / "history.jsonl"
+        if not path.is_file():
+            return out
+        lines = path.read_text(encoding="utf-8").splitlines()[-_MAX_HISTORY_LINES:]
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(row, dict):
+                out.append(row)
+        return out
+    except Exception:
+        return out
+
+
+def _snapshot_metric(snapshot: dict[str, Any], section: str, metric: str) -> float | None:
+    try:
+        sec = snapshot.get(section)
+        if not isinstance(sec, dict):
+            return None
+        value = sec.get(metric)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        if not math.isfinite(value):
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _harness_improved(before: float, after: float, direction: str) -> bool:
+    """True iff ``after`` improved on ``before`` in ``direction``, beyond a
+    small tolerance (:data:`_IMPROVEMENT_REL_TOL` / :data:`_IMPROVEMENT_ABS_TOL`)
+    — guards against float noise/rounding reading as a genuine improvement."""
+    tolerance = max(_IMPROVEMENT_ABS_TOL, abs(before) * _IMPROVEMENT_REL_TOL)
+    if direction == "lower_is_better":
+        return (before - after) > tolerance
+    if direction == "higher_is_better":
+        return (after - before) > tolerance
+    return False
+
+
+def verify_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any) -> bool:
+    """The #819 forge-proof verification: True ONLY IF, in order —
+
+    1. the operator trust switch is on (:func:`benchmark_trust_enabled`);
+    2. a safe ``cycle_id`` names an existing artifact that passes
+       :func:`validate_benchmark` (shape + claimed-improvement check);
+    3. the artifact's ``metric`` is in the harness-verifiable allowlist
+       (:data:`_HARNESS_METRICS`) — an unregistered metric name can NEVER
+       verify, no matter how well-formed the artifact;
+    4. the artifact's ``direction`` matches that metric's CANONICAL
+       direction (a lie about direction is rejected outright, even if it
+       happens to match the artifact's own baseline/new_value ordering);
+    5. the harness's OWN scorecard history
+       (:func:`_history_snapshots`, ``state/scorecard/history.jsonl``) shows
+       the SAME metric actually moved in the canonical improvement
+       direction, beyond a small tolerance, between the snapshot at-or-before
+       ``integration_ts`` (the "before") and the LATEST snapshot in history
+       (the "after") — and that "after" snapshot must itself be newer than
+       ``integration_ts`` (otherwise nothing has been observed since the
+       claimed change landed yet).
+
+    The artifact's own ``baseline``/``new_value`` numbers are NEVER read
+    here beyond :func:`validate_benchmark`'s shape check — they are not part
+    of the pass/fail decision. This is the non-forgeability invariant: an
+    instance can write a fully-shaped, internally-consistent benchmark
+    artifact with fabricated numbers, or write
+    ``confirmed=true, signal="benchmark"`` directly into
+    ``demand/completed.json``, and it buys nothing — this function (and the
+    ``usage_evidence.confirm_serves`` Pass 2 caller, which re-runs it on
+    EVERY optimization-claim entry regardless of stored state) always
+    re-derives the verdict from the harness's own history.
 
     Fail-closed on every axis: an unsafe/empty ``cycle_id``, the trust
-    switch being off (the default — see the module docstring's PROVENANCE
-    WARNING), a missing file, an unreadable/corrupt file, or a file that
-    fails schema/measurement validation all read as ``False``. An
-    optimization claim gets no benefit of the doubt.
+    switch being off, a missing/unreadable/corrupt/schema-invalid artifact,
+    an unregistered or direction-mismatched metric, an unparseable
+    ``integration_ts``, missing/unreadable history, no snapshot at-or-before
+    ``integration_ts``, no snapshot after it yet, or no corroborated
+    improvement all read as ``False``. Never raises.
     """
     try:
         safe_id = _is_safe_cycle_id(cycle_id)
@@ -232,7 +381,65 @@ def has_valid_benchmark(state_dir: Path, cycle_id: str) -> bool:
         path = benchmark_path(state_dir, safe_id)
         if not path.is_file():
             return False
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return not validate_benchmark(data)
+        try:
+            artifact = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return False
+        if validate_benchmark(artifact):
+            return False  # shape/claimed-improvement check failed
+
+        metric = str(artifact.get("metric") or "").strip()
+        spec = _HARNESS_METRICS.get(metric)
+        if spec is None:
+            return False  # unregistered metric — can never verify
+        section, canonical_direction = spec
+
+        direction = str(artifact.get("direction") or "").strip()
+        if direction != canonical_direction:
+            return False  # lied about (or mismatched) direction
+
+        ts = _parse_ts(integration_ts)
+        if ts is None:
+            return False
+
+        history = _history_snapshots(state_dir)
+        if not history:
+            return False
+
+        before = before_ts = after = after_ts = None
+        for snapshot in history:
+            if not isinstance(snapshot, dict):
+                continue
+            snap_ts = _parse_ts(snapshot.get("computed_at_utc"))
+            if snap_ts is None:
+                continue
+            value = _snapshot_metric(snapshot, section, metric)
+            if value is None:
+                continue
+            if snap_ts <= ts and (before_ts is None or snap_ts > before_ts):
+                before, before_ts = value, snap_ts
+            if after_ts is None or snap_ts > after_ts:
+                after, after_ts = value, snap_ts
+
+        if before is None or after is None:
+            return False  # no corroborating before and/or after snapshot
+        if after_ts <= ts:
+            return False  # nothing observed since the claimed change landed
+
+        return _harness_improved(before, after, canonical_direction)
     except Exception:
         return False
+
+
+def has_valid_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any = None) -> bool:
+    """#819: now delegates entirely to :func:`verify_benchmark` — the
+    shape+trust-switch check alone (pre-#819 behavior) is no longer
+    sufficient; the harness's own scorecard history must also corroborate
+    the claimed improvement around ``integration_ts``. Kept as the stable
+    public gate name for callers (``usage_evidence.confirm_serves``); see
+    :func:`verify_benchmark` for the full contract and fail-closed axes.
+    ``integration_ts`` defaults to ``None`` for source compatibility, but a
+    ``None``/unparseable value always fails closed (there is no ts to
+    corroborate a "before" against).
+    """
+    return verify_benchmark(state_dir, cycle_id, integration_ts)

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -662,10 +662,27 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
 # re-hashes right before the gate verdict (#789 spawn-boundary tamper
 # detection). Defined HERE — the fitness module, per the #603 placement rule
 # — so instance-facing sources never spell out the protected set.
+#
+# #819: "scorecard/history.jsonl" joined this set — it is the trust root
+# benchmark_evidence.verify_benchmark corroborates a claimed optimization
+# against. Without it here, an instance could append fabricated
+# ever-improving snapshots to history.jsonl at runtime and the spawn-boundary
+# hash check would never notice (the file wasn't in the protected set), so
+# verify_benchmark would happily "corroborate" a forged claim against
+# forged history — a full bypass of the whole #819 guarantee. Timing is
+# safe: history.jsonl is appended by the SAME compute_scorecard call that
+# overwrites latest.json (see the `_write_json(_latest_path(...))` followed
+# immediately by the history.jsonl append below in this module), so it
+# changes exactly when the already-protected latest.json does — no new
+# window relative to the existing spawn-boundary check. Note (same as every
+# other sidecar here): #789 only DETECTS a spawn-boundary write on this
+# sidecar and records it (`phase: "integrity"`); it does not roll the file
+# back — detection, not prevention.
 FITNESS_SIDECARS = (
     "demand/completed.json",
     "demand/exhausted.json",
     "scorecard/latest.json",
+    "scorecard/history.jsonl",
     "heldout/results.json",
     "usage/last_used.json",
 )

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -259,7 +259,11 @@ def _harness_signals() -> frozenset[str]:
 
         return _ue.HARNESS_SIGNALS
     except Exception:
-        return frozenset({"pycache", "output"})
+        # #819: kept in sync with usage_evidence.HARNESS_SIGNALS — "benchmark"
+        # joined that set when the benchmark-evidence gate became
+        # harness-history-corroborated (verify_benchmark), so this fallback
+        # (used only if the usage_evidence import itself fails) must match.
+        return frozenset({"pycache", "output", "benchmark"})
 
 
 def _confirmed_cycle_ids(state_dir: Path) -> set[str]:

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -416,7 +416,13 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
     evidence demand.py turns into a ``defect`` item), and ONE ledger row
     ``{"phase": "integrity", "reason": "sidecar_tamper"}`` is appended per
     repair. The stripped entry then re-evaluates honestly from usage
-    evidence like any unconfirmed entry.
+    evidence like any unconfirmed entry. #819 MED fix: ``"benchmark"`` being
+    IN :data:`HARNESS_SIGNALS` is not enough on its own — it is trusted here
+    ONLY when the entry is also an optimization claim
+    (``benchmark_evidence.is_optimization_claim``), since Pass 2 below is
+    its sole legitimate writer and only ever writes it on such an entry. A
+    ``signal: "benchmark"`` on a non-optimization-claim entry is foreign and
+    is repaired exactly like any signal outside :data:`HARNESS_SIGNALS`.
 
     Benchmark-evidence gate (#813, made forge-proof by #819), checked BEFORE
     the "already confirmed" fast path in the harness-confirm pass below
@@ -479,16 +485,33 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
         gated = 0
         now_iso = _iso(datetime.now(timezone.utc))
 
-        # Pass 1 (#789, unchanged): tamper repair. Runs first so a foreign
-        # signal is stripped off an entry regardless of whether it also
-        # turns out to be an optimization claim below — the benchmark gate
-        # in Pass 2 must see the honestly-stripped state, not a
+        # Pass 1 (#789, extended #819 MED): tamper repair. Runs first so a
+        # foreign signal is stripped off an entry regardless of whether it
+        # also turns out to be an optimization claim below — the benchmark
+        # gate in Pass 2 must see the honestly-stripped state, not a
         # non-harness-authored ``signal``.
+        #
+        # #819 MED: "benchmark" is trusted context-free by HARNESS_SIGNALS,
+        # but it is ONLY ever a legitimate write on an optimization-claim
+        # entry (Pass 2 below is its sole writer, and only for entries where
+        # is_optimization_claim(serves) is true). A `signal: "benchmark"` on
+        # a NON-optimization-claim entry could never have been written
+        # honestly — it is foreign/forged exactly like a signal outside
+        # HARNESS_SIGNALS entirely (e.g. a bare `{"confirmed": true,
+        # "signal": "benchmark"}` written directly into completed.json by
+        # instance code, with no ``serves`` at all, would otherwise sail
+        # past Pass 1 as "harness-authored", never reach Pass 2 (not an
+        # optimization claim), and never reach Pass 3 (already confirmed) —
+        # persisting forever). pycache/output remain trusted context-free.
         for entry_id, entry in completed["entries"].items():
             if not isinstance(entry, dict) or not entry.get("confirmed"):
                 continue
             signal = str(entry.get("signal") or "")
-            if signal in HARNESS_SIGNALS:
+            benchmark_signal_without_claim = (
+                signal == "benchmark"
+                and not benchmark_evidence.is_optimization_claim(entry.get("serves"))
+            )
+            if signal in HARNESS_SIGNALS and not benchmark_signal_without_claim:
                 continue  # harness-authored confirmation — untouched
             # TAMPERED: foreign/missing signal on a confirmed entry. Strip
             # the falsified fields; the honest re-evaluation below treats it

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -71,7 +71,16 @@ USAGE_SCHEMA = "usage-evidence-v1"
 # fitness input (live reward-hack 2026-07-17: instance script wrote
 # `signal: "operator-confirmed"` into demand/completed.json) and the entry
 # is repaired on the next confirm_serves pass.
-HARNESS_SIGNALS: frozenset[str] = frozenset({"pycache", "output"})
+#
+# #819: "benchmark" joins the set — the signal confirm_serves' Pass 2 writes
+# when an optimization claim is VERIFIED against harness scorecard history
+# (benchmark_evidence.verify_benchmark). This is safe to trust exactly like
+# pycache/output ONLY because Pass 2 re-verifies every optimization-claim
+# entry from harness history on every call, regardless of the entry's stored
+# `confirmed`/`signal` — a forged `signal: "benchmark"` entry gets no benefit
+# of the doubt; it is re-derived and revoked the same way a foreign signal
+# is (Pass 1), just via a different check (Pass 2).
+HARNESS_SIGNALS: frozenset[str] = frozenset({"pycache", "output", "benchmark"})
 
 _RESCAN_HOURS = 6
 _HEADER_LINES = 50  # bounded output-path extraction window
@@ -409,36 +418,52 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
     repair. The stripped entry then re-evaluates honestly from usage
     evidence like any unconfirmed entry.
 
-    Benchmark-evidence gate (#813), checked BEFORE the "already confirmed"
-    fast path in the harness-confirm pass below (though AFTER tamper repair,
-    so a foreign signal is honestly stripped first — see the ordering note
-    in the implementation), so it can never be bypassed by an entry that is
-    already ``confirmed`` (HIGH-1 fix: a forged ``{"confirmed": true,
-    "signal": "pycache", "serves": "optimization ..."}`` entry has a
-    legitimate-looking harness signal and would otherwise sail past both
-    the tamper check — its signal IS in :data:`HARNESS_SIGNALS` — and the
-    old "confirmed is True: continue" short-circuit): an entry whose
-    ``serves`` (folded by
-    ``demand._fold_completed``) is an optimization claim
-    (``benchmark_evidence.is_optimization_claim``) is evaluated against
-    ``benchmark_evidence.has_valid_benchmark`` REGARDLESS of its current
-    ``confirmed`` value. If no valid benchmark artifact is found, the entry
-    is forced (or, if already confirmed, REVOKED to)
-    ``"confirmed": False`` with an ``unconfirmed_reason`` of
-    ``"benchmark_missing"`` (no artifact file at all) or
-    ``"benchmark_untrusted"`` (a file exists but the operator trust switch
-    ``benchmark_evidence.TRUST_ENV`` is off, or the file fails schema/
-    measurement validation) — see that module's PROVENANCE WARNING for why
-    the switch defaults off pending #819. A gated entry never proceeds to
-    the harness-signal match below this call. Once a valid, trusted
-    benchmark artifact exists, the entry confirms via the normal
-    harness-signal path, unchanged. A non-optimization entry (``serves``
-    empty, missing, or any other prefix) is completely unaffected by this
-    gate and falls straight through to the pre-#813 logic below.
+    Benchmark-evidence gate (#813, made forge-proof by #819), checked BEFORE
+    the "already confirmed" fast path in the harness-confirm pass below
+    (though AFTER tamper repair, so a foreign signal is honestly stripped
+    first — see the ordering note in the implementation), so it can never be
+    bypassed by an entry that is already ``confirmed`` (HIGH-1 fix: a forged
+    ``{"confirmed": true, "signal": "pycache", "serves": "optimization ..."}``
+    entry has a legitimate-looking harness signal and would otherwise sail
+    past both the tamper check — its signal IS in :data:`HARNESS_SIGNALS` —
+    and the old "confirmed is True: continue" short-circuit): an entry whose
+    ``serves`` (folded by ``demand._fold_completed``) is an optimization
+    claim (``benchmark_evidence.is_optimization_claim``) is evaluated
+    against ``benchmark_evidence.has_valid_benchmark`` (#819:
+    harness-history-corroborated verification, keyed on the entry's own
+    ``ts``) REGARDLESS of its current ``confirmed`` value, on EVERY call —
+    this re-derivation, not the stored signal, is what makes ``"benchmark"``
+    safe to add to :data:`HARNESS_SIGNALS` below.
 
-    Returns the number of entries NEWLY confirmed this call only — a gated
-    or revoked entry still triggers a sidecar write (its ``confirmed``/
-    ``unconfirmed_reason`` fields changed) but is never counted in the
+    - VERIFIED (harness scorecard history corroborates the named metric
+      improved after this entry's ``ts``): the entry gains/keeps
+      ``"confirmed": true``, ``"signal": "benchmark"``, and
+      ``confirmed_at`` is (re)stamped, with any stale ``unconfirmed_reason``
+      cleared. This is BOTH the ordinary confirm path for a fresh entry AND
+      the SELF-HEAL path for a previously-revoked one — the same branch,
+      because verification is re-run from scratch every call regardless of
+      the entry's prior state.
+    - NOT verified: the entry is forced (or, if already confirmed, REVOKED
+      to) ``"confirmed": false`` with an ``unconfirmed_reason`` of
+      ``"benchmark_missing"`` (no artifact file at all),
+      ``"benchmark_untrusted"`` (a file exists but the operator trust switch
+      ``benchmark_evidence.TRUST_ENV`` is off), or ``"benchmark_unverified"``
+      (a file exists, trust is on, but the artifact fails schema/shape
+      validation, names an unregistered/direction-mismatched metric, or the
+      harness's own scorecard history does not corroborate an improvement)
+      — see ``benchmark_evidence``'s module docstring for the full
+      non-forgeability rationale. A gated entry never proceeds to the
+      harness-signal match below this call.
+
+    A non-optimization entry (``serves`` empty, missing, or any other
+    prefix) is completely unaffected by this gate and falls straight
+    through to the pre-#813 logic below.
+
+    Returns the number of entries NEWLY confirmed this call only — this
+    includes a Pass 2 benchmark self-heal/confirm (it IS a confirmation,
+    same as a Pass 3 harness-signal one) but never a revoked/gated entry: a
+    revocation still triggers a sidecar write (its ``confirmed``/
+    ``unconfirmed_reason`` fields changed) but is not counted in the
     returned total; fail-open to ``0``.
     """
     try:
@@ -490,14 +515,23 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
             except Exception:
                 pass
 
-        # Pass 2 (#813 HIGH-1): benchmark-evidence gate, over EVERY entry
-        # (confirmed or not) — independent of, and before, Pass 3's
-        # "already confirmed" fast path, so an optimization claim can never
-        # ride an already-``confirmed: true`` state (forged, or legitimately
+        # Pass 2 (#813 HIGH-1, forge-proof re-derivation added by #819):
+        # benchmark-evidence gate, over EVERY entry (confirmed or not) —
+        # independent of, and before, Pass 3's "already confirmed" fast
+        # path, so an optimization claim can never ride an already-
+        # ``confirmed: true`` state (forged, or legitimately
         # harness-signalled before a benchmark requirement existed) past
         # this check. Must run AFTER Pass 1 so a foreign-signal entry that
         # also happens to be an optimization claim is evaluated on its
         # post-repair (stripped) state.
+        #
+        # #819: has_valid_benchmark now means "harness scorecard history
+        # corroborates this metric improved after entry['ts']" (delegates to
+        # benchmark_evidence.verify_benchmark) — re-run from scratch on
+        # EVERY call. This is simultaneously the confirm path for a fresh
+        # entry AND the SELF-HEAL path for a previously-revoked one: there is
+        # no separate "restore" branch because nothing is ever trusted from
+        # the entry's own prior state.
         for entry in completed["entries"].values():
             if not isinstance(entry, dict):
                 continue
@@ -505,35 +539,52 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
             if not benchmark_evidence.is_optimization_claim(serves):
                 continue
             cycle_id = entry.get("cycle_id")
-            if benchmark_evidence.has_valid_benchmark(state_dir, cycle_id):
-                # Valid, trusted benchmark: clear any stale gate marker from
-                # a prior call so Pass 3 can (re)confirm normally. Popping an
-                # absent key is a no-op; only count it as a change (for the
-                # write-gate) when something actually came off the entry.
-                if entry.pop("unconfirmed_reason", None) is not None:
-                    gated += 1
+            integration_ts = entry.get("ts")
+            if benchmark_evidence.has_valid_benchmark(state_dir, cycle_id, integration_ts):
+                # VERIFIED: confirm (or re-confirm/self-heal). Idempotent —
+                # only counted as a change (and only written) when something
+                # actually differs from the entry's current state, so a
+                # steady-state verified entry does not get its
+                # confirmed_at/write repeated every call.
+                already = entry.get("confirmed") is True and entry.get("signal") == "benchmark"
+                had_reason = entry.get("unconfirmed_reason") is not None
+                if not already or had_reason:
+                    entry["confirmed"] = True
+                    entry["signal"] = "benchmark"
+                    entry["confirmed_at"] = now_iso
+                    entry.pop("unconfirmed_reason", None)
+                    newly_confirmed += 1
                 continue
-            reason = (
-                "benchmark_missing"
-                if not benchmark_evidence.benchmark_file_exists(state_dir, cycle_id)
-                else "benchmark_untrusted"
-            )
+            # NOT verified: force (or revoke to) confirmed=False with a
+            # reason distinguishing why. File-existence is checked first
+            # (mirrors benchmark_file_exists' own priority), then the trust
+            # switch, so "unverified" specifically means "we looked and the
+            # harness history didn't corroborate it" — not merely absent or
+            # untrusted.
+            if not benchmark_evidence.benchmark_file_exists(state_dir, cycle_id):
+                reason = "benchmark_missing"
+            elif not benchmark_evidence.benchmark_trust_enabled():
+                reason = "benchmark_untrusted"
+            else:
+                reason = "benchmark_unverified"
             if entry.get("confirmed") is not False or entry.get("unconfirmed_reason") != reason:
                 entry["confirmed"] = False
                 entry["unconfirmed_reason"] = reason
+                entry.pop("signal", None)  # never leave a stale "benchmark" signal on a revoked entry
                 gated += 1
 
         # Pass 3 (pre-#813, extended): the ordinary harness-signal confirm.
         for entry in completed["entries"].values():
             if not isinstance(entry, dict) or entry.get("confirmed") is True:
                 continue
-            # #813: an optimization-claim entry that failed the benchmark
-            # gate above was just forced to confirmed=False with an
-            # unconfirmed_reason set — it must not be re-confirmed here via
-            # a harness usage signal alone.
+            # #813/#819: an optimization-claim entry that failed the
+            # benchmark gate above was just forced to confirmed=False with
+            # an unconfirmed_reason set — it must not be re-confirmed here
+            # via a harness usage signal alone.
             if (
                 benchmark_evidence.is_optimization_claim(entry.get("serves"))
-                and entry.get("unconfirmed_reason") in ("benchmark_missing", "benchmark_untrusted")
+                and entry.get("unconfirmed_reason")
+                in ("benchmark_missing", "benchmark_untrusted", "benchmark_unverified")
             ):
                 continue
             completed_ts = _parse_ts(entry.get("ts"))

--- a/tests/test_benchmark_evidence.py
+++ b/tests/test_benchmark_evidence.py
@@ -473,6 +473,45 @@ class TestVerifyBenchmark:
         )
         assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-stale", integration_ts) is False
 
+    def test_false_when_immediate_after_flat_even_if_a_later_snapshot_improved(self, tmp_path, monkeypatch):
+        """#819 HIGH fix: verify_benchmark must corroborate against the
+        CYCLE'S OWN immediate before/after snapshots — the latest snapshot
+        with computed_at_utc <= ts, and the EARLIEST one strictly after ts —
+        never the global-latest snapshot. An improvement that only shows up
+        in a LATER, unrelated cycle must not retroactively corroborate this
+        claim (pre-fix, using the global-latest snapshot as "after" would
+        have made this pass)."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-window", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _write_history(
+            tmp_path,
+            [
+                {"computed_at_utc": _now_iso(3), "cost": {"tokens_per_integration": 1000}},  # before
+                {"computed_at_utc": _now_iso(1.5), "cost": {"tokens_per_integration": 1000}},  # immediate after: flat
+                {"computed_at_utc": _now_iso(0), "cost": {"tokens_per_integration": 400}},  # later, unrelated improvement
+            ],
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-window", integration_ts) is False
+
+    def test_true_when_immediate_after_improved_even_with_a_later_regression(self, tmp_path, monkeypatch):
+        """The mirror case: the cycle's own immediate before/after DOES show
+        improvement — a later snapshot regressing again must not retroactively
+        invalidate this cycle's own corroboration (the window is anchored to
+        the cycle, not to whatever the metric does afterward)."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-window2", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _write_history(
+            tmp_path,
+            [
+                {"computed_at_utc": _now_iso(3), "cost": {"tokens_per_integration": 1000}},  # before
+                {"computed_at_utc": _now_iso(1.5), "cost": {"tokens_per_integration": 400}},  # immediate after: improved
+                {"computed_at_utc": _now_iso(0), "cost": {"tokens_per_integration": 1000}},  # later regression
+            ],
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-window2", integration_ts) is True
+
     def test_false_for_unparseable_integration_ts(self, tmp_path, monkeypatch):
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         _write_benchmark(tmp_path, "cyc-badts", _VERIFIABLE_BENCHMARK)

--- a/tests/test_benchmark_evidence.py
+++ b/tests/test_benchmark_evidence.py
@@ -1,16 +1,21 @@
-"""Tests for #813: benchmark-evidence gate.
+"""Tests for #813/#819: benchmark-evidence gate.
 
 Covers the schema+measurement validator (:func:`validate_benchmark`), the
 explicit structured optimization-claim signal (:func:`is_optimization_claim`),
 the operator trust switch (:func:`benchmark_trust_enabled`,
 ``SELFEVO_BENCHMARK_TRUST``), the fail-closed existence/validity check
-(:func:`has_valid_benchmark`, :func:`benchmark_file_exists`), and the
-cycle_id path-traversal rejection.
+(:func:`has_valid_benchmark`, :func:`benchmark_file_exists`), the cycle_id
+path-traversal rejection, and (#819) the forge-proof harness-history
+corroboration (:func:`verify_benchmark`) that :func:`has_valid_benchmark`
+now delegates to — a benchmark artifact is only ever a CLAIM; the harness's
+own ``scorecard/history.jsonl`` decides whether the named, allowlisted
+metric actually moved.
 """
 from __future__ import annotations
 
 import json
 import math
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nanobot.runtime import benchmark_evidence
@@ -24,11 +29,64 @@ _GOOD_BENCHMARK = {
     "direction": "lower_is_better",
 }
 
+# #819: an artifact naming a metric that IS in the harness-verifiable
+# allowlist (benchmark_evidence._HARNESS_METRICS) — used by every test that
+# needs to get past the metric/direction gate into history corroboration.
+_VERIFIABLE_BENCHMARK = {
+    "metric": "tokens_per_integration",
+    "baseline": 1000,
+    "new_value": 400,
+    "method": "scorecard cost section, before/after the integration cycle",
+    "direction": "lower_is_better",
+}
+
 
 def _write_benchmark(state_dir: Path, cycle_id: str, payload: dict) -> None:
     path = benchmark_evidence.benchmark_path(state_dir, cycle_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _now_iso(days_ago: float = 0) -> str:
+    return _iso(datetime.now(timezone.utc) - timedelta(days=days_ago))
+
+
+def _write_history(state_dir: Path, snapshots: list[dict]) -> None:
+    """Write ``snapshots`` (each a full scorecard-history-line dict) to
+    ``<state_dir>/scorecard/history.jsonl`` — the harness trust root
+    :func:`verify_benchmark` reads."""
+    path = Path(state_dir) / "scorecard" / "history.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for snap in snapshots:
+            fh.write(json.dumps(snap) + "\n")
+
+
+def _corroborating_history(
+    state_dir: Path,
+    *,
+    section: str = "cost",
+    metric: str = "tokens_per_integration",
+    before_value: float = 1000,
+    after_value: float = 400,
+    before_days_ago: float = 3,
+    after_days_ago: float = 0,
+) -> None:
+    """The harness's own history showing ``metric`` moved from
+    ``before_value`` to ``after_value`` — the corroborating shape
+    :func:`verify_benchmark` needs regardless of what the artifact itself
+    claims."""
+    _write_history(
+        state_dir,
+        [
+            {"computed_at_utc": _now_iso(before_days_ago), section: {metric: before_value}},
+            {"computed_at_utc": _now_iso(after_days_ago), section: {metric: after_value}},
+        ],
+    )
 
 
 class TestValidateBenchmark:
@@ -212,16 +270,24 @@ class TestBenchmarkTrustSwitch:
 
 class TestHasValidBenchmark:
     def test_false_by_default_even_for_schema_valid_file(self, tmp_path, monkeypatch):
-        """#813 HIGH-2: fail-closed default — a perfectly valid artifact is
-        still not trusted until the operator opts in."""
+        """#813 HIGH-2: fail-closed default — a perfectly valid, even
+        harness-history-corroborated artifact is still not trusted until the
+        operator opts in."""
         monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
-        _write_benchmark(tmp_path, "cycle-abc123", _GOOD_BENCHMARK)
-        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123") is False
+        _write_benchmark(tmp_path, "cycle-abc123", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path)
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123", integration_ts) is False
 
-    def test_true_for_schema_valid_file_when_trusted(self, tmp_path, monkeypatch):
+    def test_true_for_schema_valid_file_when_trusted_and_corroborated(self, tmp_path, monkeypatch):
+        """#819: trust ON + a schema-valid artifact naming an allowlisted
+        metric is STILL not enough — the harness's own scorecard history
+        must corroborate the improvement around the integration ts."""
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
-        _write_benchmark(tmp_path, "cycle-abc123", _GOOD_BENCHMARK)
-        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123") is True
+        _write_benchmark(tmp_path, "cycle-abc123", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path)  # before=1000 (3d ago) -> after=400 (now)
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle-abc123", integration_ts) is True
 
     def test_false_when_file_missing_even_if_trusted(self, tmp_path, monkeypatch):
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
@@ -273,8 +339,10 @@ class TestHasValidBenchmark:
         uuid-like id) is not a traversal attempt and must still resolve —
         only an actual '..' sequence, or a path separator, is rejected."""
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
-        _write_benchmark(tmp_path, "cycle.abc123", _GOOD_BENCHMARK)
-        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle.abc123") is True
+        _write_benchmark(tmp_path, "cycle.abc123", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path)
+        assert benchmark_evidence.has_valid_benchmark(tmp_path, "cycle.abc123", integration_ts) is True
 
 
 class TestBenchmarkFileExists:
@@ -289,3 +357,135 @@ class TestBenchmarkFileExists:
     def test_false_for_empty_or_none_cycle_id(self, tmp_path):
         assert benchmark_evidence.benchmark_file_exists(tmp_path, "") is False
         assert benchmark_evidence.benchmark_file_exists(tmp_path, None) is False
+
+
+# ─── #819: harness-history-corroborated verification ────────────────────────
+
+
+class TestVerifyBenchmark:
+    """:func:`verify_benchmark` is the actual #819 trust root — the
+    artifact is only ever a claim; these tests pin that the harness's own
+    ``scorecard/history.jsonl`` (never the artifact's own numbers) decides
+    the verdict."""
+
+    def test_true_when_registered_metric_direction_correct_and_history_improved(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-good", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path, before_value=1000, after_value=400)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-good", integration_ts) is True
+
+    def test_higher_is_better_metric_also_verifies(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        obj = dict(
+            _VERIFIABLE_BENCHMARK,
+            metric="compile_clean_ratio",
+            direction="higher_is_better",
+            baseline=0.5,
+            new_value=0.9,
+        )
+        _write_benchmark(tmp_path, "cyc-hib", obj)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(
+            tmp_path,
+            section="quality",
+            metric="compile_clean_ratio",
+            before_value=0.5,
+            after_value=0.95,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-hib", integration_ts) is True
+
+    def test_false_when_metric_not_in_allowlist(self, tmp_path, monkeypatch):
+        """A metric name the harness does not track can NEVER verify, no
+        matter how well-shaped the artifact or how favorable any history."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-bad-metric", dict(_GOOD_BENCHMARK))  # p95_latency_ms
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-bad-metric", integration_ts) is False
+
+    def test_false_when_direction_mismatches_canonical(self, tmp_path, monkeypatch):
+        """tokens_per_integration is canonically lower_is_better — an
+        artifact claiming higher_is_better for it must be rejected outright,
+        even if its own baseline/new_value are internally consistent with
+        that (lying) direction."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        obj = dict(
+            _VERIFIABLE_BENCHMARK,
+            direction="higher_is_better",
+            baseline=400,
+            new_value=1000,
+        )
+        _write_benchmark(tmp_path, "cyc-wrong-dir", obj)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path, before_value=1000, after_value=400)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-wrong-dir", integration_ts) is False
+
+    def test_false_when_history_shows_no_improvement(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-flat", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path, before_value=1000, after_value=1000)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-flat", integration_ts) is False
+
+    def test_false_when_history_shows_a_regression(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-regress", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path, before_value=400, after_value=1000)  # got WORSE
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-regress", integration_ts) is False
+
+    def test_false_when_no_history_at_all(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-nohist", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-nohist", integration_ts) is False
+
+    def test_false_when_trust_off_even_with_corroborating_history(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_BENCHMARK_TRUST", raising=False)
+        _write_benchmark(tmp_path, "cyc-untrusted", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path, before_value=1000, after_value=400)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-untrusted", integration_ts) is False
+
+    def test_forged_artifact_numbers_do_not_matter_when_history_is_flat(self, tmp_path, monkeypatch):
+        """The non-forgeability invariant: an internally-consistent,
+        schema-valid artifact claiming a huge improvement is worthless if
+        the harness's own history shows the real metric flat/regressed —
+        the artifact's baseline/new_value are never part of the decision."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        forged = dict(_VERIFIABLE_BENCHMARK, baseline=10_000, new_value=1)  # fabricated 10000x win
+        _write_benchmark(tmp_path, "cyc-forged", forged)
+        integration_ts = _now_iso(days_ago=2)
+        _corroborating_history(tmp_path, before_value=1000, after_value=1000)  # actually flat
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-forged", integration_ts) is False
+
+    def test_false_when_no_snapshot_after_integration_yet(self, tmp_path, monkeypatch):
+        """Both history entries are BEFORE the integration ts — nothing has
+        been observed since the claimed change landed, so there is nothing
+        to corroborate against yet."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-stale", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=0)
+        _corroborating_history(
+            tmp_path, before_value=1000, after_value=400,
+            before_days_ago=3, after_days_ago=2,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-stale", integration_ts) is False
+
+    def test_false_for_unparseable_integration_ts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-badts", _VERIFIABLE_BENCHMARK)
+        _corroborating_history(tmp_path)
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-badts", "not-a-timestamp") is False
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-badts", None) is False
+
+    def test_false_for_corrupt_history_lines(self, tmp_path, monkeypatch):
+        """A corrupt history file must degrade to False, never raise."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_benchmark(tmp_path, "cyc-corrupthist", _VERIFIABLE_BENCHMARK)
+        integration_ts = _now_iso(days_ago=2)
+        hist = tmp_path / "scorecard" / "history.jsonl"
+        hist.parent.mkdir(parents=True, exist_ok=True)
+        hist.write_text("{not json\nalso not json\n", encoding="utf-8")
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-corrupthist", integration_ts) is False

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -826,3 +826,36 @@ class TestGoalGaps:
         _minimal_repeat_failure_ledger(state_dir)
         for gap in scorecard.goal_gaps(state_dir, None):
             assert gap["vector"] in ("V1", "V2")
+
+
+# ─── #819 CRITICAL-1: history.jsonl must be a protected fitness sidecar ─────
+
+
+class TestHistoryIsFitnessProtected:
+    def test_history_jsonl_is_in_fitness_sidecars(self):
+        """benchmark_evidence.verify_benchmark (#819) treats
+        scorecard/history.jsonl as its trust root. Without it in
+        FITNESS_SIDECARS, the #789 spawn-boundary hash check (bridge.py,
+        which iterates this exact tuple) would never notice an instance
+        appending fabricated improving snapshots at runtime — a full bypass
+        of the #819 non-forgeability guarantee. Regression pin."""
+        assert "scorecard/history.jsonl" in scorecard.FITNESS_SIDECARS
+
+    def test_latest_and_history_are_both_hashed_and_change_together(self, tmp_path):
+        """Both sidecars are written by the SAME compute_scorecard call
+        (latest.json overwritten, history.jsonl appended immediately after)
+        — so a recompute changes both hashes together, confirming there is
+        no timing gap where history.jsonl could be considered "already
+        covered" by some other window than the one latest.json already
+        gets checked in."""
+        state_dir = tmp_path / "state"
+        _minimal_repeat_failure_ledger(state_dir)
+        before = scorecard.fitness_sidecar_hashes(state_dir)
+        assert before["scorecard/latest.json"] == "absent"
+        assert before["scorecard/history.jsonl"] == "absent"
+
+        scorecard.compute_scorecard(state_dir, None, force=True)
+
+        after = scorecard.fitness_sidecar_hashes(state_dir)
+        assert after["scorecard/latest.json"] != "absent"
+        assert after["scorecard/history.jsonl"] != "absent"

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -907,6 +907,59 @@ class TestTamperRepair:
         assert "tamper_repaired_at" not in entry
         assert _ledger_rows(state_dir) == []
 
+    # ─── #819 MED: "benchmark" is trusted ONLY on an optimization claim ────
+
+    def test_benchmark_signal_on_non_optimization_entry_is_tampered(self, tmp_path, monkeypatch):
+        """The MED bypass: `signal: "benchmark"` is context-free-trusted by
+        HARNESS_SIGNALS, but Pass 2 (its sole legitimate writer) only ever
+        writes it on an optimization-claim entry. A bare
+        `{"confirmed": true, "signal": "benchmark"}` with no (or a
+        non-optimization) `serves` could never have been written honestly —
+        it must be stripped by Pass 1 exactly like any other foreign signal,
+        not waved through as "harness-authored"."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"priority-forged-sig": {
+                "cycle_id": "cycle-forged-sig",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "priority 5",  # NOT an optimization claim
+                "confirmed": True,
+                "signal": "benchmark",
+            }},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["priority-forged-sig"]
+        assert "confirmed" not in entry
+        assert "signal" not in entry
+        assert entry["tamper_repaired_at"]
+        assert entry["tamper_signal"] == "benchmark"
+        rows = [r for r in _ledger_rows(state_dir) if r.get("phase") == "integrity"]
+        assert len(rows) == 1
+        assert rows[0]["foreign_signal"] == "benchmark"
+
+    def test_benchmark_signal_on_optimization_entry_is_not_tampered_by_pass1(self, tmp_path, monkeypatch):
+        """The legitimate counterpart: an optimization-claim entry carrying
+        `signal: "benchmark"` is NOT stripped by Pass 1 — it is left for
+        Pass 2 to re-verify from harness history (which will confirm or
+        revoke it based on actual corroboration, not merely on the presence
+        of the signal)."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-legit-sig", "cycle-legit-sig",
+            confirmed=True, signal="benchmark", ts_days_ago=2,
+        )
+        _write_benchmark(state_dir, "cycle-legit-sig", dict(_VERIFIABLE_BENCHMARK))
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
+        usage_evidence.confirm_serves(state_dir, None)
+        entry = _read_completed(state_dir)["entries"]["defect-legit-sig"]
+        assert "tamper_repaired_at" not in entry  # Pass 1 left it alone
+        assert entry["confirmed"] is True  # Pass 2 re-verified and confirmed it
+        assert entry["signal"] == "benchmark"
+
     def test_repaired_entry_reevaluates_honestly_same_pass(self, tmp_path):
         """A tampered entry whose artifact DOES have newer harness usage
         evidence is stripped, then re-confirmed honestly in the same pass —

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -316,7 +316,7 @@ class TestConfirmServes:
         assert usage_evidence.confirm_serves(state_dir, None) == 0
 
 
-# ─── #813: benchmark-evidence gate ──────────────────────────────────────────
+# ─── #813/#819: benchmark-evidence gate ─────────────────────────────────────
 
 
 _GOOD_BENCHMARK = {
@@ -327,11 +327,55 @@ _GOOD_BENCHMARK = {
     "direction": "lower_is_better",
 }
 
+# #819: an artifact naming a metric that IS in the harness-verifiable
+# allowlist (benchmark_evidence._HARNESS_METRICS) — used by every test that
+# needs the affirmative (or self-heal) path to actually land.
+_VERIFIABLE_BENCHMARK = {
+    "metric": "tokens_per_integration",
+    "baseline": 1000,
+    "new_value": 400,
+    "method": "scorecard cost section, before/after the integration cycle",
+    "direction": "lower_is_better",
+}
+
 
 def _write_benchmark(state_dir: Path, cycle_id: str, payload: dict) -> None:
     path = benchmark_evidence.benchmark_path(state_dir, cycle_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_history(state_dir: Path, snapshots: list[dict]) -> None:
+    """Write ``snapshots`` (each a full scorecard-history-line dict) to
+    ``<state_dir>/scorecard/history.jsonl`` — the harness trust root
+    ``benchmark_evidence.verify_benchmark`` reads (#819)."""
+    path = Path(state_dir) / "scorecard" / "history.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        for snap in snapshots:
+            fh.write(json.dumps(snap) + "\n")
+
+
+def _corroborating_history(
+    state_dir: Path,
+    *,
+    section: str = "cost",
+    metric: str = "tokens_per_integration",
+    before_value: float = 1000,
+    after_value: float = 400,
+    before_days_ago: float = 3,
+    after_days_ago: float = 0,
+) -> None:
+    """The harness's own scorecard history showing ``metric`` moved from
+    ``before_value`` to ``after_value`` — independent of whatever the
+    benchmark artifact itself claims (the #819 non-forgeability point)."""
+    _write_history(
+        state_dir,
+        [
+            {"computed_at_utc": _now_iso(before_days_ago), section: {metric: before_value}},
+            {"computed_at_utc": _now_iso(after_days_ago), section: {metric: after_value}},
+        ],
+    )
 
 
 def _completed_optimization_entry(
@@ -341,10 +385,11 @@ def _completed_optimization_entry(
     *,
     confirmed: bool | None = None,
     signal: str | None = None,
+    ts_days_ago: float = 2,
 ) -> None:
     entry: dict = {
         "cycle_id": cycle_id,
-        "ts": _now_iso(days_ago=2),
+        "ts": _now_iso(days_ago=ts_days_ago),
         "files_changed": ["scripts/used_tool.py"],
         "serves": "optimization latency",
     }
@@ -461,11 +506,16 @@ class TestBenchmarkEvidenceGateTrustOn:
     """SELFEVO_BENCHMARK_TRUST=1 (explicit operator opt-in): the affirmative
     path is live."""
 
-    def test_valid_benchmark_confirms_on_harness_signal(self, tmp_path, monkeypatch):
+    def test_valid_corroborated_benchmark_confirms_via_benchmark_signal(self, tmp_path, monkeypatch):
+        """#819: a schema-valid artifact naming an allowlisted metric AND
+        corroborated by the harness's own scorecard history confirms the
+        entry directly in Pass 2 — signal is ``"benchmark"``, not whatever
+        usage-evidence signal happens to also be present."""
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         state_dir = _state_dir(tmp_path)
-        _completed_optimization_entry(state_dir, "defect-opt3", "cycle-opt-3")
-        _write_benchmark(state_dir, "cycle-opt-3", dict(_GOOD_BENCHMARK))
+        _completed_optimization_entry(state_dir, "defect-opt3", "cycle-opt-3", ts_days_ago=2)
+        _write_benchmark(state_dir, "cycle-opt-3", dict(_VERIFIABLE_BENCHMARK))
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
         _write_usage_sidecar(
             state_dir,
             {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
@@ -474,7 +524,8 @@ class TestBenchmarkEvidenceGateTrustOn:
         assert usage_evidence.confirm_serves(state_dir, None) == 1
         entry = _read_completed(state_dir)["entries"]["defect-opt3"]
         assert entry["confirmed"] is True
-        assert entry["signal"] == "pycache"
+        assert entry["signal"] == "benchmark"
+        assert entry["confirmed_at"]
         assert "unconfirmed_reason" not in entry
 
     def test_no_benchmark_never_confirms(self, tmp_path, monkeypatch):
@@ -492,6 +543,10 @@ class TestBenchmarkEvidenceGateTrustOn:
         assert entry["unconfirmed_reason"] == "benchmark_missing"
 
     def test_invalid_benchmark_never_confirms(self, tmp_path, monkeypatch):
+        """#819: a schema-invalid artifact IS present (file_exists True) and
+        trust IS on — the reason is now ``benchmark_unverified`` (we looked
+        and could not verify it), distinct from both ``benchmark_missing``
+        and ``benchmark_untrusted``."""
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         state_dir = _state_dir(tmp_path)
         _completed_optimization_entry(state_dir, "defect-opt2", "cycle-opt-2")
@@ -504,19 +559,21 @@ class TestBenchmarkEvidenceGateTrustOn:
         assert usage_evidence.confirm_serves(state_dir, None) == 0
         entry = _read_completed(state_dir)["entries"]["defect-opt2"]
         assert entry["confirmed"] is False
-        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+        assert entry["unconfirmed_reason"] == "benchmark_unverified"
 
     def test_regression_benchmark_never_confirms(self, tmp_path, monkeypatch):
         """A benchmark file exists and is well-typed but proves a
-        regression (fails validate_benchmark's improvement check) — still
-        gated as untrusted, never confirms."""
+        regression (fails validate_benchmark's improvement check) — gated as
+        unverified (file present, trust on, but not verifiable), never
+        confirms."""
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         state_dir = _state_dir(tmp_path)
         _completed_optimization_entry(state_dir, "defect-opt5", "cycle-opt-5")
         _write_benchmark(
             state_dir, "cycle-opt-5",
-            dict(_GOOD_BENCHMARK, baseline=180, new_value=420),  # got SLOWER
+            dict(_VERIFIABLE_BENCHMARK, baseline=400, new_value=1000),  # got SLOWER
         )
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
         _write_usage_sidecar(
             state_dir,
             {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
@@ -525,7 +582,21 @@ class TestBenchmarkEvidenceGateTrustOn:
         assert usage_evidence.confirm_serves(state_dir, None) == 0
         entry = _read_completed(state_dir)["entries"]["defect-opt5"]
         assert entry["confirmed"] is False
-        assert entry["unconfirmed_reason"] == "benchmark_untrusted"
+        assert entry["unconfirmed_reason"] == "benchmark_unverified"
+
+    def test_corroborated_metric_but_unregistered_metric_name_never_confirms(self, tmp_path, monkeypatch):
+        """A schema-valid, well-typed artifact naming a metric NOT in the
+        harness allowlist can never confirm, even with trust on and even if
+        a same-named history section happens to exist — the metric-name gate
+        comes before history corroboration."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-opt6", "cycle-opt-6")
+        _write_benchmark(state_dir, "cycle-opt-6", dict(_GOOD_BENCHMARK))  # p95_latency_ms
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-opt6"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_unverified"
 
     def test_non_optimization_entry_unaffected(self, tmp_path, monkeypatch):
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
@@ -582,20 +653,43 @@ class TestBenchmarkEvidenceGateTrustOn:
         assert entry["confirmed"] is False
         assert entry["unconfirmed_reason"] == "benchmark_untrusted"
 
-    def test_preconfirmed_entry_with_valid_trusted_benchmark_stays_confirmed(self, tmp_path, monkeypatch):
+    def test_preconfirmed_entry_with_valid_trusted_corroborated_benchmark_stays_confirmed(
+        self, tmp_path, monkeypatch
+    ):
         """Not every pre-confirmed optimization entry is revoked — one that
-        already has a valid, trusted benchmark artifact is left confirmed."""
+        already verifies against harness history is left confirmed (#819:
+        via the ``benchmark`` signal Pass 2 itself owns, correcting a stale
+        ``pycache`` signal that never should have been the confirmer for an
+        optimization claim in the first place)."""
         monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
         state_dir = _state_dir(tmp_path)
         _completed_optimization_entry(
             state_dir, "defect-legit", "cycle-legit",
-            confirmed=True, signal="pycache",
+            confirmed=True, signal="pycache", ts_days_ago=2,
         )
-        _write_benchmark(state_dir, "cycle-legit", dict(_GOOD_BENCHMARK))
-        assert usage_evidence.confirm_serves(state_dir, None) == 0  # already confirmed, not "newly"
+        _write_benchmark(state_dir, "cycle-legit", dict(_VERIFIABLE_BENCHMARK))
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
         entry = _read_completed(state_dir)["entries"]["defect-legit"]
         assert entry["confirmed"] is True
+        assert entry["signal"] == "benchmark"
         assert "unconfirmed_reason" not in entry
+
+    def test_second_pass_over_already_benchmark_confirmed_entry_is_idempotent(self, tmp_path, monkeypatch):
+        """A steady-state verified entry (already confirmed=True,
+        signal="benchmark") must not be rewritten/re-counted on a second
+        pass — confirm_serves is watermark-cheap for the common case."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-steady", "cycle-steady", ts_days_ago=2,
+        )
+        _write_benchmark(state_dir, "cycle-steady", dict(_VERIFIABLE_BENCHMARK))
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        first = _read_completed(state_dir)
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        assert _read_completed(state_dir) == first
 
     def test_foreign_signal_optimization_entry_is_repaired_then_gated(self, tmp_path, monkeypatch):
         """A confirmed entry with BOTH a foreign (non-harness) signal and an
@@ -616,6 +710,113 @@ class TestBenchmarkEvidenceGateTrustOn:
         assert entry["unconfirmed_reason"] == "benchmark_missing"
 
 
+# ─── #819: harness-corroborated confirm / revoke / self-heal ────────────────
+
+
+class TestBenchmarkEvidenceHarnessCorroboration:
+    """The #819 acceptance shapes: an optimization claim confirms ONLY when
+    the harness's own scorecard history corroborates the named metric
+    improved; a forged pre-written confirmation is revoked when it doesn't;
+    and a previously-revoked entry SELF-HEALS once the history catches up —
+    all via the SAME re-derivation in Pass 2, never a separate restore path.
+    """
+
+    def test_harness_corroborated_optimization_confirms(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(state_dir, "defect-real", "cycle-real", ts_days_ago=2)
+        _write_benchmark(state_dir, "cycle-real", dict(_VERIFIABLE_BENCHMARK))
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["defect-real"]
+        assert entry["confirmed"] is True
+        assert entry["signal"] == "benchmark"
+
+    def test_forged_preconfirmed_entry_with_flat_history_is_revoked(self, tmp_path, monkeypatch):
+        """The exact forge shape #819 closes: confirmed=true and
+        signal="benchmark" are pre-written directly into completed.json (as
+        if by instance-authored code), AND a schema-valid benchmark artifact
+        with fabricated numbers exists — but the harness's own scorecard
+        history shows the metric never actually moved. Must be REVOKED to
+        confirmed=False / unconfirmed_reason=benchmark_unverified, not
+        trusted merely because the stored fields already look legitimate."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _completed_optimization_entry(
+            state_dir, "defect-forged-claim", "cycle-forged-claim",
+            confirmed=True, signal="benchmark", ts_days_ago=2,
+        )
+        _write_benchmark(
+            state_dir, "cycle-forged-claim",
+            dict(_VERIFIABLE_BENCHMARK, baseline=10_000, new_value=1),  # fabricated huge win
+        )
+        _corroborating_history(state_dir, before_value=1000, after_value=1000)  # actually flat
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-forged-claim"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_unverified"
+        assert entry.get("signal") != "benchmark"
+
+    def test_previously_revoked_entry_self_heals_once_history_corroborates(self, tmp_path, monkeypatch):
+        """A previously-revoked entry (confirmed=False,
+        unconfirmed_reason=benchmark_unverified from an earlier pass, before
+        the harness had observed the after-snapshot) becomes confirmed=True
+        the moment the harness's own history shows the improvement — no
+        separate restore branch, just the same re-derivation Pass 2 always
+        runs."""
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"defect-heal": {
+                "cycle_id": "cycle-heal",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "optimization latency",
+                "confirmed": False,
+                "unconfirmed_reason": "benchmark_unverified",
+            }},
+        )
+        _write_benchmark(state_dir, "cycle-heal", dict(_VERIFIABLE_BENCHMARK))
+        # First pass: history not yet corroborating (flat) — stays revoked.
+        _corroborating_history(state_dir, before_value=1000, after_value=1000)
+        assert usage_evidence.confirm_serves(state_dir, None) == 0
+        entry = _read_completed(state_dir)["entries"]["defect-heal"]
+        assert entry["confirmed"] is False
+        assert entry["unconfirmed_reason"] == "benchmark_unverified"
+
+        # Second pass: the harness has since observed the real improvement —
+        # self-heals to confirmed=True, signal="benchmark".
+        _corroborating_history(state_dir, before_value=1000, after_value=400)
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["defect-heal"]
+        assert entry["confirmed"] is True
+        assert entry["signal"] == "benchmark"
+        assert "unconfirmed_reason" not in entry
+
+    def test_non_optimization_entry_unaffected_by_harness_corroboration(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        state_dir = _state_dir(tmp_path)
+        _write_completed(
+            state_dir,
+            {"priority-normal2": {
+                "cycle_id": "cycle-normal2",
+                "ts": _now_iso(days_ago=2),
+                "files_changed": ["scripts/used_tool.py"],
+                "serves": "priority 5",
+            }},
+        )
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/used_tool.py": {"last_used": _now_iso(days_ago=1),
+                                      "last_touched": None, "signal": "pycache"}},
+        )
+        assert usage_evidence.confirm_serves(state_dir, None) == 1
+        entry = _read_completed(state_dir)["entries"]["priority-normal2"]
+        assert entry["confirmed"] is True
+        assert entry["signal"] == "pycache"
+
+
 # ─── #789: tamper repair (trust only harness signals) ───────────────────────
 
 
@@ -633,8 +834,10 @@ def _ledger_rows(state_dir: Path) -> list[dict]:
 class TestTamperRepair:
     def test_harness_signals_is_exactly_what_the_module_writes(self):
         """The whitelist IS the set of signal values refresh_usage puts into
-        used_candidates (and confirm_serves copies into entries)."""
-        assert usage_evidence.HARNESS_SIGNALS == frozenset({"pycache", "output"})
+        used_candidates (and confirm_serves copies into entries), plus
+        "benchmark" (#819) — the signal confirm_serves' Pass 2 writes on a
+        harness-history-verified optimization claim."""
+        assert usage_evidence.HARNESS_SIGNALS == frozenset({"pycache", "output", "benchmark"})
 
     def test_foreign_signal_entry_repaired_with_one_integrity_row(self, tmp_path):
         """The live 2026-07-17 shape: instance code wrote confirmed=True with


### PR DESCRIPTION
## Summary

Closes #819. Makes the #813 benchmark-evidence gate forge-proof so the operator trust switch (`SELFEVO_BENCHMARK_TRUST`, default OFF) can eventually be enabled safely.

- `benchmark_evidence.py`: adds `_HARNESS_METRICS` — an allowlist of the only 4 metrics a benchmark artifact can ever verify against (`tokens_per_integration`, `compile_clean_ratio`, `repeat_failure_rate`, `heldout_gap`), each mapped to its scorecard snapshot section + canonical improvement direction. Adds `verify_benchmark(state_dir, cycle_id, integration_ts)`: true only if trust is on, the artifact is schema-valid and names an allowlisted metric with the correct direction, AND the harness's own `state/scorecard/history.jsonl` shows that metric actually improved between the snapshot at-or-before `integration_ts` and the latest snapshot. The artifact's own `baseline`/`new_value` numbers are never part of the decision — only harness-observed data. `has_valid_benchmark` now delegates to `verify_benchmark` (gained an `integration_ts` param).
- `usage_evidence.py`: `confirm_serves` Pass 2 re-runs the verified check on *every* optimization-claim entry regardless of stored `confirmed`/`signal`. VERIFIED → `confirmed=True, signal="benchmark"` (this is simultaneously the confirm path and the self-heal path for a previously-revoked entry — no separate restore branch). NOT verified → `confirmed=False` with `unconfirmed_reason` ∈ `{benchmark_missing, benchmark_untrusted, benchmark_unverified}`. `"benchmark"` joins `HARNESS_SIGNALS` — safe only because Pass 2 always re-derives from harness history, so a forged `signal="benchmark"` entry gets no benefit of the doubt.
- `scorecard.py`: only the fallback `_harness_signals()` default set gained `"benchmark"`, kept in sync with `usage_evidence.HARNESS_SIGNALS`. No fitness/gap/ordering logic touched.

`SELFEVO_BENCHMARK_TRUST` still defaults OFF — #819 makes enabling it safe, it doesn't enable it.

## Test plan
- [x] `python -m pytest tests/test_benchmark_evidence.py tests/test_usage_evidence.py tests/test_scorecard.py -q` → 152 passed, 0 failed
- [x] `python -m py_compile` on all three modified runtime modules
- [x] New `TestVerifyBenchmark` class covers: allowlisted-metric+corroborated-history → True; unregistered metric → False; direction mismatch → False; flat/regressed history → False; no history → False; trust off → False; forged (fabricated numbers, flat real history) → False
- [x] New `TestBenchmarkEvidenceHarnessCorroboration` class in usage_evidence tests covers: harness-corroborated confirm; forged pre-written `confirmed=true/signal=benchmark` with flat history → revoked to `benchmark_unverified`; previously-revoked entry self-heals once history corroborates; non-optimization entries unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)