### PR TITLE
fix(runtime): gate extension policy — non-exercisable files cannot auto-integrate (#863)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2478,6 +2478,22 @@ _BLOCKED_FILE_PATTERNS = (
 # Allowed path prefixes for changed files (relative to repo root)
 _ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/')
 
+# #863: the gate can only exercise/see-through these file types. Prefix
+# rules bound WHERE the instance may write; this bounds WHAT KIND of file
+# can auto-integrate. Unknown/compiled-language extensions (.rs/.c/.so/...)
+# would integrate unexercised — fail closed instead.
+# NB deliberately NOT listed: .env / .gitignore / .gitattributes — the
+# _BLOCKED_FILE_PATTERNS substring check (".env", ".git") hard-blocks those
+# paths BEFORE this policy runs; listing them here would falsely imply they
+# can auto-integrate. Operator adds an extension by product PR editing this
+# list — no env-flag relaxation path exists by design.
+_GATE_EXT_ALLOWLIST = frozenset((
+    ".py", ".md", ".json", ".yaml", ".yml", ".toml", ".txt",
+    ".sh", ".service", ".timer", ".conf", ".cron", ".html", ".css",
+    ".ts", ".js", ".example",
+))
+_GATE_BASENAME_ALLOWLIST = frozenset(("Makefile", "Dockerfile"))
+
 
 def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
     """Validate that changed files respect the bounded mutation surface contract.
@@ -2593,8 +2609,10 @@ def _classify_mutation_surface(
     :func:`_validate_mutation_surfaces` (kept intact for its tests):
 
     - ``blocked``   : blocked filename-pattern hits (#678 F3) — hard block.
-    - ``violations``: surface violations — a deny-set hit, or a file in neither
-      the script surface nor the operator-approved runtime slice — hard block.
+    - ``violations``: surface violations — a deny-set hit, a file in neither
+      the script surface nor the operator-approved runtime slice, or a file
+      in an allowed prefix whose extension is not gate-exercisable (#863,
+      ``_GATE_EXT_ALLOWLIST`` / ``_GATE_BASENAME_ALLOWLIST``) — hard block.
     - ``tier``      : ``'script'`` when every non-blocked file is in the existing
       script surface (auto-integrate on green — unchanged behavior); ``'runtime'``
       when at least one file is an operator-approved runtime-slice module (green
@@ -2618,6 +2636,17 @@ def _classify_mutation_surface(
             violations.append(f'runtime deny-set path (immutable safety shell): {f}')
             continue
         if any(f.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES):
+            # #863: prefix rules bound WHERE; this bounds WHAT KIND of file can
+            # auto-integrate. A file in an allowed prefix but of an unknown/
+            # non-exercisable extension (e.g. scripts/foo.rs, scripts/blob.so)
+            # would otherwise pass the smoke gate (py_compile + pytest only
+            # touch .py) and integrate with zero content verification.
+            basename = Path(f).name
+            suffix = Path(f).suffix.lower()
+            if basename not in _GATE_BASENAME_ALLOWLIST and suffix not in _GATE_EXT_ALLOWLIST:
+                violations.append(
+                    f'file extension not gate-exercisable (auto-integration denied): {f}'
+                )
             continue
         if f.replace('\\', '/') in slice_paths:
             tier = 'runtime'

--- a/tests/test_runtime_slice.py
+++ b/tests/test_runtime_slice.py
@@ -163,6 +163,81 @@ def test_classify_outside_surface_is_violation(monkeypatch):
     assert "outside allowed paths" in violations[0]
 
 
+# ─── #863: gate extension policy (WHAT KIND of file may auto-integrate) ─────
+# Prefix rules (_ALLOWED_PATH_PREFIXES) bound WHERE the instance may write.
+# The smoke gate only py_compiles changed .py files and runs pytest — a
+# non-Python/non-text file (e.g. scripts/foo.rs, scripts/blob.so) under an
+# allowed prefix previously passed both checks unexercised. These tests cover
+# the extension/basename allowlist enforced inside _classify_mutation_surface.
+
+def test_classify_rust_extension_is_violation(monkeypatch):
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    blocked, violations, tier = bridge._classify_mutation_surface(["scripts/foo.rs"])
+    assert blocked == []
+    assert len(violations) == 1
+    assert "not gate-exercisable" in violations[0]
+    assert "scripts/foo.rs" in violations[0]
+
+def test_classify_shared_object_extension_is_violation(monkeypatch):
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    blocked, violations, tier = bridge._classify_mutation_surface(["scripts/blob.so"])
+    assert blocked == []
+    assert len(violations) == 1
+    assert "not gate-exercisable" in violations[0]
+    assert "scripts/blob.so" in violations[0]
+
+def test_classify_known_extensions_have_no_extension_violation(monkeypatch):
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    for f in (
+        "scripts/tool.sh",
+        "docs/note.md",
+        "surfaces/w.json",
+        "memory/x.yaml",
+    ):
+        blocked, violations, tier = bridge._classify_mutation_surface([f])
+        assert blocked == [], f
+        assert violations == [], f
+        assert tier == "script", f
+
+def test_classify_makefile_basename_is_allowed(monkeypatch):
+    # basename allowlist covers extension-less build files (checked before suffix).
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    blocked, violations, tier = bridge._classify_mutation_surface(["scripts/Makefile"])
+    assert blocked == []
+    assert violations == []
+    assert tier == "script"
+
+def test_classify_example_suffix_is_allowed(monkeypatch):
+    # multi-dot filename: Path.suffix is only the last dotted segment (".example").
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    blocked, violations, tier = bridge._classify_mutation_surface(["surfaces/settings.example"])
+    assert blocked == []
+    assert violations == []
+    assert tier == "script"
+
+def test_classify_extensionless_file_is_violation(monkeypatch):
+    # the most likely real bypass: an extension-less payload (suffix '') in an
+    # allowed prefix whose basename is not allowlisted — must fail closed.
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    blocked, violations, tier = bridge._classify_mutation_surface(["scripts/payload"])
+    assert blocked == []
+    assert len(violations) == 1
+    assert "not gate-exercisable" in violations[0]
+    assert "scripts/payload" in violations[0]
+
+
+def test_classify_extension_violation_and_prefix_violation_are_independent(monkeypatch):
+    # a file outside the allowed prefixes is still a plain "outside allowed
+    # paths" violation, not an extension violation — the extension check only
+    # runs once the prefix check already passed.
+    monkeypatch.delenv(_SLICE_ENV, raising=False)
+    blocked, violations, tier = bridge._classify_mutation_surface(["state/foo.rs"])
+    assert blocked == []
+    assert len(violations) == 1
+    assert "outside allowed paths" in violations[0]
+    assert "not gate-exercisable" not in violations[0]
+
+
 # ─── _record_runtime_slice_candidate (promotion, not integration) ────────────
 
 def test_record_candidate_writes_pending_promotion(tmp_path: Path):


### PR DESCRIPTION
Closes #863

## Problem
The bridge gate's smoke checks (py_compile + pytest) can only exercise Python; other allowed text formats are at least reviewable by structural checks. Binary or unknown file types (.rs, .so, extensionless payloads) written under an allowed mutation-surface prefix pass through completely unseen and would auto-integrate with zero verification.

## Fix
- `_GATE_EXT_ALLOWLIST` (py, md, json, yaml/yml, toml, txt, sh, service, timer, conf, cron, html, css, ts, js, example) + `_GATE_BASENAME_ALLOWLIST` (Makefile, Dockerfile) in `nanobot/runtime/bridge.py`.
- Checked inside `_classify_mutation_surface`'s allowed-prefix branch; violations ride the existing `mutation_surface_violation` fail-closed plumbing (denied, ledgered, no integration).
- Deliberately NOT listed: .env / .gitignore / .gitattributes — `_BLOCKED_FILE_PATTERNS` substring check hard-blocks those paths before this policy runs.
- No env-flag relaxation path — operator extends the list via product PR only.

## Tests
7 new tests in `tests/test_runtime_slice.py`: .rs violation, .so violation, extensionless violation, known-ext pass loop, Makefile basename pass, .example pass, extension+prefix violation independence. 29/29 pass targeted; full suite 2000 passed / 31 known Windows-only failures (Linux CI arbiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)