### PR TITLE
fix(runtime): coordinator no longer self-accepts its own promotions (#853)

### DIFF
--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -20,7 +20,6 @@ from nanobot.runtime._io import utc_now as _utc_now
 from nanobot.runtime.autoevolve import resolve_terminal_selfevo_issue
 from nanobot.runtime.promotion import (
     complete_promotion_readiness_packet,
-    review_promotion_candidate,
     supply_missing_promotion_readiness_inputs,
 )
 from nanobot.runtime.lessons import update_lessons_from_cycle
@@ -446,7 +445,9 @@ async def run_self_evolving_cycle(
         experiment["budget_used"]["tool_calls"] = max(int(experiment["budget_used"].get("tool_calls") or 0), 2)
         if current_plan.get("current_task_id") == "subagent-verify-materialized-improvement":
             experiment["budget_used"]["subagents"] = max(int(experiment["budget_used"].get("subagents") or 0), 1)
-        if (current_plan.get("feedback_decision") or {}).get("mode") in {"complete_active_lane", "handoff_to_next_candidate", "handoff_to_subagent_verification"}:
+        # #853: require a verified concrete diff before a cycle can ever reach
+        # ready-for-policy-review — a metadata-only cycle must not qualify.
+        if (current_plan.get("feedback_decision") or {}).get("mode") in {"complete_active_lane", "handoff_to_next_candidate", "handoff_to_subagent_verification"} and _has_concrete_changes(workspace, state_root=state_root, cycle_started_utc=cycle_started):
             experiment["review_status"] = "ready_for_policy_review"
             experiment["decision"] = "ready_for_policy_review"
             experiment["readiness_checks"] = [
@@ -590,41 +591,18 @@ async def run_self_evolving_cycle(
             encoding="utf-8",
         )
         if review_status == "ready_for_policy_review" and final_artifact_path:
-            review_result = review_promotion_candidate(
-                workspace=state_root.parent,
-                state_root=state_root,
-                candidate_id=promotion_candidate_id,
-                decision="accept",
-                decision_reason="autonomous runtime accepted a ready self-evolving promotion with materialized artifact evidence",
-            )
-            decision_record_path = promotions_dir / "decisions" / f"{promotion_candidate_id}.json"
-            accepted_record_path = promotions_dir / "accepted" / f"{promotion_candidate_id}.json"
-            decision_record_value = str(decision_record_path)
-            accepted_record_value = str(accepted_record_path) if accepted_record_path.exists() else None
-            review_status = str(review_result.get("review_status") or "reviewed")
-            decision = str(review_result.get("decision") or "accept")
-            experiment["review_status"] = review_status
-            experiment["decision"] = decision
+            # #853: an "accept" decision requires a real external actor. The
+            # autonomous runtime must NOT accept its own promotion candidate —
+            # doing so fabricated a false 'reviewed/accepted' audit trail with
+            # no verified diff (base_commit/patch_hash=None). The candidate
+            # stays pending operator review: the base promotion record written
+            # above already carries review_status=ready_for_policy_review and a
+            # pending_operator_review governance packet, so we only record the
+            # pending decision markers and leave promotions/accepted/ empty.
+            decision_record_value = "pending_operator_review_packet"
+            accepted_record_value = None
             experiment["decision_record"] = decision_record_value
             experiment["accepted_record"] = accepted_record_value
-            final_promotion_record = {
-                **review_result,
-                "decision_record": decision_record_value,
-                "accepted_record": accepted_record_value,
-                "governance_packet": {
-                    **(final_promotion_record.get("governance_packet") if isinstance(final_promotion_record.get("governance_packet"), dict) else {}),
-                    "review_packet_status": "accepted" if accepted_record_value else "reviewed",
-                    "review_status": review_status,
-                    "decision": decision,
-                    "decision_record": decision_record_value,
-                    "accepted_record": accepted_record_value,
-                },
-            }
-            promotion_path.write_text(json.dumps(final_promotion_record, indent=2, ensure_ascii=False), encoding="utf-8")
-            (promotions_dir / "latest.json").write_text(
-                json.dumps({**final_promotion_record, "candidate_path": str(promotion_path)}, indent=2, ensure_ascii=False),
-                encoding="utf-8",
-            )
         elif review_status == "not_ready_for_policy_review" and decision == "not_ready_for_policy_review":
             readiness_result = complete_promotion_readiness_packet(
                 workspace=state_root.parent,

--- a/tests/test_generated_cleanup_and_readiness.py
+++ b/tests/test_generated_cleanup_and_readiness.py
@@ -11,7 +11,16 @@ def _read_json(path: Path):
     return json.loads(path.read_text(encoding='utf-8'))
 
 
-def test_consumed_generated_lanes_are_retired_and_artifact_semantics_are_rich(tmp_path: Path):
+def test_consumed_generated_lanes_are_retired_and_artifact_semantics_are_rich(tmp_path: Path, monkeypatch):
+    # #853: readiness-for-policy-review now requires a verified concrete diff.
+    # This scenario represents a genuine materialized improvement (which by
+    # definition carries a real change), so pin _has_concrete_changes True —
+    # the test exercises lane-retirement + rich-artifact + ready semantics,
+    # not the empty-cycle path (covered in tests/test_runtime_coordinator.py).
+    monkeypatch.setattr(
+        'nanobot.runtime.coordinator._has_concrete_changes',
+        lambda *a, **k: True,
+    )
     approvals_dir = tmp_path / 'state' / 'approvals'
     approvals_dir.mkdir(parents=True)
     expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)

--- a/tests/test_materialized_lane_value.py
+++ b/tests/test_materialized_lane_value.py
@@ -75,11 +75,14 @@ def test_materialized_lane_gets_reward_bonus_readiness_and_deeper_budget(tmp_pat
     assert report['reward_signal']['value'] >= 1.2
     assert report['reward_signal']['source'] == 'materialized_improvement_artifact'
     assert report['budget_used']['tool_calls'] >= 2
-    assert report['review_status'] == 'reviewed'
-    assert report['decision'] == 'accept'
-    assert summary['experiment']['review_status'] == 'reviewed'
-    assert summary['experiment']['decision'] == 'accept'
+    # #853: the coordinator must not self-accept its own promotion candidate —
+    # a ready candidate stays pending operator review, not auto-reviewed/accepted.
+    assert report['review_status'] == 'ready_for_policy_review'
+    assert report['decision'] == 'ready_for_policy_review'
+    assert summary['experiment']['review_status'] == 'ready_for_policy_review'
+    assert summary['experiment']['decision'] == 'ready_for_policy_review'
     latest = _read_json(tmp_path / 'state' / 'promotions' / 'latest.json')
     candidate_id = latest['promotion_candidate_id']
-    assert latest['decision_record'].endswith(f'decisions/{candidate_id}.json')
-    assert latest['accepted_record'].endswith(f'accepted/{candidate_id}.json')
+    assert latest['decision_record'] == 'pending_operator_review_packet'
+    assert latest['accepted_record'] is None
+    assert not (tmp_path / 'state' / 'promotions' / 'accepted' / f'{candidate_id}.json').exists()

--- a/tests/test_promotion_governance_packet.py
+++ b/tests/test_promotion_governance_packet.py
@@ -84,15 +84,16 @@ def test_ready_materialized_lane_writes_governance_packet_into_promotion_candida
     candidate_id = latest['promotion_candidate_id']
     candidate = _read_json(tmp_path / 'state' / 'promotions' / f'{candidate_id}.json')
 
-    assert candidate['review_status'] == 'reviewed'
-    assert candidate['decision'] == 'accept'
+    # #853: the coordinator must not self-accept its own promotion candidate —
+    # a ready candidate stays pending operator review, not auto-reviewed/accepted.
+    assert candidate['review_status'] == 'ready_for_policy_review'
+    assert candidate['decision'] == 'ready_for_policy_review'
     assert candidate['readiness_checks']
     assert candidate['readiness_reasons']
-    assert candidate['decision_record'].endswith(f"decisions/{candidate_id}.json")
-    assert candidate['accepted_record'].endswith(f"accepted/{candidate_id}.json")
-    assert Path(candidate['decision_record']).exists()
-    assert Path(candidate['accepted_record']).exists()
+    assert candidate['decision_record'] == 'pending_operator_review_packet'
+    assert candidate['accepted_record'] is None
+    assert not (tmp_path / 'state' / 'promotions' / 'accepted' / f'{candidate_id}.json').exists()
     assert candidate['artifact_path']
     assert candidate['governance_packet']
-    assert candidate['governance_packet']['review_packet_status'] == 'accepted'
+    assert candidate['governance_packet']['review_packet_status'] == 'pending_operator_review'
     assert candidate['governance_packet']['source_artifact'] == candidate['artifact_path']

--- a/tests/test_runtime_coordinator.py
+++ b/tests/test_runtime_coordinator.py
@@ -3658,3 +3658,142 @@ def test_synthesize_fast_path_not_triggered_when_materialize_pending(tmp_path: P
 
     assert decision is not None
     assert decision.get("selection_source") != "feedback_synthesize_verify_complete_fast_path"
+
+
+# --- Issue #853: the coordinator must never auto-accept its own promotion
+# candidate. review_status may only reach "ready_for_policy_review" behind a
+# verified concrete-diff check, and even then the candidate must stay pending
+# operator review — no promotions/accepted/*.json, no fabricated audit trail.
+
+def _write_ready_materialized_cycle_fixture(tmp_path: Path) -> tuple[datetime, Path]:
+    """Shared fixture: a fresh approval gate + a task plan whose feedback_decision
+    mode + materialized artifact would otherwise qualify for ready_for_policy_review.
+    """
+    approvals_dir = tmp_path / "state" / "approvals"
+    approvals_dir.mkdir(parents=True)
+    expires_at = datetime(2026, 4, 15, 13, 0, tzinfo=timezone.utc)
+    (approvals_dir / "apply.ok").write_text(
+        json.dumps({"expires_at_utc": expires_at.isoformat(), "ttl_minutes": 60}),
+        encoding="utf-8",
+    )
+
+    goals_dir = tmp_path / "state" / "goals"
+    goals_dir.mkdir(parents=True)
+    artifact_path = tmp_path / "state" / "improvements" / "materialized-853.json"
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_path.write_text(json.dumps({"ok": True}), encoding="utf-8")
+    current_payload = {
+        "schema_version": "task-plan-v1",
+        "current_task_id": "materialize-pass-streak-improvement",
+        "tasks": [
+            {"task_id": "record-reward", "title": "Record cycle reward", "status": "pending"},
+            {
+                "task_id": "materialize-pass-streak-improvement",
+                "title": "Materialize one concrete bounded improvement from the repeated PASS insight",
+                "status": "active",
+                "kind": "execution",
+            },
+        ],
+        "generated_candidates": [
+            {
+                "task_id": "materialize-pass-streak-improvement",
+                "title": "Materialize one concrete bounded improvement from the repeated PASS insight",
+                "status": "active",
+                "kind": "execution",
+            },
+        ],
+        "materialized_improvement_artifact_path": str(artifact_path),
+    }
+    (goals_dir / "current.json").write_text(json.dumps(current_payload), encoding="utf-8")
+    return expires_at - timedelta(minutes=15), tmp_path
+
+
+def test_metadata_only_cycle_never_reaches_ready_for_policy_review(tmp_path, monkeypatch):
+    """#853: with no verified concrete diff, review_status must never become
+    ready_for_policy_review, even when the feedback_decision mode and a
+    materialized artifact are otherwise present.
+
+    (In this fixture the pre-existing materialize-lane gate at ~line 269 also
+    withholds promotion_candidate_id entirely when there's no concrete diff —
+    an even stronger outcome than a downgraded review_status. Either way,
+    ready_for_policy_review must not appear, and no accepted record exists.)
+    """
+    now, workspace = _write_ready_materialized_cycle_fixture(tmp_path)
+    monkeypatch.setattr("nanobot.runtime.coordinator._has_concrete_changes", lambda *args, **kwargs: False)
+
+    result = asyncio.run(
+        run_self_evolving_cycle(
+            workspace=workspace,
+            tasks="prepare candidate",
+            execute_turn=AsyncMock(return_value="bounded work complete"),
+            now=now,
+        )
+    )
+    assert "PASS" in result
+
+    runtime = load_runtime_state(tmp_path)
+    report = _read_json(runtime["report_path"])
+    assert report["review_status"] != "ready_for_policy_review"
+
+    latest_path = tmp_path / "state" / "promotions" / "latest.json"
+    if latest_path.exists():
+        latest = _read_json(latest_path)
+        candidate_id = latest["promotion_candidate_id"]
+        candidate = _read_json(tmp_path / "state" / "promotions" / f"{candidate_id}.json")
+        assert candidate["review_status"] != "ready_for_policy_review"
+        assert not (tmp_path / "state" / "promotions" / "accepted" / f"{candidate_id}.json").exists()
+    accepted_dir = tmp_path / "state" / "promotions" / "accepted"
+    assert not accepted_dir.exists() or list(accepted_dir.glob("*.json")) == []
+
+
+def test_full_cycle_never_writes_accepted_promotion_record(tmp_path, monkeypatch):
+    """#853: no cycle — including one that reaches ready_for_policy_review —
+    may write promotions/accepted/*.json. Acceptance requires a real external
+    actor calling review_promotion_candidate(decision="accept") itself, never
+    the coordinator's own cycle loop.
+    """
+    now, workspace = _write_ready_materialized_cycle_fixture(tmp_path)
+    monkeypatch.setattr("nanobot.runtime.coordinator._has_concrete_changes", lambda *args, **kwargs: True)
+
+    asyncio.run(
+        run_self_evolving_cycle(
+            workspace=workspace,
+            tasks="prepare candidate",
+            execute_turn=AsyncMock(return_value="bounded work complete"),
+            now=now,
+        )
+    )
+
+    accepted_dir = tmp_path / "state" / "promotions" / "accepted"
+    accepted_files = list(accepted_dir.glob("*.json")) if accepted_dir.exists() else []
+    assert accepted_files == []
+
+
+def test_ready_concrete_cycle_stays_pending_operator_review(tmp_path, monkeypatch):
+    """#853: a cycle with a verified concrete diff and a qualifying
+    feedback_decision mode reaches review_status=ready_for_policy_review with a
+    pending_operator_review governance packet, but decision/accepted_record
+    stay pending — the coordinator does not self-accept.
+    """
+    now, workspace = _write_ready_materialized_cycle_fixture(tmp_path)
+    monkeypatch.setattr("nanobot.runtime.coordinator._has_concrete_changes", lambda *args, **kwargs: True)
+
+    result = asyncio.run(
+        run_self_evolving_cycle(
+            workspace=workspace,
+            tasks="prepare candidate",
+            execute_turn=AsyncMock(return_value="bounded work complete"),
+            now=now,
+        )
+    )
+    assert "PASS" in result
+
+    latest = _read_json(tmp_path / "state" / "promotions" / "latest.json")
+    candidate_id = latest["promotion_candidate_id"]
+    candidate = _read_json(tmp_path / "state" / "promotions" / f"{candidate_id}.json")
+
+    assert candidate["review_status"] == "ready_for_policy_review"
+    assert candidate["decision"] == "ready_for_policy_review"
+    assert candidate["decision_record"] == "pending_operator_review_packet"
+    assert candidate["accepted_record"] is None
+    assert candidate["governance_packet"]["review_packet_status"] == "pending_operator_review"


### PR DESCRIPTION
Closes #853. From the #846 gate audit (top-severity advisory hole).

## Problem
The self-evolving lane (`run_self_evolving_cycle`, LIVE via eeepc-self-evolving-agent.service) auto-accepted its OWN promotion candidates with no verified diff and no human: `review_status` reached `ready_for_policy_review` from a mode check (not gated on `_has_concrete_changes`), then the coordinator itself called `review_promotion_candidate(decision="accept")`, writing `promotions/accepted/*.json` with `base_commit/patch_hash=None` — a fabricated "reviewed/accepted" audit trail.

## Change (coordinator.py only, 2 surgical edits)
- `review_status→ready_for_policy_review` now also requires `_has_concrete_changes(...)` (same fail-closed probe already used at the promotion-candidate + reward gates). Metadata-only cycles can no longer qualify.
- Removed the autonomous `review_promotion_candidate(decision="accept")` call + the `accepted/` write. An accept now requires a real external actor. Ready candidates stay **pending operator review** — the base promotion record already carries the pending governance packet.

**No fitness change:** `result_status="PASS"`, reward/metric/frontier/stall, and the base record build are byte-unchanged. Dead import removed. Readers of `promotions/accepted/` already guard with `.exists()`.

## Verify
```
python -m pytest tests/test_runtime_coordinator.py tests/test_materialized_lane_value.py tests/test_promotion_governance_packet.py -q
75 passed, 1 pre-existing-unrelated failure (test_cycle_executes_configured_subagent_executor... — fails identically on base via git stash; Windows-only)
```
New tests: metadata-only never reaches ready; full cycle writes no `accepted/` record; ready+concrete stays pending_operator_review. Two prior tests pinning the old self-accept updated.

Opus review: all critical paths traced — metrics invariant, no stale var, no crash on missing `accepted/`, elif intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)