### PR TITLE
feat(runtime): honest confirmable denominator — exclude off-goal successes (#836)

### DIFF
--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -386,6 +386,17 @@ def _loop_section(
     # archivals must not dilute it either (the #801/#802 principle). The
     # fitness ratio is scoped to this "confirmable" universe: non-decay
     # success cycles whose files_changed includes a scripts/ path.
+    # #836: that alone still admitted a second permanently-unconfirmable
+    # class — a success whose `proposed` row carried no `demand_id` is
+    # never off-goal-tracked and therefore never folded into
+    # completed.json, so confirm_serves can never reach it either. Being
+    # goal-linked (demand_id present on the proposed row) is required in
+    # addition to the scripts/ touch, symmetric with the decay exclusion
+    # above. This does NOT reintroduce the #814 bug: a goal-linked success
+    # that IS folded but not yet confirmed still counts here — only
+    # unconfirmed status is reporting-only (see confirmed_integrations
+    # below); goal-linkage is a foldability gate, not a confirmed-status
+    # gate.
     confirmable_integrations = 0
     confirmed_confirmable_integrations = 0
     idle_rows = 0
@@ -401,12 +412,23 @@ def _loop_section(
     # and the create→archive treadmill farmed one credit per archival. Those
     # successes count as decay_integrations, never as integrations.
     decay_cycles: set[str] = set()
+    # #836: cycles whose `proposed` row carried a non-empty demand_id — i.e.
+    # goal-linked work that IS foldable into completed.json and therefore
+    # CAN eventually be confirmed. decay-* cycles also carry a demand_id but
+    # are already excluded from the confirmable universe above as decay, so
+    # membership in both sets is harmless (decay_cycles is checked first).
+    goal_linked_cycles: set[str] = set()
     for row in rows:
         if row.get("phase") != "proposed":
             continue
         cycle_id = str(row.get("cycle_id") or "").strip()
-        if cycle_id and str(row.get("demand_id") or "").startswith("decay-"):
+        if not cycle_id:
+            continue
+        demand_id = str(row.get("demand_id") or "").strip()
+        if demand_id.startswith("decay-"):
             decay_cycles.add(cycle_id)
+        if demand_id:
+            goal_linked_cycles.add(cycle_id)
     for row in rows:
         phase = row.get("phase")
         if phase == "idle":
@@ -432,8 +454,10 @@ def _loop_section(
                     else:
                         unconfirmed_integrations += 1
                     files_changed = row.get("files_changed")
-                    is_confirmable = isinstance(files_changed, list) and any(
-                        isinstance(f, str) and f.startswith("scripts/") for f in files_changed
+                    is_confirmable = (
+                        cycle_id in goal_linked_cycles
+                        and isinstance(files_changed, list)
+                        and any(isinstance(f, str) and f.startswith("scripts/") for f in files_changed)
                     )
                     if is_confirmable:
                         confirmable_integrations += 1
@@ -461,11 +485,17 @@ def _loop_section(
         # see confirmable_integrations.
         "confirmed_integrations": confirmed_integrations,
         "unconfirmed_integrations": unconfirmed_integrations,
-        # Non-decay success cycles whose files_changed includes a scripts/
-        # path — the only integrations confirm_serves can ever confirm.
-        # confirmed_integration_ratio's denominator, so a runtime/docs/config
-        # integration (permanently unconfirmable) never drags it down, and a
-        # decay-heavy window never dilutes it (#814 review fix).
+        # Non-decay, goal-linked success cycles whose files_changed includes
+        # a scripts/ path — the only integrations confirm_serves can ever
+        # confirm. confirmed_integration_ratio's denominator, so a
+        # runtime/docs/config integration (permanently unconfirmable) never
+        # drags it down, a decay-heavy window never dilutes it (#814 review
+        # fix), and — #836 — an off-goal success whose proposed row carried
+        # no demand_id (never folded into completed.json, so confirm_serves
+        # can never reach it) never drags it down either. A goal-linked
+        # success that IS folded but not yet confirmed still counts here
+        # (#814 semantics preserved) — the new requirement gates on
+        # foldability, not on confirmed status.
         "confirmable_integrations": confirmable_integrations,
         "confirmed_integration_ratio": _ratio(confirmed_confirmable_integrations, confirmable_integrations),
         "skips_by_class": skips_by_class,

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -321,6 +321,101 @@ class TestConfirmedIntegrationSplit:
         assert all(g["metric"] != "confirmed_integration_ratio" for g in snap["gaps"])
 
 
+class TestGoalLinkedConfirmableDenominator:
+    """#836: confirmable_integrations additionally requires the cycle's
+    `proposed` row to have carried a non-empty demand_id (goal-linked). An
+    off-goal success (no demand_id on its proposed row, or no proposed row
+    at all) is never folded into demand/completed.json, so confirm_serves
+    can never reach it — it must not sit in the denominator forever,
+    symmetric with the existing decay exclusion. #814 semantics are
+    preserved: a goal-linked success that IS folded but not yet confirmed
+    still counts as confirmable."""
+
+    def _write_completed(self, state_dir: Path, entries: dict) -> None:
+        (state_dir / "demand").mkdir(parents=True, exist_ok=True)
+        (state_dir / "demand" / "completed.json").write_text(
+            json.dumps({"schema_version": "demand-completed-v1", "entries": entries}),
+            encoding="utf-8",
+        )
+
+    def test_goal_linked_success_still_counts_as_confirmable(self, tmp_path):
+        """Unchanged behavior: a non-decay success touching scripts/ whose
+        proposed row carried a demand_id is confirmable."""
+        state_dir = tmp_path / "state"
+        _write_ledger(
+            state_dir,
+            [
+                {"phase": "proposed", "cycle_id": "c1", "demand_id": "priority-a", "ts": _iso(20)},
+                {"phase": "outcome", "cycle_id": "c1", "outcome": "success",
+                 "files_changed": ["scripts/foo.py"], "ts": _iso(19)},
+            ],
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        loop = snap["loop"]
+        assert loop["integrations"] == 1
+        assert loop["confirmable_integrations"] == 1
+
+    def test_off_goal_success_excluded_from_denominator(self, tmp_path):
+        """An otherwise-identical success whose proposed row has NO
+        demand_id is never foldable into completed.json — it must not
+        count as confirmable, and confirmed_integration_ratio must not be
+        fabricated from a 0-sized confirmable universe."""
+        state_dir = tmp_path / "state"
+        _write_ledger(
+            state_dir,
+            [
+                {"phase": "proposed", "cycle_id": "c1", "ts": _iso(20)},
+                {"phase": "outcome", "cycle_id": "c1", "outcome": "success",
+                 "files_changed": ["scripts/foo.py"], "ts": _iso(19)},
+            ],
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        loop = snap["loop"]
+        assert loop["integrations"] == 1
+        assert loop["unconfirmed_integrations"] == 1
+        assert loop["confirmable_integrations"] == 0
+        assert loop["confirmed_integration_ratio"] is None
+
+    def test_off_goal_success_no_proposed_row_excluded(self, tmp_path):
+        """Same exclusion when the cycle has no `proposed` row at all
+        (demand_id is unknowable, so it cannot be treated as goal-linked)."""
+        state_dir = tmp_path / "state"
+        _write_ledger(
+            state_dir,
+            [
+                {"phase": "outcome", "cycle_id": "c1", "outcome": "success",
+                 "files_changed": ["scripts/foo.py"], "ts": _iso(19)},
+            ],
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        loop = snap["loop"]
+        assert loop["integrations"] == 1
+        assert loop["confirmable_integrations"] == 0
+        assert loop["confirmed_integration_ratio"] is None
+
+    def test_confirmed_goal_linked_success_counts_in_numerator(self, tmp_path):
+        """A confirmed goal-linked success (completed.json confirmed=true,
+        harness signal pycache) counts in the confirmed_integration_ratio
+        numerator too — #814 semantics preserved by the #836 tightening."""
+        state_dir = tmp_path / "state"
+        _write_ledger(
+            state_dir,
+            [
+                {"phase": "proposed", "cycle_id": "c1", "demand_id": "priority-a", "ts": _iso(20)},
+                {"phase": "outcome", "cycle_id": "c1", "outcome": "success",
+                 "files_changed": ["scripts/foo.py"], "ts": _iso(19)},
+            ],
+        )
+        self._write_completed(
+            state_dir,
+            {"a": {"cycle_id": "c1", "ts": _iso(18), "confirmed": True, "signal": "pycache"}},
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        loop = snap["loop"]
+        assert loop["confirmable_integrations"] == 1
+        assert loop["confirmed_integration_ratio"] == 1.0
+
+
 # ─── compute: cost section (#675 telemetry) ─────────────────────────────────
 
 


### PR DESCRIPTION
Closes #836. confirmed_integration_ratio denominator counted every non-decay script-touching success, incl. ones whose proposal had no demand_id → never folded into completed.json → structurally unconfirmable, dragging the ratio down forever. Fix: require the cycle be goal-linked (proposed row carried a demand_id) to be confirmable, symmetric with the decay exclusion. #814 semantics preserved: a goal-linked folded-but-unconfirmed success stays confirmable (unconfirmed-churn windows still show a gap). Uses ledger rows only, no completed.json read, no signature change. Tests: TestGoalLinkedConfirmableDenominator (4) + full test_scorecard.py green (38). Built by Sonnet subagent, Opus-reviewed. 🤖 Claude Code