### PR TITLE
feat(runtime): #875 root-verified auto-promotion of runtime-slice candidates

### DIFF
--- a/docs/changes/875-root-verified-auto-promotion/proposal.md
+++ b/docs/changes/875-root-verified-auto-promotion/proposal.md
@@ -360,6 +360,111 @@ it can never gain root, never write the promoted tree directly, and the
 existing soak (3 clean subsequent passes) plus the held-out pack's
 invisibility (#780) bound how much a single forged pass can accomplish.
 
+## Rework round 2 (opus-review on PR #882 — RED-1, YELLOW-1, YELLOW-2)
+
+A second adversarial review of the RED1/RED2 fixes above found one more RED
+and two YELLOWs.
+
+### RED-1 (round 2) — root follows an instance-controlled symlink when touching the ledger, durably chowning PROMOTED_TREE to the attacker
+
+`state/` (and therefore `state/ledger/`) is instance-writable. The instance
+could plant `state/ledger/cycles.jsonl` as a symlink to ANYWHERE — including
+`PROMOTED_TREE` itself. `_promote`/`_rollback` used to (1) `cycle_ledger.
+append_event(STATE_DIR, …)`, which opens `state/ledger/cycles.jsonl` for
+append and follows a symlink there, and (2) `_chown_best_effort(…ledger/
+cycles.jsonl, "eeepc-agent")`, which — run as root — would follow that same
+symlink and `chown` whatever it points at to `eeepc-agent`. If the symlink
+pointed at `PROMOTED_TREE`, root itself would durably hand the promoted tree
+over to the instance uid, breaking the entire "promoted tree is root-owned"
+invariant permanently (not healed by `_ensure_promoted_tree_dir`, which only
+`mkdir`/`chmod`s — never re-checks `st_uid`).
+
+Fix (all four applied):
+
+1. Root's own promotion/rollback audit trail moved OUT of
+   `state/ledger` entirely, into a new ROOT-OWNED ledger,
+   `PROMOTED_TREE/verifier_ledger.jsonl` (`_append_verifier_ledger_event`).
+   This is the structural fix, not a symlink-follow guard bolted onto the
+   old call sites: `PROMOTED_TREE` is root-owned 0755 (non-writable by any
+   other uid), so nothing but root can ever create a file OR a symlink
+   inside it in the first place — there is no attacker-controlled path for
+   this write to ever traverse. `os.O_NOFOLLOW` is still added on the
+   ledger file itself as cheap defense-in-depth. `_chown_best_effort` and
+   the `cycle_ledger` import are gone — root no longer opens or chowns
+   ANYTHING under `STATE_DIR`.
+2. `_ensure_promoted_tree_dir` never re-asserted `PROMOTED_TREE`'s `st_uid`
+   — only `mkdir`/`chmod`. A new `_reassert_promoted_tree_root_ownership`
+   runs at the START of every `verify_pass()`: if the tree exists and is
+   not root-owned, it attempts `os.chown(tree, 0, 0)` (root can always heal
+   this); if that fails (not actually root — shouldn't happen in
+   production), the WHOLE pass fails closed (no candidates processed, no
+   manifest/state read or written) with a loud stderr line rather than
+   trusting a possibly instance-writable tree.
+3. Both rollback branches in `verify_pass` (`status == "vetoed"` and the
+   held-out-regression/integrity-event watch) previously set
+   `manifest_dirty` but not `state_dirty` — meaning a pass with zero
+   pending candidate files (nothing else touching `state_dirty`) would
+   never rewrite `verifier_state.json`, so THAT file's ownership could
+   drift and never heal. Both branches now also set `state_dirty = True`,
+   so `verifier_state.json` is rewritten (tmp + `os.replace`, healing
+   ownership) on every rollback pass.
+
+### YELLOW-1 — pin sys.path to the resolved release; protect the symlink chain around it
+
+- `_verify_release_ownership_or_exit` stat-checked the release dir's
+  REALPATH but then `sys.path.insert`ed the UNRESOLVED `current`-symlink
+  path — a check-then-use gap. It now returns the resolved `Path` and the
+  module-level bootstrap inserts THAT into `sys.path` (never the raw env
+  string again); the demoted child's `SELFEVO_RELEASE_DIR` env var carries
+  the same resolved path for the same reason (the child re-runs the
+  identical ownership-check + bootstrap).
+- `deploy_release.sh` previously only `chown -R root:root`'d the release
+  CONTENTS (`$RELEASE_DIR`, `$VENV_BASE`) — every directory the `current`/
+  `.venv` symlinks themselves LIVE IN (`/opt/eeepc-agent`, `.../runtimes`,
+  `.../self-evolving-agent`, `.../releases`) was still `eeepc-agent`-owned,
+  so the runtime uid could delete+recreate those symlinks itself and
+  re-point them at attacker-controlled content — relying entirely on
+  #880's `ProtectSystem=strict` sandbox to stop that (which does not
+  protect this root verifier itself). Every directory in the chain is now
+  `chown root:root` too (non-recursively — the release contents already got
+  `-R`), plus the symlinks' own ownership (`chown -h`).
+- Added an optional extra: `_verify_release_ownership_or_exit` also
+  stat-checks `Path(sys.executable).resolve()` — defense-in-depth against a
+  replaced/symlinked interpreter binary, best-effort (never blocks a valid
+  load if this specific check can't run).
+
+### YELLOW-2 — the deny-set did not actually cover the whole verification kernel it claimed to
+
+The original proposal claimed the verification kernel "is never
+promotable... structural, not policy" — but `runtime_deny`'s explicit files
+and tokens only covered `bridge.py`/`promotion.py`/`coordinator.py`. An
+operator accidentally listing `scorecard.py`, `benchmark_evidence.py`,
+`usage_evidence.py`, `promoted_overlay.py`, `runtime_deny.py` itself, or
+anything under `heldout/` (`microbench.py`, `checkers.py`, `__init__.py`) in
+`SELFEVO_RUNTIME_SLICE` would have made the loader/gate's OWN trust logic
+self-promotable — a candidate could delete its own deny entry
+(`runtime_deny.py`) or weaken the loader's boundary check
+(`promoted_overlay.py`) and then promote itself on a later pass.
+
+Fixed by extending `runtime_deny._RUNTIME_DENY_ALWAYS_FILES` with all five
+explicit modules, adding basename tokens (`bench`, `scorecard`, `overlay`,
+`deny`, `usage`, `evidence`, `heldout`) for future-proofing, and adding a
+`nanobot/runtime/heldout/` directory-prefix rule (a bare `heldout` basename
+token would miss `heldout/__init__.py` and `heldout/checkers.py`, whose
+basenames don't contain the word). `tests/test_runtime_slice.py` asserts
+every one of these paths is denied.
+
+### Deferred (tracked separately, not fixed here)
+
+- YELLOW-3 (integrity-event scan is itself readable from the
+  agent-writable ledger, so a sufficiently early/careful instance could in
+  principle suppress the specific integrity row the watch is looking for)
+  — contained today by root re-running the held-out pack fresh every pass
+  regardless of what the ledger says, but not eliminated. Filed as a
+  follow-up.
+- The measurement-sandbox-escape residual above and the demoted-child grandchild
+  timeout are unchanged/still accepted as documented.
+
 ## Known limitation (honest residual)
 
 The post-promotion microbench re-measurement (used for the regression watch)

--- a/docs/changes/875-root-verified-auto-promotion/proposal.md
+++ b/docs/changes/875-root-verified-auto-promotion/proposal.md
@@ -1,0 +1,275 @@
+# Change: root-verified auto-promotion of runtime-slice candidates
+
+- **change-id:** 875-root-verified-auto-promotion
+- **issue:** #875
+- **capability:** self-evolving-runtime (#812 runtime-slice tier + #822 causal
+  micro-benchmark + #780 held-out pack), eeepc host provisioning
+- **role / workstream:** trust root of the whole RSI (recursive self-
+  improvement) plan — correctness over speed
+
+## Problem: the naive design is fatal
+
+#812 added a bounded "runtime-slice" tier — an operator-approved allowlist of
+`nanobot/runtime/*.py` modules the loop may PROPOSE changes to. Those changes
+never auto-integrate: a green cycle lands as a durable candidate record under
+`state/promotions/promotion-runtime-*.json` for an operator to review by hand.
+
+That manual-review step does not scale, and the obvious next step — "auto-
+promote once the numbers look good" — is fatal to build naively, because of a
+fact discovered during a live-host security audit:
+
+> On the eeepc host, the bridge/harness AND the instance's subagent run as the
+> **same uid** (`eeepc-agent`). `state/` is instance-writable — this is why
+> #789 *detects* sidecar tampering rather than *preventing* it (there is no
+> filesystem boundary between "harness-authored" and "instance-authored"
+> inside `state/`).
+
+If an auto-promotion loader trusted an instance-written index (say, a
+candidate record's own `changed_files`/`microbench` fields) to decide what
+code to load into the harness process, the instance could forge index +
+file to get **arbitrary code execution in harness context, before any gate
+ever ran** — a total collapse of the #603 immutable-core invariant. No
+in-band signature scheme closes this: since harness and instance share a
+uid, the instance can read any verification key the harness could read too.
+
+## The solution: root is the only real boundary
+
+The only privilege boundary that actually exists on this host is **root** —
+deploys run via `sudo`, and the release tree / `/etc/eeepc-agent` are
+root-touched. The design puts root in the loop as an automated, but
+completely independent, verifier:
+
+```
+instance (eeepc-agent uid)          root (systemd timer, no User=)              eeepc-agent uid (again)
+─────────────────────────           ───────────────────────────────            ────────────────────────
+runtime-slice cycle goes green  →   eeepc_promotion_verifier.py:                nanobot.runtime.promoted_overlay:
+writes a PROPOSAL record             1. reads the PROPOSAL as untrusted          on bridge/coordinator start,
+  state/promotions/                     input — only its (module_path,           reads PROMOTED_TREE/manifest.json
+  promotion-runtime-*.json               head_sha) pair is trusted, and           (root-owned, agent can read but
+  (its own microbench numbers          that only because head_sha is a           never write) and loads any
+  are IGNORED downstream)               content-addressed git SHA               `status: "active"` module over
+                                      2. re-materializes candidate bytes         the installed copy — after
+                                         itself: `git show <head_sha>:           checking sha256 integrity and
+                                         <module_path>` against the              re-checking deny-set/slice
+                                         INSTANCE repo (content-addressed,       membership independently.
+                                         not a trust decision)
+                                      3. RE-MEASURES itself: #822's
+                                         microbench (baseline = the
+                                         ACTUAL INSTALLED product tree,
+                                         never instance git history) +
+                                         #780's held-out pack — the
+                                         instance's own numbers are
+                                         never read for this decision
+                                      4. only if independently satisfied,
+                                         soaks 3 clean passes, then
+                                         writes verified bytes into
+                                         PROMOTED_TREE (root-owned 0755,
+                                         files 0644) + updates
+                                         manifest.json
+                                      5. watches every ACTIVE promotion
+                                         every pass after that: held-out
+                                         regression, a new integrity
+                                         ledger event, or an operator
+                                         `status: "vetoed"` edit rolls
+                                         it back (removes the tree file
+                                         + manifest entry, ledgers it)
+```
+
+Filesystem permission **is** the trust boundary — there is no signing key to
+protect because there is no signing key. `PROMOTED_TREE` (default
+`/var/lib/eeepc-promoted`) is root-owned, 0755; its files are 0644. The
+eeepc-agent uid can read it (needed to load the module) but structurally
+cannot write it (no sudo, no setuid path). This is exactly the same kind of
+boundary the rest of the deploy pipeline already relies on (release tree,
+`/etc/eeepc-agent`) — #875 just extends it to cover one more artifact class.
+
+## Data flow / components
+
+| Component | Runs as | Trusts | Writes to |
+|---|---|---|---|
+| bridge/coordinator (`#812` classifier) | eeepc-agent | nothing new — same #812 gate | `state/promotions/promotion-runtime-*.json` (PROPOSAL only) |
+| `host/eeepc/libexec/eeepc_promotion_verifier.py` (**new**, C2) | **root** (systemd, no `User=`) | only `(module_path, head_sha)` from the proposal — a content-addressed pointer, not a claim | `PROMOTED_TREE/manifest.json`, `PROMOTED_TREE/verifier_state.json`, `PROMOTED_TREE/{flattened_module}.py`, a `phase: "promotion"` ledger event |
+| `nanobot.runtime.promoted_overlay` (**new**, C3) | eeepc-agent | only what root wrote into `PROMOTED_TREE`, after its own boundary + deny + sha256 checks | nothing (read-only loader) |
+| `nanobot.runtime.runtime_deny` (**new**, C1) | shared by all three above | n/a (pure stdlib logic, no external trust) | nothing |
+
+### C1 — `nanobot/runtime/runtime_deny.py`
+
+Pure-stdlib extraction of the #812 deny-set (`_RUNTIME_DENY_ALWAYS_FILES`,
+`_RUNTIME_DENY_TOKENS`, `_is_runtime_deny`) and a new pure
+`runtime_slice_paths(env_value)` (same parsing as bridge's old
+`_runtime_slice_paths()`, but taking the raw string as an argument instead of
+reading `os.environ` itself). `bridge.py` re-exports the same names
+unchanged — existing tests (`tests/test_runtime_slice.py`) still pass
+untouched. The root verifier and the agent loader import this module
+directly, so "what counts as safety-shell" and "what counts as in-slice" is
+defined exactly once and enforced identically in all three trust contexts.
+
+### C2 — `host/eeepc/libexec/eeepc_promotion_verifier.py`
+
+Standalone script, no `User=` in its systemd unit (runs as root). One
+`verify_pass()`:
+
+1. Scans `STATE_DIR/promotions/promotion-runtime-*.json` — untrusted
+   proposals.
+2. Eligibility (ignores the instance's own microbench dict entirely):
+   `changed_files` must contain **exactly one** file matching
+   `nanobot/runtime/*.py`, that file must not be `_is_runtime_deny`, and it
+   must be in the operator's `SELFEVO_RUNTIME_SLICE` (passed to the verifier
+   via the SAME instance env file the bridge reads, so it can never drift).
+3. Re-materializes candidate bytes via `git show <head_sha>:<module_path>`
+   against `INSTANCE_REPO` (argv list, no shell).
+4. Re-measures via `nanobot.runtime.heldout.microbench.run_measurement`
+   (baseline vs. candidate against the installed product tree — the #822
+   sandbag-proof design) and requires
+   `improvement_pct >= benchmark_evidence._MICROBENCH_MIN_IMPROVEMENT_PCT`,
+   then runs `nanobot.runtime.heldout.run_heldout` and requires
+   `regressions == []` and no `status == "fail"` result. Either failing marks
+   the candidate `rejected` with a reason and it is never retried (a
+   deterministic verdict re-run would only reproduce itself).
+5. An eligible candidate enters `soaking`; each subsequent pass re-checks
+   held-out cleanliness plus "no new `phase: integrity` ledger event since
+   its watermark". After 3 clean subsequent passes it promotes.
+6. Promotion writes the re-measured bytes to
+   `PROMOTED_TREE/{module_path.replace('/', '__')}` (atomic tmp+rename,
+   0644) and a `manifest.json` entry (schema `promoted-manifest-v1`:
+   `{module_path: {sha256, candidate_id, head_sha, improvement_pct,
+   verified_utc, status: "active"}}`), plus a `phase: "promotion"` /
+   `reason: "root_verified_promoted"` ledger event — the ledger file is
+   chowned back to `eeepc-agent:eeepc-agent` afterward (best-effort) so the
+   bridge keeps being able to append to it.
+7. Every active manifest entry is watched on every subsequent pass: a
+   held-out regression, a new integrity event since promotion, or an
+   explicit operator `status: "vetoed"` edit (sudo-editing the root-owned
+   manifest — this IS the veto mechanism, no separate CLI needed) rolls it
+   back — removes the tree file + manifest entry, ledgers
+   `reason: "root_verified_rolled_back"`.
+
+Every candidate and every active-manifest-entry step runs inside its own
+`try/except` — one bad record can never abort the rest of a pass, and the
+script is safe to run unattended every 15 minutes forever.
+
+### C3 — `nanobot/runtime/promoted_overlay.py`
+
+`install_promoted_overlay(promoted_tree=None) -> list[str]`. Built from
+**stdlib + `runtime_deny` only** — no other `nanobot.runtime` import, so
+installing the overlay never depends on anything the overlay could itself
+replace.
+
+- Resolves `PROMOTED_TREE` (arg > env > `/var/lib/eeepc-promoted` default).
+  Missing tree or manifest → quiet no-op `[]`.
+- **Boundary self-check (the critical line):** both the tree directory and
+  `manifest.json` must be `st_uid == 0` (root-owned) and neither
+  group- nor other-writable, or **everything** is refused. POSIX-only by
+  construction; on any non-POSIX platform (`os.name != 'posix'`, e.g. a
+  developer's Windows machine) this refuses to load anything at all rather
+  than pretend the check passed — the feature is host-only.
+- Per manifest entry with `status == "active"`: re-derives the canonical
+  slice-shaped path via `runtime_deny.runtime_slice_paths` (this doubles as
+  the deny-set check, the slice-shape check, and a traversal-normalization
+  check, all in one call — a malformed or deny-set key never round-trips
+  back to itself and is refused), verifies `sha256(tree_file) ==
+  manifest["sha256"]`, then loads it via
+  `importlib.util.spec_from_file_location` under the module's real dotted
+  name, registers it in `sys.modules`, and `setattr`s it onto the (normally
+  imported) parent package so any subsequent `from nanobot.runtime import X`
+  picks up the promoted version.
+- Fail-open **per module** (one bad entry never blocks the others — the
+  installed copy of that module is simply kept); fail-**closed** overall
+  (any unexpected top-level exception returns `[]`, i.e. degrade to the
+  fully-installed, already-reviewed product tree).
+
+**Wiring.** `bridge.py` calls `install_promoted_overlay()` at the very top
+of its import block — immediately before `from nanobot.runtime import
+llm_proposer` (the first `nanobot.runtime.*` import in that file) — so a
+promoted module shadows the installed one from the first import site, not
+just for call sites deeper in the file. `coordinator.py` calls the same
+function too, but **inside `run_self_evolving_cycle()`'s body**, not at
+module level, for a load-bearing reason documented below.
+
+**Why coordinator.py's call site is NOT at module top-level (a deliberate
+deviation).** `nanobot/runtime/__init__.py` unconditionally imports
+`coordinator.py` for **any** `nanobot.runtime.*` import — including the
+`heldout/microbench.py` sandboxed subprocess's own
+`from nanobot.runtime import existence_index as ei` (used by every
+microbench spec script, see `MICROBENCHES`). If `install_promoted_overlay()`
+were called at coordinator's module scope, it would fire **inside that
+sandboxed measurement subprocess too**, and since the subprocess's stripped
+env does not set `PROMOTED_TREE`, the loader would fall back to the real,
+production `/var/lib/eeepc-promoted` default — letting the ACTUAL root-owned
+overlay leak into what must be a pure, harness-controlled baseline/candidate
+comparison over a throwaway tree copy (defeating the #822 isolation
+guarantee, and in the worst case measuring the SAME already-promoted bytes
+for both baseline and candidate). Gating the call to only fire when a cycle
+actually **runs** (inside the function body, not on mere import) keeps the
+microbench sandbox subprocess overlay-free with zero special-casing needed
+in `microbench.py` itself. `bridge.py` does not have this problem —
+nothing in the package-init chain imports `bridge.py`, so its module-level
+call site only ever fires when something explicitly imports the bridge.
+
+### C4 — `scorecard.py` visibility
+
+`control_plane.runtime_promotions` (added inside
+`_control_plane_snapshot()`, so both the success and fail-open branches of
+`compute_scorecard` get it): `{"active": <n from manifest.json>, "soaking":
+<n>, "rejected": <n>}` (soaking/rejected from `verifier_state.json`,
+candidate ids joined by status). Cheap, read-only, fail-open to
+`{"active": 0, "soaking": 0, "rejected": 0}` on any missing/unreadable file —
+same posture as the rest of `control_plane`.
+
+### C5 — provisioning
+
+- `host/eeepc/systemd/eeepc-promotion-verifier.service` (no `User=` → root)
+  + `.timer` (`OnBootSec=5m`, `OnUnitActiveSec=15m`, matching the bridge's
+  own cadence — the existing `install_units`/`install_libexec` glob loops in
+  `install.sh` pick both files up automatically, no loop changes needed).
+- `install.sh`: `/var/lib/eeepc-promoted` is now created explicitly, AFTER
+  (and outside) the recursive `eeepc-agent` chown, owned `root:eeepc-agent`,
+  mode `0755` — and `eeepc-promotion-verifier.timer` was added to the
+  `enable_timers` list.
+- `deploy_release.sh`: the libexec sync's `chmod +x` was previously scoped
+  to `eeepc-self-evolving-*.py`, which would have silently left
+  `eeepc_promotion_verifier.py` non-executable — broadened to every synced
+  `.py`. Also now syncs systemd units on every deploy (previously only done
+  once at `install.sh` time) and enables+starts the new timer.
+
+## Trust invariants (also in C2/C3 docstrings verbatim)
+
+- The instance authors only PROPOSALS (candidate records, git branches). It
+  never authors the promoted bytes or the numbers: root re-materializes from
+  a content-addressed git SHA and re-measures itself, from scratch, on
+  every candidate.
+- The promoted tree is root-owned; the agent-side loader REFUSES to load
+  anything if the tree is not root-owned or is group/other-writable.
+- Deny-set + slice membership are enforced in BOTH the root verifier and the
+  agent loader, using the identical `runtime_deny` logic the bridge's own
+  gate uses.
+- The verification kernel (bridge/gate/scorecard/benchmark/usage/heldout/
+  coordinator — the runtime deny-set) is never promotable.
+
+## Rollback
+
+Automatic: a held-out regression or a new integrity ledger event on an
+active promotion rolls it back on the very next verifier pass (tree file +
+manifest entry removed, `reason: "root_verified_rolled_back"` ledgered).
+Manual/operator: `sudo`-edit the module's manifest entry to
+`"status": "vetoed"` — the next pass rolls it back the same way. Because
+`PROMOTED_TREE` is entirely separate from the installed release tree, a
+rollback (automatic or manual) simply restores the pre-promotion behavior —
+the installed `nanobot/runtime/*.py` copy was never touched.
+
+## Known limitation (honest residual)
+
+The post-promotion microbench re-measurement (used for the regression watch)
+would ideally verify the promoted module against a baseline that reflects
+"the world with this promotion already active", but `heldout/microbench.py`'s
+baseline is still, per its own #822 design, the currently-**installed**
+product tree — a promoted-but-not-yet-shipped module is not folded into that
+baseline until a product PR actually lands it in the release. This does not
+weaken the trust boundary (a wrong/stale baseline can only make the gate
+stricter or looser on a subsequent candidate touching the SAME module — it
+cannot forge an unrelated promotion), but it means the microbench signal for
+a second, stacked promotion of the same module is measured against the
+pre-first-promotion baseline until the product catches up. Flagged rather
+than silently accepted; fixing it is out of scope here (it requires a
+product-side change to `heldout/microbench.py`'s baseline resolution, tracked
+as a follow-up, not part of #875's trust-root scope).

--- a/docs/changes/875-root-verified-auto-promotion/proposal.md
+++ b/docs/changes/875-root-verified-auto-promotion/proposal.md
@@ -257,6 +257,109 @@ Manual/operator: `sudo`-edit the module's manifest entry to
 rollback (automatic or manual) simply restores the pre-promotion behavior —
 the installed `nanobot/runtime/*.py` copy was never touched.
 
+## Rework after #880 (opus-review RED1/RED2)
+
+#880 landed while this design was in-flight and confirmed the trust model
+above needed two more fixes before it could be considered load-bearing.
+
+### RED1 — the root verifier imported from an agent-owned release tree (root RCE)
+
+#880 made the release tree **read-only to the runtime uid** via the process
+sandbox (`ProtectSystem=strict` on every app lane) — but did not change the
+release's **on-disk owner**, which `deploy_release.sh` still chowned
+`eeepc-agent:eeepc-agent`. The root verifier does
+`sys.path.insert(0, .../current)` and then `from nanobot.runtime import ...`
+straight out of that tree, AS ROOT. A runtime-uid-owned release means the
+runtime uid — the SAME uid the instance's subagent runs as — could plant or
+mutate a module the verifier would then import with root privilege: a
+straightforward root RCE, defeating the entire boundary this change exists
+to build.
+
+**Fix:**
+
+1. `deploy_release.sh` now chowns the release `root:root`, not
+   `eeepc-agent:eeepc-agent` (the `goal_text.json` state-seeding chown stays
+   `eeepc-agent:eeepc-agent` — that's instance-writable state, not release
+   code). The runtime uid only ever needed READ+EXEC here; #880 already
+   proved no runtime write into `/opt` exists (`ProtectSystem=strict` +
+   `PYTHONDONTWRITEBYTECODE=1` on every app lane), and world-read from the
+   release tar/umask already gives every other uid read+exec.
+2. The verifier independently proves that promise held, BEFORE it ever
+   imports anything from the release:
+   `_verify_release_ownership_or_exit()` resolves the release dir's realpath
+   and stat-checks the release dir itself, its `nanobot/` subdir, and its
+   `nanobot/runtime/` subdir — each must be `st_uid == 0` and neither
+   group- nor other-writable (`mode & 0o022 == 0`). Any failure prints one
+   reason to stderr and `sys.exit`s nonzero **without ever reaching** the
+   `from nanobot...` import lines — fail closed, no partial import.
+   Skippable only via `EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK=1`, documented
+   as a test-only escape hatch (tests run as a non-root user against temp
+   dirs / a real dev checkout that can never satisfy a real root-ownership
+   check).
+
+### RED2 — the verifier executed instance-influenced work as root (no privilege drop)
+
+Three things ran as root with no privilege drop at all: `_git_show_bytes`
+(a `git` subprocess against the INSTANCE-owned repo — `git` parses
+repo-local config/attributes/hooks, so running it as root against a repo
+the instance controls is itself an escalation surface), the microbench
+measurement (`run_measurement`, which executes the candidate's own bytes),
+and the held-out pack (`run_heldout`, which copies + executes instance
+artifacts in a sandboxed subprocess). Root must never EXECUTE anything the
+instance influenced — it may only ever receive bytes/verdicts as inert
+DATA.
+
+**Fix:**
+
+- A demotion helper resolves `pwd.getpwnam(EEEPC_VERIFIER_DEMOTE_USER or
+  "eeepc-agent")` once and builds a `preexec_fn` that does
+  `os.setgroups([gid]); os.setgid(gid); os.setuid(uid)`, in that order
+  (uid dropped last, or the process loses the permission needed to change
+  gid/groups first). Guarded behind `os.name == "posix"` /
+  `os.geteuid() == 0` checks throughout, so the module still imports (and
+  the demotion is simply skipped, with an explicit stderr log line) on a
+  non-root runner — tests, dev boxes, Windows.
+- `git show` against `INSTANCE_REPO` now runs via
+  `_git_show_bytes_demoted()` — the same `git show` invocation, wrapped
+  with the demoted `preexec_fn` when running as root.
+- The microbench measurement and the held-out pack now run inside a
+  **demoted CHILD process**: the verifier re-invokes its own interpreter
+  (`sys.executable __file__ --child-verify --mode {full,heldout}`) with
+  `preexec_fn=demote` and a minimal env (PATH, HOME pointed at a
+  root-created tmpdir chowned to the demoted uid, STATE_DIR/INSTANCE_REPO/
+  SELFEVO_RELEASE_DIR, `PYTHONDONTWRITEBYTECODE=1`). The child re-runs the
+  same sys.path bootstrap + ownership check + imports as the parent, does
+  the actual `git show` / `run_measurement` / `run_heldout` calls, and
+  prints exactly ONE JSON object to stdout. The root parent parses that
+  JSON as untrusted data (`_run_child_verify`) — a nonzero child exit or
+  unparseable stdout is folded into `{"ok": False, ...}`, which every
+  caller treats as "could not verify this pass", never as a green light.
+  Hard 600s timeout per child invocation.
+- **The trust decision never moved into the child.** The child reports raw
+  numbers (`baseline_ms`, `candidate_ms`, `heldout_clean`); the root parent
+  (`_measure_candidate`) computes `improvement_pct` itself and compares it
+  against the #822 `MICROBENCH_MIN_IMPROVEMENT_PCT` floor itself, exactly as
+  before this rework — the child cannot forge a promotion by lying about a
+  pre-computed verdict, only by lying about (or having a compromised)
+  measurement of raw numbers the parent still gates on.
+- `eeepc-promotion-verifier.service` gained `NoNewPrivileges=yes` (setuid
+  DROP is still permitted under `no_new_privs` — this only blocks GAINING
+  privilege), `PrivateTmp=yes`, `ProtectHome=yes`, `ProtectSystem=strict`,
+  `ReadWritePaths=/var/lib/eeepc-promoted /var/lib/eeepc-agent`, and
+  `Environment=PYTHONDONTWRITEBYTECODE=1` — the same sandbox posture #880
+  gave every other app lane.
+
+**Accepted residual risk.** The measured candidate code necessarily
+EXECUTES inside the demoted measurement child — there is no way to measure
+it without running it somewhere. A sufficiently adversarial candidate could
+compromise that sandboxed, unprivileged child process, but the child starts
+with no root access and no write access to `PROMOTED_TREE` (root-owned,
+0755, files 0644 — the child never touches it). Compromising the child can
+at most forge THAT child's own reported numbers for one measurement pass;
+it can never gain root, never write the promoted tree directly, and the
+existing soak (3 clean subsequent passes) plus the held-out pack's
+invisibility (#780) bound how much a single forged pass can accomplish.
+
 ## Known limitation (honest residual)
 
 The post-promotion microbench re-measurement (used for the regression watch)

--- a/host/eeepc/libexec/eeepc_promotion_verifier.py
+++ b/host/eeepc/libexec/eeepc_promotion_verifier.py
@@ -146,15 +146,55 @@ _OWNERSHIP_SKIP_ENV = "EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK"
 _WRITABLE_BY_OTHERS_MASK = 0o022
 
 
-def _verify_release_ownership_or_exit(release_dir: str) -> None:
+def _stat_root_owned_and_not_writable(target: Path) -> None:
+    """Shared leaf check for :func:`_verify_release_ownership_or_exit`:
+    ``target`` must stat-able, ``st_uid == 0``, and neither group- nor
+    other-writable. Prints one reason and ``sys.exit(1)``s otherwise."""
+    try:
+        st = target.stat()
+    except OSError as exc:
+        print(
+            f"eeepc_promotion_verifier: refusing to import — cannot stat "
+            f"release path {target}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if st.st_uid != 0:
+        print(
+            f"eeepc_promotion_verifier: refusing to import — {target} is "
+            f"not root-owned (uid={st.st_uid}); a root-run verifier must "
+            f"never import code a non-root uid could have planted",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if st.st_mode & _WRITABLE_BY_OTHERS_MASK:
+        print(
+            f"eeepc_promotion_verifier: refusing to import — {target} is "
+            f"group/other writable (mode={oct(st.st_mode & 0o777)})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _verify_release_ownership_or_exit(release_dir: str) -> Path:
     """Refuse to let this process import a release tree a non-root uid
     could have planted or modified. Skippable ONLY via
     ``EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK=1`` — documented test-only escape
     hatch, because tests run as a non-root user against temp dirs that can
     never satisfy a real root-ownership check.
+
+    Returns the RESOLVED (realpath) release dir — callers MUST use this
+    return value for ``sys.path`` (see the module-level call site just
+    below), never the raw ``release_dir`` string again. This closes a
+    check-then-use gap (opus-review round 2, YELLOW-1): stat-checking the
+    unresolved ``current`` symlink and then separately re-resolving it for
+    ``sys.path.insert`` leaves a window where the symlink could be flipped
+    between the two; resolving ONCE here and using that same concrete path
+    for both the check and the import removes the second, independent
+    resolution entirely.
     """
     if os.environ.get(_OWNERSHIP_SKIP_ENV) == "1":
-        return
+        return Path(release_dir).resolve()
     if os.name != "posix":
         print(
             "eeepc_promotion_verifier: refusing to run — the release-"
@@ -166,39 +206,29 @@ def _verify_release_ownership_or_exit(release_dir: str) -> None:
 
     root = Path(release_dir).resolve()
     for rel in ("", "nanobot", "nanobot/runtime"):
-        target = (root / rel) if rel else root
-        try:
-            st = target.stat()
-        except OSError as exc:
-            print(
-                f"eeepc_promotion_verifier: refusing to import — cannot stat "
-                f"release path {target}: {exc}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        if st.st_uid != 0:
-            print(
-                f"eeepc_promotion_verifier: refusing to import — {target} is "
-                f"not root-owned (uid={st.st_uid}); a root-run verifier must "
-                f"never import code a non-root uid could have planted",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        if st.st_mode & _WRITABLE_BY_OTHERS_MASK:
-            print(
-                f"eeepc_promotion_verifier: refusing to import — {target} is "
-                f"group/other writable (mode={oct(st.st_mode & 0o777)})",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        _stat_root_owned_and_not_writable((root / rel) if rel else root)
+
+    # Optional extra (opus-review round 2, YELLOW-1): the interpreter this
+    # process itself is running under should also be root-owned — in
+    # production this is the release's own venv (already covered by
+    # deploy_release.sh's root:root chown of VENV_BASE), so this is
+    # defense-in-depth against a replaced/symlinked interpreter binary, not
+    # a new trust boundary on its own.
+    try:
+        _stat_root_owned_and_not_writable(Path(sys.executable).resolve())
+    except SystemExit:
+        raise
+    except Exception:
+        pass  # sys.executable resolution is best-effort; never block on it
+
+    return root
 
 
-_verify_release_ownership_or_exit(_release_dir)
+_release_dir_resolved = _verify_release_ownership_or_exit(_release_dir)
 
-if _release_dir and _release_dir not in sys.path:
-    sys.path.insert(0, _release_dir)
+if str(_release_dir_resolved) not in sys.path:
+    sys.path.insert(0, str(_release_dir_resolved))
 
-from nanobot.runtime import cycle_ledger as _cycle_ledger  # noqa: E402
 from nanobot.runtime.benchmark_evidence import (  # noqa: E402
     _MICROBENCH_MIN_IMPROVEMENT_PCT as MICROBENCH_MIN_IMPROVEMENT_PCT,
 )
@@ -329,19 +359,100 @@ def _ensure_promoted_tree_dir(promoted_tree: Path) -> None:
         pass
 
 
-def _chown_best_effort(path: Path, user: str) -> None:
-    """Best-effort chown back to ``user:user`` (POSIX only). Used after this
-    root process appends a ledger event, so the eeepc-agent-uid bridge keeps
-    being able to write that same file afterwards."""
-    if os.name != "posix":
-        return
-    try:
-        import grp
-        import pwd
+def _reassert_promoted_tree_root_ownership(promoted_tree: Path) -> bool:
+    """RED1 fix (opus-review round 2): re-check PROMOTED_TREE's root
+    ownership at the START of every pass, not just rely on it having been
+    created root-owned once. ``_ensure_promoted_tree_dir`` never re-asserts
+    ``st_uid`` — a one-time drift (e.g. the very symlink-chown attack this
+    same rework closes elsewhere) would otherwise persist forever, silently
+    downgrading the agent-side loader's boundary self-check from "trusted"
+    to "would refuse everything" without anyone noticing why.
 
-        pw = pwd.getpwnam(user)
-        gr = grp.getgrnam(user)
-        os.chown(path, pw.pw_uid, gr.gr_gid)
+    Returns ``True`` if the tree is (now) root-owned and safe to use this
+    pass. Returns ``False`` if it drifted AND could not be healed — the
+    caller must fail the WHOLE pass closed rather than trust a possibly
+    instance-writable tree; this prints a loud stderr line (systemd/
+    journalctl visible) since writing that failure into the tree's own
+    ledger would mean trusting the very tree that just failed its check.
+
+    Skippable via the same ``EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK=1`` escape
+    hatch as the release check (test-only: tests create PROMOTED_TREE as
+    the current non-root user, which can never satisfy this for real).
+    """
+    if os.environ.get(_OWNERSHIP_SKIP_ENV) == "1":
+        return True
+    if os.name != "posix":
+        return True  # ownership semantics are POSIX-only; nothing to check here
+    try:
+        if not promoted_tree.is_dir():
+            return True  # not created yet — _ensure_promoted_tree_dir makes it fresh, root-owned
+        st = promoted_tree.stat()
+        if st.st_uid == 0:
+            return True
+    except Exception:
+        print(
+            "eeepc_promotion_verifier: could not stat PROMOTED_TREE to verify "
+            "root ownership — refusing to process this pass (fail closed)",
+            file=sys.stderr,
+        )
+        return False
+
+    # Drifted away from root. Running as root we CAN heal it directly; if
+    # this process is not actually root (shouldn't happen in production —
+    # the systemd unit has no User=), chown itself will fail and we must
+    # fail this pass closed rather than guess.
+    try:
+        os.chown(promoted_tree, 0, 0)
+        return True
+    except Exception:
+        print(
+            "eeepc_promotion_verifier: PROMOTED_TREE is not root-owned "
+            f"(uid={st.st_uid}) and could not be chowned back to root — "
+            "refusing to process this pass (fail closed)",
+            file=sys.stderr,
+        )
+        return False
+
+
+_VERIFIER_LEDGER_FILENAME = "verifier_ledger.jsonl"
+
+
+def _append_verifier_ledger_event(event: dict) -> None:
+    """Append one JSON line to a ROOT-OWNED ledger under ``PROMOTED_TREE``
+    — NEVER ``STATE_DIR/ledger`` (RED1 fix, opus-review round 2).
+
+    The instance owns ``state/`` and can plant
+    ``state/ledger/cycles.jsonl`` as a symlink to ANYWHERE, e.g.
+    ``PROMOTED_TREE`` itself — a root ``open(path, "a")`` (as the old
+    ``nanobot.runtime.cycle_ledger.append_event`` call used here did) or a
+    root ``os.chown`` on that same path (as the old ``_chown_best_effort``
+    call used here did) would follow the symlink and durably corrupt/chown
+    whatever it points at, INCLUDING ``PROMOTED_TREE`` — breaking the
+    "promoted tree is root-owned" invariant this whole design rests on.
+
+    The fix is structural, not a symlink-follow guard bolted onto the old
+    call sites: root's own audit trail now lives INSIDE ``PROMOTED_TREE``,
+    which is root-owned 0755 (non-writable by any other uid) — nothing but
+    root can ever create a file OR a symlink in that directory in the
+    first place, so there is no attacker-controlled path for this write to
+    ever follow. ``os.O_NOFOLLOW`` (POSIX; silently unavailable on
+    Windows) is still added as cheap defense-in-depth for the file itself.
+    Best-effort — a ledger write must never abort a verifier pass.
+    """
+    try:
+        record = dict(event)
+        record.setdefault("ts", _utc_iso())
+        line = (json.dumps(record, ensure_ascii=False, default=str) + "\n").encode("utf-8")
+
+        ledger_path = PROMOTED_TREE / _VERIFIER_LEDGER_FILENAME
+        flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(ledger_path, flags, 0o644)
+        try:
+            os.write(fd, line)
+        finally:
+            os.close(fd)
     except Exception:
         pass
 
@@ -541,13 +652,20 @@ def _minimal_child_env(home: Path) -> "dict[str, str]":
     bootstrap finds the same release, and ``PYTHONDONTWRITEBYTECODE=1`` so
     the child never writes a ``.pyc`` anywhere. No secrets, no inherited
     process env beyond exactly these keys.
+
+    ``SELFEVO_RELEASE_DIR`` is the ALREADY-RESOLVED realpath
+    (``_release_dir_resolved``), not the raw (possibly symlink) env value —
+    same YELLOW-1 reasoning as the parent's own ``sys.path`` pin: the child
+    re-runs the identical ownership-check + bootstrap, and must check/use
+    the exact same concrete path the parent already verified, not
+    independently re-resolve a mutable symlink of its own.
     """
     env = {
         "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         "HOME": str(home),
         "STATE_DIR": str(STATE_DIR),
         "INSTANCE_REPO": str(INSTANCE_REPO),
-        "SELFEVO_RELEASE_DIR": _release_dir,
+        "SELFEVO_RELEASE_DIR": str(_release_dir_resolved),
         "PYTHONDONTWRITEBYTECODE": "1",
     }
     if os.name == "nt":
@@ -837,21 +955,18 @@ def _promote(
         }
         manifest[module_path] = entry
 
-        try:
-            _cycle_ledger.append_event(
-                STATE_DIR,
-                {
-                    "phase": "promotion",
-                    "reason": "root_verified_promoted",
-                    "candidate_id": candidate_id,
-                    "module_path": module_path,
-                    "head_sha": head_sha,
-                    "sha256": sha256,
-                },
-            )
-            _chown_best_effort(STATE_DIR / "ledger" / "cycles.jsonl", "eeepc-agent")
-        except Exception:
-            pass  # ledger write is best-effort; the promotion itself already succeeded
+        # RED1 fix (opus-review round 2): root's own audit event goes into
+        # the root-owned verifier ledger under PROMOTED_TREE — never
+        # STATE_DIR/ledger (instance-writable; see _append_verifier_ledger_event's
+        # docstring for the symlink attack this closes).
+        _append_verifier_ledger_event({
+            "phase": "promotion",
+            "reason": "root_verified_promoted",
+            "candidate_id": candidate_id,
+            "module_path": module_path,
+            "head_sha": head_sha,
+            "sha256": sha256,
+        })
 
         return entry
     except Exception:
@@ -873,20 +988,15 @@ def _rollback(
     except Exception:
         pass
     manifest.pop(module_path, None)
-    try:
-        _cycle_ledger.append_event(
-            STATE_DIR,
-            {
-                "phase": "promotion",
-                "reason": "root_verified_rolled_back",
-                "candidate_id": candidate_id,
-                "module_path": module_path,
-                "rollback_reason": reason,
-            },
-        )
-        _chown_best_effort(STATE_DIR / "ledger" / "cycles.jsonl", "eeepc-agent")
-    except Exception:
-        pass
+    # RED1 fix (opus-review round 2): same root-owned ledger as _promote —
+    # never STATE_DIR/ledger.
+    _append_verifier_ledger_event({
+        "phase": "promotion",
+        "reason": "root_verified_rolled_back",
+        "candidate_id": candidate_id,
+        "module_path": module_path,
+        "rollback_reason": reason,
+    })
 
 
 # ─── one verify pass ─────────────────────────────────────────────────────────
@@ -911,6 +1021,15 @@ def verify_pass(now: "datetime | None" = None) -> dict:
     }
 
     try:
+        # RED1 fix (opus-review round 2): re-assert PROMOTED_TREE's root
+        # ownership BEFORE doing anything else this pass — a one-time
+        # drift must never silently persist. Fails the WHOLE pass closed
+        # (no candidates processed, no manifest/state read or written) if
+        # the tree is not root-owned and could not be healed back.
+        if not _reassert_promoted_tree_root_ownership(PROMOTED_TREE):
+            summary["errors"] += 1
+            return summary
+
         _ensure_promoted_tree_dir(PROMOTED_TREE)
 
         manifest_path = PROMOTED_TREE / _MANIFEST_FILENAME
@@ -1079,6 +1198,14 @@ def verify_pass(now: "datetime | None" = None) -> dict:
                     _rollback(manifest, module_path, entry.get("candidate_id"), "operator_veto")
                     summary["rolled_back"] += 1
                     manifest_dirty = True
+                    # RED1 fix (opus-review round 2): force verifier_state.json
+                    # to be rewritten too (not just manifest.json) on every
+                    # rollback pass, even one with no pending candidate files
+                    # at all — _atomic_write_text's tmp+os.replace heals that
+                    # file's ownership every time it fires, so ownership drift
+                    # never lingers just because nothing else this pass
+                    # happened to touch verifier_state.json.
+                    state_dirty = True
                     continue
                 if status != "active":
                     continue
@@ -1101,6 +1228,7 @@ def verify_pass(now: "datetime | None" = None) -> dict:
                     _rollback(manifest, module_path, entry.get("candidate_id"), reason)
                     summary["rolled_back"] += 1
                     manifest_dirty = True
+                    state_dirty = True  # RED1 fix round 2: heal verifier_state.json ownership every rollback pass too
             except Exception:
                 summary["errors"] += 1
                 continue  # one bad manifest entry must never abort the rest

--- a/host/eeepc/libexec/eeepc_promotion_verifier.py
+++ b/host/eeepc/libexec/eeepc_promotion_verifier.py
@@ -71,6 +71,41 @@ Config: constants below + a few env vars with sane production defaults
 (the systemd unit's ``EnvironmentFile=`` line points at the SAME instance
 env file the bridge itself uses, so ``SELFEVO_RUNTIME_SLICE`` and
 ``STATE_DIR`` are read from the identical source of truth).
+
+**Rework after #880 (opus-review RED1/RED2 — see
+docs/changes/875-root-verified-auto-promotion/proposal.md for the full
+write-up).** #880 made the release tree read-only to the runtime uid via
+the SANDBOX (``ProtectSystem=strict``), but left the on-disk owner as
+``eeepc-agent`` — meaning this script, importing straight from that
+release as root, was importing runtime-uid-owned code as root (RED1: root
+RCE via a planted/mutated module). And three pieces of work here executed
+instance-influenced bytes AS ROOT with no privilege drop at all (RED2):
+``git show`` against the instance repo, the microbench measurement, and
+the held-out pack. Both are fixed now:
+
+- RED1: ``deploy_release.sh`` chowns the release ``root:root`` (the runtime
+  uid only ever needed read+exec — #880 already proved no runtime write
+  into ``/opt`` exists). This script independently verifies that promise
+  before importing anything from the release —
+  :func:`_verify_release_ownership_or_exit` fails closed (prints one
+  reason, exits nonzero) if the release dir / its ``nanobot/`` / its
+  ``nanobot/runtime/`` are not root-owned and non-group/other-writable.
+- RED2: nothing here EXECUTES instance-influenced bytes as root anymore.
+  ``git show`` runs demoted (:func:`_git_show_bytes_demoted`); the
+  measurement + held-out pack run inside a demoted CHILD re-invocation of
+  this same script (``--child-verify``, see :func:`_run_child_verify` /
+  :func:`_child_verify_main`) that prints ONE JSON verdict to stdout. Root
+  parses that JSON as untrusted DATA and makes the ONLY trust decision (the
+  improvement_pct threshold + heldout-clean check) itself — the child
+  never decides to promote anything.
+
+Accepted residual risk: the measured candidate code necessarily EXECUTES
+inside the demoted measurement sandbox (that's the whole point — root
+can't measure it without running it somewhere). A sufficiently adversarial
+candidate could compromise that sandboxed, unprivileged child process, but
+it starts with no root access and no write access to ``PROMOTED_TREE``
+(root-owned) — compromising the child can at most forge THAT child's own
+verdict, never gain root or write the promoted tree directly.
 """
 from __future__ import annotations
 
@@ -79,7 +114,10 @@ import hashlib
 import json
 import os
 import posixpath
+import shutil
+import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -91,6 +129,72 @@ from typing import Any
 # same way the bridge unit's PYTHONPATH= does.
 _DEFAULT_RELEASE_DIR = "/opt/eeepc-agent/runtimes/self-evolving-agent/current"
 _release_dir = os.environ.get("SELFEVO_RELEASE_DIR", "").strip() or _DEFAULT_RELEASE_DIR
+
+# ─── RED1 fix (opus-review): fail-closed release-ownership check ───────────
+# This process is about to `sys.path.insert` the release dir and import
+# `nanobot` straight out of it, AS ROOT. `deploy_release.sh` now chowns the
+# release `root:root` (#880 proved no runtime write into /opt exists;
+# PYTHONDONTWRITEBYTECODE=1 everywhere means no runtime write happens even
+# incidentally) — the runtime uid only ever needs read+exec, which
+# world-read from the release tar/umask already provides. Before importing
+# ANYTHING from the release, prove that promise held: the release dir
+# itself, its `nanobot/` subdir, and `nanobot/runtime/` must each be
+# `st_uid == 0` and neither group- nor other-writable. Any failure prints
+# ONE reason to stderr and exits nonzero WITHOUT ever reaching the
+# `from nanobot...` import lines below — fail closed, no partial import.
+_OWNERSHIP_SKIP_ENV = "EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK"
+_WRITABLE_BY_OTHERS_MASK = 0o022
+
+
+def _verify_release_ownership_or_exit(release_dir: str) -> None:
+    """Refuse to let this process import a release tree a non-root uid
+    could have planted or modified. Skippable ONLY via
+    ``EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK=1`` — documented test-only escape
+    hatch, because tests run as a non-root user against temp dirs that can
+    never satisfy a real root-ownership check.
+    """
+    if os.environ.get(_OWNERSHIP_SKIP_ENV) == "1":
+        return
+    if os.name != "posix":
+        print(
+            "eeepc_promotion_verifier: refusing to run — the release-"
+            "ownership check is POSIX-only (this feature is host-only); "
+            f"set {_OWNERSHIP_SKIP_ENV}=1 only for tests/dev",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    root = Path(release_dir).resolve()
+    for rel in ("", "nanobot", "nanobot/runtime"):
+        target = (root / rel) if rel else root
+        try:
+            st = target.stat()
+        except OSError as exc:
+            print(
+                f"eeepc_promotion_verifier: refusing to import — cannot stat "
+                f"release path {target}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if st.st_uid != 0:
+            print(
+                f"eeepc_promotion_verifier: refusing to import — {target} is "
+                f"not root-owned (uid={st.st_uid}); a root-run verifier must "
+                f"never import code a non-root uid could have planted",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if st.st_mode & _WRITABLE_BY_OTHERS_MASK:
+            print(
+                f"eeepc_promotion_verifier: refusing to import — {target} is "
+                f"group/other writable (mode={oct(st.st_mode & 0o777)})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+_verify_release_ownership_or_exit(_release_dir)
+
 if _release_dir and _release_dir not in sys.path:
     sys.path.insert(0, _release_dir)
 
@@ -99,6 +203,7 @@ from nanobot.runtime.benchmark_evidence import (  # noqa: E402
     _MICROBENCH_MIN_IMPROVEMENT_PCT as MICROBENCH_MIN_IMPROVEMENT_PCT,
 )
 from nanobot.runtime.heldout import run_heldout as _run_heldout  # noqa: E402
+from nanobot.runtime.heldout.microbench import _git_cmd as _microbench_git_cmd  # noqa: E402
 from nanobot.runtime.heldout.microbench import _git_show_bytes  # noqa: E402
 from nanobot.runtime.heldout.microbench import run_measurement  # noqa: E402
 from nanobot.runtime.runtime_deny import _is_runtime_deny, runtime_slice_paths  # noqa: E402
@@ -119,6 +224,15 @@ PROMOTED_TREE = Path(os.environ.get("PROMOTED_TREE", "/var/lib/eeepc-promoted"))
 # file so this is always the SAME operator-approved slice, never a second
 # copy that could drift out of sync.
 _RUNTIME_SLICE_ENV = "SELFEVO_RUNTIME_SLICE"
+
+# ─── RED2 fix (opus-review): the demoted-user this root process drops
+# privilege to before ever EXECUTING instance-influenced code (git against
+# the instance repo, the microbench measurement, the held-out pack). Root
+# only ever receives the child's stdout as DATA (a JSON verdict + numbers);
+# the promotion decision itself always stays in this root parent (see
+# _measure_candidate / _run_child_verify).
+_DEMOTE_USER = os.environ.get("EEEPC_VERIFIER_DEMOTE_USER", "").strip() or "eeepc-agent"
+_CHILD_TIMEOUT_SECONDS = 600  # hard cap: baseline + candidate measurement + heldout
 
 _SOAK_PASSES = 3
 _MANIFEST_FILENAME = "manifest.json"
@@ -308,6 +422,288 @@ def _heldout_is_clean(results: dict) -> "tuple[bool, str]":
         return False, "heldout results malformed"
 
 
+# ─── RED2 fix (opus-review): privilege drop for instance-influenced work ───
+#
+# Root must never EXECUTE anything the instance influenced — only ever
+# receive bytes/verdicts FROM a demoted child as inert data. Three things
+# used to run as root and no longer do:
+#   1. ``git show`` against INSTANCE_REPO (git parses repo-local config /
+#      attributes / hooks — running it as root against an instance-owned
+#      repo is itself a privilege-escalation surface, independent of what
+#      the blob content is used for afterward).
+#   2. the microbench measurement (``run_measurement`` executes the
+#      candidate's own bytes).
+#   3. the held-out pack (``run_heldout`` copies + executes instance
+#      artifacts in a sandboxed subprocess).
+#
+# All three now happen either (a) inside a demoted ``git`` subprocess, or
+# (b) inside a demoted CHILD re-invocation of this same interpreter/script
+# (``--child-verify``) that does the sys.path bootstrap + imports + the
+# actual measurement/heldout calls itself and prints ONE JSON object to
+# stdout. The root PARENT parses that JSON as untrusted data and makes the
+# ONLY trust decision (the improvement_pct threshold + heldout-clean check)
+# itself — the child never decides whether to promote anything.
+
+
+def _is_root() -> bool:
+    """POSIX-only by construction (``os.geteuid`` does not exist on
+    Windows) — always False on a dev box, which is exactly the "skip
+    demotion" branch every caller below already handles explicitly."""
+    return os.name == "posix" and hasattr(os, "geteuid") and os.geteuid() == 0
+
+
+def _resolve_demote_ids(user: str) -> "tuple[int, int] | None":
+    """(uid, gid) for ``user``, or ``None`` if unresolvable or non-POSIX.
+    Imports ``pwd`` lazily (module-level import would break Windows)."""
+    if os.name != "posix":
+        return None
+    try:
+        import pwd
+
+        pw = pwd.getpwnam(user)
+        return pw.pw_uid, pw.pw_gid
+    except Exception:
+        return None
+
+
+def _demote_preexec_fn(uid: int, gid: int):
+    """Build a ``preexec_fn`` for ``subprocess.run`` that drops this
+    process's child to ``uid``/``gid`` — group list, gid, then uid, in that
+    exact order (uid must be dropped last, or the process would lose the
+    permission needed to change gid/groups).
+
+    ``os.setgroups``/``os.setgid``/``os.setuid`` are POSIX-only (absent
+    from typeshed's Windows view of ``os``) — the ``# type: ignore``
+    comments match this repo's existing convention for POSIX-only stdlib
+    access (see ``bridge.py``'s ``fcntl`` import). Callers only ever build
+    (via :func:`_resolve_demote_ids`) or invoke (via :func:`_demote_kwargs`)
+    this on a path already gated by ``os.name == "posix"``.
+    """
+
+    def _demote() -> None:
+        os.setgroups([gid])  # type: ignore[attr-defined]
+        os.setgid(gid)  # type: ignore[attr-defined]
+        os.setuid(uid)  # type: ignore[attr-defined]
+
+    return _demote
+
+
+def _demote_kwargs() -> "tuple[dict, bool]":
+    """(subprocess kwargs, demoted). When this process itself is root,
+    returns ``preexec_fn`` kwargs that drop the child to
+    :data:`_DEMOTE_USER`. When not root (tests, dev boxes, Windows), skips
+    demotion entirely with an explicit log line — there is no privilege to
+    drop, and forcing a demotion attempt here would just fail on a dev
+    machine that has no ``eeepc-agent`` system user."""
+    if not _is_root():
+        print(
+            "eeepc_promotion_verifier: not running as root — skipping "
+            f"privilege drop to {_DEMOTE_USER!r} (expected under tests/dev; "
+            "the production systemd unit always runs this as root)",
+            file=sys.stderr,
+        )
+        return {}, False
+    ids = _resolve_demote_ids(_DEMOTE_USER)
+    if ids is None:
+        raise RuntimeError(
+            f"eeepc_promotion_verifier: cannot resolve demote user {_DEMOTE_USER!r} "
+            "(getpwnam failed) — refusing to run instance-influenced work as root"
+        )
+    return {"preexec_fn": _demote_preexec_fn(*ids)}, True
+
+
+def _git_show_bytes_demoted(
+    repo_root: Path, ref: str, module_path: str, *, timeout: int = 30,
+) -> "bytes | None":
+    """Same contract as ``microbench._git_show_bytes`` — but root must
+    never itself run ``git`` against the instance-owned repo (git parses
+    repo-local config/attributes/hooks). Demotes when running as root;
+    falls back to no privilege drop when not (tests/dev). Returns the blob
+    bytes as inert DATA — never executes them."""
+    kwargs, _ = _demote_kwargs()
+    try:
+        proc = subprocess.run(
+            _microbench_git_cmd(Path(repo_root)) + ["show", f"{ref}:{module_path}"],
+            capture_output=True, timeout=timeout, **kwargs,
+        )
+        if proc.returncode != 0:
+            return None
+        return proc.stdout
+    except Exception:
+        return None
+
+
+def _minimal_child_env(home: Path) -> "dict[str, str]":
+    """The stripped env for the ``--child-verify`` subprocess: PATH, HOME
+    (a root-created tmpdir chowned to the demoted uid — see
+    :func:`_run_child_verify`), the same STATE_DIR/INSTANCE_REPO this
+    process resolved, ``SELFEVO_RELEASE_DIR`` so the child's own sys.path
+    bootstrap finds the same release, and ``PYTHONDONTWRITEBYTECODE=1`` so
+    the child never writes a ``.pyc`` anywhere. No secrets, no inherited
+    process env beyond exactly these keys.
+    """
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(home),
+        "STATE_DIR": str(STATE_DIR),
+        "INSTANCE_REPO": str(INSTANCE_REPO),
+        "SELFEVO_RELEASE_DIR": _release_dir,
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    if os.name == "nt":
+        # Dev-box-only accommodation (mirrors microbench._sandbox_env):
+        # Windows' CreateProcess needs a real SYSTEMROOT to resolve system
+        # DLLs when launching the interpreter — the actual production host
+        # (eeepc, POSIX) never takes this branch.
+        env["SYSTEMROOT"] = os.environ.get("SYSTEMROOT") or os.environ.get("windir", "C:\\Windows")
+        env["USERPROFILE"] = str(home)
+        env["TMP"] = str(home)
+        env["TEMP"] = str(home)
+    # Test-only escape hatch, propagated so the CHILD's own ownership check
+    # (it re-executes this whole script from scratch) doesn't fail against
+    # a test's non-root-owned temp release dir. Never set in production —
+    # the production parent never has this env var either.
+    skip_flag = os.environ.get(_OWNERSHIP_SKIP_ENV)
+    if skip_flag:
+        env[_OWNERSHIP_SKIP_ENV] = skip_flag
+    return env
+
+
+def _run_child_verify(
+    mode: str, *, module_path: "str | None" = None, head_sha: "str | None" = None,
+    timeout: int = _CHILD_TIMEOUT_SECONDS,
+) -> dict:
+    """Re-invoke this script's own interpreter as a DEMOTED child process
+    (``--child-verify --mode <mode>``) to do every piece of work that
+    touches instance-influenced bytes or executes instance-authored code.
+    Root itself never executes any of that — it only spawns this child,
+    waits, and parses ONE JSON object from its stdout as untrusted DATA.
+
+    ``mode="full"`` (requires ``module_path``/``head_sha``): materializes
+    candidate bytes via ``git show``, measures baseline + candidate via
+    ``run_measurement``, and runs the held-out pack — all inside the one
+    child. ``mode="heldout"``: runs only the held-out pack (used by the
+    soak-continuation and post-promotion regression-watch passes, which
+    don't need a fresh measurement).
+
+    Returns a dict always containing ``"ok"``. ``"ok": False`` covers both
+    a well-formed child-reported failure (bad reason string included) AND
+    a malformed child process outcome (nonzero exit / unparseable stdout /
+    timeout) — callers must treat any of these as "could not verify this
+    pass", never as a green light. The child's numbers are parsed here but
+    the THRESHOLD/trust decision is made by the caller (``_measure_candidate``
+    or the soak/regression-watch call sites in ``verify_pass``), never by
+    this function and never by the child itself.
+    """
+    home = Path(tempfile.mkdtemp(prefix="eeepc-verifier-child-home-"))
+    try:
+        kwargs, demoted = _demote_kwargs()
+        if demoted:
+            ids = _resolve_demote_ids(_DEMOTE_USER)
+            if ids is not None:
+                try:
+                    os.chown(home, ids[0], ids[1])
+                except Exception:
+                    pass
+
+        argv = [
+            sys.executable, str(Path(__file__).resolve()),
+            "--child-verify", "--mode", mode,
+        ]
+        if module_path:
+            argv += ["--module-path", module_path]
+        if head_sha:
+            argv += ["--head-sha", head_sha]
+
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            timeout=timeout,
+            env=_minimal_child_env(home),
+            **kwargs,
+        )
+    except Exception as exc:
+        return {"ok": False, "reason": f"failed to spawn child verify process: {exc}"}
+    finally:
+        try:
+            shutil.rmtree(home, ignore_errors=True)
+        except Exception:
+            pass
+
+    if proc.returncode != 0:
+        stderr_tail = proc.stderr.decode("utf-8", "replace")[-400:] if proc.stderr else ""
+        return {
+            "ok": False,
+            "reason": f"child verify process exited {proc.returncode}: {stderr_tail}",
+        }
+    try:
+        stdout_bytes = proc.stdout or b""
+        result = json.loads(stdout_bytes.decode("utf-8"))
+    except Exception as exc:
+        return {"ok": False, "reason": f"child verify stdout unparseable: {exc}"}
+    if not isinstance(result, dict) or "ok" not in result:
+        return {"ok": False, "reason": "child verify stdout malformed (not a dict with 'ok')"}
+    return result
+
+
+def _child_verify_main(
+    mode: str, module_path: "str | None", head_sha: "str | None",
+) -> int:
+    """Entry point for the DEMOTED CHILD process (see
+    :func:`_run_child_verify`). Does every piece of instance-influenced
+    work — ``git show``, the microbench measurement, the held-out pack —
+    and prints exactly ONE JSON object to stdout. Makes NO trust decision
+    (no threshold comparison): the parent applies
+    ``MICROBENCH_MIN_IMPROVEMENT_PCT`` itself. Always exits 0 with a
+    well-formed ``{"ok": ...}`` JSON object unless something fails before
+    this function can even run (import/argv errors) — those surface to the
+    parent as a nonzero exit / no stdout, which it already treats as
+    failure.
+    """
+    result: dict = {"ok": False, "reason": f"unknown child-verify mode {mode!r}"}
+    try:
+        if mode == "full":
+            if not module_path or not head_sha:
+                result = {
+                    "ok": False,
+                    "reason": "child-verify full mode requires --module-path and --head-sha",
+                }
+            else:
+                candidate_bytes = _git_show_bytes(INSTANCE_REPO, head_sha, module_path)
+                if candidate_bytes is None:
+                    result = {
+                        "ok": False,
+                        "reason": f"failed to materialize {module_path}@{head_sha} via git show",
+                    }
+                else:
+                    baseline_ms = run_measurement(module_path, None)
+                    if baseline_ms is None or baseline_ms <= 0:
+                        result = {"ok": False, "reason": "baseline measurement failed or non-positive"}
+                    else:
+                        candidate_ms = run_measurement(module_path, candidate_bytes)
+                        if candidate_ms is None or candidate_ms <= 0:
+                            result = {"ok": False, "reason": "candidate measurement failed or non-positive"}
+                        else:
+                            heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
+                            clean, heldout_reason = _heldout_is_clean(heldout_results)
+                            result = {
+                                "ok": True,
+                                "sha256": hashlib.sha256(candidate_bytes).hexdigest(),
+                                "baseline_ms": baseline_ms,
+                                "candidate_ms": candidate_ms,
+                                "heldout_clean": clean,
+                                "heldout_reason": heldout_reason,
+                            }
+        elif mode == "heldout":
+            heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
+            clean, heldout_reason = _heldout_is_clean(heldout_results)
+            result = {"ok": True, "heldout_clean": clean, "heldout_reason": heldout_reason}
+    except Exception as exc:
+        result = {"ok": False, "reason": f"child-verify exception: {exc}"}
+    print(json.dumps(result))
+    return 0
+
+
 # ─── eligibility classification ─────────────────────────────────────────────
 
 
@@ -343,26 +739,35 @@ def _classify_candidate(
 
 
 def _measure_candidate(
-    module_path: str, head_sha: str,
+    module_path: str, head_sha: "str | None",
 ) -> "tuple[bool, str, dict | None]":
     """Re-materialize + re-measure a candidate from scratch. Returns
     (ok, reason, measurement_dict). Never trusts anything the instance
-    wrote — bytes come from ``git show``, numbers come from
-    ``run_measurement`` against the INSTALLED product tree. #875 steps 3-4.
+    wrote, and — RED2 fix — never EXECUTES any of it itself either: the
+    actual ``git show`` / measurement / heldout work happens inside a
+    demoted child process (:func:`_run_child_verify`); this function only
+    parses that child's numbers (untrusted data) and applies the ONE trust
+    decision (the improvement_pct threshold + heldout-clean check) itself.
+    #875 steps 3-4.
+
+    ``head_sha`` is typed ``str | None`` (rather than ``str``) because the
+    caller reads it straight out of an untrusted candidate record, where it
+    may genuinely be absent — the check below is exactly that case, not
+    just defensive padding.
     """
     if not head_sha:
         return False, "candidate record has no head_sha to materialize from", None
 
-    candidate_bytes = _git_show_bytes(INSTANCE_REPO, head_sha, module_path)
-    if candidate_bytes is None:
-        return False, f"failed to materialize {module_path}@{head_sha} via git show", None
+    child = _run_child_verify("full", module_path=module_path, head_sha=head_sha)
+    if not child.get("ok"):
+        return False, str(child.get("reason") or "child verify failed"), None
 
-    baseline_ms = run_measurement(module_path, None)
-    if baseline_ms is None or baseline_ms <= 0:
-        return False, "baseline measurement failed or non-positive", None
-    candidate_ms = run_measurement(module_path, candidate_bytes)
-    if candidate_ms is None or candidate_ms <= 0:
-        return False, "candidate measurement failed or non-positive", None
+    baseline_ms = child.get("baseline_ms")
+    candidate_ms = child.get("candidate_ms")
+    if isinstance(baseline_ms, bool) or not isinstance(baseline_ms, (int, float)) or baseline_ms <= 0:
+        return False, "child verify returned an invalid baseline_ms", None
+    if isinstance(candidate_ms, bool) or not isinstance(candidate_ms, (int, float)) or candidate_ms <= 0:
+        return False, "child verify returned an invalid candidate_ms", None
 
     improvement_pct = (baseline_ms - candidate_ms) / baseline_ms * 100.0
     if improvement_pct < MICROBENCH_MIN_IMPROVEMENT_PCT:
@@ -373,16 +778,18 @@ def _measure_candidate(
             None,
         )
 
-    heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
-    clean, heldout_reason = _heldout_is_clean(heldout_results)
-    if not clean:
-        return False, heldout_reason, None
+    if not child.get("heldout_clean"):
+        return False, str(child.get("heldout_reason") or "heldout not clean"), None
+
+    sha256 = child.get("sha256")
+    if not isinstance(sha256, str) or not sha256:
+        return False, "child verify returned no sha256", None
 
     return (
         True,
         "",
         {
-            "sha256": hashlib.sha256(candidate_bytes).hexdigest(),
+            "sha256": sha256,
             "improvement_pct": improvement_pct,
             "baseline_ms": baseline_ms,
             "candidate_ms": candidate_ms,
@@ -404,9 +811,15 @@ def _promote(
     content-addressed by ``head_sha`` so this is guaranteed identical to
     what was soaked) and write them + the manifest entry. Returns the new
     manifest entry, or ``None`` on failure (best-effort; caller records the
-    failure and leaves the candidate in ``soaking`` for the next pass)."""
+    failure and leaves the candidate in ``soaking`` for the next pass).
+
+    RED2 fix: the re-fetch runs via ``_git_show_bytes_demoted`` — root must
+    never run ``git`` against the instance-owned repo itself, even for this
+    read-only re-materialization; the demoted subprocess hands back the
+    same bytes as inert data.
+    """
     try:
-        candidate_bytes = _git_show_bytes(INSTANCE_REPO, head_sha, module_path)
+        candidate_bytes = _git_show_bytes_demoted(INSTANCE_REPO, head_sha, module_path)
         if candidate_bytes is None:
             return None
         sha256 = hashlib.sha256(candidate_bytes).hexdigest()
@@ -546,6 +959,7 @@ def verify_pass(now: "datetime | None" = None) -> dict:
                         summary["rejected"] += 1
                         state_dirty = True
                         continue
+                    assert module_path is not None  # eligible=True always pairs with a module_path (see _classify_candidate)
 
                     head_sha = ((record.get("rollback_record") or {}).get("head_sha"))
                     ok, reason, measurement = _measure_candidate(module_path, head_sha)
@@ -589,8 +1003,20 @@ def verify_pass(now: "datetime | None" = None) -> dict:
                     state_dirty = True
                     continue
 
-                heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
-                clean, heldout_reason = _heldout_is_clean(heldout_results)
+                # RED2 fix: heldout re-check runs in a demoted child (it
+                # executes instance artifacts) — an integrity-scan is pure
+                # ledger JSON reading, no execution, so it stays in this
+                # root parent. A malformed/failed child result here is a
+                # verifier-side error (not a soak verdict) — raise so the
+                # existing per-candidate try/except records it as an
+                # "errors" count and leaves the entry untouched for retry.
+                child = _run_child_verify("heldout")
+                if not child.get("ok"):
+                    raise RuntimeError(
+                        str(child.get("reason") or "heldout child verify failed")
+                    )
+                clean = bool(child.get("heldout_clean"))
+                heldout_reason = str(child.get("heldout_reason") or "")
                 integrity_events = _integrity_events_since(
                     STATE_DIR, entry_state.get("ledger_watermark_utc")
                 )
@@ -657,8 +1083,18 @@ def verify_pass(now: "datetime | None" = None) -> dict:
                 if status != "active":
                     continue
 
-                heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
-                clean, heldout_reason = _heldout_is_clean(heldout_results)
+                # RED2 fix: same reasoning as the soak re-check above — the
+                # heldout run executes instance artifacts, so it happens in
+                # a demoted child; a child-side error is a verifier error,
+                # not evidence of regression, so it must not roll anything
+                # back — raise into the per-entry try/except instead.
+                child = _run_child_verify("heldout")
+                if not child.get("ok"):
+                    raise RuntimeError(
+                        str(child.get("reason") or "heldout child verify failed")
+                    )
+                clean = bool(child.get("heldout_clean"))
+                heldout_reason = str(child.get("heldout_reason") or "")
                 integrity_events = _integrity_events_since(STATE_DIR, entry.get("verified_utc"))
                 if not clean or integrity_events:
                     reason = heldout_reason or f"integrity events since promotion: {len(integrity_events)}"
@@ -692,7 +1128,20 @@ def main(argv: "list[str] | None" = None) -> int:
         )
     )
     parser.add_argument("--json", action="store_true", help="print the pass summary as JSON")
+    # Internal, undocumented-to-operators re-entry point (RED2 fix): this is
+    # how the root parent gets instance-influenced work (git show, the
+    # microbench measurement, the held-out pack) executed under a demoted
+    # uid instead of as root — see _run_child_verify/_child_verify_main.
+    # help=SUPPRESS keeps it out of --help without hiding it from anyone
+    # reading the source.
+    parser.add_argument("--child-verify", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--mode", choices=("full", "heldout"), default="full", help=argparse.SUPPRESS)
+    parser.add_argument("--module-path", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--head-sha", default=None, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
+
+    if args.child_verify:
+        return _child_verify_main(args.mode, args.module_path, args.head_sha)
 
     try:
         summary = verify_pass()

--- a/host/eeepc/libexec/eeepc_promotion_verifier.py
+++ b/host/eeepc/libexec/eeepc_promotion_verifier.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""Root-run promotion verifier — the automated operator (#875).
+
+**Why this exists (the trust problem).** On the eeepc host, the bridge/
+harness AND the instance's subagent run as the SAME uid (``eeepc-agent``).
+``state/`` is instance-writable, so a loader that trusts an
+instance-authored index+bytes pair would let the instance forge its way to
+arbitrary code execution in the harness's own process, before any gate ever
+ran. No in-band signature closes this (same uid can read any key the
+harness could read too).
+
+**The fix.** The only real privilege boundary on this host is root — deploys
+run via sudo, the release tree and ``/etc/eeepc-agent`` are root-touched.
+This script IS that boundary: it runs as ROOT (no ``User=`` in its systemd
+unit), on its own timer, completely independent of the instance's own
+process. It:
+
+1. Reads the instance's runtime-slice promotion candidates
+   (``STATE_DIR/promotions/promotion-runtime-*.json``) as PROPOSALS ONLY —
+   every number the instance wrote inside them (its own microbench dict,
+   its own claimed improvement) is IGNORED. Only two things are trusted
+   from a candidate record: which file it touches, and the git SHA it
+   claims to be reviewed at (content-addressed, so that binding is
+   immutable regardless of who wrote the JSON around it).
+2. Re-materializes the candidate's bytes itself, straight from git history
+   (``git show <head_sha>:<module_path>`` against the INSTANCE repo — a
+   content-addressed read, not a trust decision) — never from anything the
+   instance wrote to disk directly.
+3. Re-measures the causal micro-benchmark itself (reusing the #822
+   ``heldout/microbench.py`` machinery: baseline is always the ACTUAL
+   INSTALLED product tree, never instance-controlled git history) and
+   re-runs the held-out behavioral pack (#780) — never trusting the
+   instance's own numbers for either.
+4. Only if independently satisfied, and only after a multi-pass SOAK
+   period with no regression or integrity incident, writes the verified
+   bytes into ``PROMOTED_TREE`` (default ``/var/lib/eeepc-promoted``) — a
+   tree this script creates ROOT-OWNED, 0755, with 0644 files. The
+   eeepc-agent-uid loader (``nanobot.runtime.promoted_overlay``) can read
+   that tree but structurally cannot write it; filesystem permission IS
+   the trust boundary, there is no key to steal because there is no key.
+5. Watches every ACTIVE promotion on every subsequent pass: a held-out
+   regression, a post-promotion integrity ledger event, or an explicit
+   operator veto (``status: "vetoed"``, hand-edited into the root-owned
+   manifest via sudo) rolls the promotion back — remove the tree file,
+   remove the manifest entry, ledger it.
+
+Trust invariants (#875, verbatim — do not weaken):
+
+- The instance authors only PROPOSALS (candidate records, git branches). It
+  never authors the promoted bytes or the numbers that gate promotion:
+  root re-materializes from a content-addressed git SHA and re-measures
+  itself, from scratch, every time.
+- The promoted tree is root-owned; nothing here ever loosens that.
+- Deny-set + slice membership are enforced HERE independently, using the
+  exact same ``nanobot.runtime.runtime_deny`` logic the bridge's own gate
+  uses — a candidate naming a deny-set path is never eligible, regardless
+  of what the instance's own (untrusted) classification claimed.
+- The verification kernel (bridge/gate/scorecard/benchmark/usage/heldout/
+  coordinator — the runtime deny-set) is never promotable: the deny-set
+  check above makes this structural, not policy.
+
+**Idempotent / fail-safe.** Every per-candidate and per-active-manifest-
+entry step is wrapped so ONE bad record can never abort the whole pass —
+this script is meant to run unattended, every N minutes, forever. A
+completely malformed environment (unreadable STATE_DIR, no instance repo,
+no PROMOTED_TREE writable) degrades to a no-op pass, not a crash loop —
+though :func:`main` DOES surface a nonzero exit code on a pass-level
+failure so systemd/journalctl still show it.
+
+Config: constants below + a few env vars with sane production defaults
+(the systemd unit's ``EnvironmentFile=`` line points at the SAME instance
+env file the bridge itself uses, so ``SELFEVO_RUNTIME_SLICE`` and
+``STATE_DIR`` are read from the identical source of truth).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import posixpath
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ─── sys.path bootstrap: import the RELEASE's nanobot, not whatever might
+# already be on PYTHONPATH — this script is copied into /usr/local/libexec
+# and invoked standalone (see host/eeepc/systemd/eeepc-promotion-
+# verifier.service), so it has to point itself at the deployed release the
+# same way the bridge unit's PYTHONPATH= does.
+_DEFAULT_RELEASE_DIR = "/opt/eeepc-agent/runtimes/self-evolving-agent/current"
+_release_dir = os.environ.get("SELFEVO_RELEASE_DIR", "").strip() or _DEFAULT_RELEASE_DIR
+if _release_dir and _release_dir not in sys.path:
+    sys.path.insert(0, _release_dir)
+
+from nanobot.runtime import cycle_ledger as _cycle_ledger  # noqa: E402
+from nanobot.runtime.benchmark_evidence import (  # noqa: E402
+    _MICROBENCH_MIN_IMPROVEMENT_PCT as MICROBENCH_MIN_IMPROVEMENT_PCT,
+)
+from nanobot.runtime.heldout import run_heldout as _run_heldout  # noqa: E402
+from nanobot.runtime.heldout.microbench import _git_show_bytes  # noqa: E402
+from nanobot.runtime.heldout.microbench import run_measurement  # noqa: E402
+from nanobot.runtime.runtime_deny import _is_runtime_deny, runtime_slice_paths  # noqa: E402
+
+# ─── Config: constants + env overrides ──────────────────────────────────────
+STATE_DIR = Path(
+    os.environ.get("STATE_DIR", "/var/lib/eeepc-agent/self-evolving-agent/state")
+)
+INSTANCE_REPO = Path(
+    os.environ.get(
+        "INSTANCE_REPO",
+        "/var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving",
+    )
+)
+PROMOTED_TREE = Path(os.environ.get("PROMOTED_TREE", "/var/lib/eeepc-promoted"))
+# Same env var name the bridge classifier reads (SELFEVO_RUNTIME_SLICE) — the
+# systemd unit's EnvironmentFile= points at the bridge's own instance env
+# file so this is always the SAME operator-approved slice, never a second
+# copy that could drift out of sync.
+_RUNTIME_SLICE_ENV = "SELFEVO_RUNTIME_SLICE"
+
+_SOAK_PASSES = 3
+_MANIFEST_FILENAME = "manifest.json"
+_MANIFEST_SCHEMA = "promoted-manifest-v1"
+_VERIFIER_STATE_FILENAME = "verifier_state.json"
+_VERIFIER_STATE_SCHEMA = "promotion-verifier-state-v1"
+# Terminal verifier_state statuses — never reprocessed from scratch once
+# reached (a deterministic candidate re-evaluated on the same content would
+# only re-derive the same verdict; retrying forever would just burn CPU).
+_TERMINAL_STATUSES = frozenset({"rejected", "promoted", "rolled_back"})
+
+
+# ─── small pure helpers ──────────────────────────────────────────────────────
+
+
+def _utc_iso(now: "datetime | None" = None) -> str:
+    dt = now or datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: Any) -> "datetime | None":
+    try:
+        text = str(value).replace("Z", "+00:00")
+        dt = datetime.fromisoformat(text)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def _normalize_path(path: str) -> str:
+    return posixpath.normpath(str(path).replace("\\", "/")).lstrip("/")
+
+
+def _is_runtime_py_shape(path: str) -> bool:
+    norm = _normalize_path(path)
+    return norm.startswith("nanobot/runtime/") and norm.endswith(".py")
+
+
+def _flattened_filename(module_path: str) -> str:
+    """Shared on-disk naming convention with the agent-side loader
+    (``nanobot.runtime.promoted_overlay._flattened_filename``): keep these
+    two IN SYNC — this is the writer, that module is the reader."""
+    return module_path.replace("/", "__")
+
+
+def _read_json_dict(path: Path, default: dict) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return dict(default)
+
+
+def _atomic_write_text(path: Path, text: str, *, mode: int = 0o644) -> None:
+    """Write ``text`` to ``path`` atomically (tmp + rename) and chmod it —
+    readers (the eeepc-agent-uid overlay loader) must never observe a
+    partially-written manifest/promoted file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(text, encoding="utf-8")
+    try:
+        os.chmod(tmp_path, mode)
+    except Exception:
+        pass
+    os.replace(tmp_path, path)
+
+
+def _atomic_write_bytes(path: Path, data: bytes, *, mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_bytes(data)
+    try:
+        os.chmod(tmp_path, mode)
+    except Exception:
+        pass
+    os.replace(tmp_path, path)
+
+
+def _ensure_promoted_tree_dir(promoted_tree: Path) -> None:
+    """Idempotent maintenance: PROMOTED_TREE must always be 0755. Best-effort
+    — a chmod failure here must not abort the pass (the boundary self-check
+    on the agent side is what actually enforces trust; this is just upkeep).
+    """
+    try:
+        promoted_tree.mkdir(parents=True, exist_ok=True)
+        os.chmod(promoted_tree, 0o755)
+    except Exception:
+        pass
+
+
+def _chown_best_effort(path: Path, user: str) -> None:
+    """Best-effort chown back to ``user:user`` (POSIX only). Used after this
+    root process appends a ledger event, so the eeepc-agent-uid bridge keeps
+    being able to write that same file afterwards."""
+    if os.name != "posix":
+        return
+    try:
+        import grp
+        import pwd
+
+        pw = pwd.getpwnam(user)
+        gr = grp.getgrnam(user)
+        os.chown(path, pw.pw_uid, gr.gr_gid)
+    except Exception:
+        pass
+
+
+# ─── ledger integrity scan (regression-watch / soak-watch input) ───────────
+
+
+def _integrity_events_since(state_dir: Path, since_iso: "str | None") -> "list[dict]":
+    """Scan the cycle ledger (active file + a bounded window of recent
+    gzip archives, mirroring ``scorecard``'s rotation-aware read pattern)
+    for ``phase == "integrity"`` rows strictly AFTER ``since_iso``.
+
+    Fail-open to ``[]`` — a ledger-read problem must never itself look like
+    "no integrity events", but it also must never crash the verifier pass;
+    callers treat an empty list as "nothing new to worry about", which is
+    the safe direction for a scan that could not complete.
+    """
+    events: "list[dict]" = []
+    try:
+        since_dt = _parse_iso(since_iso) if since_iso else None
+        ledger_dir = state_dir / "ledger"
+        active = ledger_dir / "cycles.jsonl"
+        candidates: "list[Path]" = [active] if active.is_file() else []
+        try:
+            candidates.extend(
+                sorted(ledger_dir.glob("cycles-*.jsonl.gz"), reverse=True)[:3]
+            )
+        except Exception:
+            pass
+
+        for file_path in candidates:
+            try:
+                if file_path.suffix == ".gz":
+                    import gzip
+
+                    with gzip.open(file_path, "rt", encoding="utf-8") as fh:
+                        lines = fh.readlines()
+                else:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+            except Exception:
+                continue
+            for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(row, dict) or row.get("phase") != "integrity":
+                    continue
+                row_dt = _parse_iso(row.get("ts"))
+                if since_dt is not None and row_dt is not None and row_dt <= since_dt:
+                    continue
+                events.append(row)
+    except Exception:
+        return []
+    return events
+
+
+def _heldout_is_clean(results: dict) -> "tuple[bool, str]":
+    """(clean, reason) from a ``run_heldout`` result dict — clean iff
+    ``regressions == []`` AND no artifact has ``status == 'fail'``."""
+    try:
+        regressions = results.get("regressions") or []
+        result_map = results.get("results") or {}
+        failed = sorted(
+            artifact
+            for artifact, res in result_map.items()
+            if isinstance(res, dict) and res.get("status") == "fail"
+        )
+        if regressions:
+            return False, f"heldout regressions: {regressions}"
+        if failed:
+            return False, f"heldout failures: {failed}"
+        return True, ""
+    except Exception:
+        return False, "heldout results malformed"
+
+
+# ─── eligibility classification ─────────────────────────────────────────────
+
+
+def _classify_candidate(
+    record: dict, slice_paths: "set[str]",
+) -> "tuple[bool, str, str | None]":
+    """(eligible, reason, module_path). Ignores every instance-supplied
+    number (microbench dict) entirely — only the SHAPE of ``changed_files``
+    and deny/slice membership decide eligibility. #875 step 2."""
+    changed_files = record.get("changed_files")
+    if not isinstance(changed_files, list) or not changed_files:
+        return False, "changed_files missing or empty", None
+
+    runtime_files = sorted(
+        {
+            _normalize_path(f)
+            for f in changed_files
+            if isinstance(f, str) and _is_runtime_py_shape(f)
+        }
+    )
+    if len(runtime_files) != 1:
+        return (
+            False,
+            f"expected exactly one runtime-tier file in changed_files, found {len(runtime_files)}",
+            None,
+        )
+    module_path = runtime_files[0]
+    if _is_runtime_deny(module_path):
+        return False, f"module is on the immutable runtime deny-set: {module_path}", None
+    if module_path not in slice_paths:
+        return False, f"module not in the operator-approved runtime slice: {module_path}", None
+    return True, "", module_path
+
+
+def _measure_candidate(
+    module_path: str, head_sha: str,
+) -> "tuple[bool, str, dict | None]":
+    """Re-materialize + re-measure a candidate from scratch. Returns
+    (ok, reason, measurement_dict). Never trusts anything the instance
+    wrote — bytes come from ``git show``, numbers come from
+    ``run_measurement`` against the INSTALLED product tree. #875 steps 3-4.
+    """
+    if not head_sha:
+        return False, "candidate record has no head_sha to materialize from", None
+
+    candidate_bytes = _git_show_bytes(INSTANCE_REPO, head_sha, module_path)
+    if candidate_bytes is None:
+        return False, f"failed to materialize {module_path}@{head_sha} via git show", None
+
+    baseline_ms = run_measurement(module_path, None)
+    if baseline_ms is None or baseline_ms <= 0:
+        return False, "baseline measurement failed or non-positive", None
+    candidate_ms = run_measurement(module_path, candidate_bytes)
+    if candidate_ms is None or candidate_ms <= 0:
+        return False, "candidate measurement failed or non-positive", None
+
+    improvement_pct = (baseline_ms - candidate_ms) / baseline_ms * 100.0
+    if improvement_pct < MICROBENCH_MIN_IMPROVEMENT_PCT:
+        return (
+            False,
+            f"improvement {improvement_pct:.2f}% below required "
+            f"{MICROBENCH_MIN_IMPROVEMENT_PCT:.2f}%",
+            None,
+        )
+
+    heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
+    clean, heldout_reason = _heldout_is_clean(heldout_results)
+    if not clean:
+        return False, heldout_reason, None
+
+    return (
+        True,
+        "",
+        {
+            "sha256": hashlib.sha256(candidate_bytes).hexdigest(),
+            "improvement_pct": improvement_pct,
+            "baseline_ms": baseline_ms,
+            "candidate_ms": candidate_ms,
+        },
+    )
+
+
+# ─── promote / rollback ──────────────────────────────────────────────────────
+
+
+def _promote(
+    manifest: dict,
+    candidate_id: str,
+    module_path: str,
+    head_sha: str,
+    now: datetime,
+) -> "dict | None":
+    """Materialize the FINAL verified bytes once more (defense-in-depth —
+    content-addressed by ``head_sha`` so this is guaranteed identical to
+    what was soaked) and write them + the manifest entry. Returns the new
+    manifest entry, or ``None`` on failure (best-effort; caller records the
+    failure and leaves the candidate in ``soaking`` for the next pass)."""
+    try:
+        candidate_bytes = _git_show_bytes(INSTANCE_REPO, head_sha, module_path)
+        if candidate_bytes is None:
+            return None
+        sha256 = hashlib.sha256(candidate_bytes).hexdigest()
+
+        _ensure_promoted_tree_dir(PROMOTED_TREE)
+        tree_file = PROMOTED_TREE / _flattened_filename(module_path)
+        _atomic_write_bytes(tree_file, candidate_bytes, mode=0o644)
+
+        entry = {
+            "sha256": sha256,
+            "candidate_id": candidate_id,
+            "head_sha": head_sha,
+            "verified_utc": _utc_iso(now),
+            "status": "active",
+        }
+        manifest[module_path] = entry
+
+        try:
+            _cycle_ledger.append_event(
+                STATE_DIR,
+                {
+                    "phase": "promotion",
+                    "reason": "root_verified_promoted",
+                    "candidate_id": candidate_id,
+                    "module_path": module_path,
+                    "head_sha": head_sha,
+                    "sha256": sha256,
+                },
+            )
+            _chown_best_effort(STATE_DIR / "ledger" / "cycles.jsonl", "eeepc-agent")
+        except Exception:
+            pass  # ledger write is best-effort; the promotion itself already succeeded
+
+        return entry
+    except Exception:
+        return None
+
+
+def _rollback(
+    manifest: dict,
+    module_path: str,
+    candidate_id: "str | None",
+    reason: str,
+) -> None:
+    """Remove the tree file + manifest entry and ledger the rollback.
+    Best-effort/idempotent — safe to call on an already-rolled-back entry."""
+    try:
+        tree_file = PROMOTED_TREE / _flattened_filename(module_path)
+        if tree_file.exists():
+            tree_file.unlink()
+    except Exception:
+        pass
+    manifest.pop(module_path, None)
+    try:
+        _cycle_ledger.append_event(
+            STATE_DIR,
+            {
+                "phase": "promotion",
+                "reason": "root_verified_rolled_back",
+                "candidate_id": candidate_id,
+                "module_path": module_path,
+                "rollback_reason": reason,
+            },
+        )
+        _chown_best_effort(STATE_DIR / "ledger" / "cycles.jsonl", "eeepc-agent")
+    except Exception:
+        pass
+
+
+# ─── one verify pass ─────────────────────────────────────────────────────────
+
+
+def verify_pass(now: "datetime | None" = None) -> dict:
+    """Run one full verification pass over every pending/soaking candidate
+    and every active manifest entry. Safe to call every N minutes forever —
+    every candidate and every active entry is processed inside its own
+    try/except so one bad record can never abort the rest of the pass.
+
+    Returns a small summary dict (counts) for logging/tests; never raises.
+    """
+    current = now or datetime.now(timezone.utc)
+    summary = {
+        "processed": 0,
+        "rejected": 0,
+        "soaking": 0,
+        "promoted": 0,
+        "rolled_back": 0,
+        "errors": 0,
+    }
+
+    try:
+        _ensure_promoted_tree_dir(PROMOTED_TREE)
+
+        manifest_path = PROMOTED_TREE / _MANIFEST_FILENAME
+        verifier_state_path = PROMOTED_TREE / _VERIFIER_STATE_FILENAME
+        manifest = _read_json_dict(manifest_path, {"_schema_version": _MANIFEST_SCHEMA})
+        verifier_state = _read_json_dict(
+            verifier_state_path, {"schema_version": _VERIFIER_STATE_SCHEMA, "candidates": {}}
+        )
+        candidates_state = verifier_state.get("candidates")
+        if not isinstance(candidates_state, dict):
+            candidates_state = {}
+        manifest_dirty = False
+        state_dirty = False
+
+        slice_paths = runtime_slice_paths(os.environ.get(_RUNTIME_SLICE_ENV))
+
+        promotions_dir = STATE_DIR / "promotions"
+        candidate_files = (
+            sorted(promotions_dir.glob("promotion-runtime-*.json"))
+            if promotions_dir.is_dir()
+            else []
+        )
+
+        for candidate_path in candidate_files:
+            candidate_id = candidate_path.stem
+            try:
+                summary["processed"] += 1
+                entry_state = candidates_state.get(candidate_id)
+
+                if isinstance(entry_state, dict) and entry_state.get("status") in _TERMINAL_STATUSES:
+                    continue  # deterministic outcome already reached — never retried
+
+                record = json.loads(candidate_path.read_text(encoding="utf-8"))
+                if not isinstance(record, dict):
+                    raise ValueError("candidate record is not a JSON object")
+
+                if entry_state is None or entry_state.get("status") not in ("soaking",):
+                    # ── fresh candidate: classify, materialize, measure ──
+                    eligible, reason, module_path = _classify_candidate(record, slice_paths)
+                    if not eligible:
+                        candidates_state[candidate_id] = {
+                            "status": "rejected",
+                            "reason": reason,
+                            "last_checked_utc": _utc_iso(current),
+                        }
+                        summary["rejected"] += 1
+                        state_dirty = True
+                        continue
+
+                    head_sha = ((record.get("rollback_record") or {}).get("head_sha"))
+                    ok, reason, measurement = _measure_candidate(module_path, head_sha)
+                    if not ok:
+                        candidates_state[candidate_id] = {
+                            "status": "rejected",
+                            "reason": reason,
+                            "module_path": module_path,
+                            "head_sha": head_sha,
+                            "last_checked_utc": _utc_iso(current),
+                        }
+                        summary["rejected"] += 1
+                        state_dirty = True
+                        continue
+
+                    candidates_state[candidate_id] = {
+                        "status": "soaking",
+                        "module_path": module_path,
+                        "head_sha": head_sha,
+                        "sha256": measurement["sha256"],
+                        "improvement_pct": measurement["improvement_pct"],
+                        "soak_passes_done": 0,
+                        "ledger_watermark_utc": _utc_iso(current),
+                        "first_soaking_utc": _utc_iso(current),
+                        "last_checked_utc": _utc_iso(current),
+                    }
+                    summary["soaking"] += 1
+                    state_dirty = True
+                    continue
+
+                # ── already soaking: re-check heldout + integrity, advance or reject ──
+                module_path = entry_state.get("module_path")
+                head_sha = entry_state.get("head_sha")
+                if not module_path or not head_sha:
+                    candidates_state[candidate_id] = {
+                        "status": "rejected",
+                        "reason": "soaking entry missing module_path/head_sha (corrupt state)",
+                        "last_checked_utc": _utc_iso(current),
+                    }
+                    summary["rejected"] += 1
+                    state_dirty = True
+                    continue
+
+                heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
+                clean, heldout_reason = _heldout_is_clean(heldout_results)
+                integrity_events = _integrity_events_since(
+                    STATE_DIR, entry_state.get("ledger_watermark_utc")
+                )
+                if not clean or integrity_events:
+                    reason = heldout_reason or f"integrity events since watermark: {len(integrity_events)}"
+                    candidates_state[candidate_id] = {
+                        **entry_state,
+                        "status": "rejected",
+                        "reason": f"soak failed: {reason}",
+                        "last_checked_utc": _utc_iso(current),
+                    }
+                    summary["rejected"] += 1
+                    state_dirty = True
+                    continue
+
+                soak_passes_done = int(entry_state.get("soak_passes_done") or 0) + 1
+                if soak_passes_done >= _SOAK_PASSES:
+                    new_entry = _promote(manifest, candidate_id, module_path, head_sha, current)
+                    if new_entry is None:
+                        # promotion write failed — stay in soaking, try again next pass
+                        candidates_state[candidate_id] = {
+                            **entry_state,
+                            "soak_passes_done": soak_passes_done - 1,
+                            "last_checked_utc": _utc_iso(current),
+                        }
+                        summary["errors"] += 1
+                        state_dirty = True
+                        continue
+                    candidates_state[candidate_id] = {
+                        **entry_state,
+                        "status": "promoted",
+                        "soak_passes_done": soak_passes_done,
+                        "last_checked_utc": _utc_iso(current),
+                    }
+                    summary["promoted"] += 1
+                    manifest_dirty = True
+                    state_dirty = True
+                else:
+                    candidates_state[candidate_id] = {
+                        **entry_state,
+                        "soak_passes_done": soak_passes_done,
+                        "last_checked_utc": _utc_iso(current),
+                    }
+                    summary["soaking"] += 1
+                    state_dirty = True
+            except Exception:
+                summary["errors"] += 1
+                continue  # one bad candidate must never abort the pass
+
+        # ── regression watch + operator veto over every manifest entry ──
+        for module_path in list(manifest.keys()):
+            if module_path.startswith("_"):
+                continue  # schema/meta keys, not a module entry
+            try:
+                entry = manifest.get(module_path)
+                if not isinstance(entry, dict):
+                    continue
+                status = entry.get("status")
+                if status == "vetoed":
+                    _rollback(manifest, module_path, entry.get("candidate_id"), "operator_veto")
+                    summary["rolled_back"] += 1
+                    manifest_dirty = True
+                    continue
+                if status != "active":
+                    continue
+
+                heldout_results = _run_heldout(STATE_DIR, INSTANCE_REPO)
+                clean, heldout_reason = _heldout_is_clean(heldout_results)
+                integrity_events = _integrity_events_since(STATE_DIR, entry.get("verified_utc"))
+                if not clean or integrity_events:
+                    reason = heldout_reason or f"integrity events since promotion: {len(integrity_events)}"
+                    _rollback(manifest, module_path, entry.get("candidate_id"), reason)
+                    summary["rolled_back"] += 1
+                    manifest_dirty = True
+            except Exception:
+                summary["errors"] += 1
+                continue  # one bad manifest entry must never abort the rest
+
+        if manifest_dirty:
+            _atomic_write_text(manifest_path, json.dumps(manifest, indent=2), mode=0o644)
+        if state_dirty:
+            verifier_state["candidates"] = candidates_state
+            verifier_state["schema_version"] = _VERIFIER_STATE_SCHEMA
+            verifier_state["updated_utc"] = _utc_iso(current)
+            _atomic_write_text(
+                verifier_state_path, json.dumps(verifier_state, indent=2), mode=0o644
+            )
+    except Exception:
+        summary["errors"] += 1
+
+    return summary
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Root-run promotion verifier (#875): re-verify eeepc runtime-slice "
+            "promotion candidates independently of the instance's own claims."
+        )
+    )
+    parser.add_argument("--json", action="store_true", help="print the pass summary as JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = verify_pass()
+    except Exception as exc:  # pragma: no cover - verify_pass is itself fail-open
+        print(f"eeepc_promotion_verifier: pass failed unexpectedly: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary))
+    else:
+        print(
+            "eeepc_promotion_verifier: processed={processed} rejected={rejected} "
+            "soaking={soaking} promoted={promoted} rolled_back={rolled_back} "
+            "errors={errors}".format(**summary)
+        )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -93,10 +93,20 @@ sudo chown -R eeepc-agent:eeepc-agent "$RELEASE_DIR" "$VENV_BASE" 2>/dev/null ||
 
 echo "[remote] syncing libexec scripts from release"
 # Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`
-# straight from the release; only auxiliary libexec scripts are synced.
+# straight from the release; only auxiliary libexec scripts are synced
+# (this now includes eeepc_promotion_verifier.py, #875).
 sudo cp "$RELEASE_DIR/host/eeepc/libexec/"*.py /usr/local/libexec/ 2>/dev/null || true
 sudo rm -f /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
-sudo chmod +x /usr/local/libexec/eeepc-self-evolving-*.py 2>/dev/null || true
+# NOTE: was previously scoped to eeepc-self-evolving-*.py, which silently
+# skipped eeepc_promotion_verifier.py (#875) — broadened to every libexec
+# script so a new file here is never quietly left non-executable.
+sudo chmod +x /usr/local/libexec/*.py 2>/dev/null || true
+
+echo "[remote] syncing systemd units + reloading"
+sudo cp "$RELEASE_DIR/host/eeepc/systemd/"*.service "$RELEASE_DIR/host/eeepc/systemd/"*.timer /etc/systemd/system/ 2>/dev/null || true
+sudo systemctl daemon-reload
+sudo systemctl enable --now eeepc-promotion-verifier.timer 2>/dev/null || true
+
 echo "[remote] reloading systemd + restarting agent"
 sudo systemctl daemon-reload
 sudo systemctl restart eeepc-self-evolving-agent.service || true

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -104,6 +104,24 @@ echo "[remote] fixing ownership"
 # on being true.
 sudo chown -R root:root "$RELEASE_DIR" "$VENV_BASE" 2>/dev/null || true
 
+# YELLOW-1 fix (opus-review round 2): the RELEASE CONTENTS being root:root
+# is not enough on its own — every directory the `current`/`.venv` symlinks
+# themselves LIVE IN was still eeepc-agent-owned, meaning the runtime uid
+# (the SAME uid the instance's subagent runs as) could delete+recreate
+# `current` (or `.venv`) itself and re-point it at attacker-controlled
+# content — relying entirely on #880's ProtectSystem=strict sandbox to stop
+# that, which does not protect this root verifier itself. Root:root every
+# directory in the chain (non-recursively — the release CONTENTS already
+# got -R above; this is just the path scaffolding around it), plus the
+# symlinks' own ownership (-h, so `chown` doesn't follow them).
+sudo chown root:root /opt/eeepc-agent 2>/dev/null || true
+sudo chown root:root /opt/eeepc-agent/runtimes 2>/dev/null || true
+sudo chown root:root /opt/eeepc-agent/runtimes/self-evolving-agent 2>/dev/null || true
+sudo chown root:root "$RELEASES_DIR" 2>/dev/null || true
+sudo chown -h root:root /opt/eeepc-agent/runtimes/self-evolving-agent/current 2>/dev/null || true
+sudo chown -h root:root "$RELEASE_DIR/.venv" 2>/dev/null || true
+sudo chown root:root /opt/eeepc-agent/venv 2>/dev/null || true
+
 echo "[remote] syncing libexec scripts from release"
 # Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`
 # straight from the release; only auxiliary libexec scripts are synced

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -89,7 +89,20 @@ sudo chown eeepc-agent:eeepc-agent "$STATE_DIR/goals/goal_text.json"
 echo "[remote] goal_text.json seeded: $(wc -c < $STATE_DIR/goals/goal_text.json) bytes"
 
 echo "[remote] fixing ownership"
-sudo chown -R eeepc-agent:eeepc-agent "$RELEASE_DIR" "$VENV_BASE" 2>/dev/null || true
+# #875 RED1 fix (opus-review): root:root, NOT eeepc-agent:eeepc-agent. #880
+# already proved the runtime uid never writes into /opt (ProtectSystem=strict
+# makes /opt read-only inside every app-lane sandbox regardless of on-disk
+# ownership, and PYTHONDONTWRITEBYTECODE=1 stops even a stray .pyc) — so the
+# runtime uid only ever needs READ+EXEC here, which world-read from the
+# release tar/umask already provides. The root-run promotion verifier
+# (host/eeepc/libexec/eeepc_promotion_verifier.py) imports straight out of
+# this tree AS ROOT; if it were eeepc-agent-owned, the runtime uid could
+# plant/mutate a module the verifier would then import with root privilege —
+# a straightforward root RCE. The verifier independently fails closed if it
+# ever finds this tree not root-owned (see its ownership self-check), so
+# this chown is not just defense-in-depth, it is the thing that check relies
+# on being true.
+sudo chown -R root:root "$RELEASE_DIR" "$VENV_BASE" 2>/dev/null || true
 
 echo "[remote] syncing libexec scripts from release"
 # Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`

--- a/host/eeepc/scripts/install.sh
+++ b/host/eeepc/scripts/install.sh
@@ -77,6 +77,17 @@ create_dirs() {
     fi
   done
   run chown -R eeepc-agent:eeepc-agent /opt/eeepc-agent /var/lib/eeepc-agent
+
+  # #875: the root-verified promotion tree. Deliberately a SIBLING of
+  # /var/lib/eeepc-agent, created AFTER (and outside) the recursive chown
+  # above — it must stay root-owned so the eeepc-agent-uid bridge/loader can
+  # read but never write it (filesystem permission IS the trust boundary
+  # here; see nanobot.runtime.promoted_overlay's boundary self-check, which
+  # REFUSES to load anything if this tree is ever not root-owned).
+  log "creating root-owned promoted-runtime tree /var/lib/eeepc-promoted"
+  run mkdir -p /var/lib/eeepc-promoted
+  run chown root:eeepc-agent /var/lib/eeepc-promoted
+  run chmod 0755 /var/lib/eeepc-promoted
 }
 
 # ---------------------------------------------------------------------------
@@ -236,6 +247,7 @@ enable_timers() {
     eeepc-self-evolving-subagent-bridge.timer
     eeepc-self-evolving-agent-health.timer
     eeepc-strong-reflection.timer
+    eeepc-promotion-verifier.timer
   )
   for t in "${timers[@]}"; do
     run systemctl enable "$t"

--- a/host/eeepc/systemd/eeepc-promotion-verifier.service
+++ b/host/eeepc/systemd/eeepc-promotion-verifier.service
@@ -18,4 +18,22 @@ WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 # still starts (with the script's own hardcoded defaults) if the file is
 # ever absent.
 EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
+Environment=PYTHONDONTWRITEBYTECODE=1
+# #875 rework (opus-review RED1/RED2) sandbox hardening — this unit still
+# runs as root (no User=), but is confined the same way #880 confined every
+# other lane: NoNewPrivileges=yes still permits this process to DROP
+# privilege via setuid/setgid (that's how the demoted git-show/measurement/
+# heldout child gets its uid — see _run_child_verify), it only blocks
+# GAINING privilege. ProtectSystem=strict makes everything outside
+# ReadWritePaths= read-only (including /opt, the release this script
+# imports from and the demoted child re-execs) regardless of on-disk
+# ownership — belt-and-suspenders alongside the root-ownership self-check
+# in the script itself. The verifier writes only PROMOTED_TREE (default
+# /var/lib/eeepc-promoted) and appends to the instance's cycle ledger under
+# /var/lib/eeepc-agent, both explicitly carved out below.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-promoted /var/lib/eeepc-agent
 ExecStart=/opt/eeepc-agent/venv/bin/python /usr/local/libexec/eeepc_promotion_verifier.py

--- a/host/eeepc/systemd/eeepc-promotion-verifier.service
+++ b/host/eeepc/systemd/eeepc-promotion-verifier.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Root-verified auto-promotion — re-verify runtime-slice candidates (#875)
+After=network-online.target
+
+[Service]
+Type=oneshot
+# No User= line: this unit MUST run as root. Root is the only privilege
+# boundary on this host (the bridge/harness and the instance's subagent
+# share the eeepc-agent uid) — this script re-materializes and re-measures
+# every runtime-slice promotion candidate itself, trusting nothing the
+# instance wrote, and is the sole writer of the root-owned PROMOTED_TREE
+# the eeepc-agent-uid loader (nanobot.runtime.promoted_overlay) can read
+# but never write.
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+# Same instance env file the subagent bridge itself uses, so this always
+# sees the identical operator-approved SELFEVO_RUNTIME_SLICE and STATE_DIR
+# — never a second, potentially-drifted copy. "-" prefix: optional, unit
+# still starts (with the script's own hardcoded defaults) if the file is
+# ever absent.
+EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
+ExecStart=/opt/eeepc-agent/venv/bin/python /usr/local/libexec/eeepc_promotion_verifier.py

--- a/host/eeepc/systemd/eeepc-promotion-verifier.timer
+++ b/host/eeepc/systemd/eeepc-promotion-verifier.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Periodically re-verify runtime-slice promotion candidates as root (#875)
+
+[Timer]
+OnBootSec=5m
+# Same 15-minute cadence as the subagent bridge timer — a soak needs
+# _SOAK_PASSES (3) clean subsequent passes, so this cadence bounds how
+# quickly a genuinely clean, above-threshold candidate can reach promotion
+# (roughly one hour: one pass to measure + enter soaking, three more to
+# clear the soak).
+OnUnitActiveSec=15m
+Unit=eeepc-promotion-verifier.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -35,8 +35,20 @@ from nanobot.bus.queue import MessageBus
 from nanobot.cli.commands import _make_provider
 from nanobot.config.loader import load_config, set_config_path
 from nanobot.observability.llm_telemetry import set_call_context
-from nanobot.runtime import llm_proposer
-from nanobot.runtime.cycle_ledger import (
+
+# #875: install the root-verified runtime-slice overlay BEFORE any
+# nanobot.runtime.* module is imported below — a root-promoted module must
+# shadow the installed one from the very first import site in this process,
+# not just for call sites deeper in the file. install_promoted_overlay() is
+# itself fully fail-closed/fail-open internally (see its docstring); this
+# call site never wraps it in try/except so an unexpected exception there
+# would be a genuine bug worth surfacing, not something to paper over.
+from nanobot.runtime.promoted_overlay import install_promoted_overlay
+
+install_promoted_overlay()
+
+from nanobot.runtime import llm_proposer  # noqa: E402
+from nanobot.runtime.cycle_ledger import (  # noqa: E402
     VALID_OUTCOMES,
     append_event,
     record_cycle_outcome,
@@ -44,8 +56,8 @@ from nanobot.runtime.cycle_ledger import (
     record_dedup_decision,
     record_gate_decision,
 )
-from nanobot.runtime.cycle_planning import filter_completed_priorities_from_goal_text
-from nanobot.runtime.existence_index import derive_intent, find_duplicate_script, intents_match
+from nanobot.runtime.cycle_planning import filter_completed_priorities_from_goal_text  # noqa: E402
+from nanobot.runtime.existence_index import derive_intent, find_duplicate_script, intents_match  # noqa: E402
 
 # #789: the fitness-input sidecar list + hash helper live in scorecard.py
 # (the fitness module — #603 placement; the list's contents stay out of this
@@ -56,13 +68,13 @@ from nanobot.runtime.existence_index import derive_intent, find_duplicate_script
 # (demand fold/exhaustion updates via collect_demand, scorecard recompute —
 # all on the proposer path) happen OUTSIDE this window, so a clean cycle
 # never records an incident (pinned in tests/test_bridge_fitness_integrity.py).
-from nanobot.runtime.scorecard import (
+from nanobot.runtime.scorecard import (  # noqa: E402
     FITNESS_SIDECARS as _FITNESS_SIDECARS,
 )
-from nanobot.runtime.scorecard import (
+from nanobot.runtime.scorecard import (  # noqa: E402
     fitness_sidecar_hashes as _fitness_sidecar_hashes,
 )
-from nanobot.runtime.stop_guards import REVISION_CAP_DEFAULT, revision_outcome
+from nanobot.runtime.stop_guards import REVISION_CAP_DEFAULT, revision_outcome  # noqa: E402
 
 STATE_DIR = Path(os.environ.get('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state'))
 TARGET_WORKSPACE = Path(os.environ.get('TARGET_WORKSPACE', '/opt/eeepc-agent/runtimes/self-evolving-agent/current'))
@@ -2565,67 +2577,31 @@ def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
 # (usage_evidence.py) — the instance cannot set it (nanobot/ is off-surface).
 _RUNTIME_SLICE_ENV = 'SELFEVO_RUNTIME_SLICE'
 
-# Immutable deny-set: the safety shell. These paths may NEVER be mutated by the
-# loop even if an operator mistakenly lists them in SELFEVO_RUNTIME_SLICE — the
-# allow-slice can only ADD compute modules, never re-open the gate/promotion/
-# approval path. Product-PR-owned (this list lives in off-surface nanobot/), so
-# the instance cannot widen it. #812 / #603 (bounded blast radius).
-_RUNTIME_DENY_ALWAYS_FILES = frozenset({
-    'nanobot/runtime/bridge.py',       # this file: the gate + the allow/deny lists
-    'nanobot/runtime/promotion.py',    # promotion candidate review/apply workflow
-    'nanobot/runtime/coordinator.py',  # cycle orchestration + promotion minting
-})
-# Fail-closed token match: any runtime file whose basename contains one of these
-# is also denied, so a future gate/safety/approval module is covered without
-# having to remember to add it to the explicit list above.
-_RUNTIME_DENY_TOKENS = (
-    'gate', 'precheck', 'promotion', 'approval', 'safety', 'security', 'stop_guard',
-)
-
-
-def _is_runtime_deny(path: str) -> bool:
-    """True if ``path`` is in the immutable runtime deny-set (safety shell). #812.
-
-    Defense-in-depth (independent of git's already-canonical path output): the
-    path is backslash-normalized and ``..``/``.`` segments are collapsed before
-    matching, and the explicit-file match is case-insensitive — so a deny path
-    cannot be smuggled past the check via traversal or a case variant.
-    """
-    import posixpath as _pp
-    p = _pp.normpath(path.replace('\\', '/')).lstrip('/')
-    if p in _RUNTIME_DENY_ALWAYS_FILES:
-        return True
-    pl = p.casefold()
-    if any(pl == d.casefold() for d in _RUNTIME_DENY_ALWAYS_FILES):
-        return True
-    base = p.rsplit('/', 1)[-1].lower()
-    return any(tok in base for tok in _RUNTIME_DENY_TOKENS)
+# #875: the deny-set + slice-parsing logic moved to the stdlib-only
+# nanobot.runtime.runtime_deny module UNCHANGED, so the root promotion
+# verifier (host/eeepc/libexec/eeepc_promotion_verifier.py) and the
+# agent-side promoted_overlay loader can share the EXACT same
+# safety-shell/slice-membership logic the gate uses below, rather than each
+# maintaining its own copy. Re-exported here under the same names — existing
+# tests (tests/test_runtime_slice.py) reference bridge._is_runtime_deny /
+# bridge._runtime_slice_paths() directly and keep working unchanged.
+from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES  # noqa: E402
+from nanobot.runtime.runtime_deny import _RUNTIME_DENY_TOKENS  # noqa: E402
+from nanobot.runtime.runtime_deny import _is_runtime_deny  # noqa: E402
+from nanobot.runtime.runtime_deny import runtime_slice_paths as _runtime_slice_paths_pure  # noqa: E402
 
 
 def _runtime_slice_paths() -> 'set[str]':
     """Operator-approved runtime-slice paths from SELFEVO_RUNTIME_SLICE (#812).
 
-    Comma-separated, repo-relative. Empty/unset → empty set (feature off). Only
-    ``nanobot/runtime/*.py`` paths are honored; anything else in the env is
-    ignored (the env cannot re-open state/ or add a deny-set path). Deny-set
-    entries are dropped even if listed — the safety shell is never mutable.
-    Fail-open to empty on any trouble: an unreadable env must never widen surface.
+    Thin env-reading wrapper around the pure
+    :func:`nanobot.runtime.runtime_deny.runtime_slice_paths` (#875
+    extraction) — kept as a zero-arg function so existing callers/tests
+    (``bridge._runtime_slice_paths()``, ``monkeypatch.setenv``) are
+    unaffected. See that function's docstring for the parsing/fail-open
+    contract.
     """
-    import posixpath as _pp
-    raw = os.environ.get(_RUNTIME_SLICE_ENV, '') or ''
-    out: 'set[str]' = set()
-    for part in raw.split(','):
-        p = part.strip().replace('\\', '/')
-        if not p:
-            continue
-        # collapse traversal so 'nanobot/runtime/../bridge.py' can't sneak in
-        p = _pp.normpath(p).lstrip('/')
-        if not p.startswith('nanobot/runtime/') or not p.endswith('.py'):
-            continue  # slice is compute-module-only; env cannot widen elsewhere
-        if _is_runtime_deny(p):
-            continue  # deny-set always wins over the allow-slice
-        out.add(p)
-    return out
+    return _runtime_slice_paths_pure(os.environ.get(_RUNTIME_SLICE_ENV))
 
 
 def _classify_mutation_surface(

--- a/nanobot/runtime/coordinator.py
+++ b/nanobot/runtime/coordinator.py
@@ -202,6 +202,26 @@ async def run_self_evolving_cycle(
     now: datetime | None = None,
 ) -> str:
     """Run one bounded self-evolving cycle and persist canonical artifacts."""
+    # #875: defense-in-depth install of the root-verified runtime-slice
+    # overlay for this entry point too (bridge.py already installs it at
+    # module import time, which covers the bridge process; the coordinator
+    # can also run standalone via the app/agent turn path). Deliberately
+    # called HERE — inside the function body — rather than at this module's
+    # top level: nanobot/runtime/__init__.py unconditionally imports this
+    # module for ANY `nanobot.runtime.*` import (including the microbench
+    # sandbox subprocess's `from nanobot.runtime import existence_index`,
+    # see heldout/microbench.py), so a module-level call would fire inside
+    # that sandboxed measurement subprocess too and let the REAL, root-owned
+    # PROMOTED_TREE leak into what must be a pure, harness-controlled
+    # baseline/candidate comparison. Gating the call to only fire when a
+    # cycle actually RUNS (never merely on import) keeps that subprocess
+    # overlay-free without needing any special-casing in microbench.py.
+    try:
+        from nanobot.runtime.promoted_overlay import install_promoted_overlay
+
+        install_promoted_overlay()
+    except Exception:
+        pass
     current = _utc_now(now)
     state_root = _resolve_runtime_state_root(workspace)
     reports_dir = state_root / "reports"

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -59,57 +59,29 @@ _ALLOWED_PATH_PREFIXES = ("surfaces/", "scripts/", "memory/", "lessons/", "docs/
 
 # #823: runtime-slice tier mirror. #812 widened the bounded GATE
 # (bridge._classify_mutation_surface) to allow an operator-approved slice of
-# nanobot/runtime/*.py modules, but the proposer keeps its own independent copy
-# of the surface allowlist (above) and hard-rejects a runtime target_path before
-# the gate ever sees it. These mirror bridge._RUNTIME_SLICE_ENV /
-# _RUNTIME_DENY_ALWAYS_FILES / _RUNTIME_DENY_TOKENS / _is_runtime_deny /
-# _runtime_slice_paths EXACTLY (duplicated, not imported — bridge.py imports this
-# module, so importing back would be circular; same reasoning as
-# _ALLOWED_PATH_PREFIXES above). Keep these in sync with bridge.py.
+# nanobot/runtime/*.py modules, but the proposer keeps its own hard-rejection
+# of a runtime target_path before the gate ever sees it.
+#
+# #875 update: this used to be a hand-duplicated copy of bridge.py's deny-set
+# logic (comment here previously explained "not imported — bridge.py imports
+# this module, so importing back would be circular"). #875 extracted that
+# logic into the stdlib-only nanobot.runtime.runtime_deny module specifically
+# so it has NO dependency on bridge.py or this module — the circular-import
+# obstacle no longer exists, so this now imports the SAME canonical functions
+# bridge.py, the root promotion verifier, and the agent-side overlay loader
+# all use, instead of maintaining a fourth copy that could silently drift.
 _RUNTIME_SLICE_ENV = "SELFEVO_RUNTIME_SLICE"
-_RUNTIME_DENY_ALWAYS_FILES = frozenset({
-    "nanobot/runtime/bridge.py",
-    "nanobot/runtime/promotion.py",
-    "nanobot/runtime/coordinator.py",
-})
-_RUNTIME_DENY_TOKENS = (
-    "gate", "precheck", "promotion", "approval", "safety", "security", "stop_guard",
-)
-
-
-def _is_runtime_deny(path: str) -> bool:
-    """Mirror of bridge._is_runtime_deny — immutable runtime deny-set. #823."""
-    import posixpath as _pp
-
-    p = _pp.normpath(str(path).replace("\\", "/")).lstrip("/")
-    if p in _RUNTIME_DENY_ALWAYS_FILES:
-        return True
-    pl = p.casefold()
-    if any(pl == d.casefold() for d in _RUNTIME_DENY_ALWAYS_FILES):
-        return True
-    base = p.rsplit("/", 1)[-1].lower()
-    return any(tok in base for tok in _RUNTIME_DENY_TOKENS)
+from nanobot.runtime.runtime_deny import _is_runtime_deny  # noqa: E402
+from nanobot.runtime.runtime_deny import runtime_slice_paths as _runtime_slice_paths_pure  # noqa: E402
 
 
 def _runtime_slice_paths() -> "set[str]":
-    """Mirror of bridge._runtime_slice_paths — operator-approved runtime slice
-    from SELFEVO_RUNTIME_SLICE. Empty/unset → empty set (feature off, proposer
-    behaviour byte-identical to pre-#823). Deny-set entries dropped. #823."""
-    import posixpath as _pp
-
-    raw = os.environ.get(_RUNTIME_SLICE_ENV, "") or ""
-    out: "set[str]" = set()
-    for part in raw.split(","):
-        p = part.strip().replace("\\", "/")
-        if not p:
-            continue
-        p = _pp.normpath(p).lstrip("/")
-        if not p.startswith("nanobot/runtime/") or not p.endswith(".py"):
-            continue
-        if _is_runtime_deny(p):
-            continue
-        out.add(p)
-    return out
+    """Operator-approved runtime slice from SELFEVO_RUNTIME_SLICE — thin
+    env-reading wrapper around the shared, pure
+    :func:`nanobot.runtime.runtime_deny.runtime_slice_paths` (#875). Empty/
+    unset -> empty set (feature off, proposer behaviour byte-identical to
+    pre-#823)."""
+    return _runtime_slice_paths_pure(os.environ.get(_RUNTIME_SLICE_ENV))
 
 
 # #826: sized to fit the operator goal_text (~5KB) PLUS the bounded guardrail

--- a/nanobot/runtime/promoted_overlay.py
+++ b/nanobot/runtime/promoted_overlay.py
@@ -1,0 +1,215 @@
+"""eeepc-agent-side loader for root-verified promoted runtime modules (#875).
+
+**The trust problem this closes.** On the eeepc host, the bridge/harness AND
+the instance's subagent run as the SAME uid (``eeepc-agent``). ``state/`` is
+instance-writable — so a loader that execs code from ``state/`` trusting an
+instance-written index would let the instance forge index+file into
+arbitrary code execution in the harness's own process, before any gate ever
+runs. No in-band signature closes this: same uid means the instance can read
+any verification key the harness could read too.
+
+**The only real boundary on this host is root.** A root-run systemd timer
+(``host/eeepc/libexec/eeepc_promotion_verifier.py``) independently
+re-measures and re-verifies each runtime-slice promotion candidate the
+instance PROPOSED, and only if it is satisfied writes the verified module
+bytes into ``PROMOTED_TREE`` (default ``/var/lib/eeepc-promoted``) — a
+ROOT-OWNED, 0755 directory the ``eeepc-agent`` uid can read but never write.
+Filesystem permission IS the boundary; there is no crypto key to steal
+because there is no crypto key.
+
+This module is the OTHER half: the eeepc-agent-uid loader that installs
+those root-verified modules into the running process, shadowing the
+as-installed ``nanobot/runtime/*.py`` copy. It is deliberately built from
+STDLIB + :mod:`nanobot.runtime.runtime_deny` ONLY — no other nanobot.runtime
+import — so that installing the overlay never itself depends on any module
+that overlay could plausibly ever replace.
+
+Trust invariants (#875, verbatim — do not weaken):
+
+- The instance never authors the promoted bytes or the "verified" numbers;
+  it only ever authors PROPOSALS. This module trusts nothing the instance
+  wrote — it trusts only what ROOT wrote into ``PROMOTED_TREE``.
+- :func:`install_promoted_overlay` REFUSES to load anything — returns ``[]``
+  — unless BOTH ``PROMOTED_TREE`` itself and its ``manifest.json`` are
+  root-owned (``st_uid == 0``) and neither group- nor other-writable. A
+  misprovisioned or (impossibly, but defense-in-depth) instance-writable
+  tree must never be trusted, no matter what its manifest claims.
+- The deny-set + runtime-slice shape are re-checked HERE, independently of
+  whatever the root verifier already checked, via the SAME
+  ``nanobot.runtime.runtime_deny`` logic the bridge's gate uses — a
+  manifest entry naming a deny-set path (however it got there) is refused.
+- Content integrity: the on-disk promoted file's sha256 must match the
+  manifest's recorded ``sha256`` for that module — a root-owned tree whose
+  file was corrupted/truncated/only-partially-written is refused for that
+  one module (installed stays), not trusted regardless.
+- Fail-open PER MODULE (one bad entry never blocks the others; the
+  installed copy of that one module is kept) but fail-CLOSED overall: any
+  unexpected top-level exception anywhere in this function returns ``[]``
+  (nothing loaded) rather than partially/ambiguously loading — an error
+  here must degrade to the fully-installed, already-reviewed product tree,
+  never to an unknown state.
+- Host-only feature: on any non-POSIX platform (``os.name != 'posix'``,
+  e.g. a developer's Windows machine) the ownership check ``os.stat(...)
+  .st_uid`` is not meaningful, so this refuses to load ANYTHING there
+  rather than silently skip the check.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from nanobot.runtime.runtime_deny import runtime_slice_paths
+
+# Matches the systemd EnvironmentFile default this loader and the root
+# verifier (host/eeepc/libexec/eeepc_promotion_verifier.py) agree on. An
+# explicit ``promoted_tree`` argument or the ``PROMOTED_TREE`` env var
+# override this for tests / non-default deployments.
+_DEFAULT_PROMOTED_TREE = "/var/lib/eeepc-promoted"
+_MANIFEST_FILENAME = "manifest.json"
+
+# Any write bit for group or other (0o020 | 0o002) makes a path untrusted —
+# only the owner (root, checked separately via st_uid) may ever write here.
+_WRITABLE_BY_OTHERS_MASK = 0o022
+
+
+def _resolve_promoted_tree(promoted_tree: "str | Path | None") -> Path:
+    if promoted_tree:
+        return Path(promoted_tree)
+    env_value = os.environ.get("PROMOTED_TREE")
+    if env_value:
+        return Path(env_value)
+    return Path(_DEFAULT_PROMOTED_TREE)
+
+
+def _root_owned_and_not_writable(path: Path) -> bool:
+    """True iff ``path`` is owned by root (uid 0) and not group/other-writable.
+
+    POSIX-only by construction (``os.stat().st_uid`` is meaningless
+    elsewhere) — callers gate this behind ``os.name == 'posix'`` first.
+    """
+    st = path.stat()
+    if st.st_uid != 0:
+        return False
+    if st.st_mode & _WRITABLE_BY_OTHERS_MASK:
+        return False
+    return True
+
+
+def _boundary_ok(tree_dir: Path, manifest_path: Path) -> bool:
+    """The critical self-check: refuse EVERYTHING unless both the promoted
+    tree directory and its manifest are root-owned and not group/other
+    writable. Host-only (POSIX); refuses unconditionally elsewhere."""
+    if os.name != "posix":
+        return False
+    try:
+        return _root_owned_and_not_writable(tree_dir) and _root_owned_and_not_writable(manifest_path)
+    except Exception:
+        return False
+
+
+def _flattened_filename(module_path: str) -> str:
+    """The on-disk filename convention shared with the root verifier:
+    ``nanobot/runtime/existence_index.py`` -> ``nanobot__runtime__existence_index.py``.
+    """
+    return module_path.replace("/", "__")
+
+
+def _load_one_module(tree_dir: Path, module_path: str, entry: "dict[str, Any]") -> bool:
+    """Load exactly one manifest-active module. Returns True on success.
+
+    Never raises — any failure here means "skip this module, keep the
+    installed copy", handled by the caller's per-entry try/except.
+    """
+    # Re-derive the canonical slice-shaped path for this key via the SAME
+    # deny-set/slice logic the bridge gate + root verifier use. If the key
+    # is malformed (traversal, backslashes, wrong prefix/suffix) or on the
+    # immutable deny-set, runtime_slice_paths normalizes/drops it and the
+    # result will not be exactly {module_path} — refuse in that case.
+    if runtime_slice_paths(module_path) != {module_path}:
+        return False
+
+    sha_expected = entry.get("sha256")
+    if not isinstance(sha_expected, str) or not sha_expected:
+        return False
+
+    tree_file = tree_dir / _flattened_filename(module_path)
+    if not tree_file.is_file():
+        return False
+
+    data = tree_file.read_bytes()
+    if hashlib.sha256(data).hexdigest() != sha_expected:
+        return False  # root-written file doesn't match root's own manifest — refuse
+
+    dotted = module_path[: -len(".py")].replace("/", ".")
+    parent_dotted, _, leaf = dotted.rpartition(".")
+    parent_mod = importlib.import_module(parent_dotted) if parent_dotted else None
+
+    spec = importlib.util.spec_from_file_location(dotted, str(tree_file))
+    if spec is None or spec.loader is None:
+        return False
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec, matching the standard import
+    # protocol (supports the module's own internal imports resolving it if
+    # something re-enters, and matches importlib convention).
+    sys.modules[dotted] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(dotted, None)
+        raise
+    if parent_mod is not None:
+        setattr(parent_mod, leaf, module)
+    return True
+
+
+def install_promoted_overlay(promoted_tree: "str | Path | None" = None) -> "list[str]":
+    """Install every ACTIVE root-verified module from ``PROMOTED_TREE`` over
+    the installed ``nanobot/runtime/*.py`` copies, in THIS process.
+
+    Returns the list of ``module_path`` entries actually loaded (possibly
+    empty). Call this ONCE, as early as possible, before importing any
+    ``nanobot.runtime`` module that might be in the operator's runtime
+    slice (see ``bridge.py``'s wiring) — a module already imported before
+    this call keeps running its installed copy for any reference already
+    bound to it.
+
+    Fail-closed overall (``[]`` on any unexpected top-level error) /
+    fail-open per module (one bad manifest entry never blocks the rest).
+    See the module docstring for the full trust-invariant list.
+    """
+    try:
+        tree_dir = _resolve_promoted_tree(promoted_tree)
+        manifest_path = tree_dir / _MANIFEST_FILENAME
+        if not tree_dir.is_dir() or not manifest_path.is_file():
+            return []  # nothing provisioned — quiet no-op
+
+        if not _boundary_ok(tree_dir, manifest_path):
+            return []  # misprovisioned/instance-writable tree — refuse EVERYTHING
+
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+        if not isinstance(manifest, dict):
+            return []
+
+        loaded: "list[str]" = []
+        for module_path, entry in manifest.items():
+            try:
+                if not isinstance(module_path, str) or not isinstance(entry, dict):
+                    continue
+                if entry.get("status") != "active":
+                    continue
+                if _load_one_module(tree_dir, module_path, entry):
+                    loaded.append(module_path)
+            except Exception:
+                continue  # per-module fail-open — the installed copy stays
+        return loaded
+    except Exception:
+        return []  # fail-closed to fully-installed

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -1,0 +1,108 @@
+"""Runtime-slice immutable deny-set + slice-path helpers (#875 extraction).
+
+Pure stdlib module: no imports beyond the standard library. This is
+deliberate — it is imported by THREE independent trust contexts that must
+never accidentally pull in a heavier (and therefore more attackable or more
+failure-prone) dependency chain:
+
+- ``nanobot.runtime.bridge`` (the eeepc-agent-uid gate that classifies a
+  cycle's changed files, #812/#812-classify),
+- ``host/eeepc/libexec/eeepc_promotion_verifier.py`` (the ROOT-run verifier,
+  #875 — re-checks eligibility itself, never trusting the instance's own
+  classification),
+- ``nanobot.runtime.promoted_overlay`` (the eeepc-agent-side loader, #875 —
+  re-checks deny/slice membership again before loading a root-promoted
+  module, independent of what the verifier already checked).
+
+Originally this logic lived directly in ``bridge.py`` (#812). #875 moved it
+here UNCHANGED (zero behavior change) so the root verifier and the agent
+loader can share the exact same deny-set/slice-membership logic the gate
+uses, rather than each hand-rolling (and potentially drifting from) their
+own copy of "what counts as safety-shell" and "what counts as in-slice".
+``bridge.py`` re-exports ``_RUNTIME_DENY_ALWAYS_FILES``,
+``_RUNTIME_DENY_TOKENS`` and ``_is_runtime_deny`` under the SAME names for
+backward compatibility (existing tests reference ``bridge._is_runtime_deny``
+etc.) and keeps its own env-reading ``_runtime_slice_paths()`` wrapper
+around :func:`runtime_slice_paths` here.
+
+Trust invariant (#875, verbatim — do not weaken): the deny-set is the
+safety shell around the runtime-slice tier. It must be enforced identically
+wherever a candidate module is considered for execution — the bridge's
+classifier, the root verifier's eligibility check, and the agent-side
+overlay loader's final guard — so that a deny-set path can NEVER become
+promotable/loadable no matter which of the three call sites is asked.
+"""
+from __future__ import annotations
+
+import posixpath as _pp
+
+# Immutable deny-set: the safety shell. These paths may NEVER be mutated by
+# the loop even if an operator mistakenly lists them in SELFEVO_RUNTIME_SLICE
+# — the allow-slice can only ADD compute modules, never re-open the
+# gate/promotion/approval path. Product-PR-owned (this list lives in
+# off-surface nanobot/), so the instance cannot widen it. #812 / #603
+# (bounded blast radius).
+_RUNTIME_DENY_ALWAYS_FILES = frozenset({
+    'nanobot/runtime/bridge.py',       # the gate + the allow/deny lists
+    'nanobot/runtime/promotion.py',    # promotion candidate review/apply workflow
+    'nanobot/runtime/coordinator.py',  # cycle orchestration + promotion minting
+})
+# Fail-closed token match: any runtime file whose basename contains one of these
+# is also denied, so a future gate/safety/approval module is covered without
+# having to remember to add it to the explicit list above.
+_RUNTIME_DENY_TOKENS = (
+    'gate', 'precheck', 'promotion', 'approval', 'safety', 'security', 'stop_guard',
+)
+
+
+def _is_runtime_deny(path: str) -> bool:
+    """True if ``path`` is in the immutable runtime deny-set (safety shell). #812.
+
+    Defense-in-depth (independent of git's already-canonical path output): the
+    path is backslash-normalized and ``..``/``.`` segments are collapsed before
+    matching, and the explicit-file match is case-insensitive — so a deny path
+    cannot be smuggled past the check via traversal or a case variant.
+    """
+    p = _pp.normpath(path.replace('\\', '/')).lstrip('/')
+    if p in _RUNTIME_DENY_ALWAYS_FILES:
+        return True
+    pl = p.casefold()
+    if any(pl == d.casefold() for d in _RUNTIME_DENY_ALWAYS_FILES):
+        return True
+    base = p.rsplit('/', 1)[-1].lower()
+    return any(tok in base for tok in _RUNTIME_DENY_TOKENS)
+
+
+def runtime_slice_paths(env_value: 'str | None') -> 'set[str]':
+    """Parse a ``SELFEVO_RUNTIME_SLICE``-style comma value into a set of
+    operator-approved ``nanobot/runtime/*.py`` paths (#875 extraction of the
+    #812 logic, made PURE — takes the raw env string as an argument instead
+    of reading ``os.environ`` itself, so callers with no business reading
+    process env — the root verifier is handed its own copy of the value,
+    never trusting ``os.environ`` implicitly — and unit tests can exercise
+    it without ``monkeypatch``).
+
+    Comma-separated, repo-relative. Empty/``None`` -> empty set (feature
+    off). Only ``nanobot/runtime/*.py`` paths are honored; anything else is
+    ignored (the value cannot re-open ``state/`` or add a deny-set path).
+    Deny-set entries are dropped even if listed — the safety shell is never
+    mutable. Fail-open to empty on any trouble: an unreadable value must
+    never widen surface.
+    """
+    out: 'set[str]' = set()
+    try:
+        raw = env_value or ''
+        for part in raw.split(','):
+            p = part.strip().replace('\\', '/')
+            if not p:
+                continue
+            # collapse traversal so 'nanobot/runtime/../bridge.py' can't sneak in
+            p = _pp.normpath(p).lstrip('/')
+            if not p.startswith('nanobot/runtime/') or not p.endswith('.py'):
+                continue  # slice is compute-module-only; value cannot widen elsewhere
+            if _is_runtime_deny(p):
+                continue  # deny-set always wins over the allow-slice
+            out.add(p)
+    except Exception:
+        return set()
+    return out

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -46,12 +46,41 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     'nanobot/runtime/bridge.py',       # the gate + the allow/deny lists
     'nanobot/runtime/promotion.py',    # promotion candidate review/apply workflow
     'nanobot/runtime/coordinator.py',  # cycle orchestration + promotion minting
+    # #875 YELLOW-2 fix (opus-review round 2): the REST of the verification
+    # kernel. The proposal claims this kernel "is never promotable" — that
+    # was only structurally true for bridge/promotion/coordinator above;
+    # an operator listing any of these in SELFEVO_RUNTIME_SLICE would have
+    # made the loader's OWN trust logic (or the gate's evidence inputs)
+    # self-promotable, e.g. instance-influenced bytes replacing
+    # runtime_deny.py (the deny-set definition itself) or
+    # promoted_overlay.py (the agent-side loader + its boundary
+    # self-check) — a candidate could then simply delete its own deny
+    # entry, or weaken the boundary check, and promote itself next pass.
+    'nanobot/runtime/scorecard.py',           # #822/#875 control-plane + promotion visibility
+    'nanobot/runtime/benchmark_evidence.py',  # #819/#822 benchmark-claim corroboration gate
+    'nanobot/runtime/usage_evidence.py',      # reference-signal / usage-evidence gate input
+    'nanobot/runtime/promoted_overlay.py',    # #875 agent-side loader + its boundary self-check
+    'nanobot/runtime/runtime_deny.py',        # this module — the deny-set definition itself
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without
 # having to remember to add it to the explicit list above.
 _RUNTIME_DENY_TOKENS = (
     'gate', 'precheck', 'promotion', 'approval', 'safety', 'security', 'stop_guard',
+    # #875 YELLOW-2 fix: basename tokens for the rest of the verification
+    # kernel (same fail-closed rationale as the tokens above) — covers a
+    # FUTURE file in this family (e.g. a second scorecard/evidence helper)
+    # without anyone having to remember to widen the explicit list too.
+    'bench', 'scorecard', 'overlay', 'deny', 'usage', 'evidence', 'heldout',
+)
+# The entire #780 held-out pack — the invisible verification kernel this
+# whole design depends on never being instance-visible/mutable. A bare
+# basename token match on "heldout" (above) would miss
+# nanobot/runtime/heldout/__init__.py and .../checkers.py (their basenames
+# don't contain "heldout"), so the WHOLE subtree is denied structurally
+# here instead — current AND any future file added to that package.
+_RUNTIME_DENY_DIR_PREFIXES = (
+    'nanobot/runtime/heldout/',
 )
 
 
@@ -68,6 +97,8 @@ def _is_runtime_deny(path: str) -> bool:
         return True
     pl = p.casefold()
     if any(pl == d.casefold() for d in _RUNTIME_DENY_ALWAYS_FILES):
+        return True
+    if pl.startswith(_RUNTIME_DENY_DIR_PREFIXES):
         return True
     base = p.rsplit('/', 1)[-1].lower()
     return any(tok in base for tok in _RUNTIME_DENY_TOKENS)

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -118,6 +118,53 @@ _CONTROL_PLANE_KEYS: tuple[str, ...] = (
 )
 
 
+# ─── #875: root-verified runtime-slice promotions visibility ────────────────
+#
+# The root promotion verifier (host/eeepc/libexec/eeepc_promotion_verifier.py)
+# writes its manifest + per-candidate state into PROMOTED_TREE (default
+# /var/lib/eeepc-promoted), entirely outside state_dir. This gives operators
+# a cheap read-only glance at that pipeline from the SAME scorecard they
+# already check, without granting the instance any write access to it (the
+# manifest/verifier_state files are root-owned; this is a read-only peek).
+_PROMOTED_TREE_ENV = "PROMOTED_TREE"
+_DEFAULT_PROMOTED_TREE = "/var/lib/eeepc-promoted"
+
+
+def _runtime_promotions_snapshot() -> dict[str, Any]:
+    """Cheap, fail-open, read-only counts of the #875 root-verification
+    pipeline: ``active`` promotions (from PROMOTED_TREE/manifest.json) plus
+    ``soaking``/``rejected`` counts (from PROMOTED_TREE/verifier_state.json,
+    joined against STATE_DIR/promotions/promotion-runtime-*.json candidate
+    ids). Never raises; missing files/dirs degrade to zeros — this section
+    is visibility-only, same as the rest of control_plane.
+    """
+    counts: dict[str, Any] = {"active": 0, "soaking": 0, "rejected": 0}
+    promoted_tree = Path(os.environ.get(_PROMOTED_TREE_ENV) or _DEFAULT_PROMOTED_TREE)
+    try:
+        manifest = _read_json(promoted_tree / "manifest.json", None)
+        if isinstance(manifest, dict):
+            counts["active"] = sum(
+                1
+                for key, entry in manifest.items()
+                if not str(key).startswith("_") and isinstance(entry, dict) and entry.get("status") == "active"
+            )
+    except Exception:
+        pass
+    try:
+        verifier_state = _read_json(promoted_tree / "verifier_state.json", None)
+        candidates = verifier_state.get("candidates") if isinstance(verifier_state, dict) else None
+        if isinstance(candidates, dict):
+            counts["soaking"] = sum(
+                1 for entry in candidates.values() if isinstance(entry, dict) and entry.get("status") == "soaking"
+            )
+            counts["rejected"] = sum(
+                1 for entry in candidates.values() if isinstance(entry, dict) and entry.get("status") == "rejected"
+            )
+    except Exception:
+        pass
+    return counts
+
+
 def _control_plane_snapshot() -> dict[str, Any]:
     """Active operator env values at compute time — visibility only.
 
@@ -127,6 +174,7 @@ def _control_plane_snapshot() -> dict[str, Any]:
     per-key: a single lookup error never blocks the rest of the section.
     """
     snapshot: dict[str, Any] = {}
+    snapshot["runtime_promotions"] = _runtime_promotions_snapshot()
     for key in _CONTROL_PLANE_KEYS:
         try:
             snapshot[key] = os.environ.get(key)

--- a/tests/test_promoted_overlay.py
+++ b/tests/test_promoted_overlay.py
@@ -1,0 +1,224 @@
+"""Tests for #875: the eeepc-agent-side promoted-runtime-module loader.
+
+``nanobot.runtime.promoted_overlay.install_promoted_overlay`` is the OTHER
+half of the root-verified auto-promotion trust boundary (the root verifier,
+``host/eeepc/libexec/eeepc_promotion_verifier.py``, is the writer side — see
+``tests/test_promotion_verifier.py``). These tests exercise the loader in
+isolation: the boundary self-check, deny/slice re-validation, sha256
+integrity, and the various fail-open/fail-closed paths — WITHOUT actually
+needing root privileges, by monkeypatching the ownership check itself (the
+one piece of logic that genuinely requires POSIX + root to exercise for
+real) while keeping every other check (deny-set, slice-shape, sha256,
+manifest status, actual module loading) fully real.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import promoted_overlay
+
+
+def _write_manifest(tree_dir: Path, entries: dict) -> None:
+    (tree_dir / "manifest.json").write_text(json.dumps(entries), encoding="utf-8")
+
+
+def _write_module(tree_dir: Path, module_path: str, source: str) -> str:
+    """Write ``source`` under the flattened filename convention and return
+    its sha256 hex digest (what a manifest entry would record).
+
+    Writes raw bytes (not ``write_text``) so no platform newline
+    translation can occur — the sha256 recorded here must match EXACTLY
+    what :func:`hashlib.sha256` computes over the bytes the loader reads
+    back with ``read_bytes()`` (production is POSIX-only anyway, but this
+    keeps the test byte-exact on any dev platform too).
+    """
+    flat = module_path.replace("/", "__")
+    data = source.encode("utf-8")
+    (tree_dir / flat).write_bytes(data)
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _force_boundary_ok(monkeypatch):
+    """Most tests below want to exercise the POST-boundary logic (deny/
+    slice/sha256/loading) without needing a real root-owned tree on disk.
+    Individual tests that specifically test the boundary check itself
+    override this fixture's effect by monkeypatching ``_boundary_ok`` again
+    with a narrower behavior, or by not using this fixture at all (see
+    the dedicated boundary-check tests, which patch ``_root_owned_and_not_writable``
+    at a lower level instead).
+    """
+    return None
+
+
+class TestAbsentOrEmptyTree:
+    def test_absent_tree_is_a_quiet_noop(self, tmp_path: Path):
+        assert promoted_overlay.install_promoted_overlay(tmp_path / "does-not-exist") == []
+
+    def test_tree_without_manifest_is_a_quiet_noop(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(promoted_overlay, "_boundary_ok", lambda *_: True)
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_default_tree_resolution_uses_env_var(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("PROMOTED_TREE", str(tmp_path / "nope"))
+        assert promoted_overlay.install_promoted_overlay() == []
+
+
+class TestBoundarySelfCheck:
+    """The critical refuse-everything check. Exercised by monkeypatching the
+    actual ownership primitive (``_root_owned_and_not_writable``) rather than
+    ``_boundary_ok`` itself, so the real AND-of-two-paths logic in
+    ``_boundary_ok`` is genuinely exercised."""
+
+    def test_non_posix_refuses_everything(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(promoted_overlay.os, "name", "nt")
+        # Even a tree that WOULD pass ownership checks must be refused.
+        monkeypatch.setattr(promoted_overlay, "_root_owned_and_not_writable", lambda p: True)
+        _write_manifest(tmp_path, {})
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_posix_root_owned_readonly_tree_is_trusted(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(promoted_overlay.os, "name", "posix")
+        monkeypatch.setattr(promoted_overlay, "_root_owned_and_not_writable", lambda p: True)
+        _write_manifest(tmp_path, {})
+        # Empty manifest -> loads nothing, but must not be REFUSED (returns
+        # [] either way, so assert via a non-empty manifest in a sibling test).
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_posix_but_not_root_owned_refuses_everything(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(promoted_overlay.os, "name", "posix")
+        monkeypatch.setattr(promoted_overlay, "_root_owned_and_not_writable", lambda p: False)
+        module_src = "VALUE = 'should-never-load'\n"
+        sha = _write_module(tmp_path, "nanobot/runtime/probes.py", module_src)
+        _write_manifest(tmp_path, {
+            "nanobot/runtime/probes.py": {"sha256": sha, "status": "active"},
+        })
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_boundary_ok_false_on_stat_exception(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(promoted_overlay.os, "name", "posix")
+
+        def _raise(_path):
+            raise OSError("boom")
+
+        monkeypatch.setattr(promoted_overlay, "_root_owned_and_not_writable", _raise)
+        _write_manifest(tmp_path, {})
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+
+class TestManifestEntryValidation:
+    """With the boundary check forced True, exercise per-entry validation:
+    status gating, deny-set, slice-shape, and sha256 integrity."""
+
+    @pytest.fixture(autouse=True)
+    def _trust_boundary(self, monkeypatch):
+        monkeypatch.setattr(promoted_overlay, "_boundary_ok", lambda *_: True)
+
+    def test_loads_valid_active_entry(self, tmp_path: Path):
+        module_src = "VALUE_875 = 'from-overlay'\n"
+        sha = _write_module(tmp_path, "nanobot/runtime/probes.py", module_src)
+        _write_manifest(tmp_path, {
+            "nanobot/runtime/probes.py": {"sha256": sha, "status": "active"},
+        })
+        try:
+            loaded = promoted_overlay.install_promoted_overlay(tmp_path)
+            assert loaded == ["nanobot/runtime/probes.py"]
+            mod = sys.modules["nanobot.runtime.probes"]
+            assert mod.VALUE_875 == "from-overlay"
+            import nanobot.runtime as pkg
+            assert pkg.probes is mod
+        finally:
+            sys.modules.pop("nanobot.runtime.probes", None)
+            importlib.reload(importlib.import_module("nanobot.runtime.probes"))
+
+    def test_non_active_status_is_skipped(self, tmp_path: Path):
+        sha = _write_module(tmp_path, "nanobot/runtime/probes.py", "X = 1\n")
+        for status in ("pending", "soaking", "rejected", "vetoed", None):
+            _write_manifest(tmp_path, {
+                "nanobot/runtime/probes.py": {"sha256": sha, "status": status},
+            })
+            assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_deny_set_module_is_refused_even_if_manifest_claims_active(self, tmp_path: Path):
+        sha = _write_module(tmp_path, "nanobot/runtime/bridge.py", "X = 1\n")
+        _write_manifest(tmp_path, {
+            "nanobot/runtime/bridge.py": {"sha256": sha, "status": "active"},
+        })
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_non_slice_shape_module_is_refused(self, tmp_path: Path):
+        # not under nanobot/runtime/, or not .py — both must be refused.
+        for bad_path in ("nanobot/agent/subagent.py", "scripts/foo.py", "nanobot/runtime/foo.txt"):
+            sha = _write_module(tmp_path, bad_path, "X = 1\n")
+            _write_manifest(tmp_path, {bad_path: {"sha256": sha, "status": "active"}})
+            assert promoted_overlay.install_promoted_overlay(tmp_path) == [], bad_path
+
+    def test_traversal_key_is_refused(self, tmp_path: Path):
+        bad_key = "nanobot/runtime/../bridge.py"
+        sha = _write_module(tmp_path, "nanobot/runtime/bridge.py", "X = 1\n")
+        _write_manifest(tmp_path, {bad_key: {"sha256": sha, "status": "active"}})
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_sha256_mismatch_is_refused(self, tmp_path: Path):
+        _write_module(tmp_path, "nanobot/runtime/probes.py", "X = 1\n")
+        _write_manifest(tmp_path, {
+            "nanobot/runtime/probes.py": {"sha256": "0" * 64, "status": "active"},
+        })
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_missing_tree_file_is_refused(self, tmp_path: Path):
+        _write_manifest(tmp_path, {
+            "nanobot/runtime/probes.py": {"sha256": "0" * 64, "status": "active"},
+        })
+        # no nanobot__runtime__probes.py written at all
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_missing_or_malformed_sha256_field_is_refused(self, tmp_path: Path):
+        _write_module(tmp_path, "nanobot/runtime/probes.py", "X = 1\n")
+        for bad_entry in ({"status": "active"}, {"sha256": 123, "status": "active"}, {"sha256": "", "status": "active"}):
+            _write_manifest(tmp_path, {"nanobot/runtime/probes.py": bad_entry})
+            assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_one_bad_entry_never_blocks_a_good_sibling_entry(self, tmp_path: Path):
+        good_src = "GOOD_875 = 42\n"
+        good_sha = _write_module(tmp_path, "nanobot/runtime/probes.py", good_src)
+        bad_sha = "deadbeef" * 8
+        _write_module(tmp_path, "nanobot/runtime/system_map.py", "BAD=1\n")
+        _write_manifest(tmp_path, {
+            "nanobot/runtime/probes.py": {"sha256": good_sha, "status": "active"},
+            "nanobot/runtime/system_map.py": {"sha256": bad_sha, "status": "active"},  # mismatch
+        })
+        try:
+            loaded = promoted_overlay.install_promoted_overlay(tmp_path)
+            assert loaded == ["nanobot/runtime/probes.py"]
+        finally:
+            sys.modules.pop("nanobot.runtime.probes", None)
+            importlib.reload(importlib.import_module("nanobot.runtime.probes"))
+
+    def test_manifest_meta_keys_with_non_dict_value_are_skipped_not_crashed(self, tmp_path: Path):
+        _write_manifest(tmp_path, {"_schema_version": "promoted-manifest-v1"})
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_malformed_manifest_json_fails_closed(self, tmp_path: Path):
+        (tmp_path / "manifest.json").write_text("{not valid json", encoding="utf-8")
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    def test_manifest_that_is_a_json_list_fails_closed(self, tmp_path: Path):
+        (tmp_path / "manifest.json").write_text("[1, 2, 3]", encoding="utf-8")
+        assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+
+def test_flattened_filename_convention_matches_verifier_writer_side():
+    # Must stay in sync with eeepc_promotion_verifier._flattened_filename —
+    # this is the one piece of shared naming convention between the two
+    # independent processes (root writer, eeepc-agent reader).
+    assert (
+        promoted_overlay._flattened_filename("nanobot/runtime/existence_index.py")
+        == "nanobot__runtime__existence_index.py"
+    )

--- a/tests/test_promotion_verifier.py
+++ b/tests/test_promotion_verifier.py
@@ -456,6 +456,172 @@ class TestOperatorVeto:
         assert "nanobot/runtime/existence_index.py" not in manifest
         assert not (verifier.promoted_tree / "nanobot__runtime__existence_index.py").exists()
 
+    def test_vetoed_rollback_with_no_pending_candidates_still_rewrites_verifier_state(self, verifier):
+        """RED1 fix round 2 (opus-review): a rollback pass with ZERO pending
+        candidate files (the candidate-processing loop contributes nothing
+        to state_dirty) must still rewrite verifier_state.json, not just
+        manifest.json — that rewrite (tmp + os.replace) is what re-asserts
+        the file's root ownership every pass. Before this fix, only
+        manifest_dirty was set on a rollback branch, so verifier_state.json
+        ownership could drift silently forever on a host with no other
+        pending candidates."""
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-vetonly",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        for _ in range(4):
+            verifier.verify_pass()
+        # Remove the (now terminal) candidate file: the candidate-processing
+        # loop below will find NOTHING to process this pass.
+        (verifier.state_dir / "promotions" / "promotion-runtime-vetonly.json").unlink()
+
+        manifest_path = verifier.promoted_tree / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["nanobot/runtime/existence_index.py"]["status"] = "vetoed"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        vs_path = verifier.promoted_tree / "verifier_state.json"
+        before = vs_path.read_text()
+        s = verifier.verify_pass()
+        assert s["rolled_back"] == 1
+        assert s["processed"] == 0  # confirms the candidate loop contributed nothing
+        after = vs_path.read_text()
+        assert after != before  # rewritten (updated_utc bumped) despite no candidate files
+
+
+class TestVerifierLedgerIsRootOwnedNotStateLedger:
+    """RED1 fix round 2 (opus-review): the instance owns state/ledger/ and
+    could plant it (or cycles.jsonl inside it) as a symlink to ANYWHERE,
+    including PROMOTED_TREE itself. A root write (open+append) or a root
+    chown following that symlink would durably corrupt whatever it points
+    at. The fix: root's own promotion/rollback audit trail now lives in a
+    SEPARATE, root-owned ledger under PROMOTED_TREE — root never opens or
+    chowns anything under STATE_DIR at all anymore.
+    """
+
+    def test_promote_writes_to_promoted_tree_ledger_not_state_ledger(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-ledger1",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        for _ in range(4):
+            verifier.verify_pass()
+
+        ledger_path = verifier.promoted_tree / "verifier_ledger.jsonl"
+        assert ledger_path.is_file()
+        events = [json.loads(ln) for ln in ledger_path.read_text().splitlines() if ln.strip()]
+        assert any(e.get("reason") == "root_verified_promoted" for e in events)
+        # Root never touched state/ledger at all.
+        assert not (verifier.state_dir / "ledger" / "cycles.jsonl").exists()
+
+    def test_rollback_writes_to_promoted_tree_ledger_not_state_ledger(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-ledger2",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        for _ in range(4):
+            verifier.verify_pass()
+
+        manifest_path = verifier.promoted_tree / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["nanobot/runtime/existence_index.py"]["status"] = "vetoed"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        verifier.verify_pass()
+
+        ledger_path = verifier.promoted_tree / "verifier_ledger.jsonl"
+        events = [json.loads(ln) for ln in ledger_path.read_text().splitlines() if ln.strip()]
+        assert any(e.get("reason") == "root_verified_rolled_back" for e in events)
+        assert not (verifier.state_dir / "ledger" / "cycles.jsonl").exists()
+
+    @pytest.mark.skipif(os.name != "posix", reason="os.symlink + O_NOFOLLOW refusal are POSIX-only")
+    def test_append_verifier_ledger_event_refuses_to_follow_a_symlink(self, verifier, tmp_path):
+        """Defense-in-depth check on the ledger writer itself (independent
+        of the "PROMOTED_TREE is root-owned so nothing else could ever
+        create a symlink there" argument): even if a symlink somehow ended
+        up at the ledger's own path, O_NOFOLLOW must refuse to write
+        through it rather than follow it."""
+        evil_target = tmp_path / "evil_target.jsonl"
+        verifier.promoted_tree.mkdir(parents=True, exist_ok=True)
+        ledger_path = verifier.promoted_tree / "verifier_ledger.jsonl"
+        os.symlink(str(evil_target), str(ledger_path))
+
+        verifier._append_verifier_ledger_event({"phase": "promotion", "reason": "test"})
+
+        assert not evil_target.exists()  # never followed the symlink to write there
+
+
+class TestPromotedTreeOwnershipReassertion:
+    """RED1 fix round 2 (opus-review): PROMOTED_TREE's root ownership is
+    re-checked at the START of every pass, not just relied upon once at
+    creation time."""
+
+    def test_missing_tree_is_fine_not_yet_created(self, verifier):
+        never_created = verifier.promoted_tree / "does-not-exist-yet"
+        assert verifier._reassert_promoted_tree_root_ownership(never_created) is True
+
+    def test_skip_flag_short_circuits(self, verifier, monkeypatch):
+        monkeypatch.setenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", "1")
+        verifier.promoted_tree.mkdir(parents=True, exist_ok=True)
+        assert verifier._reassert_promoted_tree_root_ownership(verifier.promoted_tree) is True
+
+    @pytest.mark.skipif(os.name != "posix", reason="st_uid ownership semantics are POSIX-only")
+    def test_non_root_owned_tree_without_skip_flag_fails_closed(self, verifier, monkeypatch):
+        if verifier._is_root():
+            pytest.skip("test runner is root — cannot exercise the non-root branch")
+        monkeypatch.delenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", raising=False)
+        verifier.promoted_tree.mkdir(parents=True, exist_ok=True)
+        # The current (non-root) test process created this dir, so it is
+        # never root-owned; chowning it back to root will fail (only root
+        # can chown to uid 0) — this exercises the fail-closed branch.
+        assert verifier._reassert_promoted_tree_root_ownership(verifier.promoted_tree) is False
+
+    def test_verify_pass_fails_closed_when_reassertion_fails(self, verifier, monkeypatch):
+        monkeypatch.delenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", raising=False)
+        verifier._reassert_promoted_tree_root_ownership = lambda promoted_tree: False
+        s = verifier.verify_pass()
+        assert s == {
+            "processed": 0, "rejected": 0, "soaking": 0,
+            "promoted": 0, "rolled_back": 0, "errors": 1,
+        }
+
+
+class TestReleasePathResolution:
+    """YELLOW-1 fix (opus-review round 2): sys.path must be pinned to the
+    RESOLVED release realpath, not the raw (possibly-symlink) env value —
+    closes the check-then-use gap between the ownership stat check and the
+    later import."""
+
+    def test_release_dir_resolved_matches_the_real_repo_root(self, verifier):
+        assert verifier._release_dir_resolved == Path(_REPO_ROOT).resolve()
+        assert str(verifier._release_dir_resolved) in sys.path
+
+    @pytest.mark.skipif(os.name != "posix", reason="os.symlink is POSIX-only")
+    def test_symlinked_release_dir_resolves_to_the_real_path(self, tmp_path, monkeypatch):
+        symlinked_release = tmp_path / "current"
+        os.symlink(str(_REPO_ROOT), str(symlinked_release), target_is_directory=True)
+
+        monkeypatch.setenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", "1")
+        monkeypatch.setenv("SELFEVO_RELEASE_DIR", str(symlinked_release))
+        monkeypatch.setenv("STATE_DIR", str(tmp_path / "state"))
+        monkeypatch.setenv("INSTANCE_REPO", str(tmp_path / "instance_repo"))
+        monkeypatch.setenv("PROMOTED_TREE", str(tmp_path / "promoted"))
+
+        module, mod_name = _load_verifier_module({})
+        try:
+            assert module._release_dir_resolved == Path(_REPO_ROOT).resolve()
+            assert str(symlinked_release) not in sys.path  # only the RESOLVED path was inserted
+        finally:
+            sys.modules.pop(mod_name, None)
+
 
 class TestPassIsIdempotentAndFailSafe:
     def test_empty_state_is_a_clean_noop(self, verifier):

--- a/tests/test_promotion_verifier.py
+++ b/tests/test_promotion_verifier.py
@@ -1,0 +1,426 @@
+"""Tests for #875: the root-run promotion verifier (the automated operator).
+
+``host/eeepc/libexec/eeepc_promotion_verifier.py`` is a standalone script
+(not a ``nanobot`` package module — it is deployed to ``/usr/local/libexec``
+and run by systemd as root), so it is loaded here via
+``importlib.util.spec_from_file_location`` exactly the way it would be
+invoked in production, with a REAL tiny git repository standing in for the
+instance repo (so ``git show <head_sha>:<module_path>`` materialization is
+genuinely exercised, not mocked) while the two genuinely-slow/hardware-
+dependent pieces — the microbench wall-clock measurement and the held-out
+subprocess pack — are monkeypatched to deterministic values per test.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_VERIFIER_PATH = _REPO_ROOT / "host" / "eeepc" / "libexec" / "eeepc_promotion_verifier.py"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _init_instance_repo(repo: Path, files: dict) -> str:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "a@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    for rel, content in files.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content.encode("utf-8"))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "commit")
+    out = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def verifier(tmp_path, monkeypatch):
+    """Load a FRESH module instance of the verifier script per test, with
+    STATE_DIR/INSTANCE_REPO/PROMOTED_TREE/SELFEVO_RUNTIME_SLICE env vars set
+    BEFORE import (the script binds these to module-level constants at
+    import time), and its two slow/hardware-dependent entry points
+    (``run_measurement``, ``_run_heldout``) defaulted to deterministic
+    "clean and improved" stand-ins that individual tests override."""
+    state_dir = tmp_path / "state"
+    instance_repo = tmp_path / "instance_repo"
+    promoted_tree = tmp_path / "promoted"
+    (state_dir / "promotions").mkdir(parents=True)
+
+    monkeypatch.setenv("STATE_DIR", str(state_dir))
+    monkeypatch.setenv("INSTANCE_REPO", str(instance_repo))
+    monkeypatch.setenv("PROMOTED_TREE", str(promoted_tree))
+    monkeypatch.setenv("SELFEVO_RUNTIME_SLICE", "nanobot/runtime/existence_index.py")
+    monkeypatch.setenv("SELFEVO_RELEASE_DIR", str(_REPO_ROOT))
+
+    mod_name = f"eeepc_promotion_verifier_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(mod_name, _VERIFIER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+
+    # Default stand-ins: 20% improvement, clean heldout. Individual tests
+    # override module.run_measurement / module._run_heldout as needed.
+    module.run_measurement = lambda module_path, candidate_bytes=None, timeout=120: (
+        100.0 if candidate_bytes is None else 80.0
+    )
+    module._run_heldout = lambda state_dir, repo, **kw: {"regressions": [], "results": {}}
+
+    module.state_dir = state_dir
+    module.instance_repo = instance_repo
+    module.promoted_tree = promoted_tree
+    yield module
+    sys.modules.pop(mod_name, None)
+
+
+def _write_candidate(state_dir: Path, candidate_id: str, changed_files, head_sha, **extra) -> Path:
+    record = {
+        "schema_version": "runtime-slice-promotion-candidate-v1",
+        "promotion_candidate_id": candidate_id,
+        "changed_files": changed_files,
+        "rollback_record": {"head_sha": head_sha},
+        **extra,
+    }
+    path = state_dir / "promotions" / f"{candidate_id}.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+class TestEligibleCandidateSoaksAndPromotes:
+    def test_full_lifecycle_soak_then_promote(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-cyc1",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+
+        s1 = verifier.verify_pass()
+        assert s1["soaking"] == 1 and s1["rejected"] == 0
+
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        entry = vs["candidates"]["promotion-runtime-cyc1"]
+        assert entry["status"] == "soaking"
+        assert entry["soak_passes_done"] == 0
+        assert entry["improvement_pct"] == pytest.approx(20.0)
+
+        # 3 subsequent clean passes required to promote.
+        for _ in range(2):
+            s = verifier.verify_pass()
+            assert s["soaking"] == 1
+        s_final = verifier.verify_pass()
+        assert s_final["promoted"] == 1
+
+        manifest = json.loads((verifier.promoted_tree / "manifest.json").read_text())
+        entry = manifest["nanobot/runtime/existence_index.py"]
+        assert entry["status"] == "active"
+        assert entry["head_sha"] == head_sha
+        assert entry["candidate_id"] == "promotion-runtime-cyc1"
+
+        promoted_file = verifier.promoted_tree / "nanobot__runtime__existence_index.py"
+        assert promoted_file.read_text(encoding="utf-8") == "X = 1\n"
+        assert entry["sha256"] == __import__("hashlib").sha256(b"X = 1\n").hexdigest()
+
+        # Terminal: further passes never reprocess this candidate_id again.
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert vs["candidates"]["promotion-runtime-cyc1"]["status"] == "promoted"
+
+    def test_forged_instance_microbench_number_is_ignored(self, verifier):
+        """The instance's OWN claimed improvement_pct in the candidate record
+        must never influence the verdict — only the root's own re-measure
+        does. Root re-measure here is set BELOW threshold, so a forged 99%
+        instance claim must still be rejected."""
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-forged",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+            microbench={"improvement_pct": 99.0, "forged": True},
+        )
+        verifier.run_measurement = lambda module_path, candidate_bytes=None, timeout=120: (
+            100.0 if candidate_bytes is None else 98.0  # real improvement: 2%, below threshold
+        )
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        entry = vs["candidates"]["promotion-runtime-forged"]
+        assert entry["status"] == "rejected"
+        assert "below required" in entry["reason"]
+
+
+class TestRejectionPaths:
+    def test_heldout_regression_at_measurement_time_rejects(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-r1",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        verifier._run_heldout = lambda state_dir, repo, **kw: {
+            "regressions": ["scripts/foo.py"], "results": {},
+        }
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert "heldout regressions" in vs["candidates"]["promotion-runtime-r1"]["reason"]
+
+    def test_heldout_failure_at_measurement_time_rejects(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-r2",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        verifier._run_heldout = lambda state_dir, repo, **kw: {
+            "regressions": [], "results": {"scripts/bar.py": {"status": "fail"}},
+        }
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+
+    def test_multi_file_candidate_is_rejected_not_measured(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {
+                "nanobot/runtime/existence_index.py": "X = 1\n",
+                "nanobot/runtime/probes.py": "Y = 1\n",
+            }
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-multi",
+            ["nanobot/runtime/existence_index.py", "nanobot/runtime/probes.py"], head_sha,
+        )
+        measured = []
+        verifier.run_measurement = lambda *a, **kw: measured.append(1) or 100.0
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        assert measured == []  # never even attempted a measurement
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert "exactly one" in vs["candidates"]["promotion-runtime-multi"]["reason"]
+
+    def test_deny_set_module_is_rejected(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/bridge.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-deny",
+            ["nanobot/runtime/bridge.py"], head_sha,
+        )
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert "deny-set" in vs["candidates"]["promotion-runtime-deny"]["reason"]
+        assert not (verifier.promoted_tree / "manifest.json").exists() or json.loads(
+            (verifier.promoted_tree / "manifest.json").read_text()
+        ) == {"_schema_version": "promoted-manifest-v1"}
+
+    def test_module_not_in_operator_slice_is_rejected(self, verifier, monkeypatch):
+        monkeypatch.setenv("SELFEVO_RUNTIME_SLICE", "nanobot/runtime/existence_index.py")
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/probes.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-notinslice",
+            ["nanobot/runtime/probes.py"], head_sha,
+        )
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert "not in the operator-approved" in vs["candidates"]["promotion-runtime-notinslice"]["reason"]
+
+    def test_missing_head_sha_is_rejected(self, verifier):
+        _init_instance_repo(verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"})
+        path = verifier.state_dir / "promotions" / "promotion-runtime-nohash.json"
+        path.write_text(json.dumps({
+            "changed_files": ["nanobot/runtime/existence_index.py"],
+            "rollback_record": {},
+        }), encoding="utf-8")
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+
+    def test_unresolvable_head_sha_is_rejected(self, verifier):
+        _init_instance_repo(verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"})
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-badsha",
+            ["nanobot/runtime/existence_index.py"], "0" * 40,
+        )
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+
+    def test_malformed_candidate_json_does_not_abort_the_pass(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        (verifier.state_dir / "promotions" / "promotion-runtime-bad.json").write_text(
+            "{not valid json", encoding="utf-8"
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-good",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        s = verifier.verify_pass()
+        assert s["errors"] == 1
+        assert s["soaking"] == 1  # the good sibling candidate still processed
+
+
+class TestTerminalStatesNeverRetried:
+    def test_rejected_candidate_is_not_reevaluated(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/bridge.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-deny",
+            ["nanobot/runtime/bridge.py"], head_sha,
+        )
+        verifier.verify_pass()
+        calls = []
+        verifier.run_measurement = lambda *a, **kw: calls.append(1) or 100.0
+        verifier.verify_pass()
+        assert calls == []  # never re-attempted
+
+
+class TestSoakRegressionAndIntegrityWatch:
+    def test_regression_during_soak_rejects(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-soakfail",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        verifier.verify_pass()  # enters soaking
+        verifier._run_heldout = lambda state_dir, repo, **kw: {
+            "regressions": ["scripts/newly_broken.py"], "results": {},
+        }
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert vs["candidates"]["promotion-runtime-soakfail"]["status"] == "rejected"
+
+    def test_integrity_event_during_soak_rejects(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-integrity",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        verifier.verify_pass()  # enters soaking, sets ledger watermark
+
+        from nanobot.runtime import cycle_ledger
+        cycle_ledger.append_event(verifier.state_dir, {"phase": "integrity", "reason": "test-tamper"})
+
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert "integrity events" in vs["candidates"]["promotion-runtime-integrity"]["reason"]
+
+    def test_regression_after_promotion_rolls_back(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-pr1",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        for _ in range(4):
+            verifier.verify_pass()
+        manifest = json.loads((verifier.promoted_tree / "manifest.json").read_text())
+        assert manifest["nanobot/runtime/existence_index.py"]["status"] == "active"
+
+        verifier._run_heldout = lambda state_dir, repo, **kw: {
+            "regressions": ["scripts/broke_after_promotion.py"], "results": {},
+        }
+        s = verifier.verify_pass()
+        assert s["rolled_back"] == 1
+        manifest = json.loads((verifier.promoted_tree / "manifest.json").read_text())
+        assert "nanobot/runtime/existence_index.py" not in manifest
+        promoted_file = verifier.promoted_tree / "nanobot__runtime__existence_index.py"
+        assert not promoted_file.exists()
+
+    def test_integrity_event_after_promotion_rolls_back(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-pr2",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        for _ in range(4):
+            verifier.verify_pass()
+
+        from nanobot.runtime import cycle_ledger
+        cycle_ledger.append_event(verifier.state_dir, {"phase": "integrity", "reason": "test-tamper-2"})
+
+        s = verifier.verify_pass()
+        assert s["rolled_back"] == 1
+
+
+class TestOperatorVeto:
+    def test_vetoed_manifest_entry_rolls_back(self, verifier):
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-veto",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        for _ in range(4):
+            verifier.verify_pass()
+
+        manifest_path = verifier.promoted_tree / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["nanobot/runtime/existence_index.py"]["status"] = "vetoed"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        s = verifier.verify_pass()
+        assert s["rolled_back"] == 1
+        manifest = json.loads(manifest_path.read_text())
+        assert "nanobot/runtime/existence_index.py" not in manifest
+        assert not (verifier.promoted_tree / "nanobot__runtime__existence_index.py").exists()
+
+
+class TestPassIsIdempotentAndFailSafe:
+    def test_empty_state_is_a_clean_noop(self, verifier):
+        s = verifier.verify_pass()
+        assert s == {
+            "processed": 0, "rejected": 0, "soaking": 0,
+            "promoted": 0, "rolled_back": 0, "errors": 0,
+        }
+
+    def test_missing_promotions_dir_is_a_clean_noop(self, verifier):
+        import shutil
+        shutil.rmtree(verifier.state_dir / "promotions")
+        s = verifier.verify_pass()
+        assert s["processed"] == 0 and s["errors"] == 0
+
+    def test_promoted_tree_created_and_chmodded(self, verifier):
+        verifier.verify_pass()
+        assert verifier.promoted_tree.is_dir()
+
+
+class TestMainEntrypoint:
+    def test_main_returns_zero_on_clean_pass(self, verifier, capsys):
+        rc = verifier.main([])
+        assert rc == 0
+
+    def test_main_json_flag_prints_json_summary(self, verifier, capsys):
+        rc = verifier.main(["--json"])
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        parsed = json.loads(out)
+        assert set(parsed) == {"processed", "rejected", "soaking", "promoted", "rolled_back", "errors"}

--- a/tests/test_promotion_verifier.py
+++ b/tests/test_promotion_verifier.py
@@ -6,14 +6,26 @@ and run by systemd as root), so it is loaded here via
 ``importlib.util.spec_from_file_location`` exactly the way it would be
 invoked in production, with a REAL tiny git repository standing in for the
 instance repo (so ``git show <head_sha>:<module_path>`` materialization is
-genuinely exercised, not mocked) while the two genuinely-slow/hardware-
-dependent pieces — the microbench wall-clock measurement and the held-out
-subprocess pack — are monkeypatched to deterministic values per test.
+genuinely exercised, not mocked).
+
+Rework after #880 (opus-review RED1/RED2): the verifier no longer executes
+the microbench measurement / held-out pack / git-show-against-instance-repo
+directly — that work now happens inside a demoted CHILD subprocess
+(``--child-verify``, see ``_run_child_verify``/``_child_verify_main`` in the
+verifier module), and a fail-closed release-ownership check runs before the
+verifier ever imports ``nanobot``. Most lifecycle tests below monkeypatch
+the ``_run_child_verify`` seam (the same role ``run_measurement``/
+``_run_heldout`` monkeypatching played before this rework) with a
+deterministic "clean and improved" stand-in; a dedicated class exercises
+the REAL child subprocess, the ownership fail-closed check, and the
+demotion helpers directly.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import uuid
@@ -46,14 +58,66 @@ def _init_instance_repo(repo: Path, files: dict) -> str:
     return out.stdout.strip()
 
 
+def _load_verifier_module(env: dict) -> "tuple[object, str]":
+    """Load a FRESH module instance of the verifier script with ``env``
+    applied on top of the current process env (restored by the caller)."""
+    mod_name = f"eeepc_promotion_verifier_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(mod_name, _VERIFIER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module, mod_name
+
+
+def _make_child_verify_stub(
+    module, *, baseline_ms=100.0, candidate_ms=80.0, heldout_clean=True, heldout_reason="",
+):
+    """A deterministic stand-in for ``module._run_child_verify`` — the same
+    role ``run_measurement``/``_run_heldout`` monkeypatching played before
+    the demoted-child rework. Still fetches REAL candidate bytes via the
+    (unmodified) ``_git_show_bytes`` helper for ``mode="full"`` so sha256/
+    promoted-file-content assertions downstream still exercise real git
+    materialization, not a fake.
+    """
+
+    def _stub(mode, *, module_path=None, head_sha=None, timeout=None):
+        if mode == "full":
+            candidate_bytes = module._git_show_bytes(module.INSTANCE_REPO, head_sha, module_path)
+            if candidate_bytes is None:
+                return {"ok": False, "reason": f"stub: git show failed for {module_path}@{head_sha}"}
+            return {
+                "ok": True,
+                "sha256": hashlib.sha256(candidate_bytes).hexdigest(),
+                "baseline_ms": baseline_ms,
+                "candidate_ms": candidate_ms,
+                "heldout_clean": heldout_clean,
+                "heldout_reason": heldout_reason,
+            }
+        if mode == "heldout":
+            return {"ok": True, "heldout_clean": heldout_clean, "heldout_reason": heldout_reason}
+        return {"ok": False, "reason": f"stub: unknown mode {mode!r}"}
+
+    return _stub
+
+
 @pytest.fixture
 def verifier(tmp_path, monkeypatch):
     """Load a FRESH module instance of the verifier script per test, with
     STATE_DIR/INSTANCE_REPO/PROMOTED_TREE/SELFEVO_RUNTIME_SLICE env vars set
     BEFORE import (the script binds these to module-level constants at
-    import time), and its two slow/hardware-dependent entry points
-    (``run_measurement``, ``_run_heldout``) defaulted to deterministic
-    "clean and improved" stand-ins that individual tests override."""
+    import time). ``EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK=1`` is set too —
+    tests run as a non-root user against temp dirs/a real checkout that can
+    never satisfy the real root-ownership check (RED1); that env var is
+    also propagated into any child-verify subprocess this module spawns
+    (see ``_minimal_child_env``), so the child's own copy of the same check
+    doesn't fail either.
+
+    ``_run_child_verify`` (the demoted-child orchestrator, RED2) is
+    defaulted to a deterministic "20% improvement, clean heldout" stand-in
+    — individual tests override ``verifier._run_child_verify`` as needed.
+    The REAL function is kept accessible as ``verifier._real_run_child_verify``
+    for the dedicated real-subprocess round-trip tests.
+    """
     state_dir = tmp_path / "state"
     instance_repo = tmp_path / "instance_repo"
     promoted_tree = tmp_path / "promoted"
@@ -64,19 +128,12 @@ def verifier(tmp_path, monkeypatch):
     monkeypatch.setenv("PROMOTED_TREE", str(promoted_tree))
     monkeypatch.setenv("SELFEVO_RUNTIME_SLICE", "nanobot/runtime/existence_index.py")
     monkeypatch.setenv("SELFEVO_RELEASE_DIR", str(_REPO_ROOT))
+    monkeypatch.setenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", "1")
 
-    mod_name = f"eeepc_promotion_verifier_test_{uuid.uuid4().hex}"
-    spec = importlib.util.spec_from_file_location(mod_name, _VERIFIER_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[mod_name] = module
-    spec.loader.exec_module(module)
+    module, mod_name = _load_verifier_module({})
 
-    # Default stand-ins: 20% improvement, clean heldout. Individual tests
-    # override module.run_measurement / module._run_heldout as needed.
-    module.run_measurement = lambda module_path, candidate_bytes=None, timeout=120: (
-        100.0 if candidate_bytes is None else 80.0
-    )
-    module._run_heldout = lambda state_dir, repo, **kw: {"regressions": [], "results": {}}
+    module._real_run_child_verify = module._run_child_verify
+    module._run_child_verify = _make_child_verify_stub(module)
 
     module.state_dir = state_dir
     module.instance_repo = instance_repo
@@ -132,7 +189,7 @@ class TestEligibleCandidateSoaksAndPromotes:
 
         promoted_file = verifier.promoted_tree / "nanobot__runtime__existence_index.py"
         assert promoted_file.read_text(encoding="utf-8") == "X = 1\n"
-        assert entry["sha256"] == __import__("hashlib").sha256(b"X = 1\n").hexdigest()
+        assert entry["sha256"] == hashlib.sha256(b"X = 1\n").hexdigest()
 
         # Terminal: further passes never reprocess this candidate_id again.
         vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
@@ -141,8 +198,9 @@ class TestEligibleCandidateSoaksAndPromotes:
     def test_forged_instance_microbench_number_is_ignored(self, verifier):
         """The instance's OWN claimed improvement_pct in the candidate record
         must never influence the verdict — only the root's own re-measure
-        does. Root re-measure here is set BELOW threshold, so a forged 99%
-        instance claim must still be rejected."""
+        (via the demoted child) does. The child's numbers here are set
+        BELOW threshold, so a forged 99% instance claim must still be
+        rejected."""
         head_sha = _init_instance_repo(
             verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
         )
@@ -151,9 +209,8 @@ class TestEligibleCandidateSoaksAndPromotes:
             ["nanobot/runtime/existence_index.py"], head_sha,
             microbench={"improvement_pct": 99.0, "forged": True},
         )
-        verifier.run_measurement = lambda module_path, candidate_bytes=None, timeout=120: (
-            100.0 if candidate_bytes is None else 98.0  # real improvement: 2%, below threshold
-        )
+        # real improvement: 2%, below threshold
+        verifier._run_child_verify = _make_child_verify_stub(verifier, candidate_ms=98.0)
         s = verifier.verify_pass()
         assert s["rejected"] == 1
         vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
@@ -171,9 +228,9 @@ class TestRejectionPaths:
             verifier.state_dir, "promotion-runtime-r1",
             ["nanobot/runtime/existence_index.py"], head_sha,
         )
-        verifier._run_heldout = lambda state_dir, repo, **kw: {
-            "regressions": ["scripts/foo.py"], "results": {},
-        }
+        verifier._run_child_verify = _make_child_verify_stub(
+            verifier, heldout_clean=False, heldout_reason="heldout regressions: ['scripts/foo.py']",
+        )
         s = verifier.verify_pass()
         assert s["rejected"] == 1
         vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
@@ -187,9 +244,9 @@ class TestRejectionPaths:
             verifier.state_dir, "promotion-runtime-r2",
             ["nanobot/runtime/existence_index.py"], head_sha,
         )
-        verifier._run_heldout = lambda state_dir, repo, **kw: {
-            "regressions": [], "results": {"scripts/bar.py": {"status": "fail"}},
-        }
+        verifier._run_child_verify = _make_child_verify_stub(
+            verifier, heldout_clean=False, heldout_reason="heldout failures: ['scripts/bar.py']",
+        )
         s = verifier.verify_pass()
         assert s["rejected"] == 1
 
@@ -205,10 +262,12 @@ class TestRejectionPaths:
             ["nanobot/runtime/existence_index.py", "nanobot/runtime/probes.py"], head_sha,
         )
         measured = []
-        verifier.run_measurement = lambda *a, **kw: measured.append(1) or 100.0
+        verifier._run_child_verify = lambda *a, **kw: measured.append(1) or {
+            "ok": True, "heldout_clean": True, "heldout_reason": "",
+        }
         s = verifier.verify_pass()
         assert s["rejected"] == 1
-        assert measured == []  # never even attempted a measurement
+        assert measured == []  # never even attempted a child verify
         vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
         assert "exactly one" in vs["candidates"]["promotion-runtime-multi"]["reason"]
 
@@ -288,7 +347,9 @@ class TestTerminalStatesNeverRetried:
         )
         verifier.verify_pass()
         calls = []
-        verifier.run_measurement = lambda *a, **kw: calls.append(1) or 100.0
+        verifier._run_child_verify = lambda *a, **kw: calls.append(1) or {
+            "ok": True, "heldout_clean": True, "heldout_reason": "",
+        }
         verifier.verify_pass()
         assert calls == []  # never re-attempted
 
@@ -303,9 +364,10 @@ class TestSoakRegressionAndIntegrityWatch:
             ["nanobot/runtime/existence_index.py"], head_sha,
         )
         verifier.verify_pass()  # enters soaking
-        verifier._run_heldout = lambda state_dir, repo, **kw: {
-            "regressions": ["scripts/newly_broken.py"], "results": {},
-        }
+        verifier._run_child_verify = _make_child_verify_stub(
+            verifier, heldout_clean=False,
+            heldout_reason="heldout regressions: ['scripts/newly_broken.py']",
+        )
         s = verifier.verify_pass()
         assert s["rejected"] == 1
         vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
@@ -342,9 +404,10 @@ class TestSoakRegressionAndIntegrityWatch:
         manifest = json.loads((verifier.promoted_tree / "manifest.json").read_text())
         assert manifest["nanobot/runtime/existence_index.py"]["status"] == "active"
 
-        verifier._run_heldout = lambda state_dir, repo, **kw: {
-            "regressions": ["scripts/broke_after_promotion.py"], "results": {},
-        }
+        verifier._run_child_verify = _make_child_verify_stub(
+            verifier, heldout_clean=False,
+            heldout_reason="heldout regressions: ['scripts/broke_after_promotion.py']",
+        )
         s = verifier.verify_pass()
         assert s["rolled_back"] == 1
         manifest = json.loads((verifier.promoted_tree / "manifest.json").read_text())
@@ -424,3 +487,181 @@ class TestMainEntrypoint:
         out = capsys.readouterr().out.strip()
         parsed = json.loads(out)
         assert set(parsed) == {"processed", "rejected", "soaking", "promoted", "rolled_back", "errors"}
+
+
+# ─── RED1: fail-closed release-ownership check ──────────────────────────────
+
+
+class TestOwnershipFailClosed:
+    def _minimal_env(self, tmp_path, release_dir):
+        return {
+            "STATE_DIR": str(tmp_path / "state"),
+            "INSTANCE_REPO": str(tmp_path / "instance_repo"),
+            "PROMOTED_TREE": str(tmp_path / "promoted"),
+            "SELFEVO_RELEASE_DIR": str(release_dir),
+        }
+
+    def test_ownership_check_exits_nonzero_without_skip_flag(self, tmp_path, monkeypatch):
+        """No EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK set: importing the module
+        against a real (temp) release dir must fail closed — SystemExit
+        with a nonzero code, and it must happen BEFORE `from nanobot...`
+        ever runs (a plain temp dir has no `nanobot/` subdir at all, so if
+        the ownership check were skipped the subsequent import would raise
+        ModuleNotFoundError instead — this test would then fail with the
+        WRONG exception, which is itself a useful signal the check didn't
+        fire)."""
+        monkeypatch.delenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", raising=False)
+        for key, value in self._minimal_env(tmp_path, _REPO_ROOT).items():
+            monkeypatch.setenv(key, value)
+
+        mod_name = f"eeepc_promotion_verifier_ownercheck_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(mod_name, _VERIFIER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = module
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                spec.loader.exec_module(module)
+            assert exc_info.value.code != 0
+        finally:
+            sys.modules.pop(mod_name, None)
+
+    def test_ownership_check_skipped_when_flag_set(self, tmp_path, monkeypatch):
+        """The escape hatch actually works — with the flag set, the module
+        loads all the way through (this is what the ``verifier`` fixture
+        relies on for every other test in this file)."""
+        monkeypatch.setenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", "1")
+        for key, value in self._minimal_env(tmp_path, _REPO_ROOT).items():
+            monkeypatch.setenv(key, value)
+
+        mod_name = f"eeepc_promotion_verifier_ownercheck_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(mod_name, _VERIFIER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = module
+        try:
+            spec.loader.exec_module(module)  # must not raise
+            assert module.verify_pass is not None
+        finally:
+            sys.modules.pop(mod_name, None)
+
+    @pytest.mark.skipif(os.name != "posix", reason="root-ownership stat semantics are POSIX-only")
+    def test_ownership_check_rejects_non_root_owned_release(self, tmp_path, monkeypatch):
+        """On POSIX, a release dir that genuinely exists (with a nanobot/
+        runtime/ subtree) but is owned by the current (non-root) test user
+        must be refused with a uid-mismatch reason, not just because the
+        check is platform-gated."""
+        release = tmp_path / "release"
+        (release / "nanobot" / "runtime").mkdir(parents=True)
+        monkeypatch.delenv("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", raising=False)
+        for key, value in self._minimal_env(tmp_path, release).items():
+            monkeypatch.setenv(key, value)
+
+        mod_name = f"eeepc_promotion_verifier_ownercheck_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(mod_name, _VERIFIER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = module
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                spec.loader.exec_module(module)
+            assert exc_info.value.code != 0
+        finally:
+            sys.modules.pop(mod_name, None)
+
+
+# ─── RED2: demoted child — real subprocess, failure modes, demotion helpers ─
+
+
+class TestDemotedChildRealSubprocess:
+    def test_child_verify_heldout_real_subprocess_json_round_trip(self, verifier):
+        """Exercises the REAL ``_run_child_verify`` (not the fixture's
+        stub) end to end: it spawns an actual ``sys.executable`` subprocess
+        re-running this script with ``--child-verify --mode heldout``,
+        which re-executes the ownership check + nanobot imports + a real
+        (unmocked) ``run_heldout`` call, and must hand back one well-formed
+        JSON object."""
+        verifier.instance_repo.mkdir(parents=True, exist_ok=True)
+        result = verifier._real_run_child_verify("heldout")
+        assert result.get("ok") is True
+        assert isinstance(result.get("heldout_clean"), bool)
+
+    def test_run_child_verify_nonzero_exit_is_not_ok(self, verifier, monkeypatch):
+        class _FakeProc:
+            returncode = 3
+            stdout = b""
+            stderr = b"boom"
+
+        monkeypatch.setattr(verifier.subprocess, "run", lambda *a, **kw: _FakeProc())
+        result = verifier._real_run_child_verify("heldout")
+        assert result["ok"] is False
+        assert "exited 3" in result["reason"]
+
+    def test_run_child_verify_unparseable_stdout_is_not_ok(self, verifier, monkeypatch):
+        class _FakeProc:
+            returncode = 0
+            stdout = b"not json"
+            stderr = b""
+
+        monkeypatch.setattr(verifier.subprocess, "run", lambda *a, **kw: _FakeProc())
+        result = verifier._real_run_child_verify("heldout")
+        assert result["ok"] is False
+        assert "unparseable" in result["reason"]
+
+    def test_child_verify_failure_rejects_candidate_not_promoted(self, verifier):
+        """A malformed child outcome (nonzero exit / unparseable stdout —
+        simulated here via the ``_run_child_verify`` seam) must reject the
+        candidate, never promote it — fail closed."""
+        head_sha = _init_instance_repo(
+            verifier.instance_repo, {"nanobot/runtime/existence_index.py": "X = 1\n"}
+        )
+        _write_candidate(
+            verifier.state_dir, "promotion-runtime-childfail",
+            ["nanobot/runtime/existence_index.py"], head_sha,
+        )
+        verifier._run_child_verify = lambda mode, **kw: {
+            "ok": False, "reason": "child verify process exited 1: boom",
+        }
+        s = verifier.verify_pass()
+        assert s["rejected"] == 1
+        assert s["promoted"] == 0
+        vs = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        assert "child verify" in vs["candidates"]["promotion-runtime-childfail"]["reason"]
+        assert not (verifier.promoted_tree / "manifest.json").exists() or json.loads(
+            (verifier.promoted_tree / "manifest.json").read_text()
+        ) == {"_schema_version": "promoted-manifest-v1"}
+
+
+class TestDemotionHelpers:
+    def test_is_root_returns_a_bool(self, verifier):
+        assert isinstance(verifier._is_root(), bool)
+
+    def test_is_root_false_on_non_posix(self, verifier):
+        if os.name != "posix":
+            assert verifier._is_root() is False
+
+    @pytest.mark.skipif(os.name != "posix", reason="pwd is POSIX-only")
+    def test_resolve_demote_ids_for_current_user(self, verifier):
+        import pwd
+
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        ids = verifier._resolve_demote_ids(current_user)
+        assert ids == (os.getuid(), os.getgid())
+
+    def test_resolve_demote_ids_unknown_user_returns_none(self, verifier):
+        if os.name != "posix":
+            assert verifier._resolve_demote_ids("eeepc-agent") is None
+        else:
+            assert verifier._resolve_demote_ids("no-such-user-xyz-123-does-not-exist") is None
+
+    @pytest.mark.skipif(os.name != "posix", reason="setuid/setgid are POSIX-only")
+    def test_demote_preexec_fn_is_callable_and_built_lazily(self, verifier):
+        # Never actually invoked (that would require real root) — this only
+        # verifies the factory produces a plain no-arg callable, matching
+        # what subprocess.run's preexec_fn contract requires.
+        fn = verifier._demote_preexec_fn(os.getuid(), os.getgid())
+        assert callable(fn)
+
+    def test_demote_kwargs_skips_demotion_when_not_root(self, verifier):
+        if verifier._is_root():
+            pytest.skip("test runner is root — cannot exercise the non-root branch")
+        kwargs, demoted = verifier._demote_kwargs()
+        assert demoted is False
+        assert kwargs == {}

--- a/tests/test_runtime_slice.py
+++ b/tests/test_runtime_slice.py
@@ -64,6 +64,25 @@ def test_deny_explicit_files():
     ):
         assert bridge._is_runtime_deny(f), f
 
+def test_deny_covers_the_rest_of_the_verification_kernel():
+    # #875 YELLOW-2 fix (opus-review round 2): the proposal claims the
+    # verification kernel is structurally never promotable — this asserts
+    # that for every module beyond bridge/promotion/coordinator whose
+    # compromise (or deletion, or self-weakening) would also break the
+    # #875 trust boundary. An operator accidentally listing one of these
+    # in SELFEVO_RUNTIME_SLICE must never make it eligible.
+    for f in (
+        "nanobot/runtime/scorecard.py",
+        "nanobot/runtime/benchmark_evidence.py",
+        "nanobot/runtime/usage_evidence.py",
+        "nanobot/runtime/promoted_overlay.py",
+        "nanobot/runtime/runtime_deny.py",
+        "nanobot/runtime/heldout/microbench.py",
+        "nanobot/runtime/heldout/__init__.py",
+        "nanobot/runtime/heldout/checkers.py",
+    ):
+        assert bridge._is_runtime_deny(f), f
+
 def test_deny_token_match():
     # basename token match covers future gate/safety/approval modules
     for f in (

--- a/tests/test_runtime_slice.py
+++ b/tests/test_runtime_slice.py
@@ -19,10 +19,39 @@ from pathlib import Path
 
 import pytest
 
-from nanobot.runtime import bridge
+from nanobot.runtime import bridge, runtime_deny
 
 _SLICE_ENV = "SELFEVO_RUNTIME_SLICE"
 _ALLOWED_SLICE = "nanobot/runtime/probes.py"
+
+
+# ─── #875: deny-set logic extracted to nanobot.runtime.runtime_deny ──────────
+# bridge.py re-exports the same names UNCHANGED so every test above (written
+# against bridge._is_runtime_deny / bridge._runtime_slice_paths) keeps passing
+# without modification — these tests additionally pin the re-export identity
+# and exercise the new pure (env-string-argument) function directly, since
+# the root verifier and the agent-side overlay loader both import it that way.
+
+def test_bridge_reexports_are_the_same_object_as_runtime_deny():
+    assert bridge._is_runtime_deny is runtime_deny._is_runtime_deny
+    assert bridge._RUNTIME_DENY_ALWAYS_FILES is runtime_deny._RUNTIME_DENY_ALWAYS_FILES
+    assert bridge._RUNTIME_DENY_TOKENS is runtime_deny._RUNTIME_DENY_TOKENS
+
+
+def test_runtime_deny_pure_function_matches_bridge_wrapper(monkeypatch):
+    monkeypatch.setenv(_SLICE_ENV, "nanobot/runtime/probes.py,nanobot/runtime/bridge.py")
+    assert runtime_deny.runtime_slice_paths("nanobot/runtime/probes.py,nanobot/runtime/bridge.py") == bridge._runtime_slice_paths()
+
+
+def test_runtime_deny_pure_function_takes_arg_not_environ(monkeypatch):
+    # the pure function must NOT read os.environ itself — only its argument
+    monkeypatch.setenv(_SLICE_ENV, "nanobot/runtime/bridge.py")  # deny-only, would be dropped anyway
+    assert runtime_deny.runtime_slice_paths("nanobot/runtime/probes.py") == {"nanobot/runtime/probes.py"}
+
+
+def test_runtime_deny_pure_function_none_and_empty():
+    assert runtime_deny.runtime_slice_paths(None) == set()
+    assert runtime_deny.runtime_slice_paths("") == set()
 
 
 # ─── _is_runtime_deny (immutable safety shell) ───────────────────────────────

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -966,8 +966,11 @@ class TestControlPlaneSnapshot:
         state_dir = tmp_path / "state"
         snap = scorecard.compute_scorecard(state_dir, None, force=True)
         control_plane = snap["control_plane"]
-        assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS)
-        assert all(v is None for v in control_plane.values())
+        # #875: runtime_promotions is a fixed extra key (not env-driven), so
+        # it is asserted separately rather than folded into the allowlist.
+        assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {"runtime_promotions"}
+        assert all(control_plane[key] is None for key in scorecard._CONTROL_PLANE_KEYS)
+        assert control_plane["runtime_promotions"] == {"active": 0, "soaking": 0, "rejected": 0}
 
     def test_set_values_are_captured_others_stay_none(self, tmp_path, monkeypatch):
         for key in scorecard._CONTROL_PLANE_KEYS:
@@ -993,7 +996,7 @@ class TestControlPlaneSnapshot:
         state_dir = tmp_path / "state"
         snap = scorecard.compute_scorecard(state_dir, None, force=True)
         control_plane = snap["control_plane"]
-        assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS)
+        assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {"runtime_promotions"}
 
     def test_no_secret_ever_appears_in_serialized_scorecard(self, tmp_path, monkeypatch):
         """Paranoia test (#865): a real secret-shaped env var, and a
@@ -1008,6 +1011,44 @@ class TestControlPlaneSnapshot:
         assert "sk-test" not in serialized
         assert "SELFEVO_FAKE_SECRET_TOKEN" not in serialized
         assert "LITELLM_API_KEY" not in serialized
+
+    def test_runtime_promotions_counts_active_soaking_rejected(self, tmp_path, monkeypatch):
+        """#875: control_plane.runtime_promotions reflects PROMOTED_TREE's
+        manifest (active) + verifier_state (soaking/rejected) — a cheap,
+        read-only peek at the root-verification pipeline."""
+        promoted_tree = tmp_path / "promoted"
+        promoted_tree.mkdir()
+        (promoted_tree / "manifest.json").write_text(json.dumps({
+            "_schema_version": "promoted-manifest-v1",
+            "nanobot/runtime/existence_index.py": {"status": "active"},
+            "nanobot/runtime/probes.py": {"status": "active"},
+        }))
+        (promoted_tree / "verifier_state.json").write_text(json.dumps({
+            "candidates": {
+                "promotion-runtime-a": {"status": "soaking"},
+                "promotion-runtime-b": {"status": "rejected"},
+                "promotion-runtime-c": {"status": "rejected"},
+                "promotion-runtime-d": {"status": "promoted"},
+            }
+        }))
+        monkeypatch.setenv("PROMOTED_TREE", str(promoted_tree))
+        state_dir = tmp_path / "state"
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        assert snap["control_plane"]["runtime_promotions"] == {
+            "active": 2,
+            "soaking": 1,
+            "rejected": 2,
+        }
+
+    def test_runtime_promotions_fail_open_when_tree_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PROMOTED_TREE", str(tmp_path / "does-not-exist"))
+        state_dir = tmp_path / "state"
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        assert snap["control_plane"]["runtime_promotions"] == {
+            "active": 0,
+            "soaking": 0,
+            "rejected": 0,
+        }
 
     def test_visibility_only_not_fed_into_targets_or_gaps(self):
         """Regression pin: control_plane keys must never appear as a target


### PR DESCRIPTION
## Summary

Resurrects the #875 WIP (`wip/875-blocked-on-host-hardening`, based on main~1) on top of current `main` now that its prerequisite #880 (host privilege hardening) has merged, and fixes two RED findings from an Opus adversarial review before this is safe to ship.

**Design (unchanged from the WIP):** the eeepc host runs the bridge/harness and the instance's subagent under the same uid, so a naive auto-promotion loader trusting instance-written state would be a straightforward path to arbitrary code execution in harness context. `host/eeepc/libexec/eeepc_promotion_verifier.py` closes this by putting **root** in the loop as an independent, automated verifier (systemd timer, no `User=`): it treats the instance's promotion candidates as untrusted proposals, re-materializes candidate bytes itself via content-addressed `git show`, re-measures the #822 causal micro-benchmark and the #780 held-out pack itself (never trusting the instance's own numbers), and only after a 3-pass soak with no regression/integrity incident writes verified bytes into a root-owned `PROMOTED_TREE` that the agent-side loader (`nanobot.runtime.promoted_overlay`) can read but never write.

### RED1 — root RCE via agent-owned release tree

#880 made the release tree read-only to the runtime uid via the process sandbox (`ProtectSystem=strict`), but never changed its on-disk owner — `deploy_release.sh` still chowned it `eeepc-agent:eeepc-agent`. The verifier imports straight out of that tree, **as root** — meaning the runtime uid (the same uid the instance's subagent runs as) could plant/mutate a module the verifier would then import with root privilege.

Fix:
- `deploy_release.sh` now chowns the release `root:root` (the `goal_text.json` state-seeding chown stays `eeepc-agent:eeepc-agent` — that's instance-writable state, not release code).
- The verifier independently proves this held **before** it imports anything from the release: `_verify_release_ownership_or_exit()` stat-checks the release dir, `nanobot/`, and `nanobot/runtime/` for `st_uid == 0` and no group/other write bits, printing one reason and exiting nonzero on failure — fail closed, no partial import. Skippable only via `EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK=1` (documented test-only escape hatch).

### RED2 — root executing instance-influenced code (no privilege drop)

`git show` against the instance-owned repo, the microbench measurement, and the held-out pack all ran as root with zero privilege drop — root must never *execute* anything the instance influenced, only ever receive bytes/verdicts as inert data.

Fix:
- A demotion helper resolves `pwd.getpwnam(EEEPC_VERIFIER_DEMOTE_USER or "eeepc-agent")` once and builds a `setgroups`/`setgid`/`setuid` `preexec_fn` (guarded behind `os.name == "posix"` / `os.geteuid() == 0`, skipped with an explicit log line on non-root runners — tests, dev, Windows).
- `git show` now runs via a demoted subprocess (`_git_show_bytes_demoted`).
- The microbench measurement and held-out pack now run inside a **demoted child** process: the verifier re-invokes its own interpreter (`--child-verify --mode {full,heldout}`), which re-runs the sys.path bootstrap + ownership check + imports, does the actual measurement/heldout work, and prints exactly one JSON object to stdout. Root parses that JSON as untrusted data — a nonzero exit or unparseable stdout is folded into `{"ok": false, ...}`, treated as "could not verify", never a green light. **The trust decision never moved into the child** — the child reports raw numbers, the root parent still computes `improvement_pct` and applies the #822 threshold itself.
- `eeepc-promotion-verifier.service` gained `NoNewPrivileges=yes` (still permits privilege *drop*, only blocks *gaining* it), `PrivateTmp=yes`, `ProtectHome=yes`, `ProtectSystem=strict`, `ReadWritePaths=/var/lib/eeepc-promoted /var/lib/eeepc-agent` — matching #880's posture on every other lane.

Accepted residual risk (documented in the proposal): the candidate code necessarily executes inside the demoted measurement child — there's no way to measure it otherwise. A compromised child can at most forge its own reported numbers for one pass; it has no root access and no write access to `PROMOTED_TREE`.

Also addressed two Pyright-flagged spots while in the file: an `assert module_path is not None` at the one call site where a tuple-unpack couldn't statically prove non-None (true at runtime — `_classify_candidate` only returns `eligible=True` alongside a real module_path), a `str | None` annotation fix on `_measure_candidate`'s `head_sha` param (it already handled `None` at runtime), a `proc.stdout or b""` guard before decoding child stdout, and `# type: ignore[attr-defined]` on the three POSIX-only `os.setgroups`/`setgid`/`setuid` calls (matching this repo's existing `fcntl` POSIX-guard convention in `bridge.py`).

## Test plan

- [x] `tests/test_promotion_verifier.py` rewritten for the demoted-child architecture (the `_run_child_verify` seam replaces direct `run_measurement`/`_run_heldout` monkeypatching) plus new coverage: ownership fail-closed check (including a POSIX-only real-uid-mismatch test), a real-subprocess `--child-verify` JSON round-trip, nonzero-child-exit / unparseable-stdout handling, and demotion-helper unit tests (POSIX-gated with `skipif`).
- [x] `tests/test_promotion_verifier.py` alone: 31 passed, 3 skipped (skips are POSIX-only, expected on this Windows dev box).
- [x] Full suite (`python -m pytest tests/ -q`, minus 11 files that fail to even *collect* on this dev box due to a pre-existing, unrelated global Python environment issue — a stray `tests` package in the user's personal site-packages shadows this repo's local `tests` package for any file doing `from tests.test_cycle_ledger import ...`; confirmed via `git stash` that these collection errors are identical on the unmodified merge commit, unrelated to this PR): **1724 passed, 3 skipped, 28 failed**. Every one of the 28 failures reproduces identically on the unmodified merge commit (verified via `git stash` + isolated re-runs) — all Windows-dev-box-only (symlink/git-archive tests requiring POSIX symlink semantics, `flock`-based locking tests that are POSIX-only, a `typer`/`click` version mismatch causing a CLI `--help` `TypeError`, and missing optional web-search test dependencies). None touch the files this PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)