### PR TITLE
fix(host): #875 deploy — strip go-w on release + create promoted tree

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -122,6 +122,23 @@ sudo chown -h root:root /opt/eeepc-agent/runtimes/self-evolving-agent/current 2>
 sudo chown -h root:root "$RELEASE_DIR/.venv" 2>/dev/null || true
 sudo chown root:root /opt/eeepc-agent/venv 2>/dev/null || true
 
+# #875 (live-rollout fix): the verifier's fail-closed ownership self-check
+# refuses to import the release unless it is root-owned AND has NO group/other
+# write bit (`mode & 0o022 == 0`). The release tar/umask can leave directories
+# group-writable (0775), which trips that check even when the tree is root:root.
+# Strip group/other write so the check passes; read+exec (what the runtime uid
+# needs) is untouched.
+sudo chmod -R go-w "$RELEASE_DIR" 2>/dev/null || true
+
+# #875 (live-rollout fix): the root-owned promoted tree. Normally created by
+# install.sh, but a host updated via deploy alone never runs it — and the
+# verifier unit's ReadWritePaths=/var/lib/eeepc-promoted makes systemd fail
+# the unit (226/NAMESPACE) if the path is absent. Create it here idempotently,
+# root-owned so the eeepc-agent-uid loader can read but never write it.
+sudo mkdir -p /var/lib/eeepc-promoted 2>/dev/null || true
+sudo chown root:eeepc-agent /var/lib/eeepc-promoted 2>/dev/null || true
+sudo chmod 0755 /var/lib/eeepc-promoted 2>/dev/null || true
+
 echo "[remote] syncing libexec scripts from release"
 # Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`
 # straight from the release; only auxiliary libexec scripts are synced


### PR DESCRIPTION
Two deploy-script gaps found during the #875 live rollout to eeepc (both fixed + verified live):

1. **Ownership check tripped by group-write.** The verifier's fail-closed self-check requires the release tree root-owned AND `mode & 0o022 == 0`. The release tar/umask leaves dirs `0775` (group-writable) → check refuses to import even though deploy chowns `root:root`. Fix: `chmod -R go-w $RELEASE_DIR` after the chown (read+exec for the runtime uid untouched).
2. **Promoted tree missing on deploy-only hosts.** `/var/lib/eeepc-promoted` is created only by `install.sh`; a host updated via `deploy_release.sh` alone never has it, and the verifier unit's `ReadWritePaths=/var/lib/eeepc-promoted` makes systemd fail the unit `226/NAMESPACE`. Fix: create it idempotently in deploy, root-owned (`root:eeepc-agent 0755`).

**Verified live on eeepc:** after applying both, `eeepc-promotion-verifier.service` runs clean — `processed=0 rejected=0 soaking=0 promoted=0 rolled_back=0 errors=0` as root, ownership check satisfied, no NAMESPACE error. Release + full /opt chain confirmed root:root; PROMOTED_TREE root:eeepc-agent 0755; all three timers active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)