### PR TITLE
fix(runtime): exclude flaky held-out tasks from the gate signal (#842)

### DIFF
--- a/nanobot/runtime/heldout/__init__.py
+++ b/nanobot/runtime/heldout/__init__.py
@@ -28,7 +28,11 @@ state_dir, no secrets, no network assumptions. The persisted results also
 carry ``regressions`` (#841): artifacts whose status flipped from
 ``pass`` (previous run) to ``fail`` (this run) — a churn signal distinct
 from raw pass/fail counts; still-failing and newly-checked artifacts do
-not count.
+not count. A changed artifact's first non-skip verdict is confirmed with
+up to :data:`_FLAKY_CONFIRM_RUNS` identical re-runs (#842); if the status
+flips across those runs the artifact is non-deterministic noise, not
+signal, so its recorded verdict is downgraded to ``skip`` (excluded from
+the gate) and it is logged in the persisted ``flaky`` list.
 
 **Cadence.** Full runs are gated by the ``usage_evidence`` HEAD+time
 watermark (re-run only when the instance HEAD moved or
@@ -62,6 +66,12 @@ _CHECK_TIMEOUT_SECONDS = 30.0
 _MAX_EVIDENCE_CHARS = 240  # same bound as demand._MAX_EVIDENCE_CHARS
 
 _VALID_STATUSES = ("pass", "fail", "skip")
+
+_FLAKY_CONFIRM_RUNS = 2  # total checker runs for a non-skip verdict; a status
+                         # flip across identical runs => flaky => excluded (skip).
+                         # Bounded to respect the 2GB host; re-runs happen only
+                         # for CHANGED pass/fail artifacts (watermark + content-hash
+                         # gating already skip unchanged ones).
 
 
 def _results_path(state_dir: Path) -> Path:
@@ -159,6 +169,38 @@ def _check_one(artifact: str, source: str, checker: Any, now: datetime) -> dict[
     }
 
 
+def _check_stable(artifact: str, source: str, checker: Any, now: datetime) -> dict[str, Any]:
+    """Wrap :func:`_check_one` with bounded re-runs (#842) to catch a
+    non-deterministic checker verdict: a status that flips across identical
+    re-runs of the same source is noise, not signal, so it is excluded from
+    the gate as ``skip`` rather than trusted as pass or fail.
+
+    A first-run ``skip`` is returned unchanged — skip is already excluded
+    from the gate, so spending re-runs on it buys nothing. Otherwise, up to
+    :data:`_FLAKY_CONFIRM_RUNS` - 1 additional runs are made; if any disagrees
+    with the first run's status, the result is downgraded to ``skip`` with a
+    ``flaky`` marker and evidence describing the flip. All runs agreeing
+    returns the first (stable) result unchanged."""
+    first = _check_one(artifact, source, checker, now)
+    if first["status"] == "skip":
+        return first
+    for _ in range(_FLAKY_CONFIRM_RUNS - 1):
+        other = _check_one(artifact, source, checker, now)
+        if other["status"] != first["status"]:
+            evidence = (
+                f"flaky: {first['status']} then {other['status']} "
+                f"across {_FLAKY_CONFIRM_RUNS} identical runs"
+            )
+            return {
+                "status": "skip",
+                "evidence": evidence[:_MAX_EVIDENCE_CHARS],
+                "content_hash": first["content_hash"],
+                "ts": _iso(now),
+                "flaky": True,
+            }
+    return first
+
+
 def run_heldout(
     state_dir: Path,
     selfevo_repo: Path | None,
@@ -215,7 +257,7 @@ def run_heldout(
                 ):
                     results[artifact] = prev  # unchanged script — verdict reused
                     continue
-                results[artifact] = _check_one(artifact, source, checker, now)
+                results[artifact] = _check_stable(artifact, source, checker, now)
             except Exception:
                 continue  # fail-open per artifact
 
@@ -231,12 +273,22 @@ def run_heldout(
         except Exception:
             regressions = []  # fail-open — a regressions bug must never break run_heldout
 
+        try:
+            flaky = sorted(
+                artifact
+                for artifact, res in results.items()
+                if isinstance(res, dict) and res.get("flaky") is True
+            )
+        except Exception:
+            flaky = []  # fail-open — a flaky-list bug must never break run_heldout
+
         data = {
             "schema_version": HELDOUT_SCHEMA,
             "git_head": head or "",
             "checked_at_utc": _iso(now),
             "results": results,
             "regressions": regressions,  # #841: artifacts that flipped pass->fail this run
+            "flaky": flaky,  # #842: artifacts excluded as skip due to a non-deterministic verdict
         }
         _write_json(_results_path(state_dir), data)
         return data

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -240,6 +240,8 @@ class TestRunner:
         assert "checker bug" in entry["evidence"]
 
     def test_content_hash_skips_recheck(self, tmp_path, monkeypatch):
+        # A changed non-skip verdict is confirmed with _FLAKY_CONFIRM_RUNS
+        # checker calls (#842) before being trusted stable, not just 1.
         calls = {"n": 0}
 
         def _counting(ctx):
@@ -250,16 +252,16 @@ class TestRunner:
         repo = _make_repo(tmp_path, {"loop_health_report.py": SMOKE_OK})
         state_dir = tmp_path / "state"
         heldout.run_heldout(state_dir, repo, force=True)
-        assert calls["n"] == 1
+        assert calls["n"] == heldout._FLAKY_CONFIRM_RUNS
         # Second forced run: content unchanged → verdict reused, no re-exec.
         heldout.run_heldout(state_dir, repo, force=True)
-        assert calls["n"] == 1
-        # Content change → re-checked.
+        assert calls["n"] == heldout._FLAKY_CONFIRM_RUNS
+        # Content change → re-checked (confirmed again).
         (repo / "scripts" / "loop_health_report.py").write_text(
             SMOKE_OK + "# changed\n", encoding="utf-8"
         )
         heldout.run_heldout(state_dir, repo, force=True)
-        assert calls["n"] == 2
+        assert calls["n"] == heldout._FLAKY_CONFIRM_RUNS * 2
 
     def test_head_time_watermark_no_op(self, tmp_path, monkeypatch):
         calls = {"n": 0}
@@ -272,10 +274,11 @@ class TestRunner:
         repo = _make_repo(tmp_path, {"loop_health_report.py": SMOKE_OK})
         state_dir = tmp_path / "state"
         first = heldout.run_heldout(state_dir, repo)
-        assert calls["n"] == 1
+        assert calls["n"] == heldout._FLAKY_CONFIRM_RUNS
         # Same HEAD, fresh timestamp → whole run is a watermark no-op.
         second = heldout.run_heldout(state_dir, repo)
         assert second == first
+        assert calls["n"] == heldout._FLAKY_CONFIRM_RUNS
 
     def test_no_repo_and_missing_repo_fail_open(self, tmp_path):
         assert heldout.run_heldout(tmp_path / "state", None)["results"] == {}
@@ -337,6 +340,61 @@ class TestRunner:
         second = heldout.run_heldout(state_dir, repo, force=True)
         assert second["results"]["scripts/archive_old_reports.py"]["status"] == "pass"
         assert second["regressions"] == []
+
+
+# ─── flaky detection (#842: non-deterministic verdict exclusion) ───────────
+
+
+class TestFlakyDetection:
+    def test_stable_pass_no_flaky_key(self):
+        def _always_pass(ctx):
+            return "pass", "ok"
+
+        result = heldout._check_stable("scripts/x.py", "src", _always_pass, NOW)
+        assert result["status"] == "pass"
+        assert "flaky" not in result
+
+    def test_flip_fail_then_pass_is_flaky(self):
+        calls = {"n": 0}
+
+        def _flip(ctx):
+            calls["n"] += 1
+            return ("fail", "broke") if calls["n"] == 1 else ("pass", "ok")
+
+        result = heldout._check_stable("scripts/x.py", "src", _flip, NOW)
+        assert result["status"] == "skip"
+        assert result["flaky"] is True
+        assert "flaky" in result["evidence"]
+        assert calls["n"] == 2
+
+    def test_first_skip_no_extra_runs(self):
+        """A first-run skip is returned as-is — skip is already excluded
+        from the gate, so no re-runs are spent confirming it."""
+        calls = {"n": 0}
+
+        def _skip_once(ctx):
+            calls["n"] += 1
+            return "skip", "timed out"
+
+        result = heldout._check_stable("scripts/x.py", "src", _skip_once, NOW)
+        assert result["status"] == "skip"
+        assert "flaky" not in result
+        assert calls["n"] == 1
+
+    def test_end_to_end_flaky_artifact_recorded(self, tmp_path, monkeypatch):
+        calls = {"n": 0}
+
+        def _flip(ctx):
+            calls["n"] += 1
+            return ("fail", "broke") if calls["n"] == 1 else ("pass", "ok")
+
+        monkeypatch.setitem(checkers.CHECKERS, "scripts/loop_health_report.py", _flip)
+        repo = _make_repo(tmp_path, {"loop_health_report.py": SMOKE_OK})
+        data = heldout.run_heldout(tmp_path / "state", repo, force=True)
+        assert data["flaky"] == ["scripts/loop_health_report.py"]
+        entry = data["results"]["scripts/loop_health_report.py"]
+        assert entry["status"] == "skip"
+        assert entry["flaky"] is True
 
 
 # ─── sandbox ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #842.

## Problem
A held-out task that flips pass/fail across identical re-runs (no code change) is a noise source — it either falsely blocks good changes or gets explained away. Standard fix (ProdCodeBench arXiv:2604.01527): re-run and exclude flaky tasks.

## Change (heldout runner only)
- `_check_stable` wraps `_check_one` with **bounded** re-runs: a first-run `skip` returns unchanged (skip already excluded — no wasted runs); otherwise up to `_FLAKY_CONFIRM_RUNS-1` confirming re-runs. Any status flip → verdict downgraded to `skip` + `flaky=True` + evidence describing the flip.
- `run_heldout` calls `_check_stable` in the changed-artifact branch only; content-hash-reuse + watermark short-circuits untouched → idle/unchanged cycles fire **zero** extra runs (2GB-host safe).
- Persisted `flaky` list logs what was dropped (no silent cap), mirroring the #841 regressions log.
- `flaky→skip` auto-excludes from gate pass/fail counts AND from the #841 regressions signal (requires `status==fail`) → **no scorecard change**.

## Verify
```
python -m pytest tests/test_heldout.py -q
35 passed
```

Additive, fail-open, no new env. `_FLAKY_CONFIRM_RUNS=2`. Reviewed by Opus (no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)