### PR TITLE
fix(runtime): #884 auto-protect held-out-contracted scripts from decay

### DIFF
--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -145,6 +145,34 @@ def _decay_protected_paths() -> frozenset[str]:
         return frozenset()
 
 
+def _heldout_contracted_paths() -> frozenset[str]:
+    """Repo-relative ``scripts/*.py`` paths that are under a held-out
+    behavioral contract (#884): the keys of
+    :data:`nanobot.runtime.heldout.checkers.CHECKERS`.
+
+    These MUST never be decay-eligible. The held-out pack (#780) is a global
+    gate on runtime-slice auto-promotion (#875) — it must be clean for any
+    candidate to promote — so a decay-disabled contracted script keeps
+    held-out permanently RED and makes the whole promote path inert (the
+    live #884 incident: the decay lane disabled ``scripts/archive_old_reports.py``
+    while it was still contracted). Deriving the protect-set from the live
+    registry (rather than a hand-maintained list) means it can never drift
+    out of sync: remove a checker and its protection lifts automatically.
+
+    Imported lazily and fail-open (frozenset() on any error) — a protection
+    lookup must never crash the decay input, and the lazy import keeps this
+    module free of an import-time dependency on the heldout package.
+    """
+    try:
+        from nanobot.runtime.heldout.checkers import CHECKERS
+
+        return frozenset(
+            str(k).strip().replace("\\", "/") for k in CHECKERS if str(k).strip()
+        )
+    except Exception:
+        return frozenset()
+
+
 def _reference_signal_enabled() -> bool:
     """#838 kill-switch. Default ON; SELFEVO_USAGE_REFERENCE_ENABLED=0 → the
     reference signal is not computed (byte-identical to pre-#838 behavior)."""
@@ -933,12 +961,17 @@ def stale_artifacts(
         now = now or datetime.now(timezone.utc)
         cutoff = now - timedelta(days=older_than_days)
         entries = _load_usage(Path(state_dir)).get("entries") or {}
-        protected = _decay_protected_paths()
+        # #809 operator protect-list ∪ #884 held-out-contracted scripts: a
+        # script under a held-out contract must never be decay-disabled (a
+        # disabled contracted script keeps held-out RED, which makes #875
+        # auto-promotion inert). Derived from the live checker registry so it
+        # cannot drift.
+        protected = _decay_protected_paths() | _heldout_contracted_paths()
         out: list[dict[str, str]] = []
         for script in sorted(scripts_dir.glob("*.py")):
             rel = f"scripts/{script.name}"
             if rel in protected:
-                continue  # operator-protected -- never a decay candidate (#809)
+                continue  # protected -- never a decay candidate (#809 operator / #884 held-out)
             entry = entries.get(rel)
             entry = entry if isinstance(entry, dict) else {}
             if _is_archived_stub(script):

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -1416,6 +1416,35 @@ class TestDecayEligibilityGuard:
         stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
         assert [item["path"] for item in stale] == ["scripts/old_tool.py"]
 
+    def test_heldout_contracted_script_never_flagged(self, tmp_path, monkeypatch):
+        """#884: a script under a held-out behavioral contract (a key of
+        heldout.checkers.CHECKERS) must never be a decay candidate even when
+        otherwise stale-eligible and with NO operator protect env set — a
+        decay-disabled contracted script keeps held-out RED and makes #875
+        auto-promotion inert. Protection is derived from the live registry."""
+        from nanobot.runtime.heldout.checkers import CHECKERS
+
+        contracted = sorted(CHECKERS)[0]  # e.g. scripts/archive_old_reports.py
+        name = contracted.split("/", 1)[1]
+        monkeypatch.delenv("SELFEVO_DECAY_PROTECT", raising=False)
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, [name])
+        _write_usage_sidecar(
+            state_dir,
+            {contracted: {"last_used": _now_iso(days_ago=30),
+                          "last_touched": _now_iso(days_ago=20),
+                          "signal": "pycache"}},
+        )
+        stale = usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14)
+        assert contracted not in [item["path"] for item in stale]
+
+    def test_heldout_contracted_paths_helper_fail_open(self, tmp_path):
+        """The registry lookup is fail-open: it returns a frozenset of the
+        contracted paths, and never raises."""
+        paths = usage_evidence._heldout_contracted_paths()
+        assert isinstance(paths, frozenset)
+        assert "scripts/archive_old_reports.py" in paths
+
     def test_unset_protect_env_behavior_unchanged(self, tmp_path, monkeypatch):
         """No env var set at all: identical to pre-#809 behavior — a stale
         script surfaces normally."""


### PR DESCRIPTION
## Problem
The held-out pack (#780) is a **global gate** on #875 runtime-slice auto-promotion — a candidate promotes only if held-out is clean. The decay lane disabled `scripts/archive_old_reports.py` (2026-08-07) while it was under a held-out contract (`heldout/checkers.py::check_archive_old_reports`) → held-out permanently RED → **#875 promote path inert** on the live host. Surfaced by the #875 acceptance drill.

## Fix (structural, no drift)
`usage_evidence.stale_artifacts` (the sole decay-candidate input) now unions the #809 operator protect-list with the keys of the live `heldout.checkers.CHECKERS` registry. A held-out-contracted script is never a decay candidate; remove its checker and protection lifts automatically. Lazy import + fail-open (no import-time heldout dependency; never crashes the decay input).

## Tests
`test_usage_evidence.py`: +2 — a CHECKERS-registry script is never flagged even when stale-eligible with no operator env; helper is fail-open. Full local run: 72/72 usage_evidence; 1735 passed suite-wide (27 pre-existing Windows-only failures + 11 site-packages-shadow collection errors, both unrelated — CI Linux is clean).

## Scope
Product-side structural fix only. Does NOT un-stub the already-disabled `archive_old_reports.py` — that instance-side restore is the rollout step that turns held-out green (done post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)