### PR TITLE
fix(runtime): reference signal requires referencing script execution evidence (#854)

### DIFF
--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -83,8 +83,12 @@ USAGE_SCHEMA = "usage-evidence-v1"
 #
 # #838: "reference" joins the set — the signal refresh_usage's used_candidates
 # writes when a scripts/*.py artifact is CONSUMED (imported by another
-# committed script, or named in a committed *.service/*.timer/*.sh/*.cron/
-# Makefile), computed by _reference_index. This is trust-safe exactly like
+# committed script that itself has execution evidence, or named in a
+# committed *.service/*.timer/*.sh/*.cron/Makefile), computed by
+# _reference_index. The import-edge path requires the importing script to
+# have its own pycache/output evidence (#854) — a never-executed companion
+# that merely imports the target cannot manufacture credit from static text
+# alone. This is trust-safe exactly like
 # pycache/output: it is written ONLY by refresh_usage into the harness-owned
 # sidecar (never by instance/subagent code), confirm_serves re-derives
 # `confirmed` from that sidecar's `last_used`/`signal` on every call (nothing
@@ -337,10 +341,11 @@ def _ops_file_names_script(text: str, stem: str) -> bool:
     return re.search(rf"(?<!\w){re.escape(stem)}\.py\b", text) is not None
 
 
-def _reference_index(selfevo_repo: Path) -> dict[str, str]:
+def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
     """Map scripts/<name>.py -> newest mtime of a committed file that
     REFERENCES it, from the integrated repo tree (#838). A reference is:
-      - another scripts/*.py importing its module stem (not itself, not a test), or
+      - another scripts/*.py importing its module stem (not itself, not a
+        test, and the importer itself must have execution evidence — #854),
       - a committed *.service/*.timer/*.sh/*.cron/Makefile naming scripts/<name>.py
         or <name>.py.
     Harness-computed; fail-open to {} on any error. Bounded scan."""
@@ -355,9 +360,23 @@ def _reference_index(selfevo_repo: Path) -> dict[str, str]:
         index: dict[str, str] = {}
 
         # Import edges: another scripts/*.py importing this module's stem.
+        # #854: a committed no-op companion that only does `import target`
+        # (never executed) manufactures a "reference" credit from pure
+        # static text. Require the CONSUMER itself to have harness execution
+        # evidence (pycache or output) before its imports count — checked
+        # first/cheaply, before reading the consumer's text. Trust rests on
+        # the same boundary as _pycache_signal (#838): *.pyc / __pycache__/
+        # are gitignored, so the only .pyc in the integrated tree are ones
+        # the harness interpreter wrote by actually running the script — the
+        # instance cannot commit a forged one through the mutation surface.
         for consumer in sorted(scripts_dir.glob("*.py")):
             if consumer.name.startswith("test_") or "tests" in consumer.parts:
                 continue  # test files are not consumers (#838)
+            if (
+                _pycache_signal(consumer) is None
+                and _output_signal(consumer, state_dir, repo) is None
+            ):
+                continue  # consumer never ran — its imports prove nothing (#854)
             try:
                 text = consumer.read_text(encoding="utf-8", errors="replace")
             except Exception:
@@ -375,7 +394,10 @@ def _reference_index(selfevo_repo: Path) -> dict[str, str]:
 
         # Ops references: a committed *.service/*.timer/*.sh/*.cron/Makefile
         # naming scripts/<name>.py or the bare <name>.py. Bounded across all
-        # globs combined by _MAX_REFERENCE_FILES.
+        # globs combined by _MAX_REFERENCE_FILES. #854 scope note: this path
+        # is intentionally UNCHANGED — ops files are non-python (no pycache
+        # maps to them) and operator-authored, so the execution-evidence
+        # gate above does not apply here.
         scanned = 0
         for pattern in _OPS_GLOBS:
             if scanned >= _MAX_REFERENCE_FILES:
@@ -444,7 +466,7 @@ def refresh_usage(state_dir: Path, selfevo_repo: Path | None) -> dict[str, Any]:
 
         entries: dict[str, Any] = data["entries"]
         touched_map = _touched_from_results(state_dir)
-        ref_index = _reference_index(repo) if _reference_signal_enabled() else {}
+        ref_index = _reference_index(state_dir, repo) if _reference_signal_enabled() else {}
 
         scripts_dir = repo / "scripts"
         script_files = sorted(scripts_dir.glob("*.py")) if scripts_dir.is_dir() else []

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -74,6 +74,16 @@ def _set_mtime(path: Path, days_ago: float) -> None:
     os.utime(path, (ts, ts))
 
 
+def _give_pycache(script: Path) -> None:
+    """Create a ``__pycache__/<stem>.cpython-*.pyc`` next to ``script`` —
+    real execution evidence (#854), matching how ``_pycache_signal`` detects
+    that the interpreter actually imported/ran a script (as opposed to a
+    committed-but-never-executed companion)."""
+    cache = script.parent / "__pycache__"
+    cache.mkdir(exist_ok=True)
+    (cache / f"{script.stem}.cpython-311.pyc").write_bytes(b"\x00")
+
+
 def _usage_sidecar(state_dir: Path) -> dict:
     return json.loads(
         (state_dir / "usage" / "last_used.json").read_text(encoding="utf-8")
@@ -256,12 +266,16 @@ class TestRefreshUsageWatermark:
 class TestReferenceSignal:
     def test_import_edge_confirms_referenced_script(self, tmp_path):
         """Another committed script importing this one's module stem is a
-        reference — the consumed script gains signal:"reference"."""
+        reference — the consumed script gains signal:"reference" — PROVIDED
+        the importing script itself has execution evidence (#854; a
+        never-executed companion import does not count, see
+        test_forged_noop_companion_import_gets_no_reference_credit below)."""
         state_dir = _state_dir(tmp_path)
         repo = _repo_with_files(tmp_path, {
             "scripts/a.py": "x = 1\n",
             "scripts/b.py": "import scripts.a\n",
         })
+        _give_pycache(repo / "scripts" / "b.py")
         data = usage_evidence.refresh_usage(state_dir, repo)
         entry = data["entries"]["scripts/a.py"]
         assert entry["signal"] == "reference"
@@ -308,12 +322,14 @@ class TestReferenceSignal:
     def test_reference_confirms_completed_entry(self, tmp_path):
         """End-to-end: a completed.json entry for scripts/a.py with a ts
         BEFORE the importer's commit (mtime) becomes confirmed with
-        signal:"reference" after refresh_usage + confirm_serves."""
+        signal:"reference" after refresh_usage + confirm_serves. The
+        importer (scripts/b.py) has real execution evidence (#854)."""
         state_dir = _state_dir(tmp_path)
         repo = _repo_with_files(tmp_path, {
             "scripts/a.py": "x = 1\n",
             "scripts/b.py": "import scripts.a\n",
         })
+        _give_pycache(repo / "scripts" / "b.py")
         usage_evidence.refresh_usage(state_dir, repo)
         _write_completed(
             state_dir,
@@ -356,6 +372,19 @@ class TestReferenceSignal:
         repo = _repo_with_files(tmp_path, {
             "scripts/a.py": "x = 1\n",
             "foo.service": "[Service]\nExecStart=/usr/bin/python3 xa.py\n",
+        })
+        data = usage_evidence.refresh_usage(state_dir, repo)
+        assert "scripts/a.py" not in data["entries"]
+
+    def test_forged_noop_companion_import_gets_no_reference_credit(self, tmp_path):
+        """#854: a committed no-op companion that only does `import
+        scripts.a` (never actually run — no pycache, no output evidence)
+        must NOT manufacture a "reference" credit for scripts/a.py from
+        static text alone."""
+        state_dir = _state_dir(tmp_path)
+        repo = _repo_with_files(tmp_path, {
+            "scripts/a.py": "x = 1\n",
+            "scripts/b.py": "import scripts.a\n",  # committed, never executed
         })
         data = usage_evidence.refresh_usage(state_dir, repo)
         assert "scripts/a.py" not in data["entries"]


### PR DESCRIPTION
Closes #854.

## Problem
The `reference` usage signal (#838) credited a target `scripts/X.py` whenever another committed `scripts/*.py` imported X's module stem. A trivial no-op companion `scripts/b.py` containing only `import scripts.a` (never executed) manufactured a `reference` usage credit for `scripts/a.py` from pure static text — gaming the #761 confirmed_integration V2-metric. Not gate/trust-critical, V2-metric only, but anti-gaming/correctness.

## Fix
`_reference_index` import-edge path now counts a consumer's import edge **only when the consumer script itself has real harness execution evidence** — `_pycache_signal(consumer) is not None` OR `_output_signal(consumer, state_dir, repo) is not None`. A committed-but-never-run companion leaves no `.pyc`/output → no manufactured credit. Real consumers that actually ran (own `.pyc`) still credit their imports.

Gate is checked first/cheaply, scoped to the import-edge loop only.

## Scope / trust
- **Ops-reference path** (`*.service`/`*.timer`/`*.sh`/`*.cron`/`Makefile`) intentionally **unchanged** — non-python (no pycache maps), operator-authored.
- Signature gains `state_dir` (for `_output_signal`); sole caller in `refresh_usage` updated.
- `_sidecar_corroborates_use` (#838 Pass-1 forgery guard) + `SELFEVO_USAGE_REFERENCE_ENABLED` kill-switch **untouched**.
- Fail-open preserved (outer `try/except → {}`).
- Trust rests on the same boundary `_pycache_signal` (#838) already relies on: `*.pyc` / `__pycache__/` are gitignored, so the only `.pyc` in the integrated tree are ones the harness interpreter wrote by running the script — the instance cannot commit a forged one.

## Tests
`tests/test_usage_evidence.py`: existing import-edge tests updated so the consumer has execution evidence; new `test_forged_noop_companion_import_gets_no_reference_credit` pins the hole. 70/70 in that module. Ops/kill-switch/self-import/sidecar tests unchanged & green.

Opus-reviewed (2 HIGH triaged: fail-open flag was false — outer try wraps the body; pyc-forgery is upstream-blocked by gitignore + mutation surface, byte-validation would be overengineering + version-skew false-negatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)