### PR TITLE
feat(runtime): operator-controlled reasoning_effort for bridge model (#832)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -913,6 +913,22 @@ def _model_name() -> str:
     return raw
 
 
+_VALID_REASONING_EFFORTS = frozenset({"low", "medium", "high"})
+
+
+def bridge_reasoning_effort() -> str | None:
+    """Operator-selected reasoning effort for the bridge model (#832).
+
+    Reads ``SUBAGENT_BRIDGE_REASONING_EFFORT``; returns ``"low"``/``"medium"``/
+    ``"high"`` when set to a valid tier, else ``None`` (send no param — the
+    pre-#832 behavior). Lets models without a baked ``-high`` name variant
+    (e.g. ``cl/gpt-5.6-luna``) still run at high reasoning. Shared with the
+    materializer path in ``tool_harness``.
+    """
+    raw = os.environ.get("SUBAGENT_BRIDGE_REASONING_EFFORT", "").strip().lower()
+    return raw if raw in _VALID_REASONING_EFFORTS else None
+
+
 def _extract_json_object(text: str) -> dict[str, Any] | None:
     if not text:
         return None
@@ -964,7 +980,7 @@ def propose(
         )
     try:
         client = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
-        response = client.chat.completions.create(
+        create_kwargs: dict[str, Any] = dict(
             model=_model_name(),
             messages=[
                 {"role": "system", "content": system_prompt or _PROPOSER_SYSTEM_PROMPT},
@@ -973,6 +989,10 @@ def propose(
             max_tokens=400,
             temperature=0.4,
         )
+        effort = bridge_reasoning_effort()  # #832: opt-in high-reasoning proposals
+        if effort:
+            create_kwargs["reasoning_effort"] = effort
+        response = client.chat.completions.create(**create_kwargs)
         reply = response.choices[0].message.content or ""
     except Exception:
         return None

--- a/nanobot/runtime/tool_harness.py
+++ b/nanobot/runtime/tool_harness.py
@@ -51,6 +51,27 @@ DEFAULT_MAX_BYTES = 50_000
 _HEAD_FRACTION = 0.6  # 60% of the kept budget is head, 40% is tail
 
 
+def _apply_bridge_reasoning_effort(config: Any) -> str | None:
+    """Push the operator-selected bridge reasoning effort into ``config`` (#832).
+
+    ``_make_provider`` forwards ``config.agents.defaults.reasoning_effort`` (with
+    ``supermind.reasoning_effort`` winning when supermind is enabled) into the
+    completion call. Set both from ``SUBAGENT_BRIDGE_REASONING_EFFORT`` so a
+    model without a baked ``-high`` name variant (e.g. ``cl/gpt-5.6-luna``) can
+    still run the materializer at high reasoning. No-op when the env is
+    unset/invalid. Returns the applied effort (or ``None``)."""
+    from nanobot.runtime.llm_proposer import bridge_reasoning_effort
+
+    effort = bridge_reasoning_effort()
+    if not effort:
+        return None
+    config.agents.defaults.reasoning_effort = effort
+    supermind = getattr(config, "supermind", None)
+    if supermind is not None and getattr(supermind, "enabled", False):
+        supermind.reasoning_effort = effort
+    return effort
+
+
 def truncate_text(
     text: str,
     *,
@@ -717,6 +738,7 @@ def run_tool_harness_request(
     if provider is None:
         from nanobot.cli.commands import _make_provider
         config.agents.defaults.model = resolved_model
+        _apply_bridge_reasoning_effort(config)  # #832
         provider = _make_provider(config)
 
     resolved_workspace = workspace_root

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2207,3 +2207,59 @@ class TestServesDemandForm:
         assert llm_proposer._demand_id_from_serves("priority 3") == ""
         assert llm_proposer._demand_id_from_serves("") == ""
         assert llm_proposer._demand_id_from_serves(None) == ""
+
+
+# ─── #832: operator-controlled bridge reasoning effort ─────────────────────
+
+
+class TestBridgeReasoningEffort:
+    def test_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv("SUBAGENT_BRIDGE_REASONING_EFFORT", raising=False)
+        assert llm_proposer.bridge_reasoning_effort() is None
+
+    @pytest.mark.parametrize("val", ["low", "medium", "high"])
+    def test_valid_tiers(self, monkeypatch, val):
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", val)
+        assert llm_proposer.bridge_reasoning_effort() == val
+
+    def test_case_and_whitespace_normalized(self, monkeypatch):
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", "  HIGH ")
+        assert llm_proposer.bridge_reasoning_effort() == "high"
+
+    @pytest.mark.parametrize("val", ["", "bogus", "extreme", "1"])
+    def test_invalid_returns_none(self, monkeypatch, val):
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", val)
+        assert llm_proposer.bridge_reasoning_effort() is None
+
+
+class TestProposeReasoningPassthrough:
+    def _install(self, monkeypatch):
+        captured: dict = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeResponse(json.dumps({"task_title": "x", "target_path": "docs/z.md"}))
+
+        class _Client:
+            def __init__(self, *a, **kw):
+                self.chat = type("_C", (), {"completions": _Completions()})()
+
+        import openai
+
+        monkeypatch.setattr(openai, "OpenAI", lambda *a, **kw: _Client())
+        monkeypatch.setenv("LITELLM_BASE_URL", "http://fake-gateway.local")
+        monkeypatch.setenv("LITELLM_API_KEY", "sk-fake")
+        return captured
+
+    def test_high_effort_forwarded(self, monkeypatch):
+        captured = self._install(monkeypatch)
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", "high")
+        llm_proposer.propose("ctx")
+        assert captured.get("reasoning_effort") == "high"
+
+    def test_unset_sends_no_param(self, monkeypatch):
+        captured = self._install(monkeypatch)
+        monkeypatch.delenv("SUBAGENT_BRIDGE_REASONING_EFFORT", raising=False)
+        llm_proposer.propose("ctx")
+        assert "reasoning_effort" not in captured

--- a/tests/test_tool_harness.py
+++ b/tests/test_tool_harness.py
@@ -662,3 +662,65 @@ def test_materialize_research_only_profile_is_byte_identical_to_before(tmp_path)
     assert result["tool_calls_count"] is None
     assert result["tool_call_journal"] is None
     assert result["stop_reason"] is None
+
+
+# ─── #832: bridge reasoning-effort applied to materializer config ───────────
+
+
+class _FakeDefaults:
+    def __init__(self):
+        self.model = "cl/x"
+        self.reasoning_effort = None
+
+
+class _FakeAgents:
+    def __init__(self):
+        self.defaults = _FakeDefaults()
+
+
+class _FakeSupermind:
+    def __init__(self, enabled):
+        self.enabled = enabled
+        self.reasoning_effort = None
+
+
+class _FakeConfig:
+    def __init__(self, supermind=None):
+        self.agents = _FakeAgents()
+        self.supermind = supermind
+
+
+class TestApplyBridgeReasoningEffort:
+    def test_noop_when_unset(self, monkeypatch):
+        from nanobot.runtime.tool_harness import _apply_bridge_reasoning_effort
+
+        monkeypatch.delenv("SUBAGENT_BRIDGE_REASONING_EFFORT", raising=False)
+        cfg = _FakeConfig()
+        assert _apply_bridge_reasoning_effort(cfg) is None
+        assert cfg.agents.defaults.reasoning_effort is None
+
+    def test_sets_defaults(self, monkeypatch):
+        from nanobot.runtime.tool_harness import _apply_bridge_reasoning_effort
+
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", "high")
+        cfg = _FakeConfig()
+        assert _apply_bridge_reasoning_effort(cfg) == "high"
+        assert cfg.agents.defaults.reasoning_effort == "high"
+
+    def test_sets_supermind_when_enabled(self, monkeypatch):
+        from nanobot.runtime.tool_harness import _apply_bridge_reasoning_effort
+
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", "high")
+        cfg = _FakeConfig(supermind=_FakeSupermind(enabled=True))
+        _apply_bridge_reasoning_effort(cfg)
+        assert cfg.agents.defaults.reasoning_effort == "high"
+        assert cfg.supermind.reasoning_effort == "high"
+
+    def test_skips_supermind_when_disabled(self, monkeypatch):
+        from nanobot.runtime.tool_harness import _apply_bridge_reasoning_effort
+
+        monkeypatch.setenv("SUBAGENT_BRIDGE_REASONING_EFFORT", "high")
+        cfg = _FakeConfig(supermind=_FakeSupermind(enabled=False))
+        _apply_bridge_reasoning_effort(cfg)
+        assert cfg.agents.defaults.reasoning_effort == "high"
+        assert cfg.supermind.reasoning_effort is None


### PR DESCRIPTION
Closes #832.

## Why
Reasoning effort was only selectable by picking a model whose **name** baked it in (`…-high`). `cl/gpt-5.6-luna` has no `-high` variant, so it couldn't run at high reasoning. Proposer sent no `reasoning_effort` at all; materializer had the passthrough but nothing set it from the bridge env.

## What
New operator env `SUBAGENT_BRIDGE_REASONING_EFFORT` (`low|medium|high`; unset/invalid → no param, byte-identical to before):
- `bridge_reasoning_effort()` — shared parser (case/whitespace-normalized, validated tier).
- `propose()` — passes `reasoning_effort` when set.
- `tool_harness._apply_bridge_reasoning_effort()` — sets `config.agents.defaults.reasoning_effort` (+ `supermind.reasoning_effort` when supermind enabled) before `_make_provider`.

Gateway verified: `cl/gpt-5.6-luna` → 200, accepts `reasoning_effort=high`.

## Tests
- `TestBridgeReasoningEffort` (parsing: tiers, normalize, invalid→None, unset→None)
- `TestProposeReasoningPassthrough` (high forwarded; unset omits param)
- `TestApplyBridgeReasoningEffort` (defaults set; supermind set only when enabled; noop when unset)
- Full `test_llm_proposer.py` + `test_tool_harness.py` green (182).

🤖 Generated with [Claude Code](https://claude.com/claude-code)