### PR TITLE
feat(runtime): relevance-rank existing-scripts inventory for reuse (#840)

### DIFF
--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -738,6 +738,45 @@ def find_similar(
     return results
 
 
+def related_scripts(state_dir: Path, selfevo_repo: Path, query: str, limit: int = 12) -> list[str]:
+    """Repo-relative scripts/ paths most RELEVANT to `query`, best-first (#840).
+
+    Thin wrapper over find_similar for the proposer's reuse-ranking: reindexes,
+    runs the FTS query, keeps only script-kind, non-test hits, de-dups preserving
+    rank. Honors existence_index_enabled(); fail-open to [] (disabled, no match,
+    or any error) so the caller falls back to its default ordering.
+    """
+    if not query or not existence_index_enabled():
+        return []
+    try:
+        reindex(Path(state_dir), Path(selfevo_repo))
+        hits = find_similar(
+            Path(state_dir), query, target_path=None, limit=max(1, limit * 2),
+        )
+        out: list[str] = []
+        seen: set[str] = set()
+        for hit in hits:
+            if hit.get("kind") != "script":
+                continue
+            path = str(hit.get("path") or "")
+            if not path.startswith("scripts/"):
+                continue
+            if "tests/" in path:
+                continue
+            basename = path.rsplit("/", 1)[-1]
+            if basename.startswith("test_"):
+                continue
+            if path in seen:
+                continue
+            seen.add(path)
+            out.append(path)
+            if len(out) >= limit:
+                break
+        return out
+    except Exception:
+        return []
+
+
 def find_duplicate_script(
     state_dir: Path, selfevo_repo: Path, title: str, target_path: str | None = None,
 ) -> str | None:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -749,7 +749,10 @@ def _system_map_inventory_section(
                 ]
                 remaining.sort(key=_mtime_for_line, reverse=True)
                 slots = max(0, _MAX_INVENTORY_ENTRIES - len(ordered))
-                lines = ordered + remaining[:slots]
+                # Defensive final clamp (#840 review): even if `ordered` ever
+                # exceeds the cap (e.g. related_scripts' limit raised above
+                # _MAX_INVENTORY_ENTRIES), never emit more than the cap.
+                lines = (ordered + remaining[:slots])[:_MAX_INVENTORY_ENTRIES]
             else:
                 lines = sorted(lines, key=_mtime_for_line, reverse=True)[:_MAX_INVENTORY_ENTRIES]
 

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -38,7 +38,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from nanobot.runtime import demand, hypothesis_backlog, system_map
+from nanobot.runtime import demand, existence_index, hypothesis_backlog, system_map
 from nanobot.runtime.cycle_ledger import append_event
 from nanobot.runtime.cycle_planning import (
     _recent_git_log,
@@ -662,7 +662,9 @@ def _digest_ledger(rows: list[dict[str, Any]], n: int = _LEDGER_DIGEST_ROWS) -> 
     return lines
 
 
-def _system_map_inventory_section(selfevo_repo: Path | None) -> str:
+def _system_map_inventory_section(
+    selfevo_repo: Path | None, *, state_dir: Path | None = None, query: str = "",
+) -> str:
     """Bounded ``## Existing scripts`` context (#749): prefer the committed
     ``docs/SYSTEM_MAP.md`` inventory (kept fresh by :func:`update_system_map`
     each cycle); fall back to generating the inventory directly (still no
@@ -677,11 +679,21 @@ def _system_map_inventory_section(selfevo_repo: Path | None) -> str:
     ``selfevo_repo`` is not given, so the caller can omit the whole section
     gracefully.
 
-    Capped at :data:`_MAX_INVENTORY_ENTRIES` entries (the most recently
-    modified scripts by ``st_mtime`` when over the cap, prefixed with a
-    total-count note) and :data:`_MAX_INVENTORY_CHARS` characters — kept
-    separate from :data:`_MAX_CONTEXT_CHARS` so this section never eats into
-    the goal_text/ledger budget.
+    Capped at :data:`_MAX_INVENTORY_ENTRIES` entries and :data:`_MAX_INVENTORY_CHARS`
+    characters — kept separate from :data:`_MAX_CONTEXT_CHARS` so this section
+    never eats into the goal_text/ledger budget. When over the entry cap, the
+    surviving entries used to be picked purely by newest-``st_mtime`` — a
+    script RELEVANT to the current demand could be older than the cap and
+    silently drop out, inviting the proposer to rebuild it under a new name
+    (#840, the behavioral root of a low confirmed_integration_ratio). Now:
+    when ``query`` is non-empty and ``state_dir`` is given,
+    :func:`nanobot.runtime.existence_index.related_scripts` supplies a
+    best-first relevance ranking; those entries are kept FIRST (in relevance
+    order), then remaining slots are filled with the existing newest-by-mtime
+    ordering (skipping already-included paths) — relevant tools now survive
+    the cap. With ``query`` empty, no ``state_dir``, the index disabled, or no
+    relevant hits, behavior is EXACTLY the prior mtime-only ordering (no
+    regression).
     """
     if not selfevo_repo:
         return ""
@@ -701,14 +713,46 @@ def _system_map_inventory_section(selfevo_repo: Path | None) -> str:
 
         total = len(lines)
         if total > _MAX_INVENTORY_ENTRIES:
+            def _rel_for_line(line: str) -> str:
+                try:
+                    return line[2:].split(" — ", 1)[0].strip()
+                except Exception:
+                    return ""
+
             def _mtime_for_line(line: str) -> float:
                 try:
-                    rel = line[2:].split(" — ", 1)[0].strip()
+                    rel = _rel_for_line(line)
                     return (repo / rel).stat().st_mtime
                 except Exception:
                     return 0.0
 
-            lines = sorted(lines, key=_mtime_for_line, reverse=True)[:_MAX_INVENTORY_ENTRIES]
+            related: list[str] = []
+            if query and state_dir is not None:
+                try:
+                    related = existence_index.related_scripts(
+                        Path(state_dir), repo, query,
+                    )
+                except Exception:
+                    related = []
+
+            if related:
+                by_path = {_rel_for_line(line): line for line in lines}
+                ordered: list[str] = []
+                included: set[str] = set()
+                for rel in related:
+                    line = by_path.get(rel)
+                    if line is not None and rel not in included:
+                        ordered.append(line)
+                        included.add(rel)
+                remaining = [
+                    line for line in lines if _rel_for_line(line) not in included
+                ]
+                remaining.sort(key=_mtime_for_line, reverse=True)
+                slots = max(0, _MAX_INVENTORY_ENTRIES - len(ordered))
+                lines = ordered + remaining[:slots]
+            else:
+                lines = sorted(lines, key=_mtime_for_line, reverse=True)[:_MAX_INVENTORY_ENTRIES]
+
             note = f"({total} scripts total; showing the {_MAX_INVENTORY_ENTRIES} most recently modified)"
             section = note + "\n" + "\n".join(lines)
         else:
@@ -717,6 +761,32 @@ def _system_map_inventory_section(selfevo_repo: Path | None) -> str:
         if len(section) > _MAX_INVENTORY_CHARS:
             section = section[:_MAX_INVENTORY_CHARS]
         return section
+    except Exception:
+        return ""
+
+
+def _inventory_query(
+    demand_items: list[dict[str, str]] | None, goal_text: str,
+) -> str:
+    """Build the relevance query for the existing-scripts inventory (#840):
+    the demand item(s) being presented this cycle (summary/title text,
+    whichever field is populated), or — with no demand — the goal-text
+    priorities already in scope. Bounded to keep the FTS query cheap.
+    Fail-open: returns ``""`` on any error (caller then falls back to the
+    unranked, mtime-only inventory ordering)."""
+    try:
+        parts: list[str] = []
+        for item in demand_items or []:
+            if not isinstance(item, dict):
+                continue
+            text = str(
+                item.get("summary") or item.get("title") or item.get("task_title") or "",
+            ).strip()
+            if text:
+                parts.append(text)
+        if not parts:
+            parts.append(goal_text or "")
+        return " ".join(parts).strip()[:500]
     except Exception:
         return ""
 
@@ -880,10 +950,15 @@ def build_context(
                     + context
                 )
 
-        inventory_section = _system_map_inventory_section(selfevo_repo)
+        inventory_section = _system_map_inventory_section(
+            selfevo_repo,
+            state_dir=state_dir,
+            query=_inventory_query(demand_items, filtered_goal),
+        )
         if inventory_section:
             context += (
-                "\n\n## Existing scripts (do not duplicate — extend or skip instead)\n"
+                "\n\n## Existing scripts (do not duplicate — reuse or extend "
+                "one of these instead of writing a new file)\n"
                 + inventory_section
             )
 

--- a/tests/test_existence_index.py
+++ b/tests/test_existence_index.py
@@ -421,6 +421,58 @@ class TestOtherCorpora:
         assert any(h["kind"] == "hypothesis" for h in hits_research)
 
 
+# ─── #840: related_scripts (relevance ranking for the proposer inventory) ──
+
+
+class TestRelatedScripts:
+    def test_returns_relevant_script_matching_query(self, tmp_path):
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        _write_script(repo, "scripts/track_memory.py", "track memory usage over time.")
+        _write_script(repo, "scripts/deploy_release.py", "deploys the latest release.")
+
+        hits = ei.related_scripts(state_dir, repo, "track memory usage")
+
+        assert "scripts/track_memory.py" in hits
+
+    def test_excludes_test_files_and_dedups(self, tmp_path):
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        _write_script(repo, "scripts/track_memory.py", "track memory usage over time.")
+        _write_script(repo, "tests/test_track_memory.py", "tests for track memory usage.")
+
+        hits = ei.related_scripts(state_dir, repo, "track memory usage")
+
+        assert hits.count("scripts/track_memory.py") == 1
+        assert not any(h.startswith("tests/") for h in hits)
+        assert not any(Path(h).name.startswith("test_") for h in hits)
+
+    def test_disabled_returns_empty(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        _write_script(repo, "scripts/track_memory.py", "track memory usage over time.")
+
+        monkeypatch.setenv(ei.ENABLED_ENV, "0")
+        hits = ei.related_scripts(state_dir, repo, "track memory usage")
+
+        assert hits == []
+
+    def test_fail_open_on_missing_repo(self, tmp_path):
+        missing_state = tmp_path / "does-not-exist" / "state"
+        missing_repo = tmp_path / "does-not-exist" / "repo"
+
+        hits = ei.related_scripts(missing_state, missing_repo, "anything at all")
+
+        assert hits == []
+
+    def test_empty_query_returns_empty(self, tmp_path):
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        _write_script(repo, "scripts/track_memory.py", "track memory usage over time.")
+
+        assert ei.related_scripts(state_dir, repo, "") == []
+
+
 # ─── kill switch / fail-open ─────────────────────────────────────────────────
 
 

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -12,6 +12,7 @@ up by the bridge's real ``find_pending_request``.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -613,8 +614,65 @@ class TestBuildContext:
         inventory_idx = context.index("## Existing scripts")
         inventory_section = context[inventory_idx:]
         assert len(inventory_section) <= llm_proposer._MAX_INVENTORY_CHARS + len(
-            "## Existing scripts (do not duplicate — extend or skip instead)\n"
+            "## Existing scripts (do not duplicate — reuse or extend "
+            "one of these instead of writing a new file)\n"
         )
+
+
+# ─── #840: relevance-ranked existing-scripts inventory ─────────────────────
+
+
+class TestInventoryRelevanceRanking:
+    def test_relevant_old_script_survives_cap_with_query(self, tmp_path):
+        """A script relevant to the current demand/query, but with the
+        OLDEST mtime, would be dropped by the pre-#840 mtime-only cap. With
+        state_dir + a matching query, existence_index.related_scripts ranks
+        it first so it survives."""
+        state_dir = _state_dir(tmp_path)
+        repo = tmp_path / "selfevo_repo"
+        scripts_dir = repo / "scripts"
+        scripts_dir.mkdir(parents=True)
+
+        old_path = scripts_dir / "special_widget_analyzer.py"
+        old_path.write_text('"""Analyzes special widget metrics."""\n', encoding="utf-8")
+        old_time = 1_000_000_000
+        os.utime(old_path, (old_time, old_time))
+
+        for i in range(llm_proposer._MAX_INVENTORY_ENTRIES + 10):
+            p = scripts_dir / f"script_{i:03d}.py"
+            p.write_text(f'"""Script number {i}."""\n', encoding="utf-8")
+            newer_time = old_time + 1000 + i
+            os.utime(p, (newer_time, newer_time))
+
+        # Baseline (no query/state_dir): mtime-only ordering drops the old script.
+        baseline = llm_proposer._system_map_inventory_section(repo)
+        assert "special_widget_analyzer.py" not in baseline
+
+        # With a relevance query matching the old script, it survives the cap.
+        ranked = llm_proposer._system_map_inventory_section(
+            repo, state_dir=state_dir, query="special widget metrics",
+        )
+        assert "special_widget_analyzer.py" in ranked
+
+    def test_empty_query_is_byte_identical_to_no_arg_call(self, tmp_path):
+        """Regression pin (#840): query="" (the default) must produce EXACTLY
+        the same output as the pre-#840 no-keyword-arg call."""
+        state_dir = _state_dir(tmp_path)
+        repo = tmp_path / "selfevo_repo"
+        scripts_dir = repo / "scripts"
+        scripts_dir.mkdir(parents=True)
+        for i in range(llm_proposer._MAX_INVENTORY_ENTRIES + 10):
+            (scripts_dir / f"script_{i:03d}.py").write_text(
+                f'"""Script number {i}."""\n', encoding="utf-8"
+            )
+
+        default_call = llm_proposer._system_map_inventory_section(repo)
+        explicit_empty_query = llm_proposer._system_map_inventory_section(
+            repo, state_dir=state_dir, query="",
+        )
+
+        assert explicit_empty_query == default_call
+        assert default_call != ""
 
 
 # ─── #716: _recent_failed_titles (recent non-integrated attempts) ──────────


### PR DESCRIPTION
Closes #840 (top-leverage / behavioral root of low confirmed_integration_ratio). The proposer's #749 existing-scripts inventory kept newest-by-mtime when over the cap, so a script relevant to the current demand could be invisible → rebuilt under a new name. Add existence_index.related_scripts (thin reuse of the existing FTS find_similar) and rank the inventory relevance-first so relevant tools survive the cap; reframed as reuse/extend. Byte-identical when demand/index absent; fail-open; no new env; no gate/fitness/trust change (read-side context only). Sonnet-built (worktree), Opus-reviewed. Tests: TestRelatedScripts + TestInventoryRelevanceRanking; full existence_index+llm_proposer suites green (188). 🤖 Claude Code