### PR TITLE
feat(runtime): held-out regression metric — pass->fail flips (#841)

### DIFF
--- a/nanobot/runtime/heldout/__init__.py
+++ b/nanobot/runtime/heldout/__init__.py
@@ -24,7 +24,11 @@ in the instance repo into an isolated tmpdir (at its repo-relative path, so
 ``<state_dir>/heldout/results.json`` (schema ``heldout-results-v1``).
 Sandbox: subprocess via ``sys.executable``, ``cwd=tmpdir``, 30s timeout,
 env stripped to a minimal PATH + tmpdir-only PYTHONPATH/HOME/TMPDIR — no
-state_dir, no secrets, no network assumptions.
+state_dir, no secrets, no network assumptions. The persisted results also
+carry ``regressions`` (#841): artifacts whose status flipped from
+``pass`` (previous run) to ``fail`` (this run) — a churn signal distinct
+from raw pass/fail counts; still-failing and newly-checked artifacts do
+not count.
 
 **Cadence.** Full runs are gated by the ``usage_evidence`` HEAD+time
 watermark (re-run only when the instance HEAD moved or
@@ -215,11 +219,24 @@ def run_heldout(
             except Exception:
                 continue  # fail-open per artifact
 
+        try:
+            regressions = sorted(
+                artifact
+                for artifact, res in results.items()
+                if isinstance(res, dict)
+                and res.get("status") == "fail"
+                and isinstance(previous.get(artifact), dict)
+                and previous[artifact].get("status") == "pass"
+            )
+        except Exception:
+            regressions = []  # fail-open — a regressions bug must never break run_heldout
+
         data = {
             "schema_version": HELDOUT_SCHEMA,
             "git_head": head or "",
             "checked_at_utc": _iso(now),
             "results": results,
+            "regressions": regressions,  # #841: artifacts that flipped pass->fail this run
         }
         _write_json(_results_path(state_dir), data)
         return data

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -765,10 +765,15 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
     (``<state_dir>/heldout/results.json``, written by
     ``nanobot.runtime.heldout.run_heldout``). ``heldout_gap`` =
     failed / (passed + failed) — skips are excluded from the denominator (a
-    checker timeout/bug must never count against the instance). Fail-open:
-    missing/corrupt results read as zeros with a ``None`` gap (no gap
-    fabricated from missing data)."""
+    checker timeout/bug must never count against the instance).
+    ``heldout_regressions`` (#841) is the count of the persisted
+    ``regressions`` list — artifacts that were ``pass`` in the previous
+    held-out run and are ``fail`` in this one, i.e. "something that used
+    to pass now fails," surfaced separately from the raw pass/fail counts.
+    Fail-open: missing/corrupt results read as zeros with a ``None`` gap
+    (no gap fabricated from missing data)."""
     checked = passed = failed = skipped = 0
+    regressions = 0
     try:
         data = _read_json(Path(state_dir) / "heldout" / "results.json", None)
         results = data.get("results") if isinstance(data, dict) else None
@@ -788,12 +793,19 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
                     skipped += 1
     except Exception:
         pass
+    try:
+        regs = data.get("regressions") if isinstance(data, dict) else None
+        if isinstance(regs, list):
+            regressions = len(regs)
+    except Exception:
+        regressions = 0
     return {
         "checked": checked,
         "passed": passed,
         "failed": failed,
         "skipped": skipped,
         "heldout_gap": _ratio(failed, passed + failed),
+        "heldout_regressions": regressions,
     }
 
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -774,6 +774,7 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
     (no gap fabricated from missing data)."""
     checked = passed = failed = skipped = 0
     regressions = 0
+    data = None
     try:
         data = _read_json(Path(state_dir) / "heldout" / "results.json", None)
         results = data.get("results") if isinstance(data, dict) else None

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -156,20 +156,18 @@ def _repo_snapshot(repo: Path) -> set[tuple[str, bytes]]:
     }
 
 
-def _write_results(state_dir: Path, results: dict) -> None:
+def _write_results(state_dir: Path, results: dict, *, regressions: list | None = None) -> None:
+    payload = {
+        "schema_version": heldout.HELDOUT_SCHEMA,
+        "git_head": "abc",
+        "checked_at_utc": NOW.isoformat().replace("+00:00", "Z"),
+        "results": results,
+    }
+    if regressions is not None:
+        payload["regressions"] = regressions
     path = state_dir / "heldout" / "results.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(
-            {
-                "schema_version": heldout.HELDOUT_SCHEMA,
-                "git_head": "abc",
-                "checked_at_utc": NOW.isoformat().replace("+00:00", "Z"),
-                "results": results,
-            }
-        ),
-        encoding="utf-8",
-    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 # ─── runner ─────────────────────────────────────────────────────────────────
@@ -285,6 +283,61 @@ class TestRunner:
             heldout.run_heldout(tmp_path / "state", tmp_path / "nope")["results"] == {}
         )
 
+    # ─── regressions (#841: pass -> fail flips) ─────────────────────────────
+
+    def test_regression_pass_to_fail_recorded(self, tmp_path):
+        repo = _make_repo(tmp_path, {"archive_old_reports.py": GOOD_ARCHIVE})
+        state_dir = tmp_path / "state"
+        first = heldout.run_heldout(state_dir, repo, force=True)
+        assert first["results"]["scripts/archive_old_reports.py"]["status"] == "pass"
+        assert first["regressions"] == []
+        # Swap the passing script for the reward-hacked variant — same
+        # artifact path, new content → rechecked, now fails.
+        (repo / "scripts" / "archive_old_reports.py").write_text(
+            BAD_ARCHIVE, encoding="utf-8"
+        )
+        second = heldout.run_heldout(state_dir, repo, force=True)
+        assert second["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert second["regressions"] == ["scripts/archive_old_reports.py"]
+        on_disk = json.loads((state_dir / "heldout" / "results.json").read_text())
+        assert on_disk["regressions"] == ["scripts/archive_old_reports.py"]
+
+    def test_regression_still_failing_not_counted(self, tmp_path):
+        repo = _make_repo(tmp_path, {"archive_old_reports.py": BAD_ARCHIVE})
+        state_dir = tmp_path / "state"
+        first = heldout.run_heldout(state_dir, repo, force=True)
+        assert first["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert first["regressions"] == []
+        # Still buggy, but content changed → rechecked, still fails. Was
+        # already failing last run, so this is NOT a regression.
+        (repo / "scripts" / "archive_old_reports.py").write_text(
+            BAD_ARCHIVE + "\n# still broken\n", encoding="utf-8"
+        )
+        second = heldout.run_heldout(state_dir, repo, force=True)
+        assert second["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert second["regressions"] == []
+
+    def test_regression_new_only_failure_not_counted(self, tmp_path):
+        """An artifact with no prior result (first time checked) that fails
+        is not a regression — there was nothing to regress from."""
+        repo = _make_repo(tmp_path, {"archive_old_reports.py": BAD_ARCHIVE})
+        state_dir = tmp_path / "state"
+        data = heldout.run_heldout(state_dir, repo, force=True)
+        assert data["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert data["regressions"] == []
+
+    def test_regression_pass_to_pass_empty(self, tmp_path):
+        repo = _make_repo(tmp_path, {"archive_old_reports.py": GOOD_ARCHIVE})
+        state_dir = tmp_path / "state"
+        heldout.run_heldout(state_dir, repo, force=True)
+        # Content changed but still a correct implementation → still pass.
+        (repo / "scripts" / "archive_old_reports.py").write_text(
+            GOOD_ARCHIVE + "\n# still fine\n", encoding="utf-8"
+        )
+        second = heldout.run_heldout(state_dir, repo, force=True)
+        assert second["results"]["scripts/archive_old_reports.py"]["status"] == "pass"
+        assert second["regressions"] == []
+
 
 # ─── sandbox ────────────────────────────────────────────────────────────────
 
@@ -352,6 +405,7 @@ class TestScorecardHeldout:
             "failed": 1,
             "skipped": 1,
             "heldout_gap": 0.5,  # skips excluded from the denominator
+            "heldout_regressions": 0,
         }
         gap_metrics = [g["metric"] for g in snap["gaps"]]
         assert "heldout_gap" in gap_metrics
@@ -374,8 +428,36 @@ class TestScorecardHeldout:
             "failed": 0,
             "skipped": 0,
             "heldout_gap": None,
+            "heldout_regressions": 0,
         }
         assert "heldout_gap" not in [g["metric"] for g in snap["gaps"]]
+
+    def test_regressions_count_exposed(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_results(
+            state_dir,
+            {
+                "scripts/a.py": {"status": "pass", "evidence": "ok"},
+                "scripts/x.py": {"status": "fail", "evidence": "broken"},
+            },
+            regressions=["scripts/x.py"],
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        assert snap["heldout"]["heldout_regressions"] == 1
+
+    def test_regressions_missing_key_defaults_zero(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_results(state_dir, {"scripts/a.py": {"status": "pass", "evidence": "ok"}})
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        assert snap["heldout"]["heldout_regressions"] == 0
+
+    def test_regressions_empty_list_zero(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_results(
+            state_dir, {"scripts/a.py": {"status": "pass", "evidence": "ok"}}, regressions=[]
+        )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        assert snap["heldout"]["heldout_regressions"] == 0
 
     def test_corrupt_results_no_crash(self, tmp_path):
         state_dir = tmp_path / "state"


### PR DESCRIPTION
Closes #841. run_heldout records regressions (artifacts pass last run, fail this run) in results.json; scorecard._heldout_section exposes heldout_regressions. Surfaces 'used to pass, now fails' distinct from raw pass-rate — a churn/regression signal (C#4; TDAD). Still-broken and new-only failures are NOT regressions. Harness-computed, bounded (~5 held-out artifacts), fail-open, additive only. Sonnet-built (worktree), reviewed. Tests: TestRunner regression cases + TestScorecardHeldout; test_heldout.py green (31). 🤖 Claude Code