### PR TITLE
feat(runtime): control-plane visibility — active-flags snapshot in scorecard + env template sync (#865)

### DIFF
--- a/host/eeepc/etc/instances/self-evolving-agent.env
+++ b/host/eeepc/etc/instances/self-evolving-agent.env
@@ -1,5 +1,12 @@
+# TEMPLATE seeded at install time. The operator-owned live copy at
+# /etc/eeepc-agent/instances/self-evolving-agent.env takes precedence and
+# may carry secrets — LITELLM creds live ONLY in /etc/eeepc-agent/litellm.env.
+#
 # LITELLM credentials — см. /etc/eeepc-agent/litellm.env
 # Для обновления ключа редактируйте ТОЛЬКО litellm.env
+#
+# SELFEVO_DETERMINISTIC_PLANNER_ENABLED was removed (#861) — not a live flag
+# in this template; do not reintroduce it here.
 
 TARGET_WORKSPACE=/home/opencode/servers_team/repo_research/nanobot
 STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state

--- a/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
+++ b/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
@@ -1,7 +1,29 @@
+# TEMPLATE seeded at install time. The operator-owned live copy at
+# /etc/eeepc-agent/instances/self-evolving-subagent-bridge.env takes
+# precedence. LITELLM creds live ONLY in /etc/eeepc-agent/litellm.env
+# (update the key there) — never place credentials in this file.
+
+# Master kill switch for the subagent bridge (#678).
 SUBAGENT_BRIDGE_ENABLED=1
 STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
 TARGET_WORKSPACE=/home/opencode/servers_team/repo_research/nanobot
 NANOBOT_CONFIG_PATH=/run/user/1001/nanobot-eeepc/config.json
 SUBAGENT_BRIDGE_STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state/subagent_bridge
-SUBAGENT_BRIDGE_MODEL=cl/gemini-3.5-flash-low
+# Bridge proposer model. openai/ prefix is REQUIRED: the litellm
+# materializer path needs it, the raw-client proposer strips it.
+SUBAGENT_BRIDGE_MODEL=openai/an/gemini-3-flash
+# Reasoning effort passed to the bridge's tool-harness calls (#832).
+SUBAGENT_BRIDGE_REASONING_EFFORT=high
 SUBAGENT_BRIDGE_FORCE_BUDGET=extended
+
+# LLM-driven proposer loop kill switch, default OFF upstream (#739).
+SELFEVO_LLM_PROPOSER_ENABLED=1
+# Periodic goal-derived priority generation (#768/#797/#809).
+SELFEVO_GOAL_REVIEW_ENABLED=1
+# Operator-approved runtime-slice the proposer may touch (#812).
+SELFEVO_RUNTIME_SLICE=nanobot/runtime/existence_index.py
+# Decay-eligibility protect-list — paths exempt from decay archival (#809).
+SELFEVO_DECAY_PROTECT=scripts/eeebot_dashboard.py
+# Benchmark-trust gate: capability shipped (#813/#819/#822), operator flips
+# to 1 to let benchmark evidence influence acceptance. Default OFF.
+SELFEVO_BENCHMARK_TRUST=0

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -82,11 +82,57 @@ from __future__ import annotations
 
 import gzip
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 SCORECARD_SCHEMA = "scorecard-v1"
+
+# ─── control-plane visibility (#865) ─────────────────────────────────────────
+#
+# EXPLICIT allowlist of operator-facing runtime flags. NEVER dump os.environ
+# wholesale here and NEVER add a secret-bearing key (API keys/tokens/secrets,
+# remote sync URLs) — this snapshot is written to state (scorecard/latest.json
+# + history.jsonl) and is meant to be read/shared freely. Every key listed is
+# reported (value or ``None`` if unset) so a reader always sees the full
+# policy surface, not just whatever happens to be set.
+_CONTROL_PLANE_KEYS: tuple[str, ...] = (
+    "SELFEVO_LLM_PROPOSER_ENABLED",
+    "SELFEVO_GOAL_REVIEW_ENABLED",
+    "SELFEVO_RUNTIME_SLICE",
+    "SELFEVO_DECAY_PROTECT",
+    "SELFEVO_BENCHMARK_TRUST",
+    "SELFEVO_USAGE_REFERENCE_ENABLED",
+    "SELFEVO_DEMAND_DRIVEN_ENABLED",
+    "SELFEVO_EXISTENCE_INDEX_ENABLED",
+    "SELFEVO_SURFACES_DIR",
+    "SUBAGENT_BRIDGE_MODEL",
+    "SUBAGENT_BRIDGE_REASONING_EFFORT",
+    "SUBAGENT_BRIDGE_FORCE_BUDGET",
+    "SUBAGENT_BRIDGE_ENABLED",
+    "SUBAGENT_BRIDGE_FORCE_PROFILE",
+    "SUBAGENT_BRIDGE_FAILURE_SUPPRESS_HOURS",
+    "SUBAGENT_BRIDGE_MAX_SKIPS_PER_RUN",
+    "SUBAGENT_BRIDGE_MAX_REVISIONS",
+)
+
+
+def _control_plane_snapshot() -> dict[str, Any]:
+    """Active operator env values at compute time — visibility only.
+
+    Deliberately NOT fed into fitness/targets/gaps. Reads only the explicit
+    :data:`_CONTROL_PLANE_KEYS` allowlist (never ``os.environ`` wholesale),
+    so no secret-bearing env var can ever leak into this section. Fail-open
+    per-key: a single lookup error never blocks the rest of the section.
+    """
+    snapshot: dict[str, Any] = {}
+    for key in _CONTROL_PLANE_KEYS:
+        try:
+            snapshot[key] = os.environ.get(key)
+        except Exception:
+            snapshot[key] = None
+    return snapshot
 
 _WINDOW_DAYS = 7
 _RECOMPUTE_MINUTES = 30
@@ -1010,6 +1056,9 @@ def compute_scorecard(
             "value": _value_section(state_dir, selfevo_repo, now),
             "heldout": _heldout_section(state_dir),
             "integrity": _integrity_section(rows),
+            # #865: visibility-only snapshot of active operator flags — never
+            # fed into fitness/targets/gaps below.
+            "control_plane": _control_plane_snapshot(),
         }
         # Gap analysis runs against the PRE-append history so the trend
         # window never compares the snapshot against itself.
@@ -1061,6 +1110,7 @@ def compute_scorecard(
             "heldout": {},
             "integrity": {},
             "gaps": [],
+            "control_plane": _control_plane_snapshot(),
         }
 
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -954,3 +954,64 @@ class TestHistoryIsFitnessProtected:
         after = scorecard.fitness_sidecar_hashes(state_dir)
         assert after["scorecard/latest.json"] != "absent"
         assert after["scorecard/history.jsonl"] != "absent"
+
+
+# ─── #865: control-plane visibility ─────────────────────────────────────────
+
+
+class TestControlPlaneSnapshot:
+    def test_section_present_with_all_allowlisted_keys(self, tmp_path, monkeypatch):
+        for key in scorecard._CONTROL_PLANE_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        state_dir = tmp_path / "state"
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        control_plane = snap["control_plane"]
+        assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS)
+        assert all(v is None for v in control_plane.values())
+
+    def test_set_values_are_captured_others_stay_none(self, tmp_path, monkeypatch):
+        for key in scorecard._CONTROL_PLANE_KEYS:
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("SELFEVO_GOAL_REVIEW_ENABLED", "1")
+        monkeypatch.setenv("SUBAGENT_BRIDGE_MODEL", "openai/an/gemini-3-flash")
+        state_dir = tmp_path / "state"
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        control_plane = snap["control_plane"]
+        assert control_plane["SELFEVO_GOAL_REVIEW_ENABLED"] == "1"
+        assert control_plane["SUBAGENT_BRIDGE_MODEL"] == "openai/an/gemini-3-flash"
+        untouched = set(scorecard._CONTROL_PLANE_KEYS) - {
+            "SELFEVO_GOAL_REVIEW_ENABLED",
+            "SUBAGENT_BRIDGE_MODEL",
+        }
+        assert all(control_plane[key] is None for key in untouched)
+
+    def test_no_key_outside_the_allowlist_ever_appears(self, tmp_path, monkeypatch):
+        """Setting an unrelated SELFEVO_/env var must never leak into the
+        section — only the explicit allowlist tuple is ever read."""
+        monkeypatch.setenv("SELFEVO_TOTALLY_MADE_UP_FLAG", "1")
+        monkeypatch.setenv("SOME_OTHER_ENV_VAR", "1")
+        state_dir = tmp_path / "state"
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        control_plane = snap["control_plane"]
+        assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS)
+
+    def test_no_secret_ever_appears_in_serialized_scorecard(self, tmp_path, monkeypatch):
+        """Paranoia test (#865): a real secret-shaped env var, and a
+        SELFEVO_-prefixed one that merely LOOKS like a secret, must never
+        surface anywhere in the scorecard's serialized JSON — not just
+        absent from control_plane, absent from the whole payload."""
+        monkeypatch.setenv("LITELLM_API_KEY", "sk-test")
+        monkeypatch.setenv("SELFEVO_FAKE_SECRET_TOKEN", "x")
+        state_dir = tmp_path / "state"
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        serialized = json.dumps(snap)
+        assert "sk-test" not in serialized
+        assert "SELFEVO_FAKE_SECRET_TOKEN" not in serialized
+        assert "LITELLM_API_KEY" not in serialized
+
+    def test_visibility_only_not_fed_into_targets_or_gaps(self):
+        """Regression pin: control_plane keys must never appear as a target
+        metric name — this section is snapshot-only, never fitness input."""
+        assert not any(
+            key in scorecard._TARGETS for key in scorecard._CONTROL_PLANE_KEYS
+        )


