### PR TITLE
fix(runtime): suppress repeats of failed or rejected proposals (#716)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -118,6 +118,12 @@ _LEDGER_DIGEST_ROWS = 15
 _DUP_STREAK_K = 3
 _MAX_TITLE_CHARS = 120
 _RECENT_PROPOSED_TITLES_N = 10
+# #716: recency window for "attempted but never integrated" titles — see
+# _recent_failed_titles. Kept modest (same order of magnitude as
+# _LEDGER_DIGEST_ROWS) so an old failure ages out and stops blocking a
+# legitimate retry, rather than a permanent ban.
+_RECENT_FAILED_TITLES_N = 10
+_RECENT_FAILED_WINDOW_CYCLES = 15
 _MAX_LLM_CALLS = 3
 _MAX_CONSECUTIVE_NOOP_SKIPS = 3
 _MAX_SERVES_CHARS = 160
@@ -422,6 +428,90 @@ def _recent_proposed_titles(rows: list[dict[str, Any]], n: int = _RECENT_PROPOSE
     return titles
 
 
+# #716: outcomes that mean "attempted, but not integrated" — the opposite of
+# 'success'/'promotion_candidate', which DID land. Deliberately excludes
+# 'skipped-duplicate' (never an attempt at new work; already covered by
+# _recent_proposed_titles/git-log dedup).
+_NON_INTEGRATED_OUTCOMES = frozenset({"failed", "partial", "timeout"})
+# #716: gate rollback reasons that mean the cycle produced real work but it
+# was blocked from integrating — same "attempted, not integrated" bucket as
+# _NON_INTEGRATED_OUTCOMES above, just recorded on a 'gate' row instead of an
+# 'outcome' row.
+_NON_INTEGRATED_GATE_REASONS = frozenset(
+    {"mutation_surface_violation", "blocked_file_present", "gate_failed"}
+)
+
+
+def _recent_failed_titles(
+    rows: list[dict[str, Any]],
+    n: int = _RECENT_FAILED_TITLES_N,
+    window_cycles: int = _RECENT_FAILED_WINDOW_CYCLES,
+) -> list[str]:
+    """Titles of recent attempts that were NEVER integrated (#716).
+
+    Before this, the proposer's context only showed already-INTEGRATED work
+    (git log) and its OWN recently-proposed titles
+    (:func:`_recent_proposed_titles`) — it had no visibility into a theme it
+    already tried that failed, timed out, or was rolled back by the gate, so
+    it kept re-proposing the same dead-end idea (observed live: 26
+    ``proposer_reject reason=self_dedup`` in one loop run, each a re-hit of
+    an already-attempted-but-failed theme).
+
+    Joins two ledger phases back to their originating ``'proposed'`` row via
+    ``cycle_id`` (the only field that links a title to its terminal result):
+
+    - an ``'outcome'`` row whose ``outcome`` is in
+      :data:`_NON_INTEGRATED_OUTCOMES` (``failed``/``partial``/``timeout`` —
+      attempted, but never integrated; ``success`` and
+      ``promotion_candidate`` are excluded on purpose, they DID integrate);
+    - a ``'gate'`` row that blocked integration (``allowed`` falsy) with a
+      rollback ``reason`` in :data:`_NON_INTEGRATED_GATE_REASONS`.
+
+    Restricted to the last ``window_cycles`` rows of each phase — a
+    deliberate recency policy (#716): an old failure ages out and stops
+    blocking a retry, since the surrounding code/goal may have shifted
+    enough that the same title is worth another attempt. Titles are
+    deduplicated (first occurrence wins) and capped at ``n``. Fail-open: any
+    error yields ``[]`` (never blocks a proposal it can't confidently flag).
+    """
+    try:
+        title_by_cycle: dict[str, str] = {}
+        for row in _proposed_rows(rows):
+            cycle_id = str(row.get("cycle_id") or "").strip()
+            title = str(row.get("task_title") or "").strip()
+            if cycle_id and title:
+                title_by_cycle[cycle_id] = title
+
+        failed_cycle_ids: list[str] = []
+        for row in _terminal_rows(rows)[-window_cycles:]:
+            if str(row.get("outcome") or "") in _NON_INTEGRATED_OUTCOMES:
+                cycle_id = str(row.get("cycle_id") or "").strip()
+                if cycle_id:
+                    failed_cycle_ids.append(cycle_id)
+
+        gate_rows = [r for r in rows if r.get("phase") == "gate"]
+        for row in gate_rows[-window_cycles:]:
+            if row.get("allowed"):
+                continue
+            if str(row.get("reason") or "") in _NON_INTEGRATED_GATE_REASONS:
+                cycle_id = str(row.get("cycle_id") or "").strip()
+                if cycle_id:
+                    failed_cycle_ids.append(cycle_id)
+
+        titles: list[str] = []
+        seen: set[str] = set()
+        for cycle_id in failed_cycle_ids:
+            title = title_by_cycle.get(cycle_id)
+            if title and title not in seen:
+                seen.add(title)
+                titles.append(title)
+                if len(titles) >= n:
+                    break
+        return titles
+    except Exception:
+        return []
+
+
 def _last_k_all_duplicate(state_dir: Path, k: int = _DUP_STREAK_K) -> bool:
     terminal = _terminal_rows(_load_ledger_rows(state_dir))
     if len(terminal) < k:
@@ -686,6 +776,7 @@ def build_context(
         ledger_rows = _load_ledger_rows(state_dir)
         digest_lines = _digest_ledger(ledger_rows)
         recent_proposed_titles = _recent_proposed_titles(ledger_rows)
+        recent_failed_titles = _recent_failed_titles(ledger_rows)
         surface_rule = (
             "Mutable surface rule: target_path MUST be a single path under "
             "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + " — no other "
@@ -714,8 +805,18 @@ def build_context(
             "## Recently proposed (rejected as duplicates — do NOT propose these themes again)",
             "\n".join(f"- {title}" for title in recent_proposed_titles) or "(none yet)",
             "",
-            surface_rule,
         ]
+        # #716: only appended when non-empty (unlike the section above, which
+        # always shows a "(none yet)" placeholder) — with no recent failures,
+        # this keeps build_context's output byte-identical to pre-#716.
+        if recent_failed_titles:
+            parts += [
+                "## Recently attempted but NOT integrated (failed/rejected — "
+                "do NOT re-propose the same approach; choose different work)",
+                "\n".join(f"- {title}" for title in recent_failed_titles),
+                "",
+            ]
+        parts.append(surface_rule)
         context = "\n".join(parts)
         if len(context) > _MAX_CONTEXT_CHARS:
             context = context[:_MAX_CONTEXT_CHARS]
@@ -913,15 +1014,23 @@ def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
 def _is_duplicate_proposal(
     state_dir: Path, selfevo_repo: Path | None, proposal: dict[str, Any]
 ) -> tuple[bool, str, str]:
-    """Pre-write self-dedup (#707 canary novelty collapse).
+    """Pre-write self-dedup (#707 canary novelty collapse; extended by #716).
 
     Reuses the SAME per-line proportional word-overlap heuristic the bridge
     and deterministic planner already use for "is this title already done"
-    (``cycle_planning._title_already_done_in_git_log``), fed with two sources
-    concatenated: the recent git log (already-DONE work) and this proposer's
-    own recent ``'proposed'`` ledger titles (already-REJECTED-as-duplicate
-    work, which never reaches git log since no commit is ever made for it).
-    Either source matching is sufficient to flag a duplicate.
+    (``cycle_planning._title_already_done_in_git_log``), fed with three
+    sources concatenated: the recent git log (already-DONE work), this
+    proposer's own recent ``'proposed'`` ledger titles (already-REJECTED-as-
+    duplicate work, which never reaches git log since no commit is ever made
+    for it), and (#716) recent titles that WERE attempted but never
+    integrated — failed, timed out, or gate-blocked
+    (:func:`_recent_failed_titles`), which also never reach git log. Any
+    source matching is sufficient to flag a duplicate.
+
+    #716 policy note: :func:`_recent_failed_titles` only looks back a small,
+    recent window, so this is a temporary "don't immediately re-hit the same
+    dead end" guard, not a permanent ban — an old failure ages out and a
+    retry is allowed again once it exits the window.
 
     Returns ``(True, feedback_text, matched_against)`` on a match —
     ``feedback_text`` is meant to be passed as ``propose()``'s
@@ -937,8 +1046,14 @@ def _is_duplicate_proposal(
         if not title:
             return False, "", ""
         git_log = _recent_git_log(Path(selfevo_repo)) if selfevo_repo else ""
-        recent_titles = _recent_proposed_titles(_load_ledger_rows(state_dir))
-        combined_log = "\n".join([git_log] + recent_titles) if (git_log or recent_titles) else ""
+        ledger_rows = _load_ledger_rows(state_dir)
+        recent_titles = _recent_proposed_titles(ledger_rows)
+        recent_failed_titles = _recent_failed_titles(ledger_rows)
+        combined_log = (
+            "\n".join([git_log] + recent_titles + recent_failed_titles)
+            if (git_log or recent_titles or recent_failed_titles)
+            else ""
+        )
         if combined_log and _title_already_done_in_git_log(title, combined_log):
             # The heuristic is per-line (>= a proportional share of the
             # title's words on ONE line), so re-running it line-by-line
@@ -952,9 +1067,10 @@ def _is_duplicate_proposal(
                 "",
             )
             return True, (
-                f"your proposal '{title}' duplicates already-done or "
-                "recently-rejected work; propose something from a DIFFERENT "
-                "area, preferring the numbered Current priority targets"
+                f"your proposal '{title}' duplicates already-done, "
+                "recently-rejected, or recently-failed (non-integrated) "
+                "work; propose something from a DIFFERENT area, preferring "
+                "the numbered Current priority targets"
             ), matched_against
         return False, "", ""
     except Exception:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -489,6 +489,17 @@ def _recent_failed_titles(
                 if cycle_id:
                     failed_cycle_ids.append(cycle_id)
 
+        # #825 review (MED-3, deliberate, not a bug): a gate-blocked title
+        # (out-of-surface path, blocked filename, or a smoke/runtime-slice
+        # gate that never went green) feeds the SAME suppression path as a
+        # failed outcome — re-proposing the identical wrong approach is
+        # exactly #716's motivating case (an out-of-surface rejection kept
+        # getting re-proposed). This is windowed (ages out of the
+        # window_cycles lookback) and, via _is_duplicate_proposal's
+        # self_dedup rejects, subject to demand.py's existing 24h exhaustion
+        # expiry — so it is a temporary "stop repeating the same mistake"
+        # nudge, never a permanent ban. Do not "fix" this by excluding gate
+        # rows.
         gate_rows = [r for r in rows if r.get("phase") == "gate"]
         for row in gate_rows[-window_cycles:]:
             if row.get("allowed"):
@@ -498,15 +509,23 @@ def _recent_failed_titles(
                 if cycle_id:
                     failed_cycle_ids.append(cycle_id)
 
+        # #825 review fix: failed_cycle_ids is built oldest-to-newest (ledger
+        # append order), so applying the cap forward would keep the OLDEST
+        # n titles and silently drop the newest failures — exactly the
+        # recent churn #716 needs visible. Walk it newest-first to fill the
+        # cap with the most recent failures, then reverse back so the
+        # returned list matches _recent_proposed_titles' convention
+        # (oldest-first, most-recent-last).
         titles: list[str] = []
         seen: set[str] = set()
-        for cycle_id in failed_cycle_ids:
+        for cycle_id in reversed(failed_cycle_ids):
             title = title_by_cycle.get(cycle_id)
             if title and title not in seen:
                 seen.add(title)
                 titles.append(title)
                 if len(titles) >= n:
                     break
+        titles.reverse()
         return titles
     except Exception:
         return []
@@ -816,10 +835,20 @@ def build_context(
                 "\n".join(f"- {title}" for title in recent_failed_titles),
                 "",
             ]
-        parts.append(surface_rule)
-        context = "\n".join(parts)
-        if len(context) > _MAX_CONTEXT_CHARS:
-            context = context[:_MAX_CONTEXT_CHARS]
+        # #825 review fix: surface_rule (the mutable-surface path constraint)
+        # must never be truncated away. Previously the whole body + rule was
+        # joined THEN hard-cut to _MAX_CONTEXT_CHARS as one blob, so a large
+        # enough failed-titles/digest section could push surface_rule past
+        # the cut and silently drop it — the model would then lose the path
+        # rule, propose off-surface, get gate-blocked, and add ANOTHER
+        # failed-title entry next cycle (a compounding loop). Truncate only
+        # the body ahead of it, reserving room for surface_rule + the "\n"
+        # joining it, then always append surface_rule after truncation.
+        body = "\n".join(parts)
+        budget = max(0, _MAX_CONTEXT_CHARS - len(surface_rule) - 1)
+        if len(body) > budget:
+            body = body[:budget]
+        context = body + "\n" + surface_rule
 
         if demand_items:
             demand_body = _demand_section(demand_items)

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -398,6 +398,30 @@ class TestBuildContext:
         context = llm_proposer.build_context(state_dir, None)
         assert len(context) <= llm_proposer._MAX_CONTEXT_CHARS
 
+    def test_surface_rule_survives_truncation_with_oversized_context(self, tmp_path):
+        """#825 review FIX 2: surface_rule (the mutable-surface path
+        constraint) must never be truncated away. An oversized goal text
+        PLUS a burst of #716 failed-title rows (each with a fairly long
+        title, to push the joined context well past _MAX_CONTEXT_CHARS)
+        must still leave the surface rule intact in the returned context —
+        losing it would let the model target an out-of-surface path
+        uncorrected, which gate-blocks and adds yet another failed title
+        (a compounding loop)."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "x" * 6000)
+        for i in range(llm_proposer._RECENT_FAILED_WINDOW_CYCLES):
+            _append_proposed(
+                state_dir, f"c{i}",
+                f"Failing task with a fairly long descriptive title number {i}",
+            )
+            _append_outcome(state_dir, f"c{i}", "failed")
+
+        context = llm_proposer.build_context(state_dir, None)
+        assert "Mutable surface rule" in context
+        assert "no other path is acceptable." in context
+        assert context.endswith("no other path is acceptable.")
+        assert len(context) <= llm_proposer._MAX_CONTEXT_CHARS
+
     def test_missing_ledger_is_fail_open(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, "some goal text")
@@ -644,6 +668,30 @@ class TestRecentFailedTitles:
 
     def test_no_ledger_rows_is_fail_open_empty(self, tmp_path):
         assert llm_proposer._recent_failed_titles([]) == []
+
+    def test_cap_keeps_newest_not_oldest(self, tmp_path):
+        """#825 review FIX 1: failed_cycle_ids is built oldest-to-newest
+        (ledger append order); with more than _RECENT_FAILED_TITLES_N
+        distinct failures in the window, capping must keep the NEWEST
+        ones (the recent churn #716 needs visible) — not silently retain
+        the oldest N and drop the very failures that motivated this
+        feature."""
+        state_dir = _state_dir(tmp_path)
+        total = llm_proposer._RECENT_FAILED_WINDOW_CYCLES
+        for i in range(total):
+            _append_proposed(state_dir, f"c{i}", f"Failing task {i}")
+            _append_outcome(state_dir, f"c{i}", "failed")
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        titles = llm_proposer._recent_failed_titles(rows)
+
+        n = llm_proposer._RECENT_FAILED_TITLES_N
+        assert len(titles) == n
+        # Newest n are kept, returned oldest-first (matching
+        # _recent_proposed_titles' "most-recent-last" convention).
+        expected = [f"Failing task {i}" for i in range(total - n, total)]
+        assert titles == expected
+        assert "Failing task 0" not in titles
 
 
 # ─── validate_sizing ─────────────────────────────────────────────────────────

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -70,6 +70,13 @@ def _append_skip(state_dir: Path, reason: str = "nothing valuable") -> None:
     cycle_ledger.append_event(state_dir, {"phase": "proposer_skip", "reason": reason})
 
 
+def _append_gate(state_dir: Path, cycle_id: str, allowed: bool, reason: str = "") -> None:
+    cycle_ledger.append_event(
+        state_dir,
+        {"phase": "gate", "cycle_id": cycle_id, "allowed": allowed, "reason": reason},
+    )
+
+
 # ─── kill-switch ───────────────────────────────────────────────────────────
 
 
@@ -420,6 +427,37 @@ class TestBuildContext:
         context = llm_proposer.build_context(state_dir, None)
         assert "(none yet)" in context
 
+    def test_recent_failed_title_appears_under_not_integrated_section(self, tmp_path):
+        """#716: a title from a recent, non-integrated attempt (failed
+        outcome) surfaces under its own section, distinct from the
+        'Recently proposed' duplicates block, so the model sees it tried
+        and failed at this theme even though no commit for it ever landed
+        in git log."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        _append_proposed(state_dir, "c1", "Add a memory-leak detector script")
+        _append_outcome(state_dir, "c1", "failed")
+
+        context = llm_proposer.build_context(state_dir, None)
+        assert "Recently attempted but NOT integrated" in context
+        assert "do NOT re-propose the same approach" in context
+        assert "Add a memory-leak detector script" in context
+        assert len(context) <= llm_proposer._MAX_CONTEXT_CHARS
+
+    def test_no_recent_failures_omits_new_section_entirely(self, tmp_path):
+        """#716 acceptance: with no recent non-integrated attempts,
+        build_context's output is byte-identical to pre-#716 — the new
+        section is omitted entirely rather than shown empty (unlike the
+        'Recently proposed' block, which always shows a '(none yet)'
+        placeholder)."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "some real goal text")
+        _append_proposed(state_dir, "c1", "Add a memory-leak detector script")
+        _append_outcome(state_dir, "c1", "success")
+
+        context = llm_proposer.build_context(state_dir, None)
+        assert "Recently attempted but NOT integrated" not in context
+
     def test_absent_gracefully_when_no_selfevo_repo(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, "some real goal text")
@@ -528,6 +566,84 @@ class TestBuildContext:
         assert len(inventory_section) <= llm_proposer._MAX_INVENTORY_CHARS + len(
             "## Existing scripts (do not duplicate — extend or skip instead)\n"
         )
+
+
+# ─── #716: _recent_failed_titles (recent non-integrated attempts) ──────────
+
+
+class TestRecentFailedTitles:
+    def test_failed_outcome_joined_to_title_via_cycle_id(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "Add a memory-leak detector script")
+        _append_outcome(state_dir, "c1", "failed")
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        assert llm_proposer._recent_failed_titles(rows) == ["Add a memory-leak detector script"]
+
+    @pytest.mark.parametrize("outcome", ["failed", "partial", "timeout"])
+    def test_non_integrated_outcomes_are_included(self, tmp_path, outcome):
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "Add a disk-usage sweeper script")
+        _append_outcome(state_dir, "c1", outcome)
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        assert llm_proposer._recent_failed_titles(rows) == ["Add a disk-usage sweeper script"]
+
+    @pytest.mark.parametrize("outcome", ["success", "promotion_candidate", "skipped-duplicate"])
+    def test_integrated_or_deduped_outcomes_are_excluded(self, tmp_path, outcome):
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "Add a disk-usage sweeper script")
+        _append_outcome(state_dir, "c1", outcome)
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        assert llm_proposer._recent_failed_titles(rows) == []
+
+    @pytest.mark.parametrize(
+        "reason", ["mutation_surface_violation", "blocked_file_present", "gate_failed"]
+    )
+    def test_blocked_gate_rows_are_included(self, tmp_path, reason):
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "Add a runtime slice profiler")
+        _append_gate(state_dir, "c1", allowed=False, reason=reason)
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        assert llm_proposer._recent_failed_titles(rows) == ["Add a runtime slice profiler"]
+
+    def test_allowed_gate_row_is_excluded(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c1", "Add a runtime slice profiler")
+        _append_gate(state_dir, "c1", allowed=True, reason="smoke_passed")
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        assert llm_proposer._recent_failed_titles(rows) == []
+
+    def test_old_failure_outside_window_does_not_block(self, tmp_path):
+        """#716 recency policy: a failure that has scrolled outside the
+        recent window ages out — a retry of the same title is not
+        permanently blocked."""
+        state_dir = _state_dir(tmp_path)
+        _append_proposed(state_dir, "c-old", "Add a memory-leak detector script")
+        _append_outcome(state_dir, "c-old", "failed")
+        # Push c-old's outcome row out of the recent window with filler
+        # terminal rows (unrelated cycles, no matching 'proposed' title).
+        for i in range(llm_proposer._RECENT_FAILED_WINDOW_CYCLES):
+            _append_outcome(state_dir, f"filler-{i}", "success")
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        assert llm_proposer._recent_failed_titles(rows) == []
+
+    def test_dedup_and_cap(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        for i in range(llm_proposer._RECENT_FAILED_TITLES_N + 5):
+            _append_proposed(state_dir, f"c{i}", "Add a memory-leak detector script")
+            _append_outcome(state_dir, f"c{i}", "failed")
+
+        rows = llm_proposer._load_ledger_rows(state_dir)
+        titles = llm_proposer._recent_failed_titles(rows)
+        assert titles == ["Add a memory-leak detector script"]
+
+    def test_no_ledger_rows_is_fail_open_empty(self, tmp_path):
+        assert llm_proposer._recent_failed_titles([]) == []
 
 
 # ─── validate_sizing ─────────────────────────────────────────────────────────
@@ -854,6 +970,106 @@ class TestSelfDedup:
         assert len(calls) <= 3
         assert len(calls) == 2  # sizing passes both times; only the dedup retry is spent
         assert not (state_dir / "subagents" / "requests").exists()
+
+    def test_duplicate_via_recent_failed_title_rejected(self, tmp_path, monkeypatch):
+        """#716: a title never committed to git and never itself
+        re-proposed, but matching a recent attempt that FAILED (never
+        integrated), is still caught pre-write — this is the #716 loop-
+        health defect: the proposer kept re-proposing themes it had already
+        tried and failed at, because neither git log nor its own recent-
+        proposed-titles list carries a failed attempt's title."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        _append_proposed(state_dir, "c-old", "Implement lightweight memory usage monitor for eeepc")
+        _append_outcome(state_dir, "c-old", "failed")
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            if rejection_reason is None:
+                return {
+                    "task_title": "Implement lightweight memory usage tracker",
+                    "rationale": "Tracks memory usage.",
+                    "target_path": "scripts/mem.py",
+                    "serves": "priority 4",
+                }
+            return {
+                "task_title": "Document the release checklist",
+                "rationale": "Fills a documentation gap.",
+                "target_path": "docs/release.md",
+                "serves": "priority 4",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+
+        assert result is not None
+        assert "release checklist" in result
+        assert len(calls) == 2
+        assert calls[1] is not None
+        assert "recently-failed" in calls[1]
+
+    def test_genuinely_new_work_is_not_flagged_as_duplicate(self, tmp_path, monkeypatch):
+        """Sanity check for #716: a proposal unrelated to any recent failure
+        (or duplicate) passes through untouched on the first try."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        _append_proposed(state_dir, "c-old", "Add a memory-leak detector script")
+        _append_outcome(state_dir, "c-old", "failed")
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            return {
+                "task_title": "Document the deployment runbook",
+                "rationale": "Fills a documentation gap.",
+                "target_path": "docs/deploy.md",
+                "serves": "priority 4",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+
+        assert result is not None
+        assert "deployment runbook" in result
+        assert len(calls) == 1
+        assert calls[0] is None
+
+    def test_old_failure_outside_window_does_not_block_retry(self, tmp_path, monkeypatch):
+        """#716 policy: the recency window means an old (aged-out) failure
+        does not permanently ban a retry of the same theme. Filler cycles
+        are BOTH 'proposed' and 'outcome' rows so the old title also ages
+        out of the (unrelated, pre-existing) recent-proposed-titles window
+        — otherwise that separate mechanism would still catch it and the
+        test would not isolate the new #716 behavior."""
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        _append_proposed(state_dir, "c-old", "Implement lightweight memory usage monitor for eeepc")
+        _append_outcome(state_dir, "c-old", "failed")
+        for i in range(llm_proposer._RECENT_FAILED_WINDOW_CYCLES):
+            _append_proposed(state_dir, f"filler-{i}", f"Unrelated filler task {i}")
+            _append_outcome(state_dir, f"filler-{i}", "success")
+
+        calls = []
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0):
+            calls.append(rejection_reason)
+            return {
+                "task_title": "Implement lightweight memory usage tracker",
+                "rationale": "Tracks memory usage.",
+                "target_path": "scripts/mem.py",
+                "serves": "priority 4",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state_dir, None)
+
+        assert result is not None
+        assert "memory usage tracker" in result
+        assert len(calls) == 1
+        assert calls[0] is None
 
 
 # ─── prompt: prefer numbered "Current priority targets" ────────────────────


### PR DESCRIPTION
## Summary

Closes #716. The live loop showed 26 `proposer_reject reason=self_dedup`, 64% idle, `repeat_failure_rate=1.26` — the proposer kept re-proposing themes that had already been **attempted and failed** (never integrated), because its context only ever surfaced *integrated* work (git log) and its *own* recently-proposed titles, never recent non-integrated failures.

- Adds `_recent_failed_titles(rows, n=_RECENT_FAILED_TITLES_N, window_cycles=_RECENT_FAILED_WINDOW_CYCLES)` (`nanobot/runtime/llm_proposer.py:463`, after `_recent_proposed_titles`). Joins two ledger phases back to their originating `'proposed'` row via `cycle_id`:
  - an `'outcome'` row with `outcome` in `{failed, partial, timeout}` (attempted, never integrated — `success`/`promotion_candidate` are excluded, they DID integrate);
  - a `'gate'` row that blocked integration (`allowed` falsy) with `reason` in `{mutation_surface_violation, blocked_file_present, gate_failed}`.
  Restricted to the last `_RECENT_FAILED_WINDOW_CYCLES` (=15) rows of each phase — a deliberate recency policy: an old failure ages out and a retry is allowed again, it is not a permanent ban. Deduped, capped at `_RECENT_FAILED_TITLES_N` (=10). Fail-open (`[]` on any error).
- `build_context` (`nanobot/runtime/llm_proposer.py`) appends a new `"## Recently attempted but NOT integrated (failed/rejected — do NOT re-propose the same approach; choose different work)"` section, listing these titles — only when non-empty, so behavior with zero recent failures is byte-identical to before.
- `_is_duplicate_proposal` now folds `_recent_failed_titles` into its `combined_log` (alongside git log and recently-proposed titles), so a re-proposal matching a recently-failed theme is rejected pre-spawn with `reason=self_dedup`, same mechanism as an already-integrated or already-proposed duplicate.

## Ownership

Edited only `nanobot/runtime/llm_proposer.py` and `tests/test_llm_proposer.py`, per the issue's strict scope. No changes to bridge.py, demand.py, scorecard.py, usage_evidence.py, benchmark_evidence.py, or anything else — the exhaustion logic in `demand.py` (marks a demand_id exhausted after ≥2 self_dedup rejects) is untouched and now benefits from more precise self_dedup signal.

## Test plan

- [x] `python -m pytest tests/test_llm_proposer.py -q` — 131 passed (112 pre-existing + 19 new; sandbox needed an in-process `sys.modules['tests']` override to work around a stray global `tests` package shadowing the repo's `tests/` for cross-file imports — no repo files touched for this).
- [x] `python -m py_compile nanobot/runtime/llm_proposer.py tests/test_llm_proposer.py`
- [x] New tests cover: non-integrated outcome set (failed/partial/timeout) vs excluded (success/promotion_candidate/skipped-duplicate); gate-row rollback reasons; recency window aging out an old failure (unit + `maybe_propose` integration); dedup+cap; the new `build_context` section present/absent; `_is_duplicate_proposal` rejecting a recent-failure match; genuinely new work still passing through untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>