### PR TITLE
feat(runtime): per-cycle causal micro-benchmark so SELFEVO_BENCHMARK_TRUST can be enabled (#822)

### DIFF
--- a/nanobot/runtime/benchmark_evidence.py
+++ b/nanobot/runtime/benchmark_evidence.py
@@ -100,6 +100,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from nanobot.runtime.heldout import microbench as _microbench
+
 BENCHMARK_SCHEMA = "benchmark-evidence-v1"
 
 _REQUIRED_STR_FIELDS = ("metric", "method")
@@ -138,6 +140,13 @@ _IMPROVEMENT_ABS_TOL = 1e-6
 # because an optimization claim may need to look back further than 7 days
 # to find its pre-integration snapshot).
 _MAX_HISTORY_LINES = 3000
+
+# #822: the noise floor for a harness-run causal microbench entry
+# (nanobot/runtime/heldout/microbench.py) to count as a genuine win on the
+# 2GB host — a single-cycle wall-time measurement is noisier than a 7-day
+# aggregate, so this is deliberately more conservative than
+# _IMPROVEMENT_REL_TOL above.
+_MICROBENCH_MIN_IMPROVEMENT_PCT = 5.0
 
 # #813 HIGH-2: operator-owned trust switch, same SELFEVO_ / default-OFF
 # precedent as SELFEVO_DECAY_PROTECT (#809) and SELFEVO_RUNTIME_SLICE
@@ -409,6 +418,56 @@ def verify_benchmark(state_dir: Path, cycle_id: str, integration_ts: Any) -> boo
             return False
         if not benchmark_trust_enabled():
             return False
+
+        # #822: a harness-run causal microbench entry — the harness itself
+        # measured THIS cycle's own baseline/candidate wall time in isolated
+        # git-worktree subprocesses — is AUTHORITATIVE, but ONLY when the
+        # instance's OWN optimization claim (state/benchmarks/<cycle_id>.json)
+        # actually references it: claim.metric == entry.metric AND
+        # claim.module == entry.module. Without this match, keying the
+        # short-circuit on cycle_id alone would let an UNRELATED claim in the
+        # same cycle (e.g. metric=tokens_per_integration) be verified/revoked
+        # on an existence_index wall-time measurement that has nothing to do
+        # with it (opus-review RED-2). ``load_microbench_entry`` already
+        # guarantees the entry itself is well-formed (finite, positive
+        # baseline_ms/candidate_ms/improvement_pct) or returns None.
+        #
+        # A malformed/absent microbench entry, OR a present entry whose
+        # claim is absent/unreadable/non-matching, is NOT a rejection here —
+        # it just means no authoritative harness measurement applies to
+        # THIS claim, so the legacy 7-day-aggregate corroboration below
+        # still gets to decide (using the claim's own numbers, as before).
+        # A matching claim never falls through to that legacy path: it
+        # exists precisely because a single-cycle win rarely moves a 7-day
+        # aggregate, so a direct measurement settles the question outright
+        # — using the HARNESS's numbers, never the claim's own baseline/
+        # new_value.
+        micro_entry = _microbench.load_microbench_entry(state_dir, safe_id)
+        if micro_entry is not None:
+            try:
+                claim_path = benchmark_path(state_dir, safe_id)
+                claim: Any = None
+                if claim_path.is_file():
+                    try:
+                        claim = json.loads(claim_path.read_text(encoding="utf-8"))
+                    except Exception:
+                        claim = None
+                entry_metric = micro_entry.get("metric")
+                entry_module = micro_entry.get("module")
+                claim_matches = (
+                    isinstance(claim, dict)
+                    and isinstance(entry_metric, str)
+                    and entry_metric
+                    and isinstance(entry_module, str)
+                    and entry_module
+                    and claim.get("metric") == entry_metric
+                    and claim.get("module") == entry_module
+                )
+                if claim_matches:
+                    return micro_entry["improvement_pct"] >= _MICROBENCH_MIN_IMPROVEMENT_PCT
+            except Exception:
+                pass  # fail-open — fall through to the legacy path below
+
         path = benchmark_path(state_dir, safe_id)
         if not path.is_file():
             return False

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2201,9 +2201,37 @@ async def _main_impl():
                     record_gate_decision(
                         STATE_DIR, _cycle_id, True, 'runtime_slice_gate_passed', [],
                     )
+                    # ── #822 (opus-review follow-up): harness-run causal
+                    # micro-benchmark. Runs ONLY here — on the gate-PASS path,
+                    # AFTER the #789 integrity re-hash above — never on
+                    # blocked/violation/smoke-failed cycles (which would
+                    # otherwise pay 2 worktrees + subprocesses and persist an
+                    # AUTHORITATIVE entry for code that never lands), and
+                    # never inside the pre/post integrity hash window (the
+                    # entry this writes to state/heldout/microbench.json is
+                    # itself a #789 fitness sidecar — writing it between
+                    # _integrity_pre and _integrity_post fired a false
+                    # 'sidecar_write_during_spawn' incident on EVERY measured
+                    # cycle). Fail-open: a measurement failure must never
+                    # affect the gate, which is already decided above.
+                    _microbench_entry = None
+                    try:
+                        from nanobot.runtime.heldout.microbench import measure_cycle as _measure_cycle
+                        _microbench_entry = _measure_cycle(
+                            STATE_DIR, _selfevo_repo, _cycle_id, main_sha_before, cycle_branch, files_changed,
+                        )
+                        if _microbench_entry:
+                            print(
+                                f"microbench: {_microbench_entry['module']} "
+                                f"{_microbench_entry['baseline_ms']:.2f}ms -> "
+                                f"{_microbench_entry['candidate_ms']:.2f}ms "
+                                f"({_microbench_entry['improvement_pct']:+.1f}%) (#822)"
+                            )
+                    except Exception:
+                        _microbench_entry = None
                     _cand_id = _record_runtime_slice_candidate(
                         STATE_DIR, _selfevo_repo, _cycle_id, cycle_branch,
-                        main_sha_before, files_changed,
+                        main_sha_before, files_changed, microbench=_microbench_entry,
                     )
                     print(
                         f'runtime-slice: gate green — promotion candidate {_cand_id} '
@@ -2660,6 +2688,7 @@ def _classify_mutation_surface(
 def _record_runtime_slice_candidate(
     state_dir: 'Path', repo_root: 'Path', cycle_id: str, cycle_branch: str,
     base_sha: 'str | None', changed_files: 'list[str]',
+    microbench: 'dict | None' = None,
 ) -> str:
     """Record a green runtime-slice cycle as a pending promotion candidate. #812.
 
@@ -2670,6 +2699,13 @@ def _record_runtime_slice_candidate(
     so an operator can review and, if accepted, carry it into the live release via
     a product PR. Best-effort: never raises into the gate (a candidate-write
     failure must not crash the loop). Returns the candidate id.
+
+    ``microbench`` (#822) is the optional harness-run causal micro-benchmark
+    entry for this cycle (``heldout/microbench.py``'s ``measure_cycle``
+    return value, or ``None`` if no registered spec matched or a measurement
+    failed) — embedded verbatim into the candidate record so an operator
+    reviewing a runtime-slice promotion can see a real before/after number,
+    not just the diff. Optional so existing callers are unaffected.
     """
     candidate_id = f'promotion-runtime-{_safe_ref_id(cycle_id)}'
     head_sha = _safe_rev_parse(repo_root, 'HEAD') or None
@@ -2694,6 +2730,7 @@ def _record_runtime_slice_candidate(
         'review_status': 'not_ready_for_policy_review',
         'decision': 'not_ready_for_policy_review',
         'changed_files': changed_files,
+        'microbench': microbench,
         'rollback_record': {
             'cycle_branch': cycle_branch,
             'base_sha': base_sha,

--- a/nanobot/runtime/heldout/microbench.py
+++ b/nanobot/runtime/heldout/microbench.py
@@ -1,0 +1,543 @@
+"""Harness-run per-cycle causal micro-benchmark (#822).
+
+#819's ``benchmark_evidence.verify_benchmark`` corroborates an optimization
+claim against the harness's OWN ``scorecard/history.jsonl`` — but those are
+7-day WINDOWED AGGREGATES, not a single-cycle before/after measurement (see
+that module's HONEST RESIDUAL). In practice this means a real, single-cycle
+performance win almost never moves a 7-day aggregate enough to corroborate,
+so ``SELFEVO_BENCHMARK_TRUST`` stays off even for genuine wins — the #819
+guarantee (a forged artifact cannot self-corroborate) is real, but the gate
+it protects rarely fires FOR THE RIGHT REASON either.
+
+This module closes that gap with an actual causal measurement: the harness
+itself times a SELF-CONTAINED benchmark script, once against the pre-cycle
+base commit and once against the cycle's own candidate commit, in isolated
+git worktrees under a stripped subprocess env — never trusting a number the
+instance wrote. Concretely:
+
+- :data:`MICROBENCHES` is a small, product-code-owned registry mapping a
+  repo-relative module path to the SOURCE of a benchmark script for that
+  module's hot path. There is no environment variable or on-disk file that
+  can add or override an entry — the instance cannot invent its own
+  benchmark and have it trusted, symmetric with #819's
+  ``_HARNESS_METRICS`` allowlist.
+- :func:`run_measurement` executes one registered spec against one git ref
+  of a repo: a temporary ``git worktree add --detach`` checkout, the spec
+  script run via ``sys.executable`` with a stripped env (mirrors
+  ``heldout/checkers.py``'s ``_sandbox_env`` — no state dir, no secrets, no
+  network assumptions), parsing the LAST stdout line as a float
+  (milliseconds, lower=better). The worktree is always removed, even on
+  failure/timeout. Fails open to ``None`` on any error.
+- :func:`measure_cycle` is the bridge's entry point: given a cycle's
+  changed files, it finds the first one with a registered spec, measures
+  baseline (``base_sha``) then candidate (``head_ref``), and — only if BOTH
+  measurements succeed — appends a bounded (200-entry) record to
+  ``<state_dir>/heldout/microbench.json``. Fails open to ``None`` (writing
+  nothing) on any error, including a single failed measurement.
+- :func:`load_microbench_entry` is the read side ``benchmark_evidence``
+  uses: returns a well-formed entry for a cycle_id, or ``None`` if the
+  entry is absent OR malformed (a malformed entry is treated exactly like
+  an absent one — never trusted, never a hard failure either).
+
+Security invariants (do not weaken):
+
+- The instance never supplies the measured number. Both measurements are
+  taken by the harness itself, in subprocesses it spawns, against code it
+  checked out via git — the instance's own scripts/state cannot influence
+  which number gets written beyond choosing which files to change (which is
+  its normal job).
+- ``state/heldout/microbench.json`` is a #789 fitness sidecar (see
+  ``scorecard.FITNESS_SIDECARS``) — hashed at the same spawn-boundary
+  checkpoint as every other fitness input, so an instance-authored script
+  writing into it mid-cycle is detected exactly like the #789 incident that
+  motivated that check for the other sidecars.
+- Nothing here reads ``state/benchmarks/`` (the instance-forgeable
+  optimization-claim artifact #813/#819 already treat as untrusted prose) —
+  this module and ``benchmark_evidence`` are deliberately independent
+  measurement paths that happen to share a consumer.
+
+RESIDUAL ACCEPTED RISK (opus-review RED-3 — read before trusting a green
+result blindly): each registered spec now asserts CORRECTNESS on its own
+synthetic corpus (not just wall time — see the seed spec below), so a
+candidate that goes fast by returning empty/wrong results (e.g.
+``find_similar`` silently returning ``[]``) fails the spec and produces no
+entry, not an inflated ``improvement_pct``. That corpus is still
+world-readable product source, shipped with every release: a sufficiently
+adversarial instance change could in principle special-case exactly this
+synthetic corpus's shape while staying behaviorally correct ONLY on it (and
+wrong everywhere else). This module does not claim to close that gap by
+itself; it is one layer of a stack: (1) the correctness assertions here
+catch the crude "just return nothing/wrong" failure mode; (2)
+``heldout/checkers.py``'s INVISIBLE behavioral checks (a fully separate,
+never-instance-facing fixture set) are the harness's actual defense against
+narrow overfitting; (3) every green runtime-slice result — microbench
+entry included — lands only as a promotion candidate under
+``state/promotions/`` for OPERATOR REVIEW before ever reaching the live
+release (#812) — nothing here auto-integrates on its own.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+_MICROBENCH_DIR = "heldout"
+_MICROBENCH_FILENAME = "microbench.json"
+_MAX_ENTRIES = 200
+_SCHEMA = "heldout-microbench-v1"
+_ENTRY_SCHEMA = "heldout-microbench-entry-v1"
+
+# #822 MED-2: max relative disagreement allowed between the two baseline
+# runs (bracketing the candidate run) before the whole measurement is
+# discarded as too noisy to trust — see measure_cycle's drift guard.
+_BASELINE_DRIFT_MAX_REL = 0.05
+
+
+# ─── seed spec: nanobot/runtime/existence_index.py ─────────────────────────
+
+_EXISTENCE_INDEX_SPEC = '''"""Harness microbench spec: nanobot/runtime/existence_index.py (#822).
+
+Self-contained — no imports beyond stdlib + nanobot.runtime.existence_index.
+Builds a small synthetic scripts/ corpus fresh in a tempdir, exercises the
+module's real hot path (reindex + a handful of find_similar /
+find_duplicate_script queries), and prints the best-of-5 wall time in
+milliseconds as the LAST stdout line. Never touches any real state dir or
+network — every path used is inside a tempdir created by this process.
+
+CORRECTNESS, not just speed (opus-review RED-3): a candidate that goes fast
+by silently returning empty/wrong results must not be credited as a win.
+After each timed run, this spec asserts the module still gets the RIGHT
+answer on two known cases planted in the corpus: (1) a query naming an
+indexed fixture by number must return a hit containing that fixture's
+filename; (2) a title matching the module's own documented worked example
+("monitor RAM and memory usage" vs. a planted scripts/track_memory.py,
+sharing exactly the 2 words the matching rule is tuned on) must be caught
+by find_duplicate_script. Either check failing calls sys.exit(1) — a
+nonzero exit makes run_measurement() return None, so a fast-but-wrong
+candidate produces NO entry rather than an inflated improvement_pct.
+"""
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from nanobot.runtime import existence_index as ei
+
+_CORPUS_SIZE = 30
+_QUERY_COUNT = 5
+_RUNS = 5
+
+
+def _build_corpus(scripts_dir):
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(_CORPUS_SIZE):
+        path = scripts_dir / ("fixture_script_%02d.py" % i)
+        text = (
+            '"""Fixture script number %d exercising benchmark corpus text '
+            'for the existence index measurement."""\\n'
+            "def run_%d():\\n"
+            "    return %d\\n"
+        ) % (i, i, i)
+        path.write_text(text, encoding="utf-8")
+    # Planted near-duplicate pair — the module docstring's own worked
+    # calibration example ("monitor RAM and memory usage" vs. an existing
+    # track_memory.py sharing 2 words: memory, usage). A find_duplicate_script
+    # call with this exact title (no target_path, so the #798 concrete-target
+    # carve-out does not suppress different-path flagging) must return this
+    # file's path.
+    dup_path = scripts_dir / "track_memory.py"
+    dup_path.write_text(
+        \'"""Track memory usage over time."""\\ndef run():\\n    pass\\n\',
+        encoding="utf-8",
+    )
+
+
+def _fail(message):
+    sys.stderr.write("microbench correctness check failed: %s\\n" % message)
+    sys.exit(1)
+
+
+def _one_run():
+    tmp = Path(tempfile.mkdtemp(prefix="microbench-ei-"))
+    try:
+        repo = tmp / "repo"
+        state = tmp / "state"
+        _build_corpus(repo / "scripts")
+
+        start = time.perf_counter()
+        ei.reindex(state, repo)
+        for i in range(_QUERY_COUNT):
+            ei.find_similar(state, "fixture script number %d corpus text" % i, limit=5)
+        ei.find_duplicate_script(state, repo, "fixture script number 3 corpus text")
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+        # Correctness checks — deliberately NOT part of the timed window, so
+        # they cannot themselves be gamed for speed; a failure here aborts
+        # the whole measurement (see module docstring above).
+        hits = ei.find_similar(state, "fixture script number 3 corpus text", limit=5)
+        hit_paths = [h.get("path") or "" for h in hits]
+        if not hits or not any("fixture_script_03.py" in p for p in hit_paths):
+            _fail(
+                "known-similar query for fixture_script_03 returned no hit "
+                "containing the expected stem (got %r)" % (hit_paths,)
+            )
+
+        dup = ei.find_duplicate_script(state, repo, "monitor RAM and memory usage")
+        if dup != "scripts/track_memory.py":
+            _fail(
+                "find_duplicate_script did not find the planted near-duplicate "
+                "(expected scripts/track_memory.py, got %r)" % (dup,)
+            )
+
+        return elapsed_ms
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main():
+    best = min(_one_run() for _ in range(_RUNS))
+    print(best)
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+# The registry: repo-relative module path -> self-contained benchmark script
+# SOURCE. Product-code-owned; there is no env var or on-disk override — an
+# entry only exists here if it was added by a product change.
+MICROBENCHES: dict[str, str] = {
+    "nanobot/runtime/existence_index.py": _EXISTENCE_INDEX_SPEC,
+}
+
+
+# ─── sandboxed measurement ──────────────────────────────────────────────────
+
+
+def _git_cmd(repo_root: Path) -> list[str]:
+    return ["git", "-c", f"safe.directory={repo_root}", "-C", str(repo_root)]
+
+
+def _sandbox_env(worktree: Path) -> dict[str, str]:
+    """Minimal subprocess env for running a spec script: PYTHONPATH pinned
+    to the worktree (so ``import nanobot...`` resolves against the
+    CHECKED-OUT ref, not this process's own installed package) and
+    HOME/TMPDIR pinned to the worktree too — no state dir, no secrets
+    pass-through, no network configuration. Mirrors
+    ``heldout/checkers.py``'s ``_sandbox_env``.
+
+    PATH (and, on Windows, SYSTEMROOT) are widened relative to that
+    module's hardcoded ``/usr/bin:/bin`` because Windows' CreateProcess
+    needs a real PATH/SYSTEMROOT to resolve system DLLs when launching the
+    interpreter — the actual production host (eeepc, POSIX) keeps the
+    tight, checkers.py-style PATH.
+    """
+    env = {
+        "PYTHONPATH": str(worktree),
+        "HOME": str(worktree),
+        "TMPDIR": str(worktree),
+        "LANG": "C.UTF-8",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    if os.name == "nt":
+        env["PATH"] = os.environ.get("PATH", "")
+        env["SYSTEMROOT"] = os.environ.get("SYSTEMROOT") or os.environ.get("windir", "C:\\Windows")
+        env["USERPROFILE"] = str(worktree)
+        env["TMP"] = str(worktree)
+        env["TEMP"] = str(worktree)
+    else:
+        env["PATH"] = "/usr/bin:/bin"
+    return env
+
+
+def run_measurement(
+    repo_root: "Path", module_path: str, ref: str, *, timeout: int = 120,
+) -> "float | None":
+    """Measure ``MICROBENCHES[module_path]`` at git ``ref`` of ``repo_root``.
+
+    Creates a temporary detached ``git worktree`` at ``ref``, writes the
+    registered spec to a temp ``.py`` file, and runs it with
+    ``sys.executable`` under the stripped sandbox env (cwd=worktree,
+    PYTHONPATH=worktree) — no state dir, no network. The worktree is ALWAYS
+    removed in ``finally`` (best-effort ``git worktree remove --force`` +
+    a ``prune`` fallback, then the temp parent directory is deleted).
+
+    Returns the parsed LAST stdout line as a float (milliseconds), or
+    ``None`` on ANY failure: unregistered module, git worktree failure,
+    non-zero exit, empty/unparseable output, or a non-finite/negative
+    value. Never raises — fail-open.
+    """
+    spec = MICROBENCHES.get(module_path)
+    if not spec:
+        return None
+    repo_root = Path(repo_root)
+    parent: "Path | None" = None
+    worktree_dir: "Path | None" = None
+    spec_path: "Path | None" = None
+    try:
+        parent = Path(tempfile.mkdtemp(prefix="microbench-wt-"))
+        worktree_dir = parent / "wt"
+        add = subprocess.run(
+            _git_cmd(repo_root) + ["worktree", "add", "--detach", str(worktree_dir), str(ref)],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if add.returncode != 0 or not worktree_dir.is_dir():
+            return None
+
+        fd, spec_path_str = tempfile.mkstemp(
+            suffix=".py", prefix="microbench-spec-", dir=str(parent),
+        )
+        os.close(fd)
+        spec_path = Path(spec_path_str)
+        spec_path.write_text(spec, encoding="utf-8")
+
+        proc = subprocess.run(
+            [sys.executable, str(spec_path)],
+            cwd=str(worktree_dir),
+            env=_sandbox_env(worktree_dir),
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if proc.returncode != 0:
+            return None
+        lines = [ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()]
+        if not lines:
+            return None
+        try:
+            value = float(lines[-1])
+        except Exception:
+            return None
+        if not math.isfinite(value) or value < 0:
+            return None
+        return value
+    except Exception:
+        return None
+    finally:
+        if worktree_dir is not None:
+            try:
+                subprocess.run(
+                    _git_cmd(repo_root) + ["worktree", "remove", "--force", str(worktree_dir)],
+                    capture_output=True, text=True, timeout=timeout,
+                )
+            except Exception:
+                pass
+            try:
+                subprocess.run(
+                    _git_cmd(repo_root) + ["worktree", "prune"],
+                    capture_output=True, text=True, timeout=timeout,
+                )
+            except Exception:
+                pass
+        if parent is not None:
+            try:
+                shutil.rmtree(parent, ignore_errors=True)
+            except Exception:
+                pass
+
+
+# ─── cycle-level measurement + persistence ─────────────────────────────────
+
+
+def _is_safe_cycle_id(cycle_id: Any) -> str:
+    """Same rejection rule as ``benchmark_evidence._is_safe_cycle_id``: a
+    ``cycle_id`` containing a path separator or ``..`` is never safe to
+    join into ``<state_dir>/heldout/microbench.json``'s entries key (which
+    is only ever a dict key, not a path component, here — but kept
+    consistent so this module never becomes the softer link)."""
+    try:
+        c = str(cycle_id or "").strip()
+        if not c or "/" in c or "\\" in c or ".." in c:
+            return ""
+        return c
+    except Exception:
+        return ""
+
+
+def _microbench_path(state_dir: "Path") -> Path:
+    return Path(state_dir) / _MICROBENCH_DIR / _MICROBENCH_FILENAME
+
+
+def _load_microbench_file(state_dir: "Path") -> dict:
+    path = _microbench_path(state_dir)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and isinstance(data.get("entries"), dict):
+            return data
+    except Exception:
+        pass
+    return {"schema_version": _SCHEMA, "entries": {}}
+
+
+def _resolve_ref(repo_root: "Path", ref: str) -> "str | None":
+    try:
+        proc = subprocess.run(
+            _git_cmd(repo_root) + ["rev-parse", str(ref)],
+            capture_output=True, text=True, timeout=15,
+        )
+        if proc.returncode == 0:
+            out = proc.stdout.strip()
+            return out or None
+        return None
+    except Exception:
+        return None
+
+
+def measure_cycle(
+    state_dir: "Path",
+    repo_root: "Path",
+    cycle_id: str,
+    base_sha: "str | None",
+    head_ref: str,
+    changed_files: "list[str]",
+) -> "dict | None":
+    """Measure and persist a harness microbench entry for one cycle, if a
+    changed file has a registered spec. #822.
+
+    Finds the FIRST file in ``changed_files`` present in
+    :data:`MICROBENCHES`, then measures THREE times via
+    :func:`run_measurement`: baseline (``base_sha``), candidate
+    (``head_ref``), baseline again (``base_sha``) — a drift guard
+    (opus-review MED-2) against systematic host-load drift on the 2GB host
+    faking an improvement between two sequential measurements. If either
+    baseline run or the candidate run fails (``None``/non-positive), or the
+    two baseline runs disagree by more than 5% relative
+    (:data:`_BASELINE_DRIFT_MAX_REL`), the environment is judged too noisy
+    to trust and this returns ``None`` — writing nothing. Otherwise
+    ``baseline_ms`` is the MINIMUM of the two baseline runs (both recorded
+    under ``baseline_ms_runs`` for auditability), and an entry is appended
+    to ``<state_dir>/heldout/microbench.json`` keyed by ``cycle_id``
+    (newest 200 entries kept, by ``measured_at_utc``) and returned.
+
+    Also returns ``None`` — writing nothing — on: no registered changed
+    file, or an unsafe ``cycle_id``/missing ``base_sha``/``head_ref``.
+    Never raises.
+    """
+    try:
+        safe_id = _is_safe_cycle_id(cycle_id)
+        if not safe_id:
+            return None
+        if not base_sha or not head_ref:
+            return None
+
+        module_path = None
+        for f in changed_files or []:
+            normalized = str(f).replace("\\", "/")
+            if normalized in MICROBENCHES:
+                module_path = normalized
+                break
+        if module_path is None:
+            return None
+
+        repo_root = Path(repo_root)
+
+        # #822 MED-2 drift guard: baseline measured TWICE, bracketing the
+        # candidate measurement, so systematic host-load drift across the
+        # whole window shows up as baseline disagreement rather than being
+        # silently read as candidate improvement.
+        baseline_ms_1 = run_measurement(repo_root, module_path, base_sha)
+        if baseline_ms_1 is None or baseline_ms_1 <= 0:
+            return None
+        candidate_ms = run_measurement(repo_root, module_path, head_ref)
+        if candidate_ms is None or candidate_ms <= 0:
+            return None
+        baseline_ms_2 = run_measurement(repo_root, module_path, base_sha)
+        if baseline_ms_2 is None or baseline_ms_2 <= 0:
+            return None
+
+        drift = abs(baseline_ms_1 - baseline_ms_2) / min(baseline_ms_1, baseline_ms_2)
+        if drift > _BASELINE_DRIFT_MAX_REL:
+            return None  # environment too noisy this window — fail open
+
+        baseline_ms = min(baseline_ms_1, baseline_ms_2)
+        head_sha = _resolve_ref(repo_root, head_ref) or str(head_ref)
+        improvement_pct = (baseline_ms - candidate_ms) / baseline_ms * 100.0
+
+        entry = {
+            "module": module_path,
+            "metric": "wall_ms_best_of_5",
+            "baseline_ms": baseline_ms,
+            "baseline_ms_runs": [baseline_ms_1, baseline_ms_2],
+            "candidate_ms": candidate_ms,
+            "improvement_pct": improvement_pct,
+            "direction": "lower",
+            "base_sha": base_sha,
+            "head_sha": head_sha,
+            "measured_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "schema": _ENTRY_SCHEMA,
+        }
+
+        data = _load_microbench_file(state_dir)
+        entries = data.get("entries")
+        if not isinstance(entries, dict):
+            entries = {}
+        entries[safe_id] = entry
+        if len(entries) > _MAX_ENTRIES:
+            def _measured_at(item: tuple) -> str:
+                _, e = item
+                return str(e.get("measured_at_utc") or "") if isinstance(e, dict) else ""
+
+            ordered = sorted(entries.items(), key=_measured_at)
+            entries = dict(ordered[-_MAX_ENTRIES:])
+        data["entries"] = entries
+        data["schema_version"] = _SCHEMA
+
+        out_path = _microbench_path(state_dir)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return entry
+    except Exception:
+        return None
+
+
+def _entry_well_formed(entry: Any) -> bool:
+    """True iff ``entry`` has the numeric shape :func:`load_microbench_entry`
+    requires before treating it as authoritative: ``baseline_ms``,
+    ``candidate_ms`` and ``improvement_pct`` all finite numbers, and both
+    ms values strictly positive. Anything else (missing dict, non-numeric,
+    NaN/inf, zero/negative ms) is malformed — never raises."""
+    try:
+        if not isinstance(entry, dict):
+            return False
+        baseline = entry.get("baseline_ms")
+        candidate = entry.get("candidate_ms")
+        improvement = entry.get("improvement_pct")
+        for value in (baseline, candidate, improvement):
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return False
+            if not math.isfinite(value):
+                return False
+        return baseline > 0 and candidate > 0
+    except Exception:
+        return False
+
+
+def load_microbench_entry(state_dir: "Path", cycle_id: str) -> "dict | None":
+    """Return the well-formed microbench entry for ``cycle_id``, or ``None``
+    if absent, unsafe, or malformed.
+
+    This is the read side ``benchmark_evidence.verify_benchmark`` uses
+    (#822): a malformed entry is deliberately treated exactly like an
+    absent one — the caller falls back to its legacy 7-day-aggregate
+    corroboration rather than trusting (or hard-rejecting on) a corrupt
+    sidecar. Never raises.
+    """
+    try:
+        safe_id = _is_safe_cycle_id(cycle_id)
+        if not safe_id:
+            return None
+        data = _load_microbench_file(state_dir)
+        entries = data.get("entries") or {}
+        entry = entries.get(safe_id)
+        if not _entry_well_formed(entry):
+            return None
+        return entry
+    except Exception:
+        return None

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -716,6 +716,7 @@ FITNESS_SIDECARS = (
     "scorecard/latest.json",
     "scorecard/history.jsonl",
     "heldout/results.json",
+    "heldout/microbench.json",
     "usage/last_used.json",
 )
 

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -619,7 +619,24 @@ class TestInvisibility:
             path = _REPO_ROOT / rel
             if not path.is_file():
                 continue
-            assert "heldout" not in path.read_text(encoding="utf-8").lower(), (
+            content = path.read_text(encoding="utf-8").lower()
+            # #822: bridge.py legitimately calls heldout/microbench.py's
+            # measure_cycle — a harness-run causal wall-time measurement,
+            # not a hidden behavioral check. Its security does not depend on
+            # secrecy: the harness re-measures BOTH baseline and candidate
+            # itself, in isolated git-worktree subprocesses, regardless of
+            # what the instance can read in bridge.py's own source — unlike
+            # checkers.py/run_heldout's grading fixtures, which still must
+            # stay invisible (an instance that saw the fixtures/assertions
+            # could tune a solution to pass them without being correct).
+            # Strip only the microbench references before the blanket check
+            # so this invariant keeps guarding the actual secret surface.
+            sanitized = (
+                content.replace("heldout.microbench", "")
+                .replace("heldout/microbench", "")
+                .replace("heldout\\microbench", "")
+            )
+            assert "heldout" not in sanitized, (
                 f"{rel} references the held-out pack — it must stay invisible "
                 "to the instance (#603 invariant)"
             )

--- a/tests/test_microbench.py
+++ b/tests/test_microbench.py
@@ -1,0 +1,546 @@
+"""Tests for #822: harness-run per-cycle causal micro-benchmark.
+
+Covers the seed spec (:data:`microbench.MICROBENCHES`'s
+``nanobot/runtime/existence_index.py`` entry) actually measuring something
+real on the CURRENT repo, :func:`microbench.measure_cycle`'s happy path and
+fail-open axes (unregistered file, unsafe cycle_id, a failed measurement),
+the 200-entry cap, and the :func:`benchmark_evidence.verify_benchmark`
+integration: a well-formed harness microbench entry is AUTHORITATIVE (never
+falls through to the legacy 7-day-aggregate corroboration #819 already
+covers), a malformed/absent one defers to it unchanged.
+"""
+from __future__ import annotations
+
+import json
+import math
+import shutil
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import benchmark_evidence
+from nanobot.runtime.heldout import microbench
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A trivial, deterministic spec used in place of the real existence_index
+# spec for measure_cycle tests — reads a marker out of the checked-out
+# fixture module so baseline/candidate ms are known exactly (no timing
+# noise), while still exercising the REAL run_measurement subprocess/
+# git-worktree path.
+_TRIVIAL_SPEC = (
+    'from pathlib import Path\n'
+    'content = Path("fake_module.py").read_text(encoding="utf-8")\n'
+    'print(10.0 if "FAST" in content else 100.0)\n'
+)
+
+
+def _init_git_repo(repo_dir: Path) -> None:
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=str(repo_dir), check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Microbench Test"],
+        cwd=str(repo_dir), check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "microbench-test@example.com"],
+        cwd=str(repo_dir), check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"],
+        cwd=str(repo_dir), check=True, capture_output=True,
+    )
+
+
+def _commit_module(repo_dir: Path, filename: str, content: str, message: str) -> str:
+    (repo_dir / filename).write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", filename], cwd=str(repo_dir), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=str(repo_dir), check=True, capture_output=True)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo_dir),
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _fixture_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    """A tiny two-commit git repo: base has a 'SLOW' marker, head has 'FAST'."""
+    repo_dir = tmp_path / "repo"
+    _init_git_repo(repo_dir)
+    base_sha = _commit_module(repo_dir, "fake_module.py", "# SLOW marker\n", "base: slow")
+    head_sha = _commit_module(repo_dir, "fake_module.py", "# FAST marker\n", "head: fast")
+    return repo_dir, base_sha, head_sha
+
+
+# ─── 1. seed-spec smoke: run_measurement against the CURRENT repo ──────────
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git worktree unavailable in this environment")
+def test_seed_spec_measures_existence_index_on_current_repo():
+    value = microbench.run_measurement(
+        _REPO_ROOT, "nanobot/runtime/existence_index.py", "HEAD", timeout=180,
+    )
+    assert value is not None
+    assert math.isfinite(value)
+    assert value > 0
+
+
+# ─── 2. measure_cycle happy path ────────────────────────────────────────────
+
+
+def test_measure_cycle_happy_path(tmp_path: Path, monkeypatch):
+    repo_dir, base_sha, head_sha = _fixture_repo(tmp_path)
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+
+    state_dir = tmp_path / "state"
+    entry = microbench.measure_cycle(
+        state_dir, repo_dir, "cyc-1", base_sha, head_sha, ["fake_module.py"],
+    )
+
+    assert entry is not None
+    assert entry["module"] == "fake_module.py"
+    assert entry["metric"] == "wall_ms_best_of_5"
+    assert entry["baseline_ms"] == 100.0
+    assert entry["baseline_ms_runs"] == [100.0, 100.0]  # MED-2 drift guard: both base_sha runs
+    assert entry["candidate_ms"] == 10.0
+    assert entry["improvement_pct"] == pytest.approx(90.0)
+    assert entry["direction"] == "lower"
+    assert entry["base_sha"] == base_sha
+    assert entry["head_sha"] == head_sha
+    assert entry["schema"] == "heldout-microbench-entry-v1"
+    assert "measured_at_utc" in entry
+
+    on_disk = json.loads((state_dir / "heldout" / "microbench.json").read_text(encoding="utf-8"))
+    assert on_disk["schema_version"] == "heldout-microbench-v1"
+    assert on_disk["entries"]["cyc-1"] == entry
+
+
+def test_measure_cycle_caps_entries_at_200(tmp_path: Path, monkeypatch):
+    repo_dir, base_sha, head_sha = _fixture_repo(tmp_path)
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+
+    state_dir = tmp_path / "state"
+    path = state_dir / "heldout" / "microbench.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    base_time = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    entries = {}
+    for i in range(200):
+        ts = (base_time + timedelta(minutes=i)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        entries[f"old-{i:04d}"] = {
+            "module": "fake_module.py",
+            "metric": "wall_ms_best_of_5",
+            "baseline_ms": 100.0,
+            "candidate_ms": 90.0,
+            "improvement_pct": 10.0,
+            "direction": "lower",
+            "base_sha": "x",
+            "head_sha": "y",
+            "measured_at_utc": ts,
+            "schema": "heldout-microbench-entry-v1",
+        }
+    path.write_text(
+        json.dumps({"schema_version": "heldout-microbench-v1", "entries": entries}),
+        encoding="utf-8",
+    )
+
+    entry = microbench.measure_cycle(
+        state_dir, repo_dir, "cyc-new", base_sha, head_sha, ["fake_module.py"],
+    )
+    assert entry is not None
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert len(data["entries"]) == 200
+    assert "cyc-new" in data["entries"]  # newest kept
+    assert "old-0000" not in data["entries"]  # oldest evicted
+    assert "old-0001" in data["entries"]  # second-oldest survives
+
+
+# ─── 3. measure_cycle fail-open: writes nothing ─────────────────────────────
+
+
+def test_measure_cycle_returns_none_when_no_registered_file(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+    state_dir = tmp_path / "state"
+    entry = microbench.measure_cycle(
+        state_dir, tmp_path / "repo", "cyc-x", "deadbeef", "cafefeed", ["other_file.py"],
+    )
+    assert entry is None
+    assert not (state_dir / "heldout" / "microbench.json").exists()
+
+
+def test_measure_cycle_returns_none_when_measurement_fails(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+    monkeypatch.setattr(microbench, "run_measurement", lambda *a, **k: None)
+    state_dir = tmp_path / "state"
+    entry = microbench.measure_cycle(
+        state_dir, tmp_path / "repo", "cyc-y", "deadbeef", "cafefeed", ["fake_module.py"],
+    )
+    assert entry is None
+    assert not (state_dir / "heldout" / "microbench.json").exists()
+
+
+def test_measure_cycle_returns_none_without_base_or_head(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+    state_dir = tmp_path / "state"
+    assert microbench.measure_cycle(
+        state_dir, tmp_path / "repo", "cyc-z", None, "cafefeed", ["fake_module.py"],
+    ) is None
+    assert microbench.measure_cycle(
+        state_dir, tmp_path / "repo", "cyc-z", "deadbeef", "", ["fake_module.py"],
+    ) is None
+    assert not (state_dir / "heldout" / "microbench.json").exists()
+
+
+def test_run_measurement_returns_none_when_spec_correctness_check_fails(tmp_path: Path, monkeypatch):
+    """opus-review RED-3: a spec that computes a (fake, fast) timing but then
+    fails its own correctness check must sys.exit(1) — run_measurement must
+    read that nonzero exit as a failed measurement (None), never as a valid
+    (fast-but-wrong) number."""
+    repo_dir, base_sha, head_sha = _fixture_repo(tmp_path)
+    wrong_but_fast_spec = (
+        "import sys\n"
+        "print(0.001)\n"  # a suspiciously fast timing ...
+        "sys.exit(1)\n"  # ... but the spec's own correctness check failed
+    )
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": wrong_but_fast_spec})
+    result = microbench.run_measurement(repo_dir, "fake_module.py", head_sha)
+    assert result is None
+
+
+# ─── MED-2: baseline drift guard (bracketed double-baseline measurement) ───
+
+
+def _fake_run_measurement_sequence(values: list):
+    """A run_measurement stand-in that returns ``values`` in call order,
+    ignoring which ref/module was requested — models measure_cycle's three
+    real calls (baseline, candidate, baseline again) deterministically."""
+    calls = {"n": 0}
+
+    def _fake(repo_root, module_path, ref, *args, **kwargs):
+        v = values[calls["n"]]
+        calls["n"] += 1
+        return v
+
+    return _fake
+
+
+def test_measure_cycle_drift_guard_rejects_noisy_baselines(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+    # baseline1=100, candidate=10, baseline2=120 -> drift = |100-120|/100 = 20% > 5%
+    monkeypatch.setattr(
+        microbench, "run_measurement", _fake_run_measurement_sequence([100.0, 10.0, 120.0]),
+    )
+    state_dir = tmp_path / "state"
+    entry = microbench.measure_cycle(
+        state_dir, tmp_path / "repo", "cyc-noisy", "deadbeef", "cafefeed", ["fake_module.py"],
+    )
+    assert entry is None
+    assert not (state_dir / "heldout" / "microbench.json").exists()
+
+
+def test_measure_cycle_drift_guard_accepts_stable_baselines(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+    # baseline1=100, candidate=10, baseline2=102 -> drift = |100-102|/100 = 1.96% <= 5%
+    monkeypatch.setattr(
+        microbench, "run_measurement", _fake_run_measurement_sequence([100.0, 10.0, 102.0]),
+    )
+    state_dir = tmp_path / "state"
+    entry = microbench.measure_cycle(
+        state_dir, tmp_path / "repo", "cyc-stable", "deadbeef", "cafefeed", ["fake_module.py"],
+    )
+    assert entry is not None
+    assert entry["baseline_ms"] == 100.0  # min(100, 102)
+    assert entry["baseline_ms_runs"] == [100.0, 102.0]
+    assert entry["candidate_ms"] == 10.0
+    assert entry["improvement_pct"] == pytest.approx(90.0)
+
+
+# ─── 4. benchmark_evidence.verify_benchmark integration ────────────────────
+
+
+_DEFAULT_MICROBENCH_MODULE = "nanobot/runtime/existence_index.py"
+_DEFAULT_MICROBENCH_METRIC = "wall_ms_best_of_5"
+
+
+def _write_microbench_entry(
+    state_dir: Path, cycle_id: str, *,
+    baseline_ms: float, candidate_ms: float, improvement_pct: float,
+    module: str = _DEFAULT_MICROBENCH_MODULE, metric: str = _DEFAULT_MICROBENCH_METRIC,
+) -> None:
+    path = state_dir / "heldout" / "microbench.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "schema_version": "heldout-microbench-v1",
+        "entries": {
+            cycle_id: {
+                "module": module,
+                "metric": metric,
+                "baseline_ms": baseline_ms,
+                "candidate_ms": candidate_ms,
+                "improvement_pct": improvement_pct,
+                "direction": "lower",
+                "base_sha": "base123",
+                "head_sha": "head456",
+                "measured_at_utc": "2026-08-01T00:00:00Z",
+                "schema": "heldout-microbench-entry-v1",
+            }
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_malformed_microbench_entry(state_dir: Path, cycle_id: str) -> None:
+    path = state_dir / "heldout" / "microbench.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "schema_version": "heldout-microbench-v1",
+        "entries": {
+            cycle_id: {
+                "module": _DEFAULT_MICROBENCH_MODULE,
+                "baseline_ms": "not-a-number",
+                "candidate_ms": 10.0,
+                "improvement_pct": 90.0,
+            }
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_legacy_history(
+    state_dir: Path, *, integration_ts: datetime, before_value: float = 1000, after_value: float = 400,
+) -> None:
+    before_ts = (integration_ts - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    after_ts = (integration_ts + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+    path = state_dir / "scorecard" / "history.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({"computed_at_utc": before_ts, "cost": {"tokens_per_integration": before_value}}),
+        json.dumps({"computed_at_utc": after_ts, "cost": {"tokens_per_integration": after_value}}),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_claim(
+    state_dir: Path, cycle_id: str, *,
+    metric: str = "tokens_per_integration", module: "str | None" = None,
+    baseline: float = 1000, new_value: float = 400, direction: str = "lower_is_better",
+) -> None:
+    """Write the INSTANCE's optimization claim (state/benchmarks/{cycle_id}.json)
+    — the file :func:`benchmark_evidence.verify_benchmark`'s RED-2 claim-match
+    check reads to decide whether a present microbench entry actually applies
+    to this claim (``metric``+``module`` equality)."""
+    path = benchmark_evidence.benchmark_path(state_dir, cycle_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "metric": metric,
+        "baseline": baseline,
+        "new_value": new_value,
+        "method": "test claim",
+        "direction": direction,
+    }
+    if module is not None:
+        payload["module"] = module
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestVerifyBenchmarkMicrobenchAuthoritative:
+    """A well-formed microbench entry is authoritative ONLY when the
+    instance's own claim (state/benchmarks/{cycle_id}.json) references it
+    by metric+module (opus-review RED-2) — otherwise it defers to the
+    legacy 7-day-aggregate path exactly as if no entry existed."""
+
+    def test_well_formed_entry_above_threshold_with_matching_claim_is_true(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        _write_microbench_entry(
+            tmp_path, "cyc-good", baseline_ms=100.0, candidate_ms=90.0, improvement_pct=10.0,
+        )
+        _write_claim(
+            tmp_path, "cyc-good",
+            metric=_DEFAULT_MICROBENCH_METRIC, module=_DEFAULT_MICROBENCH_MODULE,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-good", "2026-08-01T00:00:00Z") is True
+
+    def test_well_formed_entry_below_threshold_with_matching_claim_is_false_even_though_legacy_would_corroborate(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        integration_ts = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        # Legacy aggregates WOULD corroborate this exact metric (1000 -> 400)
+        # — proves the microbench verdict is authoritative, not just additive,
+        # once the claim actually matches the entry.
+        _write_legacy_history(tmp_path, integration_ts=integration_ts, before_value=1000, after_value=400)
+        _write_claim(tmp_path, "cyc-noop", metric="tokens_per_integration", module="scripts/whatever.py")
+        _write_microbench_entry(
+            tmp_path, "cyc-noop", baseline_ms=100.0, candidate_ms=99.0, improvement_pct=1.0,
+            module="scripts/whatever.py", metric="tokens_per_integration",
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-noop", integration_ts) is False
+
+    def test_malformed_entry_falls_through_to_legacy(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        integration_ts = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        _write_legacy_history(tmp_path, integration_ts=integration_ts)
+        _write_claim(tmp_path, "cyc-malformed")
+        _write_malformed_microbench_entry(tmp_path, "cyc-malformed")
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-malformed", integration_ts) is True
+
+    def test_no_entry_legacy_path_unchanged(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        integration_ts = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        _write_legacy_history(tmp_path, integration_ts=integration_ts)
+        _write_claim(tmp_path, "cyc-legacy-only")
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-legacy-only", integration_ts) is True
+
+    def test_trust_off_is_false_regardless_of_microbench_entry(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "0")
+        _write_microbench_entry(
+            tmp_path, "cyc-trustoff", baseline_ms=100.0, candidate_ms=10.0, improvement_pct=90.0,
+        )
+        _write_claim(
+            tmp_path, "cyc-trustoff",
+            metric=_DEFAULT_MICROBENCH_METRIC, module=_DEFAULT_MICROBENCH_MODULE,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-trustoff", "2026-08-01T00:00:00Z") is False
+
+
+class TestVerifyBenchmarkClaimMatching:
+    """opus-review RED-2: the microbench short-circuit must key off the
+    instance's OWN claim (metric+module), not just cycle_id — an unrelated
+    claim in the same cycle must never be verified/revoked on a measurement
+    it doesn't reference."""
+
+    def test_unrelated_metric_claim_falls_through_to_legacy_unaffected_by_unrelated_entry(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        integration_ts = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        _write_legacy_history(tmp_path, integration_ts=integration_ts)  # corroborates True
+        # The instance's claim is an ordinary tokens_per_integration claim —
+        # it never mentions the microbench module/metric at all.
+        _write_claim(tmp_path, "cyc-unrelated", metric="tokens_per_integration")
+        # A huge, UNRELATED microbench win exists for this same cycle_id
+        # (e.g. an incidental existence_index touch) — it must NOT leak in.
+        _write_microbench_entry(
+            tmp_path, "cyc-unrelated", baseline_ms=100.0, candidate_ms=10.0, improvement_pct=90.0,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-unrelated", integration_ts) is True
+
+    def test_absent_claim_with_well_formed_entry_falls_through_to_legacy(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        integration_ts = datetime(2026, 8, 1, tzinfo=timezone.utc)
+        # No claim file at all — a well-formed microbench entry must not be
+        # treated as authoritative for a claim that doesn't exist.
+        _write_microbench_entry(
+            tmp_path, "cyc-noclaim", baseline_ms=100.0, candidate_ms=10.0, improvement_pct=90.0,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, "cyc-noclaim", integration_ts) is False
+
+    def test_matching_claim_uses_harness_numbers_not_claims_own_forged_numbers(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        cycle_id = "cyc-match-forged"
+        # Harness measured a genuine 10% win.
+        _write_microbench_entry(
+            tmp_path, cycle_id, baseline_ms=100.0, candidate_ms=90.0, improvement_pct=10.0,
+        )
+        # The claim references the SAME metric+module (so it is authoritative)
+        # but carries wildly forged baseline/new_value numbers that must be
+        # IGNORED — only the harness's improvement_pct decides.
+        _write_claim(
+            tmp_path, cycle_id,
+            metric=_DEFAULT_MICROBENCH_METRIC, module=_DEFAULT_MICROBENCH_MODULE,
+            baseline=999999, new_value=1,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, cycle_id, "2026-08-01T00:00:00Z") is True
+
+    def test_matching_claim_below_threshold_is_false_despite_forged_claim_numbers(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        monkeypatch.setenv("SELFEVO_BENCHMARK_TRUST", "1")
+        cycle_id = "cyc-match-forged-low"
+        # Harness measured only a 1% win (below the 5% noise floor).
+        _write_microbench_entry(
+            tmp_path, cycle_id, baseline_ms=100.0, candidate_ms=99.0, improvement_pct=1.0,
+        )
+        # Claim matches by metric+module, but its OWN numbers claim a huge
+        # win — must be ignored; the harness's 1% loses.
+        _write_claim(
+            tmp_path, cycle_id,
+            metric=_DEFAULT_MICROBENCH_METRIC, module=_DEFAULT_MICROBENCH_MODULE,
+            baseline=1, new_value=0.0001,
+        )
+        assert benchmark_evidence.verify_benchmark(tmp_path, cycle_id, "2026-08-01T00:00:00Z") is False
+
+
+# ─── 5. cycle_id sanitization ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad_id", ["../evil", "..\\evil", "a/b", "a\\b", "", "   ", ".."])
+def test_measure_cycle_rejects_unsafe_cycle_id(tmp_path: Path, bad_id, monkeypatch):
+    monkeypatch.setattr(microbench, "MICROBENCHES", {"fake_module.py": _TRIVIAL_SPEC})
+    state_dir = tmp_path / "state"
+    entry = microbench.measure_cycle(
+        state_dir, tmp_path / "repo", bad_id, "deadbeef", "cafefeed", ["fake_module.py"],
+    )
+    assert entry is None
+    assert not (state_dir / "heldout" / "microbench.json").exists()
+
+
+@pytest.mark.parametrize("bad_id", ["../evil", "..\\evil", "a/b", "a\\b", "", "..", None])
+def test_load_microbench_entry_rejects_unsafe_cycle_id(tmp_path: Path, bad_id):
+    assert microbench.load_microbench_entry(tmp_path, bad_id) is None
+
+
+# ─── 6. FITNESS_SIDECARS ────────────────────────────────────────────────────
+
+
+def test_fitness_sidecars_contains_microbench():
+    from nanobot.runtime import scorecard
+
+    assert "heldout/microbench.json" in scorecard.FITNESS_SIDECARS
+
+
+# ─── 7. bridge.py call-site placement (opus-review RED-1/MED-1) ────────────
+#
+# Statically verifies (same lexical-order-in-source technique as
+# test_bridge_subagent_workspace.py) that the measure_cycle call:
+#   (a) runs AFTER the #789 integrity post-hash check — writing
+#       heldout/microbench.json (itself a fitness sidecar) INSIDE the
+#       _integrity_pre/_integrity_post window fired a false
+#       'sidecar_write_during_spawn' incident on every measured cycle; and
+#   (b) runs on the gate-PASS path only, immediately before
+#       _record_runtime_slice_candidate — never on blocked/violation/
+#       smoke-failed cycles, which would otherwise pay for 2 (now 3, #822
+#       MED-2) worktrees + subprocesses and persist an AUTHORITATIVE entry
+#       for code that never lands.
+
+_BRIDGE_PATH = _REPO_ROOT / "nanobot" / "runtime" / "bridge.py"
+
+
+def test_microbench_call_site_is_after_integrity_check_and_on_gate_pass_path():
+    source = _BRIDGE_PATH.read_text(encoding="utf-8")
+
+    integrity_post_pos = source.index("_integrity_post = _fitness_sidecar_hashes(STATE_DIR)")
+    gate_pass_record_pos = source.index(
+        "STATE_DIR, _cycle_id, True, 'runtime_slice_gate_passed', [],"
+    )
+    measure_call_pos = source.index("from nanobot.runtime.heldout.microbench import measure_cycle")
+    candidate_call_pos = source.index("_cand_id = _record_runtime_slice_candidate(")
+
+    assert integrity_post_pos < measure_call_pos, (
+        "measure_cycle must run AFTER the #789 integrity post-hash check — "
+        "otherwise every measured cycle writes heldout/microbench.json "
+        "inside the pre/post hash window and fires a false "
+        "sidecar_write_during_spawn incident (opus-review RED-1)"
+    )
+    assert gate_pass_record_pos < measure_call_pos < candidate_call_pos, (
+        "measure_cycle must run strictly between the runtime-slice "
+        "gate-PASS record_gate_decision(...) call and "
+        "_record_runtime_slice_candidate(...) — i.e. only on the gate-PASS "
+        "path, never for blocked/violation/smoke-failed cycles "
+        "(opus-review RED-1/MED-1)"
+    )


### PR DESCRIPTION
Closes #822

## Problem
#819 made optimization-claim confirmation non-forgeable but nearly useless: corroboration runs against 7-day windowed aggregates a genuine single-cycle win rarely moves → `verify_benchmark` False for real wins → `SELFEVO_BENCHMARK_TRUST` stuck OFF.

## What ships
- **`nanobot/runtime/heldout/microbench.py` (new)** — `MICROBENCHES` registry (product-code-owned, no env override): path → self-contained bench script printing one float ms (lower=better). Seeded with `nanobot/runtime/existence_index.py` (synthetic corpus; index build + `find_similar`/`find_duplicate_script`; best-of-5 `perf_counter`). `run_measurement` = temp detached git worktree at ref + stripped sandbox env (heldout pattern) + timeout + guaranteed worktree cleanup. Correctness assertions outside the timed window — fast-but-wrong candidate exits nonzero → no entry. `measure_cycle` = baseline→candidate→baseline drift guard (baselines disagreeing >5% rel = too noisy → no entry), `baseline_ms=min`, entry → harness-owned `state/heldout/microbench.json` (cap 200).
- **`bridge.py`** — measurement only on the runtime-tier gate-PASS path, AFTER the #789 integrity post-check (outside the spawn-hash window); entry embedded into the promotion candidate for operator review.
- **`benchmark_evidence.verify_benchmark`** — well-formed harness entry is authoritative when the claim names the same non-empty metric+module: verdict = harness `improvement_pct >= 5.0` (claim's own numbers never read). Absent/non-matching claim → legacy aggregate path unchanged.
- **`scorecard.FITNESS_SIDECARS`** += `heldout/microbench.json` (#789 spawn-hash).

## Trust properties
Instance never supplies the measured number — harness re-measures both refs itself in isolated env-stripped subprocesses. Forged `state/benchmarks/*.json` claims can at most opt INTO harness judgment, never bypass it. Residual accepted risk (documented): world-readable corpus could be special-cased while staying correct on it; mitigations = correctness assertions + invisible held-out backstop + operator review of every runtime-slice candidate.

## Review
Opus 2 rounds: r1 = 3 RED (write inside #789 integrity window → false tamper events; cycle_id-only authoritativeness let unrelated claims verify on existence_index wall-time; wall-time-only spec gameable by fast-but-wrong candidate) + 2 MED (pre-gate measurement cost; sequential-run drift) — all fixed. r2 = all fixes verified REAL, 1 nit (non-empty metric/module match) fixed.

## Tests
`tests/test_microbench.py` (new, 26+ tests): seed-spec smoke vs real repo, claim-matching (unrelated/absent/forged-numbers), drift guard, spec-failure→None, call-site position invariants, sanitization, sidecar registration. Targeted 97/97 + 204/204 across microbench/benchmark/runtime-slice/scorecard/heldout/integrity. Full suite: 31 known Windows-only failures, 0 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)