### PR DESCRIPTION
Closes #865

## What ships
- **Scorecard `control_plane` section**: `_control_plane_snapshot()` over an explicit 17-key allowlist (`_CONTROL_PLANE_KEYS` — 9 `SELFEVO_*` flags found by grep across nanobot/ + 8 non-secret `SUBAGENT_BRIDGE_*` operational keys incl. FORCE_PROFILE/FAILURE_SUPPRESS_HOURS/MAX_SKIPS_PER_RUN/MAX_REVISIONS per review). Unset → null, full policy surface always present. Never iterates os.environ; on both success and fail-open paths; visibility only (no fitness/targets impact).
- **Repo env templates synced to production**: bridge model `openai/an/gemini-3-flash` (+required-prefix note), reasoning effort high, SELFEVO_LLM_PROPOSER_ENABLED=1, SELFEVO_GOAL_REVIEW_ENABLED=1, SELFEVO_RUNTIME_SLICE, SELFEVO_DECAY_PROTECT, SELFEVO_BENCHMARK_TRUST — one-line comments with issue refs; template-vs-live precedence headers; credentials remain only in litellm.env.

## Review
Opus: secret-safety CLEAN (allowlist-only, paranoia test asserts key absence in serialized JSON), fail-open schema-valid, no FITNESS_SIDECARS byte-test interplay; 1 nit (header wording) + 1 scope question (4 missing bridge tunables) — both addressed.

## Tests
43/43 test_scorecard.py (5 new). Full suite: 2044 passed / 31 known Windows-only, 0 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)