### PR TITLE
fix(runtime): integration discards gate-passing work — checkout_main_failed on a dirty tree (#828)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -488,6 +488,22 @@ def _integrate_cycle_to_main(repo_root: 'Path', cycle_branch: str, main_sha_befo
     git = _git_cmd(repo_root)
     base = main_sha_before or 'origin/main'
 
+    # #828: force the shared checkout onto the CYCLE BRANCH's committed tip with a
+    # clean tree BEFORE moving to main. Some subagents run `git checkout ...` / other
+    # git ops mid-cycle despite the branch-discipline rule, leaving the tree dirty
+    # (and occasionally moving HEAD off the cycle branch). Without this, a dirty tree
+    # makes `git checkout -B main` refuse to overwrite local modifications and return
+    # checkout_main_failed — silently discarding the committed, gate-passing cycle
+    # work (observed 8x/24h once a capable model started producing integrable work).
+    # Checking out ``cycle_branch`` BY NAME (not a bare HEAD-relative reset) also
+    # guarantees we integrate the real committed deliverable regardless of where a
+    # misbehaving subagent left HEAD (#828 review). SAFE: the deliverable is COMMITTED
+    # on ``cycle_branch``; only non-deliverable stray tree changes are cleared.
+    co_cycle = _sp_int.run(git + ['checkout', '-f', cycle_branch], capture_output=True, text=True)
+    if co_cycle.returncode != 0:
+        return {'ok': False, 'main_sha_after': main_sha_before, 'reason': 'checkout_cycle_failed'}
+    _sp_int.run(git + ['clean', '-fd'], capture_output=True)
+
     checkout_main = _sp_int.run(git + ['checkout', '-B', 'main', base], capture_output=True, text=True)
     if checkout_main.returncode != 0:
         return {'ok': False, 'main_sha_after': main_sha_before, 'reason': 'checkout_main_failed'}
@@ -500,6 +516,20 @@ def _integrate_cycle_to_main(repo_root: 'Path', cycle_branch: str, main_sha_befo
         _sp_int.run(git + ['merge', '--abort'], capture_output=True)
         _sp_int.run(git + ['reset', '--hard', base], capture_output=True)
         return {'ok': False, 'main_sha_after': main_sha_before, 'reason': 'merge_conflict'}
+
+    # #828 review: a `--no-ff` merge of a cycle branch with real commits ALWAYS
+    # creates a merge commit, so HEAD advances past ``base``. If HEAD is still at
+    # ``base`` here, ``cycle_branch`` had nothing to integrate (e.g. a misbehaving
+    # subagent committed OFF the cycle branch) — fail loudly rather than push a
+    # no-op and falsely report the cycle as integrated with ``main`` unchanged.
+    _post_merge = _sp_int.run(git + ['rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
+    # Resolve ``base`` to a sha for the comparison — it may be the literal
+    # 'origin/main' fallback, which would never equal a resolved HEAD sha and so
+    # silently defeat the guard (#828 review LOW). Only fire when both resolve.
+    _base_sha = _safe_rev_parse(repo_root, base)
+    if _post_merge and _base_sha and _post_merge == _base_sha:
+        _sp_int.run(git + ['reset', '--hard', base], capture_output=True)
+        return {'ok': False, 'main_sha_after': main_sha_before, 'reason': 'empty_integration'}
 
     push = _sp_int.run(git + ['push', 'origin', 'main'], capture_output=True, text=True)
     if push.returncode != 0:

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -124,6 +124,50 @@ class TestIntegrateCycleToMain:
         assert current_branch == "main"
         assert (work / "feature.py").exists()
 
+    def test_dirty_tree_at_integration_still_integrates(self, tmp_path):
+        """#828: a subagent may leave the shared checkout's working tree dirty
+        at integration time (stray uncommitted edits / untracked files — some
+        even run `git checkout <file>` mid-cycle despite the branch-discipline
+        rule). Before #828, `git checkout -B main` refused to overwrite those
+        local mods → checkout_main_failed → the committed, gate-passing cycle
+        work was silently discarded and main never advanced. The integration
+        must now discard the stray tree changes and land the committed work."""
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "dirtyok")
+        assert setup["ok"]
+        _commit_file(work, "feature.py", "def feature():\n    return 42\n", "feat: add feature")
+        # Dirty the tree AFTER committing the deliverable: an uncommitted edit to
+        # a tracked file + a stray untracked file, exactly what breaks checkout.
+        (work / "mod.py").write_text("def ok():\n    return 'uncommitted stray'\n")
+        (work / "stray_untracked.txt").write_text("junk\n")
+
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], setup["main_sha"])
+
+        assert integ["ok"] is True, integ
+        assert integ["reason"] != "checkout_main_failed"
+        assert _origin_main_sha(origin) == integ["main_sha_after"]
+        assert _local_main_sha(work) == integ["main_sha_after"]
+        assert (work / "feature.py").exists()  # committed deliverable landed
+        assert not (work / "stray_untracked.txt").exists()  # stray change cleared
+        # mod.py reverted to its committed content (stray edit discarded)
+        assert "uncommitted stray" not in (work / "mod.py").read_text()
+
+    def test_empty_cycle_branch_reports_failure_not_false_success(self, tmp_path):
+        """#828 review: if the cycle branch has no commits beyond base (e.g. a
+        misbehaving subagent committed OFF the cycle branch), the --no-ff merge
+        is a no-op and HEAD stays at base. Integration must report a loud failure
+        (empty_integration) with main unchanged — never a false 'integrated'."""
+        origin, work = _init_repo(tmp_path)
+        setup = bridge._setup_cycle_branch(work, "empty")
+        assert setup["ok"]
+        # Deliberately commit NOTHING on the cycle branch → it equals base.
+        integ = bridge._integrate_cycle_to_main(work, setup["branch"], setup["main_sha"])
+
+        assert integ["ok"] is False
+        assert integ["reason"] == "empty_integration"
+        assert integ["main_sha_after"] == setup["main_sha"]
+        assert _origin_main_sha(origin) == setup["main_sha"]  # origin/main untouched
+
     def test_stale_base_is_rejected_and_origin_main_untouched(self, tmp_path):
         """main_sha_before goes stale when another process advances origin/main
         after cycle-branch setup (out-of-band). The rebuilt-from-base merge


### PR DESCRIPTION
Closes #828.

## Problem (live, 8x/24h)
`_integrate_cycle_to_main` (`bridge.py:491`) — the ONLY path that advances `main` — ran `git checkout -B main <base>` with **no reset/clean first**. Any stray uncommitted/untracked change in the shared checkout at integration time made the checkout refuse to overwrite local mods → `checkout_main_failed` → the committed, **gate-passing** cycle work was silently discarded and `main` never advanced. Subagents routinely leave the tree dirty (some run `git checkout <file>` mid-cycle despite the MANDATORY branch-discipline rule). Surfaced immediately after switching the bridge model to `gemini-3.7-flash-high`: the capable model produces integrable, self-repairing work, but 8/8 recent integrations died here — the weak model had masked it by rarely producing integrable work at all (explains ~0 recent `success` / low `confirmed_integration`).

## Fix
Add `git reset --hard` + `git clean -fd` before the integration checkout, mirroring `_restore_to_main`. **Safe:** the deliverable is COMMITTED on `cycle_branch` (merged via the subsequent `--no-ff` merge); only non-deliverable stray tree changes are cleared. The git-verifiable rollback guarantee on merge_conflict / push_rejected is unchanged.

## Tests
New `test_dirty_tree_at_integration_still_integrates`: a cycle that commits its deliverable then dirties the tree (uncommitted edit + untracked file) now INTEGRATES — main advances, deliverable lands, strays cleared. Full `test_bridge_cycle_branch.py` green (36).

## Rollout
After deploy: verify `checkout_main_failed` stops and integrations resume (main advances again), unblocking the capable model's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)