### PR TITLE
docs+test(runtime): export/reload state-contract audit — verified, no gap (#847)

### DIFF
--- a/docs/changes/847-state-contract-audit/proposal.md
+++ b/docs/changes/847-state-contract-audit/proposal.md
@@ -1,0 +1,102 @@
+# Change: Export/reload state-contract audit (cycle-boundary consistency)
+
+- **change-id:** state-contract-audit
+- **issue:** #847
+- **capability:** docs/specs/self-evolving-runtime (cycle boundaries / persistence)
+- **role / workstream:** role:developer / workstream:trust-safety
+
+## Problem
+
+a-evolve treats "agent runtime (in-process) state silently diverging from the
+persisted ledger/state-dir" as THE main persistence risk, and mitigates it
+structurally (forced export-to-fs before observation, reload-from-fs after
+mutation). evoagentx/anima suffer split-truth. This is a one-time audit to
+verify our loop guarantees cycle-boundary consistency between in-process state
+and the ledger/state dir rather than assuming in-process survival — and to
+close any gap found.
+
+## Audit verdict
+
+**The loop already satisfies the export/reload contract. No trust-relevant gap
+found.** This change is documentation of the verified contract plus a
+regression test pinning its subtlest seam — there is no runtime fix, because
+forcing one where the discipline already holds would be overengineering.
+
+### Cross-cycle: structurally safe (fresh process per cycle)
+
+Both loops are single-shot `main()` entrypoints with no in-process scheduler:
+
+- Coordinator: `app/main.py` `def main()` → `asyncio.run(run_self_evolving_cycle(...))`
+  once, then exits (the load-bearing, unit-independent proof — `main()` has no
+  loop and returns after one cycle). The recurring per-cycle execution is driven
+  by `eeepc-self-evolving-agent-health.timer` → `eeepc-self-evolving-agent-health.service`
+  (`Type=oneshot`, `-m app.main`); the base `eeepc-self-evolving-agent.service`
+  is only a `Type=simple` post-deploy single-shot kick ("do NOT enable"), not the
+  recurring driver.
+- Bridge: `nanobot/runtime/bridge.py` `cli_main()` → `asyncio.run(main())`; also
+  `Type=oneshot` (`eeepc-self-evolving-subagent-bridge.service`,
+  `-m nanobot.runtime.bridge`). The module comment is explicit
+  (`bridge.py:~1381`): "*This process runs once per cycle … and exits
+  afterward … it never outlives this process.*"
+
+All state entering a cycle is read from disk at the top (coordinator:
+`goals/current.json`; bridge: `outbox/report.index.json`, `goals/registry.json`;
+demand/scorecard/usage sidecars via plain `read_text`/`json.loads`, no
+module-level cache). Nothing is held in a class instance or module global
+between invocations, so **cross-cycle divergence is structurally impossible —
+there is no process to hold stale state.**
+
+### Within-cycle: every read/mutate/decide seam already re-derives
+
+Each seam where state is read early, mutated, then used late already re-reads
+from disk/git rather than trusting an in-memory copy — and each cites the
+incident that produced the discipline:
+
+| Seam | Re-derive discipline | Origin |
+|---|---|---|
+| `origin/main` before the gate decision | `_detect_out_of_band_main` / `_safe_rev_parse` re-fetch + re-check right before integrate | #846 |
+| fitness sidecars across the spawn window | `_fitness_sidecar_hashes` hashed pre-spawn and re-hashed post-spawn before the gate verdict | #789 |
+| changed files / mutation-surface violations | `_changed_files_and_violations` recomputed after every repair turn and again right before the gate | #678 F1/F3 |
+| concrete-change probe | `_has_concrete_changes` is a live `git log` subprocess, never cached, called 3× per coordinator cycle | #565 |
+| reward → outcome/stall/stop_reason | re-derived after the materialize-artifact reward upgrade, never taken from the pre-upgrade value | #581 |
+| `demand.collect_demand` completed/exhausted suppression | the completed-sidecar fold runs after all batches are collected and a post-fold filter is a second-pass safety net; each call re-folds from the current ledger (no cross-call cache) | #773/#778 |
+
+### Two intentional staleness windows (named so they are not mistaken for gaps)
+
+1. `scorecard.compute_scorecard` — 30-minute time watermark.
+2. `usage_evidence.refresh_usage` — HEAD+6h watermark.
+
+Both are **benign, not trust-relevant**: they only feed `goal-gap`/`decay`
+*demand suggestions* that a subsequent bridge cycle must still independently
+propose, gate, and integrate. They never touch `confirm_serves`'s per-call
+re-derivation (which re-checks the current sidecar every call and tamper-repairs
+foreign signals), never touch the gate's smoke/mutation-surface decision, and a
+stale-favorable read only delays a correct demand item by up to the window — it
+cannot manufacture unearned fitness or bypass a gate. Both are documented as
+intentional ("idle cycles stay cheap"), not silent.
+
+## Intended change
+
+- This audit document (the verified export/reload contract + the two named
+  staleness windows).
+- A regression test pinning the subtlest seam — `demand.collect_demand`
+  re-reads `completed.json` on every call — so a future refactor that
+  introduces an in-memory cache of the completed/exhausted set (silently
+  re-creating split-truth) is caught.
+
+No runtime code changes: the contract already holds.
+
+## Acceptance
+
+- [x] cycle-start state is re-derived/verified from disk; no silent in-process
+  carryover of trust-relevant state (verified above — fresh-process per cycle +
+  per-seam re-derive)
+- [x] test pinning the contract at its subtlest seam; deployed
+
+## Out of scope
+
+- Adding an explicit `export_to_fs`/`reload_from_fs` framework — the loop is
+  already stateless-per-cycle by construction; a framework would be
+  overengineering with no gap to close.
+- Tightening the two intentional staleness windows (they are benign and
+  deliberately cheap).

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1698,3 +1698,61 @@ class TestRepairUnusedItems:
         monkeypatch.setattr(usage_evidence, "stale_artifacts", _boom)
 
         assert demand._repair_unused_items(state_dir, None, datetime.now(timezone.utc)) == []
+
+
+# ─── #847: no in-memory cache of the completed set ─────────────────────────
+
+
+class TestNoInMemoryCompletedCache:
+    """#847 (VERIFY-only audit; no runtime gap found — the self-evolving
+    loop already re-derives all trust-relevant state from disk each cycle).
+    This pins the subtlest seam in that export/reload contract:
+    ``collect_demand`` carries NO in-memory cache of the completed/exhausted
+    set — every call re-reads ``demand/completed.json`` from disk via
+    ``_load_completed``/``_fold_completed``. A future refactor that silently
+    cached the completed ids (a module-level global, a closure, an
+    instance attribute) would reintroduce exactly the split-truth risk
+    a-evolve hit: the in-process view of "what's done" drifting from the
+    on-disk sidecar that is the actual done-truth (#773).
+
+    The test proves the reverse holds today: a mid-life direct edit to
+    ``demand/completed.json`` — same process, same ``state_dir``, nothing
+    reimported or recreated — changes what the very next ``collect_demand``
+    call returns. A non-goal-gap (``priority``) item is used deliberately:
+    that kind has no completed-TTL exception (#778), so suppression here is
+    unambiguously the completed-set effect, not a time-boxed re-presentation."""
+
+    def test_completed_json_edit_between_calls_changes_next_result(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+
+        # Call 1: two priority demand items are live (no goal-gap TTL quirk
+        # for this kind — suppression below can only come from the
+        # completed set).
+        first = demand.collect_demand(state_dir, None)
+        priorities = [i for i in first if i["kind"] == "priority"]
+        assert len(priorities) == 2
+        target = priorities[0]
+
+        # Mid-life mutation: mark the item completed directly on disk, in
+        # the exact shape ``_load_completed`` expects. Nothing in the
+        # process is recreated, reset, or reimported.
+        _write_completed_entry(state_dir, target["id"], _now_iso(1))
+
+        # Call 2, SAME state_dir, SAME process: the item is now suppressed —
+        # proof the completed set was re-read from disk, not cached from
+        # call 1.
+        second = demand.collect_demand(state_dir, None)
+        assert not any(i["id"] == target["id"] for i in second)
+        assert any(i["kind"] == "priority" for i in second)  # the other one
+
+        # Round-trip: clear the sidecar back to an honest "nothing
+        # completed" state and call a third time — the item must reappear.
+        # If collect_demand ever cached the completed set built during call
+        # 2, this call would still show it suppressed.
+        (state_dir / "demand" / "completed.json").write_text(
+            json.dumps({"schema_version": "demand-completed-v1", "entries": {}}),
+            encoding="utf-8",
+        )
+        third = demand.collect_demand(state_dir, None)
+        assert any(i["id"] == target["id"] for i in third)


### PR DESCRIPTION
Closes #847.

## Audit verdict: contract already satisfied — no runtime gap
Audited cycle-boundary consistency (a-evolve's split-truth risk: in-process runtime state silently diverging from the persisted ledger/state dir). **The loop already satisfies the export/reload contract**, so there is no runtime code change — forcing an export/reload framework where the discipline already holds would be overengineering.

- **Cross-cycle:** both loops are single-shot `main()` entrypoints (coordinator via `eeepc-self-evolving-agent-health.timer`; bridge `Type=oneshot`) → fresh process per cycle, all state read from disk at start, nothing held in a global/instance between invocations. Cross-cycle divergence is **structurally impossible**.
- **Within-cycle:** every read-early / mutate / decide-late seam already re-derives from disk/git — origin/main (#846), fitness sidecars (#789), changed-files (#678 F1/F3), concrete-change probe (#565), reward→outcome/stall (#581), completed-set fold (#773/#778).
- Two intentional staleness windows (scorecard 30min, usage 6h) are benign — they only delay demand *suggestions*, never touch gate/confirm/fitness.

## Deliverables
- `docs/changes/847-state-contract-audit/proposal.md` — the verified contract + the two named staleness windows.
- `tests/test_demand.py::TestNoInMemoryCompletedCache` — pins the subtlest seam: `collect_demand` re-reads `demand/completed.json` every call (mid-life on-disk edit flips the next call's result; round-trip proves no cached set). Catches a future refactor that silently caches the completed/exhausted set.

## Verify
```
python -m pytest tests/test_demand.py -k TestNoInMemoryCompletedCache -q
1 passed
```
Test-only + doc; no runtime change. Opus review: sound non-vacuous pin; doc coordinator-unit citation corrected to the -health timer/service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)