### PR TITLE
fix(runtime): #887 drop obsolete archive_old_reports held-out contract (superseded by #864)

### DIFF
--- a/docs/changes/887-drop-stale-archive-checker/proposal.md
+++ b/docs/changes/887-drop-stale-archive-checker/proposal.md
@@ -1,0 +1,105 @@
+# Change: drop the obsolete archive_old_reports held-out contract
+
+- **change-id:** 887-drop-stale-archive-checker
+- **issue:** #887 (follow-up to #864, #798/#799/#800/#801/#802, #875, #876)
+- **capability:** docs/specs/subagent-bridge (held-out verification pack, #780)
+- **role / workstream:** role:developer / workstream:runtime-quality
+
+## Problem
+
+The held-out pack (`nanobot/runtime/heldout/checkers.py`) contracts
+`scripts/archive_old_reports.py` via `check_archive_old_reports`: it
+requires a loop-authored script that moves `state/reports/*.json` older
+than 30 days into monthly tar.gz archives, with a strict dry-run-is-
+side-effect-free core.
+
+That script's job is now redundant. #864 added product-code pruning —
+`coordinator.py`'s `_prune_stale_reports` with `REPORTS_RETENTION_KEEP=200`
+— which bounds `evolution-*.json` report-file bloat every cycle,
+unconditionally, without any loop-authored script. The decay system
+(#798–#802) correctly identified `archive_old_reports.py` as unused
+(nothing in the loop's own product surface calls it, and its function is
+superseded) and retired it. But the held-out pack still contracts the
+retired script's *path*, so the disabled instance copy keeps failing
+`check_archive_old_reports` — that keeps the `heldout` scorecard section
+RED and the `heldout_gap` metric over its V1 target, which blocks the
+global promote gate (#875/#876) from ever going GREEN.
+
+This is a genuine conflict, not a bug in either subsystem: a script is
+either (a) still contracted by the held-out pack and therefore decay-
+protected (per #884's `_heldout_contracted_paths()`), or (b) legitimately
+retired because a superseding mechanism exists. It cannot be both
+"decay says drop it" and "held-out says keep it" at once. Since (b) is
+true here — #864 supersedes the script's entire purpose — the held-out
+contract is the stale side of the conflict and must be dropped.
+
+## Intended change
+
+Remove the `check_archive_old_reports` checker and its
+`"scripts/archive_old_reports.py"` entry from the `CHECKERS` registry in
+`nanobot/runtime/heldout/checkers.py`. The other four checkers
+(`eeebot_dashboard`, `generate_system_map`, `prune_failed_backlog`,
+`loop_health_report`) and the `run_heldout` engine (result shape,
+regression detection, flaky-run confirmation, defect-demand emission,
+invisibility) are untouched.
+
+`tests/test_heldout.py`'s engine-level coverage that previously used
+`archive_old_reports.py` as its example fixture (good/bad pass-fail pairs,
+regression flip detection, sandbox isolation) is repointed to use the
+still-registered `eeebot_dashboard.py` (`GOOD_DASHBOARD` /
+`CRASHING_DASHBOARD`) and `generate_system_map.py`
+(`GOOD_SYSTEM_MAP` / new `BAD_SYSTEM_MAP`, a subtle-behavioral-defect
+fixture that exits 0 but omits the required per-script entries) fixtures.
+No engine assertion (result shape, regression list semantics, flaky
+exclusion, defect-demand evidence, invisibility) is weakened — only the
+example checker used to exercise them changes.
+
+`tests/test_usage_evidence.py`'s #884 tests
+(`test_heldout_contracted_script_never_flagged`,
+`test_heldout_contracted_paths_helper_fail_open`) are updated to reference
+a still-registered contracted script (`scripts/eeebot_dashboard.py`)
+instead of the removed one, so they keep proving: (a) a `CHECKERS`-
+registry script is never decay-flagged, and (b) the contracted-paths
+helper returns the live registry set.
+
+`tests/test_goal_text_priority_filter.py`'s references to
+`archive_old_reports.py` are narrative goal-text priority strings
+unrelated to the checker registry or decay behavior — left unchanged.
+
+This durably restores held-out `GREEN` (the fix lives in product code
+under `heldout/`, a runtime-deny-set package the loop cannot modify) and
+unblocks organic promotion under #875/#876.
+
+## Acceptance
+
+- [x] `check_archive_old_reports` and its registry entry are removed from
+      `nanobot/runtime/heldout/checkers.py`; the other four checkers are
+      untouched.
+- [x] `tests/test_heldout.py` passes, still exercising: results shape,
+      good→pass, bad→fail (including a non-crash subtle-defect fail
+      path), missing-artifact skip, timeout→skip, content-hash reuse,
+      regression pass→fail / still-failing / new-only-failure / pass→pass
+      semantics, flaky-run detection, sandbox isolation, scorecard
+      integration, defect-demand emission, and the invisibility invariant
+      — via the `eeebot_dashboard.py` / `generate_system_map.py` fixtures
+      instead of the removed checker.
+- [x] `tests/test_usage_evidence.py` passes, still proving a
+      `CHECKERS`-registry script is never decay-flagged and that
+      `_heldout_contracted_paths()` returns the live registry set.
+- [x] `tests/test_goal_text_priority_filter.py` is unchanged (its
+      `archive_old_reports.py` mentions are narrative goal-text content,
+      not registry/decay assertions).
+- [x] Full test suite shows no new failures beyond pre-existing
+      Windows-only / site-packages-shadow collection issues.
+- [x] `heldout/` remains in `runtime_deny` (no change to the deny-set).
+
+## Out of scope
+
+- No changes to `coordinator.py`'s `_prune_stale_reports` /
+  `REPORTS_RETENTION_KEEP` (#864) — this change only removes the now-
+  redundant held-out contract on the loop-authored equivalent.
+- No changes to the other four checkers or the `run_heldout` engine's
+  regression/flaky/defect-demand logic.
+- No changes to `runtime_deny`, decay eligibility logic (#798–#802), or
+  the #875/#876 promote-gate mechanics themselves — this change only
+  removes the stale RED signal blocking them.

--- a/nanobot/runtime/heldout/checkers.py
+++ b/nanobot/runtime/heldout/checkers.py
@@ -11,9 +11,8 @@ its own visible tests is not evidence of correctness).
 Checker discipline:
 
 - **Lenient on interface details** (exact flag names, output formatting may
-  drift) but **strict on the behavioral core**: ``archive_old_reports``'s
-  dry-run must not modify the fixture tree; the dashboard must not crash on
-  empty state; system-map regeneration must produce a file naming fixture
+  drift) but **strict on the behavioral core**: the dashboard must not crash
+  on empty state; system-map regeneration must produce a file naming fixture
   scripts. Loosely-contracted scripts get a lenient smoke check only.
 - Checkers receive a :class:`CheckContext` and return ``(status, evidence)``
   with ``status`` ∈ ``pass|fail|skip``. The evidence string is the ONLY
@@ -30,10 +29,8 @@ checker callable. Adding coverage = adding one entry here.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -88,16 +85,6 @@ def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
     return text[-_STDERR_TAIL:].replace("\n", " ")
 
 
-def _tree_snapshot(root: Path) -> set[tuple[str, int]]:
-    """(relative path, size) for every file under ``root`` — the
-    modification detector for dry-run safety."""
-    out: set[tuple[str, int]] = set()
-    for path in sorted(root.rglob("*")):
-        if path.is_file():
-            out.add((str(path.relative_to(root)), path.stat().st_size))
-    return out
-
-
 def _write_fixture_ledger(ctx: CheckContext) -> Path:
     ledger_dir = ctx.tmp_dir / "state" / "ledger"
     ledger_dir.mkdir(parents=True, exist_ok=True)
@@ -109,45 +96,6 @@ def _write_fixture_ledger(ctx: CheckContext) -> Path:
     path = ledger_dir / "cycles.jsonl"
     path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
     return path
-
-
-# ─── scripts/archive_old_reports.py ─────────────────────────────────────────
-
-
-def check_archive_old_reports(ctx: CheckContext) -> tuple[str, str]:
-    """Contract (Priority 12): moves ``state/reports/*.json`` older than 30
-    days into monthly tar.gz under ``state/reports/archive/``; ``--dry-run``
-    is the default, ``--apply`` mutates. STRICT core: the default (dry-run)
-    invocation must not modify the fixture tree."""
-    reports = ctx.tmp_dir / "state" / "reports"
-    reports.mkdir(parents=True, exist_ok=True)
-    old = reports / "cycle-old.json"
-    recent = reports / "cycle-recent.json"
-    old.write_text('{"cycle": "old"}\n', encoding="utf-8")
-    recent.write_text('{"cycle": "recent"}\n', encoding="utf-8")
-    stamp = time.time() - 60 * 86400
-    os.utime(old, (stamp, stamp))
-
-    before = _tree_snapshot(reports)
-    proc = _run(ctx)
-    if proc.returncode != 0:
-        return FAIL, f"default (dry-run) invocation exited {proc.returncode}: {_stderr_tail(proc)}"
-    after = _tree_snapshot(reports)
-    if after != before:
-        return FAIL, (
-            "dry-run modified the reports tree (files added/removed/changed) — "
-            "dry-run must be side-effect free"
-        )
-
-    proc = _run(ctx, ("--apply",))
-    if proc.returncode != 0:
-        return FAIL, f"--apply exited {proc.returncode}: {_stderr_tail(proc)}"
-    archives = list((reports / "archive").rglob("*.tar.gz")) if (reports / "archive").is_dir() else []
-    if not archives:
-        return FAIL, "--apply produced no tar.gz under state/reports/archive/"
-    if old.exists():
-        return FAIL, "--apply left the >30d-old report in state/reports/ (not moved)"
-    return PASS, "dry-run side-effect free; --apply archived the old report to tar.gz"
 
 
 # ─── scripts/eeebot_dashboard.py ────────────────────────────────────────────
@@ -234,7 +182,6 @@ def check_smoke(ctx: CheckContext) -> tuple[str, str]:
 # ─── registry ───────────────────────────────────────────────────────────────
 
 CHECKERS: dict[str, Callable[[CheckContext], tuple[str, str]]] = {
-    "scripts/archive_old_reports.py": check_archive_old_reports,
     "scripts/eeebot_dashboard.py": check_eeebot_dashboard,
     "scripts/generate_system_map.py": check_generate_system_map,
     "scripts/prune_failed_backlog.py": check_smoke,

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -1,15 +1,21 @@
 """Tests for #780: the held-out verification pack.
 
-Covers: runner dispatch against a fixture "instance repo" (correct
-archive_old_reports passes, a dry-run-that-deletes version fails; dashboard
-degrade-on-empty passes, a crashing dashboard fails), missing artifacts not
-checked, timeout → skip, content-hash reuse on the second run, the
-results.json shape, sandbox isolation (fixture repo untouched; scripts
+Covers: runner dispatch against a fixture "instance repo" (dashboard
+degrade-on-empty passes, a crashing dashboard fails; system-map regeneration
+naming fixture scripts passes, a version that omits them fails), missing
+artifacts not checked, timeout → skip, content-hash reuse on the second run,
+the results.json shape, sandbox isolation (fixture repo untouched; scripts
 cannot write outside the tmpdir), the scorecard `heldout` section +
 `heldout_gap` target breach → goal-gap, fail-open zeros on missing results,
 defect-demand emission with checker evidence, and the invisibility
 invariant (nothing instance-facing references the pack; no fixtures on
 disk in the package).
+
+#887: ``scripts/archive_old_reports.py`` was dropped from the CHECKERS
+registry (superseded by #864's product-code REPORTS_RETENTION_KEEP pruning)
+— fixtures below use the still-registered ``eeebot_dashboard.py`` and
+``generate_system_map.py`` checkers as the good/bad pairs that exercise the
+engine.
 """
 from __future__ import annotations
 
@@ -24,54 +30,6 @@ from nanobot.runtime.heldout import checkers
 NOW = datetime.now(timezone.utc)
 
 # ─── fixture instance-repo scripts ──────────────────────────────────────────
-
-GOOD_ARCHIVE = '''\
-"""Archive old reports: state/reports/*.json older than 30d into monthly tar.gz."""
-import argparse, tarfile, time
-from pathlib import Path
-
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--apply", action="store_true")
-    args = ap.parse_args()
-    reports = Path("state/reports")
-    cutoff = time.time() - 30 * 86400
-    by_month = {}
-    for p in sorted(reports.glob("*.json")):
-        if p.stat().st_mtime < cutoff:
-            by_month.setdefault(time.strftime("%Y-%m", time.gmtime(p.stat().st_mtime)), []).append(p)
-    if not args.apply:
-        for month, files in by_month.items():
-            for p in files:
-                print("would archive", p, "->", month)
-        return
-    arch = reports / "archive"
-    arch.mkdir(parents=True, exist_ok=True)
-    for month, files in by_month.items():
-        with tarfile.open(arch / f"{month}.tar.gz", "w:gz") as tar:
-            for p in files:
-                tar.add(p, arcname=p.name)
-        for p in files:
-            p.unlink()
-
-main()
-'''
-
-# Reward-hacked/buggy variant: "dry-run" actually deletes the old files.
-BAD_ARCHIVE = '''\
-"""Archive old reports (buggy: dry-run deletes)."""
-import argparse, time
-from pathlib import Path
-ap = argparse.ArgumentParser()
-ap.add_argument("--apply", action="store_true")
-ap.parse_args()
-reports = Path("state/reports")
-cutoff = time.time() - 30 * 86400
-for p in sorted(reports.glob("*.json")):
-    if p.stat().st_mtime < cutoff:
-        p.unlink()  # mutates even without --apply
-        print("archived", p)
-'''
 
 GOOD_DASHBOARD = '''\
 """Dashboard: loop-health from state/ledger/cycles.jsonl, degrades on empty."""
@@ -106,6 +64,15 @@ for p in sorted(Path("scripts").glob("*.py")):
     lines.append(f"- {p.name}: {purpose}")
 Path("docs").mkdir(exist_ok=True)
 Path("docs/SYSTEM_MAP.md").write_text("\\n".join(lines) + "\\n")
+'''
+
+# Buggy variant: exits 0 and produces a SYSTEM_MAP.md, but omits any
+# per-script entries — a subtle behavioral defect (not a crash).
+BAD_SYSTEM_MAP = '''\
+"""Regenerate docs/SYSTEM_MAP.md (buggy: omits per-script entries)."""
+from pathlib import Path
+Path("docs").mkdir(exist_ok=True)
+Path("docs/SYSTEM_MAP.md").write_text("# SYSTEM MAP\\n\\n(nothing to report)\\n")
 '''
 
 SMOKE_OK = '''\
@@ -178,7 +145,6 @@ class TestRunner:
         repo = _make_repo(
             tmp_path,
             {
-                "archive_old_reports.py": GOOD_ARCHIVE,
                 "eeebot_dashboard.py": GOOD_DASHBOARD,
                 "generate_system_map.py": GOOD_SYSTEM_MAP,
                 "loop_health_report.py": SMOKE_OK,
@@ -192,7 +158,6 @@ class TestRunner:
         results = data["results"]
         # prune_failed_backlog.py is registered but absent — not checked.
         assert set(results) == {
-            "scripts/archive_old_reports.py",
             "scripts/eeebot_dashboard.py",
             "scripts/generate_system_map.py",
             "scripts/loop_health_report.py",
@@ -206,12 +171,15 @@ class TestRunner:
         on_disk = json.loads((state_dir / "heldout" / "results.json").read_text())
         assert on_disk["results"] == results
 
-    def test_dry_run_that_mutates_fails(self, tmp_path):
-        repo = _make_repo(tmp_path, {"archive_old_reports.py": BAD_ARCHIVE})
+    def test_subtle_behavioral_defect_fails(self, tmp_path):
+        """A script that exits 0 and produces output, but violates the
+        behavioral contract (not a crash) — the engine must still fail it
+        on the checker's evidence, not just on exit code."""
+        repo = _make_repo(tmp_path, {"generate_system_map.py": BAD_SYSTEM_MAP})
         data = heldout.run_heldout(tmp_path / "state", repo, force=True)
-        entry = data["results"]["scripts/archive_old_reports.py"]
+        entry = data["results"]["scripts/generate_system_map.py"]
         assert entry["status"] == "fail"
-        assert "dry-run" in entry["evidence"]
+        assert "fixture scripts" in entry["evidence"]
 
     def test_crashing_dashboard_fails(self, tmp_path):
         repo = _make_repo(tmp_path, {"eeebot_dashboard.py": CRASHING_DASHBOARD})
@@ -289,56 +257,56 @@ class TestRunner:
     # ─── regressions (#841: pass -> fail flips) ─────────────────────────────
 
     def test_regression_pass_to_fail_recorded(self, tmp_path):
-        repo = _make_repo(tmp_path, {"archive_old_reports.py": GOOD_ARCHIVE})
+        repo = _make_repo(tmp_path, {"eeebot_dashboard.py": GOOD_DASHBOARD})
         state_dir = tmp_path / "state"
         first = heldout.run_heldout(state_dir, repo, force=True)
-        assert first["results"]["scripts/archive_old_reports.py"]["status"] == "pass"
+        assert first["results"]["scripts/eeebot_dashboard.py"]["status"] == "pass"
         assert first["regressions"] == []
-        # Swap the passing script for the reward-hacked variant — same
-        # artifact path, new content → rechecked, now fails.
-        (repo / "scripts" / "archive_old_reports.py").write_text(
-            BAD_ARCHIVE, encoding="utf-8"
+        # Swap the passing script for a crashing variant — same artifact
+        # path, new content → rechecked, now fails.
+        (repo / "scripts" / "eeebot_dashboard.py").write_text(
+            CRASHING_DASHBOARD, encoding="utf-8"
         )
         second = heldout.run_heldout(state_dir, repo, force=True)
-        assert second["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
-        assert second["regressions"] == ["scripts/archive_old_reports.py"]
+        assert second["results"]["scripts/eeebot_dashboard.py"]["status"] == "fail"
+        assert second["regressions"] == ["scripts/eeebot_dashboard.py"]
         on_disk = json.loads((state_dir / "heldout" / "results.json").read_text())
-        assert on_disk["regressions"] == ["scripts/archive_old_reports.py"]
+        assert on_disk["regressions"] == ["scripts/eeebot_dashboard.py"]
 
     def test_regression_still_failing_not_counted(self, tmp_path):
-        repo = _make_repo(tmp_path, {"archive_old_reports.py": BAD_ARCHIVE})
+        repo = _make_repo(tmp_path, {"eeebot_dashboard.py": CRASHING_DASHBOARD})
         state_dir = tmp_path / "state"
         first = heldout.run_heldout(state_dir, repo, force=True)
-        assert first["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert first["results"]["scripts/eeebot_dashboard.py"]["status"] == "fail"
         assert first["regressions"] == []
-        # Still buggy, but content changed → rechecked, still fails. Was
+        # Still broken, but content changed → rechecked, still fails. Was
         # already failing last run, so this is NOT a regression.
-        (repo / "scripts" / "archive_old_reports.py").write_text(
-            BAD_ARCHIVE + "\n# still broken\n", encoding="utf-8"
+        (repo / "scripts" / "eeebot_dashboard.py").write_text(
+            CRASHING_DASHBOARD + "\n# still broken\n", encoding="utf-8"
         )
         second = heldout.run_heldout(state_dir, repo, force=True)
-        assert second["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert second["results"]["scripts/eeebot_dashboard.py"]["status"] == "fail"
         assert second["regressions"] == []
 
     def test_regression_new_only_failure_not_counted(self, tmp_path):
         """An artifact with no prior result (first time checked) that fails
         is not a regression — there was nothing to regress from."""
-        repo = _make_repo(tmp_path, {"archive_old_reports.py": BAD_ARCHIVE})
+        repo = _make_repo(tmp_path, {"eeebot_dashboard.py": CRASHING_DASHBOARD})
         state_dir = tmp_path / "state"
         data = heldout.run_heldout(state_dir, repo, force=True)
-        assert data["results"]["scripts/archive_old_reports.py"]["status"] == "fail"
+        assert data["results"]["scripts/eeebot_dashboard.py"]["status"] == "fail"
         assert data["regressions"] == []
 
     def test_regression_pass_to_pass_empty(self, tmp_path):
-        repo = _make_repo(tmp_path, {"archive_old_reports.py": GOOD_ARCHIVE})
+        repo = _make_repo(tmp_path, {"eeebot_dashboard.py": GOOD_DASHBOARD})
         state_dir = tmp_path / "state"
         heldout.run_heldout(state_dir, repo, force=True)
         # Content changed but still a correct implementation → still pass.
-        (repo / "scripts" / "archive_old_reports.py").write_text(
-            GOOD_ARCHIVE + "\n# still fine\n", encoding="utf-8"
+        (repo / "scripts" / "eeebot_dashboard.py").write_text(
+            GOOD_DASHBOARD + "\n# still fine\n", encoding="utf-8"
         )
         second = heldout.run_heldout(state_dir, repo, force=True)
-        assert second["results"]["scripts/archive_old_reports.py"]["status"] == "pass"
+        assert second["results"]["scripts/eeebot_dashboard.py"]["status"] == "pass"
         assert second["regressions"] == []
 
 
@@ -403,12 +371,9 @@ class TestFlakyDetection:
 class TestSandbox:
     def test_fixture_repo_untouched(self, tmp_path):
         """The checked scripts run on tmpdir COPIES: even a destructive
-        script (BAD_ARCHIVE deletes; ESCAPER writes into its cwd) must leave
-        the instance repo byte-identical."""
-        repo = _make_repo(
-            tmp_path,
-            {"archive_old_reports.py": BAD_ARCHIVE, "eeebot_dashboard.py": ESCAPER},
-        )
+        script (ESCAPER writes into its cwd, trying to reach the parent
+        tree) must leave the instance repo byte-identical."""
+        repo = _make_repo(tmp_path, {"eeebot_dashboard.py": ESCAPER})
         before = _repo_snapshot(repo)
         heldout.run_heldout(tmp_path / "state", repo, force=True)
         assert _repo_snapshot(repo) == before

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -1424,7 +1424,7 @@ class TestDecayEligibilityGuard:
         auto-promotion inert. Protection is derived from the live registry."""
         from nanobot.runtime.heldout.checkers import CHECKERS
 
-        contracted = sorted(CHECKERS)[0]  # e.g. scripts/archive_old_reports.py
+        contracted = sorted(CHECKERS)[0]  # e.g. scripts/eeebot_dashboard.py
         name = contracted.split("/", 1)[1]
         monkeypatch.delenv("SELFEVO_DECAY_PROTECT", raising=False)
         state_dir = _state_dir(tmp_path)
@@ -1443,7 +1443,7 @@ class TestDecayEligibilityGuard:
         contracted paths, and never raises."""
         paths = usage_evidence._heldout_contracted_paths()
         assert isinstance(paths, frozenset)
-        assert "scripts/archive_old_reports.py" in paths
+        assert "scripts/eeebot_dashboard.py" in paths
 
     def test_unset_protect_env_behavior_unchanged(self, tmp_path, monkeypatch):
         """No env var set at all: identical to pre-#809 behavior — a stale


### PR DESCRIPTION
## Decision

The held-out pack (`nanobot/runtime/heldout/checkers.py`) contracted `scripts/archive_old_reports.py` — a loop-authored script that archives `state/reports/*.json` older than 30 days. That job is now redundant: #864 added product-code pruning (`coordinator.py`'s `_prune_stale_reports` / `REPORTS_RETENTION_KEEP=200`) that bounds report-file bloat unconditionally, every cycle. The decay system (#798-#802) correctly identified `archive_old_reports.py` as unused and retired it — but the held-out pack still contracted its path, so the disabled instance copy kept failing `check_archive_old_reports`, holding the `heldout` scorecard section RED and blocking the #875/#876 promote gate from ever going GREEN.

A script is either (a) held-out-contracted and therefore decay-protected, or (b) legitimately retired because a superseding mechanism exists — never both. Since #864 supersedes this script's entire purpose, the held-out contract was the stale side of the conflict. Operator confirmed: drop it.

## What changed

- **`nanobot/runtime/heldout/checkers.py`**: removed `check_archive_old_reports` and its `"scripts/archive_old_reports.py"` entry from `CHECKERS`. Removed now-dead `_tree_snapshot` helper and unused `os`/`time` imports. Updated the module docstring (no longer names archive_old_reports as an example). The other four checkers (`eeebot_dashboard`, `generate_system_map`, `prune_failed_backlog`, `loop_health_report`) and the `run_heldout` engine are untouched.
- **`tests/test_heldout.py`**: repointed the engine-level coverage that previously exercised `archive_old_reports.py` (good/bad pass-fail pair, regression flip detection, sandbox isolation) onto the still-registered `eeebot_dashboard.py` (`GOOD_DASHBOARD` / `CRASHING_DASHBOARD`) and `generate_system_map.py` (`GOOD_SYSTEM_MAP` / new `BAD_SYSTEM_MAP` — a non-crash subtle-behavioral-defect fixture) checkers. No engine assertion (result shape, regression semantics, flaky exclusion, defect-demand, invisibility) was weakened — only the example checker used changed. Removed the now-unused `GOOD_ARCHIVE`/`BAD_ARCHIVE` fixtures.
- **`tests/test_usage_evidence.py`**: repointed the #884 contracted-script tests (`test_heldout_contracted_script_never_flagged`, `test_heldout_contracted_paths_helper_fail_open`) onto `scripts/eeebot_dashboard.py`, still proving a `CHECKERS`-registry script is never decay-flagged and the contracted-paths helper returns the live registry set.
- **`tests/test_goal_text_priority_filter.py`**: left unchanged — its `archive_old_reports.py` mentions are narrative goal-text priority strings, not registry/decay assertions.
- **`docs/changes/887-drop-stale-archive-checker/proposal.md`**: new proposal documenting the decay-vs-held-out-contract conflict and the decision.

## Test results

`python -m pytest tests/test_heldout.py -q`:
```
35 passed in 16.96s
```

`python -m pytest tests/test_usage_evidence.py -q`:
```
72 passed in 31.88s
```

`python -m pytest -q --continue-on-collection-errors` (full suite):
```
28 failed, 1771 passed, 6 skipped, 10 warnings, 11 errors in 706.40s (0:11:46)
```
This matches the documented pre-existing baseline (~27-28 Windows-only failures + ~11 site-packages-shadow collection errors) — no new failures, and none of the failing/erroring tests touch `heldout`, `usage_evidence`, or `archive_old_reports`.

## Non-negotiables honored

- Only the one obsolete checker was dropped; the other four checkers and the `run_heldout` engine (regression/flaky/defect logic) are untouched.
- `heldout/` remains in the runtime deny-set — no change to `runtime_deny`.
- No new env vars, no deploy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)