### PR TITLE
feat(runtime): permanent novelty guard — stop rebuilding throwaway scripts (#834)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1077,6 +1077,57 @@ def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
     return True, ""
 
 
+_PERMANENT_DEDUP_MAX_COMMITS = 3000
+
+
+def _all_built_subjects(selfevo_repo: Path | None) -> str:
+    """Full-history commit subjects of the instance repo (#834 permanent novelty).
+
+    Unlike :func:`cycle_planning._recent_git_log`'s 14-day window, this is the
+    complete catalogue of everything ever integrated into ``main``, so a
+    throwaway script cannot be silently rebuilt once its creation commit ages
+    out of the recency window. Bounded to the most recent
+    :data:`_PERMANENT_DEDUP_MAX_COMMITS` subjects. Fail-open: ``""`` on any
+    error.
+    """
+    if not selfevo_repo:
+        return ""
+    import subprocess as _sp_hist
+
+    repo = Path(selfevo_repo)
+    try:
+        return _sp_hist.check_output(
+            [
+                "git", "-c", f"safe.directory={repo}", "-C", str(repo),
+                "log", "--format=%s", f"-n{_PERMANENT_DEDUP_MAX_COMMITS}",
+            ],
+            stderr=_sp_hist.DEVNULL,
+            timeout=15,
+        ).decode(errors="replace")
+    except Exception:
+        return ""
+
+
+def _proposal_creates_new_file(selfevo_repo: Path | None, proposal: dict[str, Any]) -> bool:
+    """True when the proposal would create a target_path that does NOT yet exist
+    in the instance repo (#834).
+
+    The permanent novelty guard applies only to NEW-file creation — edits and
+    improvements to an existing (possibly consumed) artifact are iteration, not
+    churn, and must never be newly blocked. Fail-open to ``False`` (treat as an
+    edit, i.e. do not apply the permanent guard) on any error.
+    """
+    if not selfevo_repo:
+        return False
+    target = str(proposal.get("target_path") or "").strip()
+    if not target:
+        return False
+    try:
+        return not (Path(selfevo_repo) / target).exists()
+    except Exception:
+        return False
+
+
 def _is_duplicate_proposal(
     state_dir: Path, selfevo_repo: Path | None, proposal: dict[str, Any]
 ) -> tuple[bool, str, str]:
@@ -1138,6 +1189,29 @@ def _is_duplicate_proposal(
                 "work; propose something from a DIFFERENT area, preferring "
                 "the numbered Current priority targets"
             ), matched_against
+
+        # #834 permanent novelty guard: for proposals that CREATE A NEW file,
+        # also reject against the full commit history (not just the 14-day
+        # window above), so a throwaway artifact is not silently rebuilt once
+        # its creation commit ages out. Edits/improvements to an existing file
+        # are iteration, not churn, and are never blocked here.
+        if _proposal_creates_new_file(selfevo_repo, proposal):
+            built_subjects = _all_built_subjects(selfevo_repo)
+            if built_subjects and _title_already_done_in_git_log(title, built_subjects):
+                matched_built = next(
+                    (
+                        line.strip()
+                        for line in built_subjects.splitlines()
+                        if line.strip() and _title_already_done_in_git_log(title, line)
+                    ),
+                    "",
+                )
+                return True, (
+                    f"your proposal '{title}' re-creates an artifact that "
+                    "ALREADY EXISTS in the repo history (built previously); "
+                    "improve/reuse the existing one, or propose genuinely NEW "
+                    "work from the numbered Current priority targets"
+                ), matched_built
         return False, "", ""
     except Exception:
         return False, "", ""

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1123,9 +1123,16 @@ def _proposal_creates_new_file(selfevo_repo: Path | None, proposal: dict[str, An
     if not target:
         return False
     try:
-        return not (Path(selfevo_repo) / target).exists()
+        repo = Path(selfevo_repo).resolve()
+        candidate = (repo / target).resolve()
+        # Reject anything that escapes the repo (absolute target_path, ``..``):
+        # pathlib's ``/`` drops the left operand on an absolute right operand,
+        # so probe containment explicitly and treat an escape as "not a repo
+        # new-file" (skip the guard; validate_sizing rejects such paths anyway).
+        candidate.relative_to(repo)
     except Exception:
         return False
+    return not candidate.exists()
 
 
 def _is_duplicate_proposal(

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2263,3 +2263,94 @@ class TestProposeReasoningPassthrough:
         monkeypatch.delenv("SUBAGENT_BRIDGE_REASONING_EFFORT", raising=False)
         llm_proposer.propose("ctx")
         assert "reasoning_effort" not in captured
+
+
+# ─── #834: permanent (history-wide) novelty guard ──────────────────────────
+
+
+def _init_instance_repo(tmp_path, *, subject, script_rel, old=True):
+    """Minimal git repo with ONE commit (dated >14 days ago when old=True) that
+    creates `script_rel`, so the 14-day recency git_log misses it but the
+    full-history _all_built_subjects catches it."""
+    import subprocess as _sp
+    repo = tmp_path / "inst"
+    repo.mkdir()
+    env = dict(__import__("os").environ)
+    if old:
+        env["GIT_AUTHOR_DATE"] = "2025-01-01T00:00:00"
+        env["GIT_COMMITTER_DATE"] = "2025-01-01T00:00:00"
+    env.setdefault("GIT_AUTHOR_NAME", "t"); env.setdefault("GIT_AUTHOR_EMAIL", "t@t")
+    env.setdefault("GIT_COMMITTER_NAME", "t"); env.setdefault("GIT_COMMITTER_EMAIL", "t@t")
+    def g(*a):
+        _sp.run(["git", "-C", str(repo), *a], capture_output=True, env=env, check=False)
+    g("init", "-b", "main")
+    g("config", "user.email", "t@t"); g("config", "user.name", "t")
+    (repo / script_rel).parent.mkdir(parents=True, exist_ok=True)
+    (repo / script_rel).write_text("# tool\n")
+    g("add", "-A")
+    _sp.run(["git", "-C", str(repo), "commit", "-m", subject],
+            capture_output=True, env=env, check=False)
+    return repo
+
+
+class TestPermanentNoveltyGuard:
+    def test_new_file_duplicating_old_built_artifact_rejected(self, tmp_path):
+        repo = _init_instance_repo(
+            tmp_path,
+            subject="create firewall log analyzer summary script",
+            script_rel="scripts/firewall_log_analyzer.py",
+        )
+        state = tmp_path / "state"; state.mkdir()
+        proposal = {
+            "task_title": "create firewall log analyzer summary script",
+            "target_path": "scripts/firewall_log_analyzer_v2.py",  # NEW file
+        }
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert "ALREADY EXISTS" in feedback
+        assert "firewall" in matched.lower()
+
+    def test_edit_of_existing_file_not_blocked(self, tmp_path):
+        repo = _init_instance_repo(
+            tmp_path,
+            subject="create firewall log analyzer summary script",
+            script_rel="scripts/firewall_log_analyzer.py",
+        )
+        state = tmp_path / "state"; state.mkdir()
+        proposal = {
+            "task_title": "create firewall log analyzer summary script",
+            "target_path": "scripts/firewall_log_analyzer.py",  # EXISTS -> edit
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False  # iteration on an existing artifact is never blocked
+
+    def test_novel_new_file_passes(self, tmp_path):
+        repo = _init_instance_repo(
+            tmp_path,
+            subject="create firewall log analyzer summary script",
+            script_rel="scripts/firewall_log_analyzer.py",
+        )
+        state = tmp_path / "state"; state.mkdir()
+        proposal = {
+            "task_title": "add dashboard latency histogram exporter",  # unrelated
+            "target_path": "scripts/latency_histogram_exporter.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_fail_open_without_repo(self, tmp_path):
+        state = tmp_path / "state"; state.mkdir()
+        proposal = {"task_title": "create firewall log analyzer summary script",
+                    "target_path": "scripts/x.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, None, proposal)
+        assert dup is False
+
+    def test_helpers_direct(self, tmp_path):
+        repo = _init_instance_repo(
+            tmp_path, subject="build token usage reporter", script_rel="scripts/token_usage_reporter.py")
+        assert "token usage reporter" in llm_proposer._all_built_subjects(repo).lower()
+        assert llm_proposer._all_built_subjects(None) == ""
+        assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "scripts/new.py"}) is True
+        assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "scripts/token_usage_reporter.py"}) is False
+        assert llm_proposer._proposal_creates_new_file(repo, {"target_path": ""}) is False
+        assert llm_proposer._proposal_creates_new_file(None, {"target_path": "scripts/x.py"}) is False

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2354,3 +2354,7 @@ class TestPermanentNoveltyGuard:
         assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "scripts/token_usage_reporter.py"}) is False
         assert llm_proposer._proposal_creates_new_file(repo, {"target_path": ""}) is False
         assert llm_proposer._proposal_creates_new_file(None, {"target_path": "scripts/x.py"}) is False
+        # #834 path-traversal containment: absolute / escaping targets are not
+        # treated as repo new-files (never probed outside the repo).
+        assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "../../etc/passwd"}) is False
+        assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "/etc/passwd"}) is False


### PR DESCRIPTION
Closes #834. Permanent (full-history) novelty guard in _is_duplicate_proposal, additive to recency checks: new-file proposals whose title overlaps a past commit subject are rejected (steering to self-generated priorities); edits to existing artifacts never blocked. Path-traversal contained. Fail-open. Tests: TestPermanentNoveltyGuard + full proposer suite green (150). Diagnosis: confirmed_integration churn from rebuilding throwaways after the 14-day dedup window ages out. 🤖 Claude Code