### PR TITLE
fix(runtime): goal-review derived priorities survive deploy — separate harness canon (#860)

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -288,6 +288,17 @@ def _priority_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
         raw_text = str(data.get("text") or "")
         if not raw_text:
             return []
+        # #860: fold in goal_review's harness-owned derived priorities
+        # (survive deploy_release.sh's goal_text.json reseed) — local import,
+        # goal_review must never be imported at module level here (see its
+        # own docstring: it lazily imports llm_proposer, which imports this
+        # module, so a module-level import here would risk a cycle).
+        try:
+            from nanobot.runtime import goal_review
+
+            raw_text = goal_review.merged_goal_text(state_dir, raw_text)
+        except Exception:
+            pass
         filtered = filter_completed_priorities_from_goal_text(
             raw_text, selfevo_repo, state_dir=state_dir
         )

--- a/nanobot/runtime/goal_review.py
+++ b/nanobot/runtime/goal_review.py
@@ -6,10 +6,13 @@ hand-writing "Priority N — ..." entries into goal_text. At most once per day
 cycle), and only behind the ``SELFEVO_GOAL_REVIEW_ENABLED`` kill switch
 (default OFF — absent/falsy is a hard no-op), this module asks the LLM to
 formulate 1-3 concrete bounded priorities from the goal vectors and the
