### PR TITLE
feat(runtime): diversity stepping-stone archive for the proposer (#844)

### DIFF
--- a/nanobot/runtime/archive.py
+++ b/nanobot/runtime/archive.py
@@ -21,6 +21,18 @@ MAX_ARCHIVE_ENTRIES = 200
 STALL_WINDOW = 5          # check last N cycles for stall detection
 STALL_THRESHOLD = 0.8     # all cycles below this → stalled
 
+# ── #844: BRIDGE-lane stepping-stone archive ────────────────────────────────
+# A small (<=5) diversity archive of gate-passing BRIDGE candidate variants,
+# keyed on a behavior signature (the primary changed area), that the LLM
+# proposer surfaces as optional stepping-stones — DGM-style "here are other
+# validated branches you could extend" rather than a MAP-Elites grid.
+# Proposer-steering ONLY: this never touches the gate, fitness, confirm, or
+# FITNESS_SIDECARS. Persisted at state/steering/stepping_stones.json,
+# separate from CycleArchive (coordinator-lane, state/goals/cycle_archive.json)
+# above — same module, different lane, different file.
+_STEPPING_STONES_MAX = 5  # #844: <=5 diverse gate-passing variants (not a grid)
+_STEPPING_STONE_SUMMARY_MAX = 160
+
 
 @dataclass
 class ArchiveEntry:
@@ -152,3 +164,95 @@ class CycleArchive:
 
     def __len__(self) -> int:
         return len(self._entries)
+
+
+# ── #844: stepping-stone functions (BRIDGE lane, proposer-steering only) ────
+
+def _stepping_stone_signature(files_changed: Any) -> str:
+    """Behavior signature = the primary changed area (#844). Prefer the first
+    scripts/*.py path (the loop's main surface), else the first path, else
+    'misc'. Fail-open to 'misc'."""
+    try:
+        paths = [str(p).strip() for p in (files_changed or []) if str(p).strip()]
+        for p in sorted(paths):
+            if p.startswith("scripts/") and p.endswith(".py"):
+                return p
+        return sorted(paths)[0] if paths else "misc"
+    except Exception:
+        return "misc"
+
+
+def _stepping_stones_path(state_dir: Any) -> Path:
+    return Path(state_dir) / "steering" / "stepping_stones.json"
+
+
+def record_stepping_stone(
+    state_dir: Any,
+    cycle_id: str,
+    files_changed: Any,
+    summary: str,
+    *,
+    now: float | None = None,
+) -> None:
+    """Append one gate-passing variant to the bounded stepping-stone archive
+    (#844), keyed on behavior signature. Keeps the NEWEST entry per signature,
+    at most _STEPPING_STONES_MAX distinct signatures (evict oldest signature) —
+    so the archive stays diverse across areas, not 5 of the same lineage.
+    Steering-only (state/steering/stepping_stones.json); NOT a fitness sidecar.
+    Fail-open: any error is swallowed."""
+    try:
+        path = _stepping_stones_path(state_dir)
+        entries: list[dict[str, Any]] = []
+        if path.exists():
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(raw, list):
+                    entries = [e for e in raw if isinstance(e, dict)]
+            except Exception:
+                entries = []
+
+        sig = _stepping_stone_signature(files_changed)
+        ts = now if now is not None else time.time()
+        try:
+            fc = [str(p) for p in (files_changed or [])][:20]
+        except Exception:
+            fc = []
+        entry = {
+            "cycle_id": str(cycle_id or ""),
+            "signature": sig,
+            "files_changed": fc,
+            "summary": str(summary or "")[:_STEPPING_STONE_SUMMARY_MAX],
+            "ts": ts,
+        }
+
+        # Newest-per-signature wins; also drop any prior entry with the same
+        # cycle_id (idempotent re-record of the same cycle).
+        entries = [
+            e for e in entries
+            if e.get("signature") != sig and str(e.get("cycle_id") or "") != entry["cycle_id"]
+        ]
+        entries.append(entry)
+        entries.sort(key=lambda e: float(e.get("ts") or 0.0), reverse=True)
+        entries = entries[:_STEPPING_STONES_MAX]
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    except Exception:
+        pass  # steering archive is non-blocking (#844)
+
+
+def read_stepping_stones(state_dir: Any) -> list[dict[str, Any]]:
+    """Return the archived stepping-stones (list of dicts), newest-first,
+    bounded to _STEPPING_STONES_MAX. Fail-open to []."""
+    try:
+        path = _stepping_stones_path(state_dir)
+        if not path.exists():
+            return []
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            return []
+        entries = [e for e in raw if isinstance(e, dict)]
+        entries.sort(key=lambda e: float(e.get("ts") or 0.0), reverse=True)
+        return entries[:_STEPPING_STONES_MAX]
+    except Exception:
+        return []

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2242,6 +2242,14 @@ async def _main_impl():
                     _integ = _integrate_cycle_to_main(_selfevo_repo, cycle_branch, main_sha_before)
                     if _integ['ok']:
                         _integrated = True
+                        try:
+                            from nanobot.runtime import archive as _archive_mod
+                            _archive_mod.record_stepping_stone(
+                                STATE_DIR, _cycle_id, files_changed,
+                                (backlog_title or req.get('task_title') or '').strip(),
+                            )
+                        except Exception:
+                            pass  # steering archive is non-blocking (#844)
                         main_sha_after = _integ['main_sha_after']
                         _cleanup_cycle_branch(_selfevo_repo, cycle_branch)
                         print(f'integrate: {cycle_branch} merged into main and pushed ({cycle_commit_count} commit(s))')

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -38,7 +38,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-from nanobot.runtime import demand, existence_index, hypothesis_backlog, system_map
+from nanobot.runtime import archive, demand, existence_index, hypothesis_backlog, system_map
 from nanobot.runtime.cycle_ledger import append_event
 from nanobot.runtime.cycle_planning import (
     _recent_git_log,
@@ -825,6 +825,30 @@ def _demand_section(demand_items: list[dict[str, str]]) -> str:
         return ""
 
 
+def _stepping_stones_section(state_dir: Path) -> str:
+    """#844: render the diversity archive as optional stepping-stones the
+    proposer MAY extend to explore a different area (escape greedy single-
+    lineage). Returns '' when empty or on any error (fail-open)."""
+    try:
+        stones = archive.read_stepping_stones(state_dir)
+        lines: list[str] = []
+        for stone in stones:
+            if not isinstance(stone, dict):
+                continue
+            signature = str(stone.get("signature") or "").strip()
+            summary = str(stone.get("summary") or "").strip()
+            cycle_id = str(stone.get("cycle_id") or "").strip()
+            if not signature:
+                continue
+            line = f"- {signature} — {summary} (cycle {cycle_id})"
+            lines.append(line)
+        if not lines:
+            return ""
+        return "\n".join(lines)
+    except Exception:
+        return ""
+
+
 def build_context(
     state_dir: Path,
     selfevo_repo: Path | None,
@@ -939,6 +963,18 @@ def build_context(
         if len(blob) > budget:
             blob = blob[:budget]
         context = blob + "\n" + guardrail_tail + "\n" + surface_rule
+
+        # #844: PROTECTED (never-truncated) stepping-stones section — optional
+        # diversity archive entries the model MAY extend instead of repeating
+        # the greedy single-lineage path. Omitted entirely when empty, keeping
+        # context byte-identical to pre-#844 in that case.
+        _stones = _stepping_stones_section(state_dir)
+        if _stones:
+            context += (
+                "\n\n## Stepping stones (validated variants — you MAY extend "
+                "one to explore a different area instead of repeating the "
+                "greedy path)\n" + _stones
+            )
 
         if demand_items:
             demand_body = _demand_section(demand_items)

--- a/tests/test_stepping_stones.py
+++ b/tests/test_stepping_stones.py
@@ -1,0 +1,169 @@
+"""Tests for #844: BRIDGE-lane stepping-stone diversity archive.
+
+A small (<=5) archive of gate-passing BRIDGE candidate variants, keyed on a
+behavior signature, surfaced by the LLM proposer as optional stepping-stones.
+Proposer-steering ONLY — never touches the gate, fitness, confirm, or
+FITNESS_SIDECARS.
+"""
+from __future__ import annotations
+
+import json
+
+from nanobot.runtime import llm_proposer
+from nanobot.runtime.archive import (
+    _STEPPING_STONES_MAX,
+    _stepping_stone_signature,
+    read_stepping_stones,
+    record_stepping_stone,
+)
+
+
+# ─── _stepping_stone_signature ──────────────────────────────────────────────
+
+def test_signature_prefers_scripts_py_path():
+    files = ["docs/notes.md", "scripts/foo_bar.py", "tests/test_foo.py"]
+    assert _stepping_stone_signature(files) == "scripts/foo_bar.py"
+
+
+def test_signature_falls_back_to_first_sorted_path_when_no_scripts_py():
+    files = ["docs/z.md", "docs/a.md"]
+    assert _stepping_stone_signature(files) == "docs/a.md"
+
+
+def test_signature_picks_lowest_scripts_py_path_when_multiple():
+    files = ["scripts/zeta.py", "scripts/alpha.py"]
+    assert _stepping_stone_signature(files) == "scripts/alpha.py"
+
+
+def test_signature_misc_on_empty():
+    assert _stepping_stone_signature([]) == "misc"
+    assert _stepping_stone_signature(None) == "misc"
+
+
+def test_signature_misc_on_garbage():
+    assert _stepping_stone_signature(object()) == "misc"
+    assert _stepping_stone_signature(42) == "misc"  # not iterable → caught, fail-open
+    assert _stepping_stone_signature(["", "   "]) == "misc"  # blank paths filtered out
+
+
+# ─── record_stepping_stone / read_stepping_stones round-trip ────────────────
+
+def test_round_trip_writes_expected_file(tmp_path):
+    state_dir = tmp_path / "state"
+    record_stepping_stone(
+        state_dir, "cycle-1", ["scripts/foo.py"], "did a thing", now=1000.0,
+    )
+    path = state_dir / "steering" / "stepping_stones.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["signature"] == "scripts/foo.py"
+    assert data[0]["summary"] == "did a thing"
+    assert data[0]["cycle_id"] == "cycle-1"
+
+    stones = read_stepping_stones(state_dir)
+    assert len(stones) == 1
+    assert stones[0]["signature"] == "scripts/foo.py"
+
+
+def test_newest_per_signature_wins(tmp_path):
+    state_dir = tmp_path / "state"
+    record_stepping_stone(
+        state_dir, "cycle-1", ["scripts/foo.py"], "first version", now=1000.0,
+    )
+    record_stepping_stone(
+        state_dir, "cycle-2", ["scripts/foo.py"], "second version", now=2000.0,
+    )
+    stones = read_stepping_stones(state_dir)
+    assert len(stones) == 1
+    assert stones[0]["cycle_id"] == "cycle-2"
+    assert stones[0]["summary"] == "second version"
+
+
+def test_cap_at_max_distinct_signatures_evicts_oldest(tmp_path):
+    state_dir = tmp_path / "state"
+    for i in range(_STEPPING_STONES_MAX + 1):
+        record_stepping_stone(
+            state_dir, f"cycle-{i}", [f"scripts/area_{i}.py"], f"summary {i}",
+            now=1000.0 + i,
+        )
+    stones = read_stepping_stones(state_dir)
+    assert len(stones) == _STEPPING_STONES_MAX
+    signatures = {s["signature"] for s in stones}
+    # oldest (area_0, ts=1000.0) evicted; newest _STEPPING_STONES_MAX remain
+    assert "scripts/area_0.py" not in signatures
+    assert f"scripts/area_{_STEPPING_STONES_MAX}.py" in signatures
+
+
+def test_idempotent_on_same_cycle_id(tmp_path):
+    state_dir = tmp_path / "state"
+    record_stepping_stone(
+        state_dir, "cycle-1", ["scripts/foo.py"], "v1", now=1000.0,
+    )
+    record_stepping_stone(
+        state_dir, "cycle-1", ["scripts/bar.py"], "v1 again", now=1001.0,
+    )
+    stones = read_stepping_stones(state_dir)
+    # same cycle_id replaces rather than accumulates
+    assert len(stones) == 1
+    assert stones[0]["signature"] == "scripts/bar.py"
+
+
+def test_fail_open_on_none_files_changed(tmp_path):
+    state_dir = tmp_path / "state"
+    # Should not raise even with None files_changed / summary
+    record_stepping_stone(state_dir, "cycle-1", None, None, now=1000.0)
+    stones = read_stepping_stones(state_dir)
+    assert len(stones) == 1
+    assert stones[0]["signature"] == "misc"
+
+
+def test_read_fail_open_on_missing_state_dir(tmp_path):
+    missing = tmp_path / "does_not_exist_at_all"
+    assert read_stepping_stones(missing) == []
+
+
+def test_read_fail_open_on_corrupt_json(tmp_path):
+    state_dir = tmp_path / "state"
+    path = state_dir / "steering" / "stepping_stones.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("not valid json {{{", encoding="utf-8")
+    assert read_stepping_stones(state_dir) == []
+
+
+def test_record_fail_open_never_raises(tmp_path):
+    # A state_dir that is actually a file (not a directory) should not raise;
+    # record_stepping_stone swallows the resulting error.
+    bad_state_dir = tmp_path / "not_a_dir"
+    bad_state_dir.write_text("i am a file", encoding="utf-8")
+    record_stepping_stone(bad_state_dir, "cycle-1", ["scripts/foo.py"], "x")
+    # No exception raised is the assertion; read should fail-open too.
+    assert read_stepping_stones(bad_state_dir) == []
+
+
+# ─── llm_proposer._stepping_stones_section ──────────────────────────────────
+
+def test_stepping_stones_section_empty_archive(tmp_path):
+    state_dir = tmp_path / "state"
+    assert llm_proposer._stepping_stones_section(state_dir) == ""
+
+
+def test_stepping_stones_section_populated(tmp_path):
+    state_dir = tmp_path / "state"
+    record_stepping_stone(
+        state_dir, "cycle-42", ["scripts/widget.py"], "built a widget",
+        now=1000.0,
+    )
+    section = llm_proposer._stepping_stones_section(state_dir)
+    assert "scripts/widget.py" in section
+    assert "built a widget" in section
+    assert "cycle-42" in section
+
+
+# ─── sidecar path is NOT a fitness sidecar ───────────────────────────────────
+
+def test_stepping_stones_sidecar_not_in_fitness_sidecars():
+    from nanobot.runtime import scorecard
+
+    assert "steering/stepping_stones.json" not in scorecard.FITNESS_SIDECARS


### PR DESCRIPTION
Closes #844. Exploration-gap fix (complements #840/#845 reuse), from the SOTA-comparison research.

## Problem
The loop integrates a single greedy lineage into main. SOTA open-ended systems (DGM, ADAS, AlphaEvolve) keep a small archive of diverse validated variants as **stepping-stones** to escape hill-climbing local optima.

## Change (DGM-style, NOT MAP-Elites)
- **archive.py**: small BRIDGE-lane stepping-stone archive (co-located with the coordinator's `CycleArchive`; distinct lane/file). `record_stepping_stone` keeps the **newest gate-passing variant per behavior signature** (primary changed area), at most **5 distinct signatures** (evict oldest) — diverse areas, not 5 of one lineage, not a grid. Persisted at `state/steering/stepping_stones.json`.
- **bridge.py** (~2246): fail-open `record_stepping_stone(...)` right after a successful integrate.
- **llm_proposer.py**: `build_context` appends a PROTECTED (never-truncated) "Stepping stones" section the model MAY extend to explore a different area; **omitted when empty → byte-identical to before**.

**PROPOSER-STEERING ONLY**: the sidecar is NOT in `FITNESS_SIDECARS`; nothing gates/scores on it — a stepping-stone is a prompt hint, still subject to the full gate. Additive, fail-open, bounded (fits 2GB).

## Verify
```
python -m pytest tests/test_stepping_stones.py -q
16 passed
```
(signature selection; newest-per-signature + 5-signature cap eviction; round-trip; fail-open; empty-archive section omitted; sidecar not in FITNESS_SIDECARS.)

Opus review: no issues — no fitness leak, diversity semantics correct, fail-open verified, happy path byte-identical, `CycleArchive` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)