### PR TITLE
fix(runtime): bound leaked selfevo/cycle-* branches (#830)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -748,7 +748,7 @@ def _prune_stale_cycle_branches(repo_root: 'Path', keep: int = _FORENSIC_CYCLE_B
             ['branch', '--merged', 'origin/main', '--list', 'selfevo/cycle-*']
         ).stdout
         merged = {
-            ln.strip().lstrip('* ').strip()
+            ln.strip().lstrip('*+ ').strip()  # '*' current, '+' checked-out in a worktree
             for ln in merged_out.splitlines()
             if ln.strip()
         }

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -470,6 +470,12 @@ def _setup_cycle_branch(repo_root: 'Path', cycle_id: str) -> dict:
     if checkout.returncode != 0:
         return {'ok': False, 'branch': branch, 'main_sha': main_sha, 'reason': 'checkout_failed'}
 
+    # #830: bound leaked cycle branches. Integrated ones are removed by
+    # _cleanup_cycle_branch, but forensic (gate-failed/blocked) branches were
+    # never pruned and grew one-per-failed-cycle. Prune now that we sit on the
+    # fresh branch; best-effort so a prune failure never blocks the cycle.
+    _prune_stale_cycle_branches(repo_root)
+
     return {'ok': True, 'branch': branch, 'main_sha': main_sha, 'reason': None}
 
 
@@ -702,6 +708,70 @@ def _cleanup_cycle_branch(repo_root: 'Path', cycle_branch: str) -> bool:
         return result.returncode == 0
     except Exception:
         return False
+
+
+_FORENSIC_CYCLE_BRANCH_KEEP = 20
+
+
+def _prune_stale_cycle_branches(repo_root: 'Path', keep: int = _FORENSIC_CYCLE_BRANCH_KEEP) -> dict:
+    """Bound the number of leaked ``selfevo/cycle-*`` branches (#830).
+
+    Every cycle runs on its own ``selfevo/cycle-<id>`` branch. Integrated
+    branches are removed by ``_cleanup_cycle_branch``; forensic ones
+    (gate-failed, blocked-file, repair-exhausted, empty-integration) are
+    intentionally kept for inspection but were never bounded, so they grew
+    one-per-failed-cycle without limit (162 accumulated on the eeepc host).
+    The full per-cycle record already lives in ``state/ledger/cycles.jsonl`` —
+    a branch older than the retention window adds nothing the ledger lacks.
+
+    Deletes: (a) every cycle branch already merged into ``origin/main`` (its
+    commits are safely in main), and (b) all but the newest ``keep`` unmerged
+    (forensic) cycle branches by commit date. Never deletes the branch that is
+    currently checked out. Best-effort: never raises; a failed delete is not a
+    cycle failure.
+
+    Returns ``{"deleted": int, "kept": int}``.
+    """
+    import subprocess as _sp_prune
+
+    if not repo_root.is_dir():
+        return {'deleted': 0, 'kept': 0}
+    git = _git_cmd(repo_root)
+
+    def _run(args):
+        return _sp_prune.run(git + args, capture_output=True, text=True)
+
+    try:
+        current = _run(['rev-parse', '--abbrev-ref', 'HEAD']).stdout.strip()
+
+        merged_out = _run(
+            ['branch', '--merged', 'origin/main', '--list', 'selfevo/cycle-*']
+        ).stdout
+        merged = {
+            ln.strip().lstrip('* ').strip()
+            for ln in merged_out.splitlines()
+            if ln.strip()
+        }
+
+        listed = _run(
+            ['for-each-ref', '--sort=-committerdate',
+             '--format=%(refname:short)', 'refs/heads/selfevo/cycle-*']
+        ).stdout
+        all_branches = [ln.strip() for ln in listed.splitlines() if ln.strip()]
+        unmerged = [b for b in all_branches if b not in merged]
+
+        to_delete = set(merged)
+        to_delete.update(unmerged[keep:])
+        to_delete.discard(current)  # never delete the branch we are on
+        to_delete.discard('')
+
+        deleted = 0
+        for branch in to_delete:
+            if _run(['branch', '-D', branch]).returncode == 0:
+                deleted += 1
+        return {'deleted': deleted, 'kept': max(len(all_branches) - deleted, 0)}
+    except Exception:
+        return {'deleted': 0, 'kept': 0}
 
 
 def _restore_to_main(repo_root: 'Path') -> bool:

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -896,12 +896,25 @@ class TestPostIntegrationBookkeepingPushGate:
         ) is True
 
 