-loop's own measured evidence, then APPENDS the validated ones to goal_text's
-"Current priority targets" section — the SAME R30 channel operator seeding
-uses (``<state_dir>/goals/goal_text.json``), so the wake-up mechanics (#760)
-and done-detection (#748/#773) are untouched.
+loop's own measured evidence, then APPENDS the validated ones — as if they
+had landed in goal_text's "Current priority targets" section, the SAME R30
+channel operator seeding uses (``<state_dir>/goals/goal_text.json``) — so
+the wake-up mechanics (#760) and done-detection (#748/#773) are untouched.
+Since #860 the append target is actually a separate harness-owned sidecar
+(see the "Canon split" note below); readers merge it in before parsing so
+this remains invisible to them.
 
 Grounding (the difference from the retired hypothesis generator):
 
@@ -28,8 +31,9 @@ Grounding (the difference from the retired hypothesis generator):
   missing either is REJECTED with a recorded reason; zero valid priorities
   is an honest no-op.
 - **Append-only, dedup, operator-safe.** Operator entries are never
-  rewritten or removed; new entries continue numbering from the highest
-  existing "Priority N" anywhere in the text (including the Completed
+  rewritten or removed; new entries continue numbering (dynamically, at
+  merge time — see the "Canon split" note below) from the highest existing
+  "Priority N" anywhere in the merged text (including the Completed
   paragraph, so retired numbers are never reused) and are formatted
   ``(<letter>) Priority N — <label>: <body>`` — the exact shape
   ``demand._PRIORITY_PATTERN`` / ``cycle_planning._priority_label_prefix``
@@ -47,6 +51,21 @@ Wiring: invoked from ``scorecard.compute_scorecard``'s recompute path
 (the ``run_heldout``/``update_explorer`` pattern), wrapped fail-open — a
 review bug must never break the scorecard or demand collection. Everything
 here is fail-open/fail-closed by design and never raises into the caller.
+
+**Canon split (#860).** ``goal_text.json`` is the OPERATOR's canon — every
+release's ``deploy_release.sh`` unconditionally reseeds it from the repo,
+which used to erase every accepted priority this module ever appended (the
+"Priority 17" minted three days running). Accepted priorities are now
+appended-only to a separate, harness-owned sidecar,
+``<state_dir>/goals/derived_priorities.json`` (see
+:func:`read_derived_priorities`), that deploy never touches. Priority
+NUMBERS are never stored there — they are assigned dynamically, at merge
+time, by :func:`merged_goal_text`, which folds the derived entries onto
+whatever goal_text the operator currently has using the exact same
+:func:`append_priorities` insertion/numbering logic. The only two readers
+that need to see derived priorities (``demand._priority_items`` and
+``llm_proposer._load_goal_text``) call :func:`merged_goal_text` before
+parsing; ``goal_text.json`` itself is never written by this module anymore.
 """
 from __future__ import annotations
 
@@ -76,6 +95,12 @@ _MAX_EVIDENCE_LINES = 12
 _MAX_HISTORY_ROWS = 10
 _MIN_EVIDENCE_SUBSTRING = 12
 _DECAY_DAYS = 14  # kept in sync with demand._DECAY_DAYS
+
+# #860: harness-owned canon for accepted priorities, separate from the
+# operator's goal_text.json (which deploy_release.sh reseeds every release).
+# No priority numbers stored — see merged_goal_text.
+_DERIVED_PRIORITIES_SCHEMA = "derived-priorities-v1"
+_DERIVED_PRIORITIES_MAX = 10
 
 # Label must survive cycle_planning._priority_label_prefix
 # (``Priority\s+\d+\s*[—–-]\s*[^:.(]{1,40}``) for done-detection: no colon,
@@ -197,6 +222,101 @@ def _load_goal_data(state_dir: Path) -> dict[str, Any] | None:
     if not isinstance(data, dict) or not str(data.get("text") or "").strip():
         return None
     return data
+
+
+def _derived_priorities_path(state_dir: Path) -> Path:
+    return Path(state_dir) / "goals" / "derived_priorities.json"
+
+
+def read_derived_priorities(state_dir: Path) -> list[dict[str, Any]]:
+    """Loop-derived priorities accepted by past reviews, not yet folded into
+    the operator's goal_text canon (#860) — read from the harness-owned
+    ``derived_priorities.json`` sidecar deploy never touches. Each entry has
+    ``label``/``body``/``vector``/``added_utc``; no priority number (numbers
+    are assigned dynamically at merge time by :func:`merged_goal_text`).
+    Malformed entries are dropped individually; fail-open to ``[]``."""
+    data = _read_json(_derived_priorities_path(Path(state_dir)), None)
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("priorities")
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        label = str(entry.get("label") or "").strip()
+        body = str(entry.get("body") or "").strip()
+        vector = str(entry.get("vector") or "").strip().upper()
+        try:
+            number = int(entry.get("number") or 0)
+        except (TypeError, ValueError):
+            number = 0
+        if not label or not body or vector not in ("V1", "V2") or number <= 0:
+            continue  # number is required (#860 review: stable demand ids)
+        out.append(
+            {
+                "label": label,
+                "body": body,
+                "vector": vector,
+                "number": number,
+                "added_utc": str(entry.get("added_utc") or ""),
+            }
+        )
+    return out
+
+
+def _write_derived_priorities(state_dir: Path, priorities: list[dict[str, Any]]) -> None:
+    """Persist ``priorities`` capped to :data:`_DERIVED_PRIORITIES_MAX`,
+    keeping the NEWEST entries (dropping the oldest beyond the cap — callers
+    always append new entries at the end of the list). Deliberately NOT
+    wrapped in try/except: a persist failure must propagate to
+    ``maybe_goal_review``'s outer handler so the ledger records "error",
+    never "appended"-without-persist. Known bounded tradeoff: an evicted
+    still-open entry leaves the dedup baseline and could be re-minted with
+    a fresh number (needs {cap} accumulated at 1-3 accepts/day)."""
+    capped = priorities[-_DERIVED_PRIORITIES_MAX:]
+    _write_json(
+        _derived_priorities_path(Path(state_dir)),
+        {"schema_version": _DERIVED_PRIORITIES_SCHEMA, "priorities": capped},
+    )
+
+
+def merged_goal_text(state_dir: Path, raw_text: str) -> str:
+    """``raw_text`` (the operator's goal_text) with every derived priority
+    (#860) folded in via the SAME :func:`append_priorities` insertion/
+    numbering logic goal_review uses when minting — never duplicated. With
+    no derived priorities this returns ``raw_text`` completely UNCHANGED
+    (byte-identical), so a harness with the kill switch off, or with no
+    accepted priorities yet, sees zero behavior change. The two priority
+    readers (``demand._priority_items``, ``llm_proposer._load_goal_text``)
+    call this before parsing so a deploy's goal_text reseed can never erase
+    a derived priority out from under them. Fail-open to ``raw_text``."""
+    try:
+        derived = read_derived_priorities(state_dir)
+        if not derived:
+            return raw_text
+        # #860 review: skip derived entries whose label the operator has
+        # since baked into goal_text itself (or that a reseed re-added) —
+        # otherwise the merged text would carry the label twice and demand
+        # would mint two items for the same work. Operator canon wins.
+        existing = _existing_priority_labels(raw_text)
+        entries = [
+            {
+                "label": d["label"],
+                "body": d["body"],
+                "vector": d["vector"],
+                "number": d["number"],
+            }
+            for d in derived
+            if _normalize_label(d["label"]) not in existing
+        ]
+        if not entries:
+            return raw_text
+        new_text, _titles = append_priorities(raw_text, entries)
+        return new_text
+    except Exception:
+        return raw_text
 
 
 def _collect_evidence(
@@ -400,7 +520,11 @@ def append_priorities(goal_text: str, accepted: list[dict[str, str]]) -> tuple[s
     titles: list[str] = []
     for offset, cand in enumerate(accepted):
         letter = _next_entry_letter(goal_text, offset)
-        n = number + offset
+        # #860 review: an entry may carry a preassigned stable number (a
+        # derived priority stores the number it was minted with, so its
+        # rendered title — and thus its demand item id — never shifts when
+        # a deploy reseed changes the operator's priority count).
+        n = int(cand.get("number") or 0) or (number + offset)
         entry_lines.append(
             f"({letter}) Priority {n} — {cand['label']} ({cand['vector']}): {cand['body']}"
         )
@@ -488,6 +612,10 @@ def maybe_goal_review(
             _record_review(state_dir, "no_goal_text")
             return []
         goal_text = str(goal_data.get("text") or "")
+        # #860: dedup/context see goal_text + already-derived priorities
+        # merged in — a priority accepted yesterday (living only in
+        # derived_priorities.json now) must still block a re-mint today.
+        merged_text = merged_goal_text(state_dir, goal_text)
 
         snapshot = _read_json(state_dir / "scorecard" / "latest.json", None)
         if not isinstance(snapshot, dict):
@@ -500,7 +628,7 @@ def maybe_goal_review(
             return []
 
         context = build_context(
-            goal_text, snapshot, evidence, _integration_history(state_dir, now)
+            merged_text, snapshot, evidence, _integration_history(state_dir, now)
         )
         inputs_hash = hashlib.sha256(context.encode("utf-8", errors="replace")).hexdigest()[:16]
 
@@ -510,7 +638,7 @@ def maybe_goal_review(
             _record_review(state_dir, "invalid_reply", inputs_hash=inputs_hash)
             return []
 
-        existing_labels = _existing_priority_labels(goal_text)
+        existing_labels = _existing_priority_labels(merged_text)
         accepted: list[dict[str, str]] = []
         rejected: list[dict[str, str]] = []
 
@@ -541,10 +669,31 @@ def maybe_goal_review(
             )
             return []
 
-        new_text, titles = append_priorities(goal_text, accepted)
-        goal_data["text"] = new_text
-        goal_data["updated_at_utc"] = _iso(now)
-        _write_json(state_dir / "goals" / "goal_text.json", goal_data)
+        # #860: numbering continues past merged_text's highest "Priority N"
+        # (same base append_priorities would use) and is ASSIGNED + STORED
+        # at accept time, so a derived priority's rendered title — and thus
+        # its demand item id — stays stable even when a deploy reseed later
+        # changes the operator's priority count (#860 review finding). The
+        # merged render is discarded — only the titles feed the ledger/
+        # return payload. goal_text.json is READ-ONLY here; the accepted
+        # entries land in derived_priorities.json, which deploy_release.sh
+        # never touches (the actual #860 fix).
+        base_number = _next_priority_number(merged_text)
+        for offset, cand in enumerate(accepted):
+            cand["number"] = base_number + offset
+        _, titles = append_priorities(merged_text, accepted)
+        now_iso = _iso(now)
+        derived_entries = read_derived_priorities(state_dir) + [
+            {
+                "label": cand["label"],
+                "vector": cand["vector"],
+                "body": cand["body"],
+                "number": cand["number"],
+                "added_utc": now_iso,
+            }
+            for cand in accepted
+        ]
+        _write_derived_priorities(state_dir, derived_entries)
 
         _record_review(
             state_dir, "appended", inputs_hash=inputs_hash, produced=titles, rejected=rejected

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -375,7 +375,18 @@ def _load_goal_text(state_dir: Path) -> str:
         return ""
     if not isinstance(data, dict):
         return ""
-    return str(data.get("text") or "")
+    raw_text = str(data.get("text") or "")
+    # #860: fold in goal_review's harness-owned derived priorities — the
+    # sidecar deploy_release.sh never touches — so a deploy's goal_text
+    # reseed can't erase an already-accepted priority out from under the
+    # proposer's context or should_propose's filter_completed path.
+    try:
+        from nanobot.runtime import goal_review
+
+        raw_text = goal_review.merged_goal_text(state_dir, raw_text)
+    except Exception:
+        pass
+    return raw_text
 
 
 def _priorities_remain(filtered_goal_text: str) -> bool:

--- a/tests/test_goal_review.py
+++ b/tests/test_goal_review.py
@@ -187,7 +187,19 @@ class TestAppend:
             "Priority 18 — Dashboard usage ping",
         ]
 
-        text = _read_goal_text(state_dir)
+        # #860: goal_text.json is the operator's canon — goal_review never
+        # writes it; the accepted entries land in derived_priorities.json.
+        assert _read_goal_text(state_dir) == GOAL_TEXT
+        derived = goal_review.read_derived_priorities(state_dir)
+        assert [d["label"] for d in derived] == [
+            "Trim proposer retry burn",
+            "Dashboard usage ping",
+        ]
+        assert [d["vector"] for d in derived] == ["V1", "V2"]
+        assert all(d["added_utc"] for d in derived)
+
+        # merged_goal_text (what demand/llm_proposer see) folds them in.
+        text = goal_review.merged_goal_text(state_dir, GOAL_TEXT)
         # Operator entries untouched, verbatim.
         assert "(A) Priority 11 — Loop health in dashboard: extend" in text
         assert "(B) Priority 16 — Cycle strip line in dashboard: add ONE" in text
@@ -223,7 +235,8 @@ class TestAppend:
         titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
         assert titles == ["Priority 17 — Trim proposer retry burn"]
 
-        text = _read_goal_text(state_dir)
+        assert _read_goal_text(state_dir) == GOAL_TEXT  # operator canon untouched
+        text = goal_review.merged_goal_text(state_dir, GOAL_TEXT)
         assert text.count("Loop health in dashboard") == 1  # operator entry only
         rows = _goal_review_rows(state_dir)
         assert rows[0]["rejected"] == [
@@ -330,7 +343,7 @@ class TestVectorBias:
         )
 
         goal_review.maybe_goal_review(state_dir, None, now=NOW)
-        text = _read_goal_text(state_dir)
+        text = goal_review.merged_goal_text(state_dir, _read_goal_text(state_dir))
         assert "Trim proposer retry burn (V1):" in text
         assert "Dashboard usage ping (V2):" in text
 
@@ -428,3 +441,238 @@ class TestWiring:
         state_dir = tmp_path / "state"
         snapshot = scorecard.compute_scorecard(state_dir, None, force=True)
         assert snapshot["schema_version"] == "scorecard-v1"
+
+
+# ─── #860: derived priorities survive deploy_release.sh's goal_text reseed ──
+
+
+class TestDerivedPriorities:
+    def test_acceptance_lands_in_derived_file_goal_text_byte_unchanged(
+        self, tmp_path, monkeypatch, enabled
+    ):
+        state_dir = tmp_path / "state"
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        monkeypatch.setattr(goal_review, "_call_llm", lambda ctx: {"priorities": [VALID_PRIORITY]})
+
+        titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
+        assert titles == ["Priority 17 — Trim proposer retry burn"]
+
+        assert _read_goal_text(state_dir) == GOAL_TEXT
+        derived = goal_review.read_derived_priorities(state_dir)
+        assert len(derived) == 1
+        assert derived[0]["label"] == "Trim proposer retry burn"
+        assert derived[0]["vector"] == "V1"
+        assert derived[0]["body"] == VALID_PRIORITY["body"]
+        assert derived[0]["added_utc"]
+        # #860 review: the number IS stored at accept time (17 = next past
+        # merged base) so the rendered title/demand id stays stable across
+        # deploy reseeds; the label itself stays number-free.
+        assert derived[0]["number"] == 17
+        assert "17" not in derived[0]["label"]
+
+    def test_merged_goal_text_empty_derived_is_byte_identical(self, tmp_path):
+        state_dir = tmp_path / "state"
+        assert goal_review.merged_goal_text(state_dir, GOAL_TEXT) == GOAL_TEXT
+
+    def test_merged_goal_text_inserts_with_correct_next_number(self, tmp_path):
+        state_dir = tmp_path / "state"
+        goal_review._write_derived_priorities(
+            state_dir,
+            [
+                {
+                    "label": "Trim proposer retry burn",
+                    "vector": "V1",
+                    "body": "Do the bounded thing.",
+                    "number": 17,
+                    "added_utc": "2026-08-01T00:00:00Z",
+                }
+            ],
+        )
+        merged = goal_review.merged_goal_text(state_dir, GOAL_TEXT)
+        assert merged != GOAL_TEXT
+        section = merged[merged.index("Current priority targets:"):]
+        assert (
+            "Priority 17 — Trim proposer retry burn (V1): Do the bounded thing." in section
+        )
+        parsed = goal_review._PRIORITY_PATTERN.findall(section)
+        assert [int(num) for num, _, _ in parsed] == [11, 16, 17]
+
+    def test_deploy_reseed_does_not_erase_derived_priority(
+        self, tmp_path, monkeypatch, enabled
+    ):
+        """THE DEPLOY TEST — #860's acceptance criterion. goal_review appends
+        a priority (into derived_priorities.json); a deploy then overwrites
+        goal_text.json with a fresh operator copy (exactly what
+        ``deploy_release.sh`` does every release); demand collection must
+        still see the derived priority afterward."""
+        from nanobot.runtime import demand
+
+        state_dir = tmp_path / "state"
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        monkeypatch.setattr(goal_review, "_call_llm", lambda ctx: {"priorities": [VALID_PRIORITY]})
+        goal_review.maybe_goal_review(state_dir, None, now=NOW)
+
+        # Simulate deploy_release.sh:87 reseeding goal_text.json from the repo.
+        _write_goal_text(state_dir, GOAL_TEXT)
+
+        items = demand.collect_demand(state_dir, None)
+        summaries = [i["summary"] for i in items if i["kind"] == "priority"]
+        assert any("Trim proposer retry burn" in s for s in summaries)
+
+    def test_dedup_rejects_remint_of_existing_derived_label(
+        self, tmp_path, monkeypatch, enabled
+    ):
+        state_dir = tmp_path / "state"
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        goal_review._write_derived_priorities(
+            state_dir,
+            [
+                {
+                    "label": "Trim proposer retry burn",
+                    "vector": "V1",
+                    "body": "Already derived yesterday.",
+                    "number": 17,
+                    "added_utc": "2026-08-01T00:00:00Z",
+                }
+            ],
+        )
+        monkeypatch.setattr(goal_review, "_call_llm", lambda ctx: {"priorities": [VALID_PRIORITY]})
+
+        titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
+        assert titles == []
+        row = _goal_review_rows(state_dir)[0]
+        assert row["outcome"] == "no_valid_priorities"
+        assert row["rejected"] == [
+            {"label": "Trim proposer retry burn", "reason": "duplicate"}
+        ]
+        # Unchanged — the pre-existing derived entry stays exactly as-is.
+        assert goal_review.read_derived_priorities(state_dir) == [
+            {
+                "label": "Trim proposer retry burn",
+                "vector": "V1",
+                "body": "Already derived yesterday.",
+                "number": 17,
+                "added_utc": "2026-08-01T00:00:00Z",
+            }
+        ]
+
+    def test_demand_sees_merged_priorities_v1_sorts_before_v2(self, tmp_path):
+        from nanobot.runtime import demand
+
+        state_dir = tmp_path / "state"
+        _write_goal_text(state_dir)
+        goal_review._write_derived_priorities(
+            state_dir,
+            [
+                {
+                    "label": "Derived V2 task",
+                    "vector": "V2",
+                    "body": "Do the V2 thing.",
+                    "number": 17,
+                    "added_utc": "2026-08-01T00:00:00Z",
+                },
+                {
+                    "label": "Derived V1 task",
+                    "vector": "V1",
+                    "body": "Do the V1 thing.",
+                    "number": 18,
+                    "added_utc": "2026-08-01T00:01:00Z",
+                },
+            ],
+        )
+
+        items = demand.collect_demand(state_dir, None)
+        summaries = [i["summary"] for i in items if i["kind"] == "priority"]
+        v1_idx = next(i for i, s in enumerate(summaries) if "Derived V1 task" in s)
+        v2_idx = next(i for i, s in enumerate(summaries) if "Derived V2 task" in s)
+        assert v1_idx < v2_idx
+
+    def test_cap_evicts_oldest_beyond_ten(self, tmp_path):
+        state_dir = tmp_path / "state"
+        existing = [
+            {
+                "label": f"Old task {i}",
+                "vector": "V1",
+                "body": "b",
+                "number": 20 + i,
+                "added_utc": f"day-{i}",
+            }
+            for i in range(10)
+        ]
+        goal_review._write_derived_priorities(state_dir, existing)
+        assert len(goal_review.read_derived_priorities(state_dir)) == 10
+
+        with_eleventh = existing + [
+            {"label": "Newest task", "vector": "V1", "body": "b", "number": 30, "added_utc": "day-10"}
+        ]
+        goal_review._write_derived_priorities(state_dir, with_eleventh)
+
+        stored = goal_review.read_derived_priorities(state_dir)
+        assert len(stored) == 10
+        assert stored[-1]["label"] == "Newest task"
+        assert all(d["label"] != "Old task 0" for d in stored)
+        assert stored[0]["label"] == "Old task 1"  # oldest (index 0) evicted
+
+    def test_operator_readding_derived_label_is_not_doubled(self, tmp_path):
+        """#860 review: if the operator later bakes a derived label into
+        goal_text itself, merged_goal_text must NOT render it twice (two
+        numbers → two demand items for the same work). Operator canon wins;
+        the derived copy is skipped."""
+        state_dir = tmp_path / "state"
+        goal_review._write_derived_priorities(
+            state_dir,
+            [
+                {
+                    "label": "Trim proposer retry burn",
+                    "vector": "V1",
+                    "body": "Derived copy.",
+                    "number": 17,
+                    "added_utc": "2026-08-01T00:00:00Z",
+                }
+            ],
+        )
+        operator_text = GOAL_TEXT + (
+            "\n(C) Priority 17 — Trim proposer retry burn (V1): Operator copy."
+        )
+        merged = goal_review.merged_goal_text(state_dir, operator_text)
+        assert merged == operator_text  # skipped entirely — no second copy
+        assert merged.count("Trim proposer retry burn") == 1
+
+    def test_derived_number_stable_across_reseed_with_changed_count(
+        self, tmp_path, monkeypatch, enabled
+    ):
+        """#860 review: a derived priority's stored number (and thus its
+        rendered title / demand item id) must NOT shift when a deploy
+        reseeds goal_text with a DIFFERENT operator priority count —
+        otherwise a demand-completed derived priority would resurface
+        under a new id."""
+        from nanobot.runtime import demand
+
+        state_dir = tmp_path / "state"
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        monkeypatch.setattr(goal_review, "_call_llm", lambda ctx: {"priorities": [VALID_PRIORITY]})
+        goal_review.maybe_goal_review(state_dir, None, now=NOW)
+
+        def _derived_item_id() -> str:
+            items = demand.collect_demand(state_dir, None)
+            return next(
+                i["id"] for i in items
+                if i["kind"] == "priority" and "Trim proposer retry burn" in i["summary"]
+            )
+
+        id_before = _derived_item_id()
+
+        # Deploy reseeds goal_text with FEWER operator priorities (11 only,
+        # 16 dropped) — the dynamic-numbering base would shift; the stored
+        # number must keep the id identical.
+        shrunk = "\n".join(
+            line for line in GOAL_TEXT.splitlines() if "Priority 16" not in line
+        )
+        assert "Priority 16" not in shrunk and "Priority 11" in shrunk
+        _write_goal_text(state_dir, shrunk)
+
+        assert _derived_item_id() == id_before


### PR DESCRIPTION
Closes #860.

## Problem (confirmed bug)
`deploy_release.sh:87` unconditionally reseeds `state/goals/goal_text.json` from the repo on EVERY release; `goal_review.maybe_goal_review` appended accepted priorities into that same file → every deploy erased the loop's self-derived priorities. Ledger smoking gun: three different "Priority 17" minted on 3 consecutive days (08-14/15/16), each wiped before use. Violates the operator's self-derive principle and burns one goal-review LLM call/day re-deriving lost work.

## Fix — canon split (KB practice: explicit canonical truth per plane)
- **Operator canon**: `goal_text.json` — deploy reseeds as before; goal_review no longer writes it (READ-ONLY).
- **Loop canon**: new harness-owned `state/goals/derived_priorities.json` (`derived-priorities-v1`, entries `{label, vector, body, number, added_utc}`, cap 10 newest, fail-open) — deploy never touches it.
- `merged_goal_text(state_dir, raw_text)`: folds derived entries into the operator text via the existing `append_priorities` insertion logic; **byte-identical passthrough when empty**.
- Readers: only the two priority consumers merge — `demand._priority_items` + `llm_proposer._load_goal_text` (lazy imports, fail-open). cycle_planning/bridge fallback untouched.
- Dedup over MERGED text: yesterday's derived priority blocks today's re-mint (this alone stops the daily churn).

## Opus review hardening (2 MED fixed)
1. **Stable ids across reseed**: priority numbers are assigned + STORED at accept time (continuing past the merged base), so a deploy that changes the operator's priority count can't shift a derived priority's rendered title/demand id — a demand-completed derived priority stays completed. Pinned by `test_derived_number_stable_across_reseed_with_changed_count`.
2. **No double items**: `merged_goal_text` skips derived entries whose label the operator has since baked into goal_text (operator canon wins). Pinned by `test_operator_readding_derived_label_is_not_doubled`.
Known bounded tradeoff (documented): cap-evicted still-open entry leaves the dedup baseline and could re-mint (needs 10 accumulated at 1-3 accepts/day).

## Trust / scope
Not in FITNESS_SIDECARS (steering-class: a forged derived priority still passes the full gate). No new env flags; SELFEVO_GOAL_REVIEW_ENABLED semantics unchanged. deploy_release.sh untouched.

## Tests
`tests/test_goal_review.py` 28/28 incl. THE DEPLOY TEST (append → reseed → demand still sees derived priority). goal_review+demand+llm_proposer suites: 270 passed (2 known Windows path-sep pre-existing, Linux CI clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)