### PR TITLE
fix(host): #880 privilege hardening — bridge non-root, release read-only to runtime uid

### DIFF
--- a/docs/changes/880-host-privilege-hardening/proposal.md
+++ b/docs/changes/880-host-privilege-hardening/proposal.md
@@ -1,0 +1,69 @@
+# #880 — Host privilege hardening: enforce the boundary the trust kernel assumes
+
+## The finding (live-host audit, 2026-08-17)
+
+The verification kernel (#603 immutable core, #789 non-forgeable fitness sidecars,
+#813/#819/#822 benchmark trust) is designed as if the instance were adversarial
+and could not run privileged code. On the real eeepc that assumption did not hold:
+
+- **The subagent-bridge lane ran as ROOT** — `eeepc-self-evolving-subagent-bridge.service`
+  had no `User=` (confirmed `_UID=0`), `ProtectSystem=no`, `NoNewPrivileges=no`, and
+  no privilege drop anywhere in `bridge.py`.
+- **The release tree was writable by the runtime uid** — `/opt/eeepc-agent/.../current/`
+  was `eeepc-agent:eeepc-agent` (664); the coordinator/reflection lanes ran as
+  `eeepc-agent` with `ReadWritePaths=/opt/eeepc-agent`.
+- The bridge lane executes instance-authored code every cycle (smoke =
+  `py_compile`+`pytest` on the instance repo; microbench/heldout subprocesses strip
+  env but did not drop uid).
+
+Consequence: instance-authored code ran at root, with write access to the harness's
+own code and fitness sidecars, every cycle — defeating the entire kernel before any
+gate verdict. Not exploited (the instance intelligence is a controlled gateway LLM),
+but #874's RSI autonomy plan treats the loop adversarially, so the boundary had to
+become real before any auto-integration of instance-authored runtime code (#875).
+
+## The fix
+
+The only privilege boundary on this host is root (deploy runs via sudo). Rather than
+add a signing key (useless when harness and instance share a uid), enforce the
+boundary with the process sandbox:
+
+1. **No lane runs as root.** The bridge lane now runs `User=eeepc-agent` like the
+   coordinator. (`approval-keeper`, referenced in the bridge `After=`, does not exist
+   on the host — the empty `User=` it reported was a non-existent-unit default.)
+2. **The release tree is read-only to the runtime uid**, enforced by
+   `ProtectSystem=strict` + `ReadWritePaths=/var/lib/eeepc-agent` on every app lane
+   (bridge, agent kick, health/coordinator driver, strong-reflection). `/opt` is now
+   `Read-only file system` inside the service sandbox regardless of on-disk ownership —
+   this is what actually enforces #603. `PYTHONDONTWRITEBYTECODE=1` stops `.pyc`
+   writes into the now-read-only tree.
+
+The runtime writes only its own state and instance repo, both under
+`/var/lib/eeepc-agent` — verified: config (`/opt/.../.nanobot/config.json`) is static
+and read-only; the bridge lock is `state/bridge.lock` (under `/var/lib`); no runtime
+`/opt` writes exist beyond `.pyc`.
+
+## Rollout & verification (2026-08-17)
+
+- Backed up every live unit (`*.bak-20260817-880`).
+- `chown -R eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent` to clear
+  ~9,500 root-owned artifacts left by the root-era bridge (so the non-root bridge can
+  rewrite them).
+- Applied the hardened units, `daemon-reload`.
+- Verified: bridge real cycle `Result=success` as `_UID=999`, no permission/EROFS
+  errors; health (coordinator driver) cycle success under strict; a full dry
+  `app.main` canary exited 0 under strict with no `/opt` write; `/opt` confirmed
+  `Read-only file system` inside the sandbox; both timers active (loop alive).
+
+## Known-orthogonal note
+
+`eeepc-strong-reflection.service` fails on missing `LITELLM_API_KEY` — a pre-existing
+config gap (its unit loads only optional `-` EnvironmentFiles and never wires
+`litellm.env`), independent of this change (the failure predates strict; env loading
+was untouched). Tracked separately if the reflection lane is to be revived.
+
+## Unblocks
+
+#875 (auto-promotion) can now rely on a real boundary: a root (or separate-uid)
+verifier can import a root-owned release snapshot and re-measure with a
+privilege-dropped child, writing a root-owned promoted tree the agent reads read-only.

--- a/host/eeepc/systemd/eeepc-self-evolving-agent-health.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-agent-health.service
@@ -10,4 +10,13 @@ WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-agent.env
 Environment=MAX_CYCLES=1
 Environment=DRY_RUN=true
+# #880: release tree read-only to the runtime uid (enforces #603). This is
+# the periodic coordinator driver — it must not be able to rewrite the
+# harness's own code.
+Environment=PYTHONDONTWRITEBYTECODE=1
 ExecStart=/opt/eeepc-agent/runtimes/self-evolving-agent/current/.venv/bin/python -m app.main
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=false
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-agent

--- a/host/eeepc/systemd/eeepc-self-evolving-agent.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-agent.service
@@ -20,8 +20,11 @@ RestartSec=15
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=false
-ProtectSystem=full
-ReadWritePaths=/var/lib/eeepc-agent /opt/eeepc-agent
+# #880: release tree read-only to the runtime uid (enforces #603). The
+# coordinator writes only state + the instance repo, both under /var/lib.
+Environment=PYTHONDONTWRITEBYTECODE=1
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-agent
 
 [Install]
 WantedBy=multi-user.target

--- a/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
@@ -1,12 +1,30 @@
 [Unit]
 Description=Run eeepc self-evolving subagent bridge
-After=network-online.target
+After=network-online.target eeepc-self-evolving-approval-keeper.service
 
 [Service]
 Type=oneshot
+# #880: the bridge executes instance-authored code every cycle (smoke
+# py_compile+pytest, microbench/heldout subprocesses). It MUST NOT run as
+# root — otherwise instance code runs at root, defeating the #603 immutable
+# core and the #789/#822 non-forgeable fitness kernel before any gate. Runs
+# as the same unprivileged uid as the coordinator lane.
+User=eeepc-agent
+Group=eeepc-agent
 WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
 Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+# Release tree is read-only to the runtime uid (#880); don't try to write
+# .pyc bytecode into it.
+Environment=PYTHONDONTWRITEBYTECODE=1
 # Bridge is a package module since #599 — no file-copy to libexec, the release
 # on PYTHONPATH (current symlink) is the single code authority.
 ExecStart=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.bridge
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=false
+# ProtectSystem=strict + explicit ReadWritePaths: everything is read-only
+# EXCEPT the instance's own state and repo. The release tree (/opt) is NOT
+# writable by the runtime uid — that is what actually enforces #603.
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-agent

--- a/host/eeepc/systemd/eeepc-strong-reflection.service
+++ b/host/eeepc/systemd/eeepc-strong-reflection.service
@@ -16,8 +16,10 @@ Nice=10
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHome=false
-ProtectSystem=full
-ReadWritePaths=/var/lib/eeepc-agent /opt/eeepc-agent
+# #880: release tree read-only to the runtime uid (enforces #603).
+Environment=PYTHONDONTWRITEBYTECODE=1
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-agent
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Closes #880. Prerequisite for #875 / the #874 RSI autonomy plan.

## Finding (live-host audit)
The kernel (#603/#789/#822) assumes the instance cannot run privileged code. It could: the **subagent-bridge lane ran as ROOT** (no User=, _UID=0, no privilege drop) and the **release tree was writable by the runtime uid**. The bridge runs instance-authored code every cycle (smoke py_compile+pytest, microbench/heldout subprocesses), so instance code ran at root with write access to harness code + fitness sidecars — defeating the whole kernel before any gate.

## Fix (all app lanes: bridge, agent kick, health/coordinator driver, reflection)
- User=eeepc-agent (bridge was root).
- ProtectSystem=strict + ReadWritePaths=/var/lib/eeepc-agent → /opt release tree is Read-only inside the sandbox regardless of ownership. Enforces #603.
- PYTHONDONTWRITEBYTECODE=1.

## Rollout & verification (live 2026-08-17)
Backups; chown -R eeepc-agent cleared ~9,500 root-era artifacts; hardened units applied. Verified: bridge real cycle Result=success as _UID=999 no permission/EROFS; coordinator-driver cycle success under strict; dry app.main canary exit 0 under strict no /opt write; /opt confirmed read-only in-sandbox; timers active. Details + orthogonal reflection-creds note in docs/changes/880-host-privilege-hardening/proposal.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)