-def _make_cycle_branch(work: Path, cid: str, *, merged: bool) -> None:
+def _make_cycle_branch(work: Path, cid: str, *, merged: bool, seq: int = 0) -> None:
     """Create a selfevo/cycle-<cid> branch. merged=True → its commit is on main
     (later fast-forward merged); merged=False → forensic (unique commit, never
-    merged), simulating a gate-failed cycle left for inspection."""
+    merged), simulating a gate-failed cycle left for inspection.
+
+    ``seq`` sets a strictly-increasing commit date so ``--sort=-committerdate``
+    ordering is deterministic in tests (real host cycles are ~10 min apart; the
+    test creates them in the same wall-clock second)."""
+    import os as _os
+
     _run(work, "checkout", "-B", f"selfevo/cycle-{cid}", "main")
-    _commit_file(work, f"c_{cid}.py", f"# {cid}\n", f"cycle {cid}")
+    (work / f"c_{cid}.py").write_text(f"# {cid}\n")
+    _run(work, "add", f"c_{cid}.py")
+    env = dict(_os.environ)
+    stamp = f"2026-01-01T00:{seq // 60:02d}:{seq % 60:02d}"
+    env["GIT_AUTHOR_DATE"] = stamp
+    env["GIT_COMMITTER_DATE"] = stamp
+    subprocess.run(_git(work) + ["commit", "-m", f"cycle {cid}"],
+                   capture_output=True, text=True, env=env)
     if merged:
         _run(work, "checkout", "main")
         _run(work, "merge", "--no-ff", f"selfevo/cycle-{cid}", "-m", f"merge {cid}")
@@ -925,7 +938,7 @@ class TestPruneStaleCycleBranches:
         origin, work = _init_repo(tmp_path)
         # 5 forensic (unmerged) branches, created oldest→newest
         for i in range(5):
-            _make_cycle_branch(work, f"f{i}", merged=False)
+            _make_cycle_branch(work, f"f{i}", merged=False, seq=i)
         res = bridge._prune_stale_cycle_branches(work, keep=2)
         remaining = [
             ln.strip().lstrip("* ").strip()
@@ -955,7 +968,7 @@ class TestPruneStaleCycleBranches:
     def test_setup_cycle_branch_prunes_on_entry(self, tmp_path):
         origin, work = _init_repo(tmp_path)
         for i in range(25):
-            _make_cycle_branch(work, f"f{i:02d}", merged=False)
+            _make_cycle_branch(work, f"f{i:02d}", merged=False, seq=i)
         # a fresh setup should trim forensic backlog to KEEP (+ the new branch)
         setup = bridge._setup_cycle_branch(work, "fresh")
         assert setup["ok"] is True

--- a/tests/test_bridge_cycle_branch.py
+++ b/tests/test_bridge_cycle_branch.py
@@ -894,3 +894,76 @@ class TestPostIntegrationBookkeepingPushGate:
         assert bridge._diff_against_remote_touches_only(
             work, "origin/main", {"lessons/lessons.yaml"}
         ) is True
+
+
+def _make_cycle_branch(work: Path, cid: str, *, merged: bool) -> None:
+    """Create a selfevo/cycle-<cid> branch. merged=True → its commit is on main
+    (later fast-forward merged); merged=False → forensic (unique commit, never
+    merged), simulating a gate-failed cycle left for inspection."""
+    _run(work, "checkout", "-B", f"selfevo/cycle-{cid}", "main")
+    _commit_file(work, f"c_{cid}.py", f"# {cid}\n", f"cycle {cid}")
+    if merged:
+        _run(work, "checkout", "main")
+        _run(work, "merge", "--no-ff", f"selfevo/cycle-{cid}", "-m", f"merge {cid}")
+        _run(work, "push", "origin", "HEAD:main")
+    _run(work, "checkout", "main")
+
+
+class TestPruneStaleCycleBranches:
+    def test_merged_branches_deleted(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        for i in range(3):
+            _make_cycle_branch(work, f"m{i}", merged=True)
+        before = _run(work, "branch", "--list", "selfevo/cycle-*").stdout
+        assert before.count("selfevo/cycle-") == 3
+        res = bridge._prune_stale_cycle_branches(work, keep=20)
+        after = _run(work, "branch", "--list", "selfevo/cycle-*").stdout
+        assert res["deleted"] == 3
+        assert "selfevo/cycle-" not in after
+
+    def test_forensic_trimmed_to_keep_newest(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        # 5 forensic (unmerged) branches, created oldest→newest
+        for i in range(5):
+            _make_cycle_branch(work, f"f{i}", merged=False)
+        res = bridge._prune_stale_cycle_branches(work, keep=2)
+        remaining = [
+            ln.strip().lstrip("* ").strip()
+            for ln in _run(work, "branch", "--list", "selfevo/cycle-*").stdout.splitlines()
+            if ln.strip()
+        ]
+        assert res["deleted"] == 3
+        assert len(remaining) == 2
+        # newest two (f3, f4 by commit order) survive
+        assert set(remaining) == {"selfevo/cycle-f3", "selfevo/cycle-f4"}
+
+    def test_current_branch_never_deleted(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        for i in range(3):
+            _make_cycle_branch(work, f"f{i}", merged=False)
+        # check out one forensic branch and prune with keep=0
+        _run(work, "checkout", "selfevo/cycle-f0")
+        res = bridge._prune_stale_cycle_branches(work, keep=0)
+        remaining = _run(work, "branch", "--list", "selfevo/cycle-*").stdout
+        assert "selfevo/cycle-f0" in remaining  # current survives despite keep=0
+        assert res["kept"] >= 1
+
+    def test_missing_repo_is_safe(self, tmp_path):
+        res = bridge._prune_stale_cycle_branches(tmp_path / "nope", keep=5)
+        assert res == {"deleted": 0, "kept": 0}
+
+    def test_setup_cycle_branch_prunes_on_entry(self, tmp_path):
+        origin, work = _init_repo(tmp_path)
+        for i in range(25):
+            _make_cycle_branch(work, f"f{i:02d}", merged=False)
+        # a fresh setup should trim forensic backlog to KEEP (+ the new branch)
+        setup = bridge._setup_cycle_branch(work, "fresh")
+        assert setup["ok"] is True
+        cycle_branches = [
+            ln.strip().lstrip("* ").strip()
+            for ln in _run(work, "branch", "--list", "selfevo/cycle-*").stdout.splitlines()
+            if ln.strip()
+        ]
+        # newest 20 forensic kept + the just-created selfevo/cycle-fresh
+        assert "selfevo/cycle-fresh" in cycle_branches
+        assert len(cycle_branches) == bridge._FORENSIC_CYCLE_BRANCH_KEEP + 1


### PR DESCRIPTION
Closes #830.

## Problem
Forensic cycle branches (gate-failed / blocked-file / repair-exhausted / empty-integration) were kept for inspection but never bounded — **162** accumulated on the eeepc host (88 already merged into main = pure garbage refs). The full per-cycle record already lives in `state/ledger/cycles.jsonl`.

## Fix
- `_prune_stale_cycle_branches(repo_root, keep=20)`: deletes every cycle branch merged into `origin/main` + all but the newest `keep` unmerged forensic branches by commit date; never deletes the current branch; best-effort, never raises. Handles `*`/`+` worktree prefixes in `git branch --merged` output.
- Wired into `_setup_cycle_branch` after the fresh checkout → backlog self-limits from the next cycle on.

## One-time
Host already swept: **162 → 20** cycle branches (24 total refs).

## Tests
5 new (`TestPruneStaleCycleBranches`): merged deleted, forensic trimmed to newest-`keep`, current branch never deleted, missing-repo safe, `_setup_cycle_branch` prunes on entry. Full `test_bridge_cycle_branch.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)