### PR TITLE
fix(runtime): validity-before-score invariant — audit + guards (#843)

### DIFF
--- a/nanobot/runtime/cycle_feedback.py
+++ b/nanobot/runtime/cycle_feedback.py
@@ -1707,7 +1707,11 @@ def _load_previous_experiment_snapshot(experiments_dir: Path) -> dict[str, Any] 
     return data if isinstance(data, dict) else None
 
 
-def _experiment_metric_summary(result_status: str, reward_signal: dict[str, Any], previous_experiment: dict[str, Any] | None) -> dict[str, Any]:
+def _experiment_metric_summary(result_status: str, reward_signal: dict[str, Any] | None, previous_experiment: dict[str, Any] | None) -> dict[str, Any]:
+    # VALIDITY-BEFORE-SCORE (#843): guard a null/malformed reward_signal so the
+    # metric summary cannot crash; missing value falls through to 0.0.
+    if not isinstance(reward_signal, dict):
+        reward_signal = {}
     metric_name = 'reward_signal.value'
     try:
         metric_current = float(reward_signal.get('value') or 0.0)

--- a/nanobot/runtime/scorer.py
+++ b/nanobot/runtime/scorer.py
@@ -108,7 +108,7 @@ def _load_weights(
 
 
 def score_cycle(
-    fd: dict,
+    fd: Optional[dict],
     budget: dict,
     commits_pushed: int,
     result_status: str,
@@ -130,6 +130,13 @@ def score_cycle(
     Returns:
         ScoringResult with value, outcome, revert_required, rationale, weights_source.
     """
+    # VALIDITY-BEFORE-SCORE (#843): a null/malformed feedback dict is not a
+    # valid submission — coerce to empty so it scores as "no signal" (unknown
+    # mode/status → defaults), never as a pass. Prevents a crash masquerading
+    # as a scoring path.
+    if not isinstance(fd, dict):
+        fd = {}
+
     mode = str(fd.get("mode") or "")
     status = str(result_status or "")
 
@@ -157,7 +164,10 @@ def score_cycle(
     )
 
     # ── Bonus: already_done is a valid, positive outcome ─────────────────────
-    if status == "already_done":
+    # VALIDITY-BEFORE-SCORE (#843): credit already_done only when a real
+    # feedback decision exists (non-empty mode). An empty/no-op submission
+    # cannot claim a passing verdict by merely asserting status="already_done".
+    if status == "already_done" and mode:
         value = max(value, 1.0)
 
     # ── Outcome gate ─────────────────────────────────────────────────────────

--- a/tests/test_validity_before_score.py
+++ b/tests/test_validity_before_score.py
@@ -1,0 +1,71 @@
+"""Tests for #843: validity-before-score invariant audit.
+
+Pins, per critical scoring/confirm path, that an EMPTY or INVALID input
+never yields a passing/perfect metric AND never crashes:
+  - scorer.score_cycle: null/empty feedback dict never scores "keep".
+  - cycle_feedback._experiment_metric_summary: null reward_signal never
+    crashes and falls through to metric_current == 0.0.
+  - scorecard._ratio: a zero denominator never fabricates a ratio (the
+    focused unit-pin of the confirmed_integration_ratio gate).
+  - heldout: an invalid/empty check status is never treated as "pass".
+"""
+from __future__ import annotations
+
+from nanobot.runtime import cycle_feedback, scorecard, scorer
+from nanobot.runtime.heldout import _VALID_STATUSES, _check_one
+from datetime import datetime, timezone
+
+
+class TestScorerValidityBeforeScore:
+    def test_none_feedback_dict_does_not_raise_and_never_keeps(self):
+        result = scorer.score_cycle(
+            fd=None, budget={}, commits_pushed=0, result_status=""
+        )
+        assert result.outcome != "keep"
+        assert result.value < scorer.THRESHOLD_KEEP
+
+    def test_empty_feedback_dict_never_keeps(self):
+        result = scorer.score_cycle(
+            fd={}, budget={}, commits_pushed=0, result_status=""
+        )
+        assert result.outcome != "keep"
+
+    def test_empty_submission_cannot_claim_already_done_keep(self):
+        """The already_done 1.0 bonus must not lift an empty/no-op submission
+        (no feedback decision, no commits) to a passing 'keep' verdict (#843)."""
+        result = scorer.score_cycle(
+            fd={}, budget={}, commits_pushed=0, result_status="already_done"
+        )
+        assert result.outcome != "keep"
+        assert result.value < scorer.THRESHOLD_KEEP
+
+
+class TestExperimentMetricSummaryValidityBeforeScore:
+    def test_none_reward_signal_does_not_raise_and_metric_is_zero(self):
+        summary = cycle_feedback._experiment_metric_summary(
+            result_status="", reward_signal=None, previous_experiment=None
+        )
+        assert summary["metric_current"] == 0.0
+
+
+class TestScorecardRatioValidityBeforeScore:
+    def test_zero_denominator_is_none_not_a_fabricated_ratio(self):
+        assert scorecard._ratio(0, 0) is None
+        assert scorecard._ratio(5, 0) is None
+
+
+class TestHeldoutValidityBeforeScore:
+    def test_valid_statuses_excludes_empty_string(self):
+        assert "" not in _VALID_STATUSES
+
+    def test_fabricated_empty_status_is_not_counted_as_pass(self):
+        """A checker returning an invalid/empty status must be coerced to
+        'skip', never silently accepted as a passing verdict (#843)."""
+        def _checker(_ctx):
+            return "", "no real verdict"
+
+        entry = _check_one(
+            "scripts/x.py", "print('x')\n", _checker, datetime.now(timezone.utc)
+        )
+        assert entry["status"] != "pass"
+        assert entry["status"] == "skip"


### PR DESCRIPTION
Closes #843.

## Audit conclusion
Audited every fitness/score/confirmation path (scorecard ratios, `confirm_serves`, heldout, `benchmark_evidence`, smoke-gate `empty_integration` #828). The validity-before-score invariant **already holds** on all critical paths. This PR closes the two remaining defensive gaps + the one real empty-scores-perfect hole, and pins the invariant with regression tests.

## Changes
- **scorer.score_cycle**: coerce null/malformed `fd` → empty (no-signal, never "keep"); gate the `already_done` 1.0 bonus on a real feedback decision (non-empty `mode`) so a no-op submission cannot claim a passing verdict by asserting `result_status="already_done"` (the documented failure class, arXiv:2605.25665).
- **cycle_feedback._experiment_metric_summary**: guard null `reward_signal` (no crash; value → 0.0).
- Params retyped `Optional` to match the guards honestly.
- **tests/test_validity_before_score.py**: pins per-path that empty/invalid input never yields a passing/perfect metric and never crashes.

## Verify
```
python -m pytest tests/test_validity_before_score.py tests/test_frozen_scorer.py -q
28 passed
```

Additive, fail-safe, no behavior change on valid inputs. Reviewed by Opus (1 MED → fixed: already_done hole; 2 LOW → kept intentionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)