### PR TITLE
feat(runtime): #878 closed hypothesis->experiment->verdict scientific loop

### DIFF
--- a/docs/changes/878-hypothesis-loop/proposal.md
+++ b/docs/changes/878-hypothesis-loop/proposal.md
@@ -1,0 +1,177 @@
+# Change: closed hypothesis -> experiment -> verdict scientific loop (RSI stage 4)
+
+- **change-id:** 878-hypothesis-loop
+- **issue:** #878
+- **capability:** self-evolving-runtime (demand collection #760, hypothesis
+  backlog #751, LLM proposer novelty guards #707/#716/#834, goal-review #768,
+  scorecard control-plane #865, held-out microbench #822, usage/value
+  evidence #761/#773, fitness-sidecar integrity #789)
+- **role / workstream:** RSI (recursive self-improvement) — closing an
+  existing loop, not building a new one
+
+## Strict product simplicity (by design constraint of this change)
+
+No new demand lane, no report generator, no new daemon, no new state
+machine. This is a thin closing layer over machinery that already exists:
+hypotheses already become experiment demand, the proposer already picks
+them up, a cycle running IS the experiment. What was missing was the other
+half of the scientific method — a VERDICT on whether the experiment
+confirmed the hypothesis, fed back into (a) never re-proposing a disproven
+idea and (b) surfacing a proven one as a priority candidate.
+
+## Problem
+
+`hypothesis_backlog.reconcile` already answers WHETHER a hypothesis's
+serving cycle integrated (`lifecycle.json` entry flips `status: "active"` ->
+`"answered"` on a same-cycle `proposed` -> `outcome: success` ledger pair).
+It never asked whether the hypothesis was actually TRUE. A hypothesis whose
+experiment cycle "succeeded" (code merged) and one that later turns out
+worthless look byte-identical in the lifecycle sidecar — the loop has no way
+to (a) stop re-proposing a title it already spent a cycle disproving, or (b)
+elevate a title it already spent a cycle proving into a follow-up priority.
+The loop was running experiments with no read-out.
+
+## Design
+
+### 1. Verdict classification — `nanobot/runtime/hypothesis_verdict.py` (new)
+
+`classify_hypothesis_verdict(state_dir, cycle_id, acceptance_text="") ->
+(verdict, evidence)`, `verdict` in `{"supported", "refuted",
+"inconclusive"}`. Tries two MEASURED, harness-trusted sources, first match
+wins:
+
+1. **microbench** (`heldout.microbench.load_microbench_entry`, #822) — a
+   causal, isolated, harness-run before/after measurement. `improvement_pct
+   >= 5.0` (`MICROBENCH_SUPPORTED_THRESHOLD_PCT`) -> `supported`; otherwise
+   -> `refuted`.
+2. **confirmed usage** (`demand/completed.json`, #773/#761) — the cycle's
+   own completed entry (matched by `cycle_id`) touched a `scripts/`
+   artifact: `confirmed is True` (set ONLY by
+   `usage_evidence.confirm_serves` from an independently-observed usage
+   signal) -> `supported`; still unconfirmed after `CONFIRM_WINDOW_DAYS`
+   (14, matching the existing decay-window convention used by
+   `demand`/`scorecard`/`goal_review`) since completion -> `refuted` (had a
+   fair window, wasn't used); still within the window -> falls through.
+3. **none** — no measured signal at all -> `inconclusive`.
+
+`acceptance_text` is accepted for interface symmetry but is NEVER read for
+the classification — the whole point is that a number the instance merely
+CLAIMS in a hypothesis's own acceptance/evidence text must never move the
+verdict (regression-pinned in `tests/test_hypothesis_verdict.py::TestTrustBoundary`).
+
+`hypothesis_backlog.reconcile` calls this the SAME pass a candidate is
+first marked `answered` (no separate hook), persisting `verdict` /
+`verdict_evidence` / `verdict_at` onto the same lifecycle entry (additive —
+`status`/`answered_evidence`/`answered_at` are untouched) and appending one
+`{"phase": "hypothesis", "reason": "verdict", "hypothesis_ref", "verdict",
+"cycle_id", "evidence"}` ledger row via `cycle_ledger.append_event`.
+
+### 2. Refuted -> permanent novelty guard — `llm_proposer.py`
+
+`_refuted_hypothesis_titles(state_dir)` reads `hypotheses/lifecycle.json`
+directly for entries with `verdict == "refuted"`, returning their titles.
+Wired into `_is_duplicate_proposal` as a THIRD source, checked
+unconditionally (not gated on `_proposal_creates_new_file` like #834's
+guard, since a hypothesis experiment need not have created a new file) and
+PERMANENT — like #834's full-history built-subject guard, not windowed like
+#716's `_recent_failed_titles`. `matched_against` is recorded as
+`"refuted-hypothesis:<title>"` so a `proposer_reject` ledger row can
+distinguish this source from the git-log/ledger-title sources at a glance
+while still keeping the matched text for debugging. Fail-open: a
+missing/corrupt `lifecycle.json` never blocks a proposal.
+
+### 3. Supported -> goal-review evidence candidate
+
+`hypothesis_backlog.supported_hypotheses(state_dir, n=3)` returns the
+newest-`verdict_at`-first, top-3 `verdict == "supported"` entries as
+`{title, evidence}` (evidence is the SAME `verdict_evidence` dict persisted
+on the lifecycle entry — never instance-authored text). Wired into
+`goal_review._collect_evidence` as an additional citable evidence line,
+exactly the way decay/goal-gap evidence already is — the smallest correct
+integration point (the task's own fallback suggestion), not a separate mint
+path. A supported hypothesis still has to be CITED by id and pass
+`goal_review.validate_priority`'s existing fail-closed checks (label
+shape, body bound, `V1`/`V2` vector, evidence-in-inputs, dedup) before it
+can ever become a `derived_priorities.json` entry — no new validation was
+added or bypassed.
+
+### 4. At most one active hypothesis experiment — `demand.py`
+
+`hypothesis_backlog.has_in_flight_experiment(state_dir)`: true iff some
+`active`-status candidate has a `'proposed'` ledger row (`serves:
+hypothesis <ref>`) whose `cycle_id` has NOT YET produced a terminal
+`'outcome'` row. `demand._hypothesis_items` applies exactly this rule:
+
+- If an experiment is in flight -> mint ZERO hypothesis-kind items this
+  pass (don't stack a second experiment on the running one).
+- Otherwise -> cap the (possibly multi-candidate) result to the first ONE
+  item, so the proposer never sees more than one hypothesis candidate per
+  cycle either.
+
+This is the whole rule — no new lifecycle status, no new state file.
+
+### 5. Scorecard visibility — `control_plane.hypothesis_loop`
+
+`hypothesis_backlog.lifecycle_counts(state_dir)` returns `{active,
+answered, supported, refuted, inconclusive}` counts over every lifecycle
+entry (`status` and `verdict` are independent fields on the same entry, so
+an answered+supported entry counts toward both `answered` and `supported`).
+Wired into `scorecard._control_plane_snapshot` as `hypothesis_loop`, same
+leaf-dependency/fail-open-to-`{}` shape as the existing `evolution_tree`
+key (#877). Visibility only — never fed into `_TARGETS`/gaps.
+
+## Trust boundary (read before touching `hypothesis_verdict.py`)
+
+`hypotheses/lifecycle.json`, `hypotheses/backlog.json` and
+`research/hypotheses.json` are INSTANCE-writable state — nothing in them is
+ever trusted for the verdict number itself. The verdict is computed
+EXCLUSIVELY from two `scorecard.FITNESS_SIDECARS` members (#789
+spawn-boundary tamper detection already protects both):
+`heldout/microbench.json` (#822 — a sandboxed, harness-run causal
+measurement) and `demand/completed.json` (#773/#761 — whose `confirmed`
+field is written ONLY by `usage_evidence.confirm_serves` from an
+independently observed usage signal, never a claim).
+
+A verdict is STEERING, never a verification gate, symmetric with the
+#819/#822 "only allowlisted sidecars are trusted" design:
+
+- `refuted` only blocks a future re-proposal of the same title — at worst a
+  wasted retry the proposer would have self-dedup-rejected anyway once it
+  re-hit the theme.
+- `supported` only injects a citable evidence line into goal-review's
+  input — the resulting candidate still has to pass
+  `validate_priority`'s full fail-closed checks and, if accepted, the
+  entire cycle gate (smoke/deny-set/held-out) before it can integrate.
+
+A forged/tampered sidecar therefore costs at worst churn (a spurious
+"refuted" wastes a proposal retry) or a rejected priority candidate — it
+can never fabricate an integration by itself. `hypothesis_verdict.py` is
+added to `runtime_deny._RUNTIME_DENY_ALWAYS_FILES` (explicit entry, no
+basename-token match applies) as cheap hardening, matching
+`benchmark_evidence.py`/`usage_evidence.py`'s existing deny-set membership —
+it is fitness-adjacent steering logic even though `lifecycle.json` itself
+(pure data) is not.
+
+## Files changed
+
+- `nanobot/runtime/hypothesis_verdict.py` (new) — verdict classification
+- `nanobot/runtime/hypothesis_backlog.py` — verdict computed on answer;
+  `supported_hypotheses`, `lifecycle_counts`, `has_in_flight_experiment`
+- `nanobot/runtime/llm_proposer.py` — `_refuted_hypothesis_titles` +
+  `_is_duplicate_proposal` wiring
+- `nanobot/runtime/demand.py` — `_hypothesis_items` <=1-active-experiment cap
+- `nanobot/runtime/goal_review.py` — `_collect_evidence` supported-hypothesis line
+- `nanobot/runtime/scorecard.py` — `control_plane.hypothesis_loop`
+- `nanobot/runtime/runtime_deny.py` — deny-set entry for `hypothesis_verdict.py`
+- `tests/test_hypothesis_verdict.py` (new), plus extensions to
+  `tests/test_hypothesis_backlog.py`, `tests/test_llm_proposer.py`,
+  `tests/test_demand.py`, `tests/test_goal_review.py`, `tests/test_scorecard.py`
+
+## Test results
+
+See the PR description for the verbatim final pytest lines (touched files
+run explicitly by path, plus the full suite with
+`--continue-on-collection-errors`; a pre-existing local site-packages
+`tests` package shadow hides `test_llm_proposer.py`/`test_demand.py` from
+default collection on this dev machine — worked around for verification by
+pre-seeding `sys.modules["tests"]`, not committed to the repo).

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -60,7 +60,12 @@ Demand kinds, in trust order (see ``docs/changes/760-demand-driven-proposer/``):
   references a file path actually present in the instance repo. The chronic
   boilerplate candidates ("Use one bounded subagent-assisted review...",
   "Synthesize one new bounded improvement candidate from retired lanes") have
-  none of these and MUST NOT qualify (regression-pinned in tests).
+  none of these and MUST NOT qualify (regression-pinned in tests). #878: at
+  most ONE hypothesis-kind item is ever minted per call, and even that one
+  is suppressed while an active hypothesis already has an unanswered
+  in-flight serving cycle (``hypothesis_backlog.has_in_flight_experiment``)
+  — the closed loop (hypothesis -> experiment -> harness-measured verdict,
+  see ``hypothesis_verdict``) runs at most one experiment at a time.
 - ``decay`` (#761, ordered LAST — priority > defect > goal-gap >
   hypothesis > decay) —
   ``scripts/*.py`` artifacts whose harness-observed ``last_used`` AND
@@ -871,7 +876,25 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
                     seen.add(title)
                     evidence = str(cand.get("evidence") or cand.get("metric") or cand.get("acceptance") or "")
                     items.append(_make_item("hypothesis", title, evidence))
-        return items
+
+        # #878: at most ONE active hypothesis experiment at a time. If a
+        # hypothesis already has an unanswered in-flight serving cycle
+        # (``hypothesis_backlog.has_in_flight_experiment`` — a 'proposed'
+        # row with no terminal 'outcome' row yet), suppress minting a NEW
+        # hypothesis demand item entirely this pass, rather than stacking a
+        # second parallel experiment on top of the one already running.
+        # Otherwise, cap to a single item — the proposer never sees more
+        # than one hypothesis-kind candidate per cycle, so it cannot start
+        # two experiments from one demand batch either. This is the whole
+        # rule; no new state machine.
+        try:
+            from nanobot.runtime import hypothesis_backlog
+
+            if hypothesis_backlog.has_in_flight_experiment(state_dir):
+                return []
+        except Exception:
+            pass
+        return items[:1]
     except Exception:
         return items
 

--- a/nanobot/runtime/goal_review.py
+++ b/nanobot/runtime/goal_review.py
@@ -323,9 +323,10 @@ def _collect_evidence(
     state_dir: Path, selfevo_repo: Path | None, snapshot: dict[str, Any], now: datetime
 ) -> dict[str, str]:
     """Evidence lines keyed ``E1``.. — the citable ground truth. Sources:
-    the scorecard snapshot's ``gaps`` (the open goal-gap demand, #765) and
-    usage/decay evidence (#761). Bounded to :data:`_MAX_EVIDENCE_LINES`;
-    fail-open per source."""
+    the scorecard snapshot's ``gaps`` (the open goal-gap demand, #765),
+    usage/decay evidence (#761), and (#878) harness-verdict-supported
+    hypotheses. Bounded to :data:`_MAX_EVIDENCE_LINES`; fail-open per
+    source."""
     lines: list[str] = []
     try:
         for gap in snapshot.get("gaps") or []:
@@ -350,6 +351,26 @@ def _collect_evidence(
                     f"decay: {rel} has no harness-observed use or modification "
                     f"since {since or 'unknown'} ({_DECAY_DAYS}+ days; goal vector V2)"
                 )
+    except Exception:
+        pass
+    # #878: a hypothesis the harness-computed verdict marked "supported"
+    # (measured evidence only — never the instance's own claim, see
+    # ``hypothesis_verdict``'s trust-boundary note) surfaces here exactly
+    # like any other evidence source — it still has to be CITED by id and
+    # pass ``validate_priority`` like every other candidate; this is the
+    # smallest correct integration point, not a separate mint path.
+    try:
+        from nanobot.runtime import hypothesis_backlog
+
+        for hyp in hypothesis_backlog.supported_hypotheses(state_dir):
+            title = str(hyp.get("title") or "").strip()
+            if not title:
+                continue
+            source = str((hyp.get("evidence") or {}).get("source") or "measured")
+            lines.append(
+                f"supported hypothesis: {title} (harness verdict: supported, "
+                f"source: {source}; goal vector V1)"
+            )
     except Exception:
         pass
     return {f"E{i}": line for i, line in enumerate(lines[:_MAX_EVIDENCE_LINES], start=1)}

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -32,6 +32,18 @@ shape, degrades to "no candidates" / "no lifecycle change" rather than
 raising. Nothing here ever touches ``backlog.json`` or
 ``research/hypotheses.json`` themselves — both remain owned by their
 existing writers.
+
+#878 (closing the hypothesis -> experiment -> verdict loop): ``reconcile``
+now also computes a harness-MEASURED verdict (:mod:`hypothesis_verdict`) the
+same pass it first marks a candidate ``answered``, persisting ``verdict``/
+``verdict_evidence``/``verdict_at`` onto the SAME lifecycle entry.
+:func:`supported_hypotheses` and :func:`lifecycle_counts` read the verdict
+back out for, respectively, ``goal_review``'s evidence input and the
+scorecard control-plane snapshot; :func:`has_in_flight_experiment` is the
+read side of the "at most one active hypothesis experiment" rule
+``demand._hypothesis_items`` enforces. See ``hypothesis_verdict``'s module
+docstring for the full trust argument (verdict is steering, never a
+verification gate).
 """
 from __future__ import annotations
 
@@ -45,6 +57,10 @@ TOP_N = 5
 MAX_SECTION_CHARS = 1200
 STALE_AFTER_DAYS = 14
 STALE_AFTER_UNTOUCHED_CYCLES = 50
+# #878: how many "supported" hypotheses (newest verdict first) goal_review
+# gets to cite as evidence per review — kept small like every other bounded
+# evidence source that module reads (decay, goal-gaps).
+SUPPORTED_TOP_N = 3
 
 _HYPOTHESIS_SERVES_RE = re.compile(r"^hypothesis\s+(.+)$", re.IGNORECASE)
 
@@ -188,6 +204,43 @@ def _serves_hypothesis_ref(serves: str) -> str | None:
     return match.group(1).strip()
 
 
+def _apply_verdict(state_dir: Path, entry: dict[str, Any], key: str, cycle_id: str, now_iso: str) -> None:
+    """#878: compute + persist the harness-measured verdict on a hypothesis
+    entry the instant it is first marked ``answered`` (same reconciliation
+    pass, no separate hook). Additive to ``entry`` in place: ``verdict``,
+    ``verdict_evidence``, ``verdict_at``. Also appends one
+    ``{"phase": "hypothesis", "reason": "verdict", ...}`` ledger row.
+    Best-effort — a verdict failure must never break ``reconcile``'s
+    existing answered/stale bookkeeping."""
+    verdict = None
+    evidence: dict[str, Any] = {}
+    try:
+        from nanobot.runtime.hypothesis_verdict import classify_hypothesis_verdict
+
+        verdict, evidence = classify_hypothesis_verdict(state_dir, cycle_id, entry.get("title") or "")
+        entry["verdict"] = verdict
+        entry["verdict_evidence"] = evidence
+        entry["verdict_at"] = now_iso
+    except Exception:
+        return
+    try:
+        from nanobot.runtime.cycle_ledger import append_event
+
+        append_event(
+            state_dir,
+            {
+                "phase": "hypothesis",
+                "reason": "verdict",
+                "hypothesis_ref": key,
+                "verdict": verdict,
+                "cycle_id": str(cycle_id),
+                "evidence": evidence,
+            },
+        )
+    except Exception:
+        pass
+
+
 def _ref_matches_candidate(ref: str, cand: dict[str, str]) -> bool:
     ref_low = ref.lower().strip()
     if not ref_low:
@@ -260,11 +313,18 @@ def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
             entry.setdefault("status", "active")
             entry.setdefault("first_seen", now_iso)
             entry.setdefault("cycles_untouched", 0)
+            entry.setdefault("title", cand["title"])
 
             if key in answered_keys and entry.get("status") != "answered":
                 entry["status"] = "answered"
                 entry["answered_evidence"] = answered_keys[key]
                 entry["answered_at"] = now_iso
+                # #878: compute + persist the harness-measured verdict the
+                # SAME pass a hypothesis is first marked answered — no
+                # separate hook into where cycle outcomes are recorded,
+                # consistent with this module's existing lazy-reconciliation
+                # design note above.
+                _apply_verdict(state_dir, entry, key, answered_keys[key], now_iso)
 
             if entry.get("status") == "active":
                 if key in touched_keys:
@@ -334,3 +394,127 @@ def context_section(state_dir: Path) -> str:
         return section
     except Exception:
         return ""
+
+
+# ─── #878: verdict-derived readers ──────────────────────────────────────────
+
+
+def supported_hypotheses(state_dir: Path, n: int = SUPPORTED_TOP_N) -> list[dict[str, Any]]:
+    """Hypotheses the harness-computed verdict (:mod:`hypothesis_verdict`)
+    marked ``"supported"`` — newest ``verdict_at`` first, capped to ``n``.
+
+    Each item is ``{"title": ..., "evidence": ...}`` where ``evidence`` is
+    the SAME ``verdict_evidence`` dict persisted on the lifecycle entry
+    (already sourced from a measured sidecar, never instance-authored
+    text). Consumed by ``goal_review._collect_evidence`` as an additional
+    citable evidence line, the same way decay/goal-gap evidence already is
+    — a supported hypothesis still has to pass ``goal_review``'s normal
+    fail-closed ``validate_priority`` before it can ever become a priority.
+    Fail-open: ``[]`` on any error or when nothing is verdict-marked yet."""
+    try:
+        state_dir = Path(state_dir)
+        lifecycle = _load_lifecycle(state_dir)
+        entries = lifecycle.get("entries", {})
+        if not isinstance(entries, dict):
+            return []
+        ranked: list[tuple[str, dict[str, Any]]] = []
+        for entry in entries.values():
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("verdict") or "") != "supported":
+                continue
+            title = str(entry.get("title") or "").strip()
+            if not title:
+                continue
+            ranked.append(
+                (str(entry.get("verdict_at") or ""), {"title": title, "evidence": entry.get("verdict_evidence") or {}})
+            )
+        ranked.sort(key=lambda pair: pair[0], reverse=True)
+        return [item for _, item in ranked[:n]]
+    except Exception:
+        return []
+
+
+def lifecycle_counts(state_dir: Path) -> dict[str, int]:
+    """``{active, answered, supported, refuted, inconclusive}`` counts over
+    every lifecycle entry (#878) — read by
+    ``scorecard._control_plane_snapshot`` for VISIBILITY ONLY, never fed
+    into fitness/targets/gaps. ``status`` (``active``/``answered``) and
+    ``verdict`` (``supported``/``refuted``/``inconclusive``) are independent
+    fields on the same entry, so an answered entry contributes to both an
+    ``answered`` count and (once verdict-marked) a verdict count. Fail-open
+    to ``{}`` on any error."""
+    try:
+        state_dir = Path(state_dir)
+        lifecycle = _load_lifecycle(state_dir)
+        entries = lifecycle.get("entries", {})
+        if not isinstance(entries, dict):
+            return {}
+        counts = {"active": 0, "answered": 0, "supported": 0, "refuted": 0, "inconclusive": 0}
+        for entry in entries.values():
+            if not isinstance(entry, dict):
+                continue
+            status = str(entry.get("status") or "")
+            if status in ("active", "answered"):
+                counts[status] += 1
+            verdict = str(entry.get("verdict") or "")
+            if verdict in ("supported", "refuted", "inconclusive"):
+                counts[verdict] += 1
+        return counts
+    except Exception:
+        return {}
+
+
+def has_in_flight_experiment(state_dir: Path) -> bool:
+    """True iff some ``active``-status hypothesis candidate has a
+    ``'proposed'`` ledger row (``serves: hypothesis <ref>``) whose
+    ``cycle_id`` has NOT YET produced a terminal ``'outcome'`` row — i.e. an
+    experiment cycle for it is currently running or awaiting its verdict.
+
+    Used by ``demand._hypothesis_items`` to enforce the #878 "at most one
+    active hypothesis experiment" rule: while this is true, no NEW
+    hypothesis-kind demand item is minted this cycle (the loop keeps
+    presenting whatever else it has instead of stacking a second parallel
+    experiment on top of the one already running). Deliberately does not
+    consult ``exhausted``/``completed`` state — this is only about a cycle
+    that is currently open, not about retry bookkeeping. Fail-open: ``False``
+    on any error (never blocks demand collection)."""
+    try:
+        state_dir = Path(state_dir)
+        candidates = _all_candidates(state_dir)
+        if not candidates:
+            return False
+        lifecycle = _load_lifecycle(state_dir)
+        entries = lifecycle.get("entries", {})
+        active_keys = {
+            cand["key"]
+            for cand in candidates
+            if str((entries.get(cand["key"]) or {}).get("status") or "active") == "active"
+        }
+        if not active_keys:
+            return False
+
+        rows = _load_ledger_rows(state_dir)
+        outcome_cycle_ids: set[str] = set()
+        proposed_cycle_ids: set[str] = set()
+        for row in rows:
+            cid = row.get("cycle_id")
+            if not cid:
+                continue
+            phase = row.get("phase")
+            if phase == "outcome":
+                outcome_cycle_ids.add(cid)
+                continue
+            if phase != "proposed":
+                continue
+            ref = _serves_hypothesis_ref(str(row.get("serves") or ""))
+            if not ref:
+                continue
+            for cand in candidates:
+                if cand["key"] in active_keys and _ref_matches_candidate(ref, cand):
+                    proposed_cycle_ids.add(cid)
+                    break
+
+        return any(cid not in outcome_cycle_ids for cid in proposed_cycle_ids)
+    except Exception:
+        return False

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -61,6 +61,15 @@ STALE_AFTER_UNTOUCHED_CYCLES = 50
 # gets to cite as evidence per review — kept small like every other bounded
 # evidence source that module reads (decay, goal-gaps).
 SUPPORTED_TOP_N = 3
+# #878 opus-review Y1 fix: a 'proposed' cycle with no terminal 'outcome' row
+# is normally "still running" — but a cycle that crashed/was killed on the
+# host (power loss, OOM-kill) never writes a terminal outcome at all, so
+# without a timeout has_in_flight_experiment would read as permanently
+# in-flight and freeze the whole hypothesis demand lane until the candidate
+# ages into STALE_AFTER_DAYS (14 days). A proposed row older than this many
+# days is treated as abandoned/dead rather than still-running, giving the
+# lane a release path far short of the stale window.
+IN_FLIGHT_TIMEOUT_DAYS = 3
 
 _HYPOTHESIS_SERVES_RE = re.compile(r"^hypothesis\s+(.+)$", re.IGNORECASE)
 
@@ -241,6 +250,63 @@ def _apply_verdict(state_dir: Path, entry: dict[str, Any], key: str, cycle_id: s
         pass
 
 
+def _maybe_upgrade_inconclusive_verdict(
+    state_dir: Path, entry: dict[str, Any], key: str, now_iso: str
+) -> None:
+    """#878 opus-review N1 fix: re-evaluate an already-answered hypothesis's
+    verdict on a LATER reconcile pass if it is still ``"inconclusive"``.
+
+    ``_apply_verdict`` originally only ran once, at the exact moment a
+    candidate flips to ``answered`` — day 0. At that instant the
+    confirmed-usage source (:func:`hypothesis_verdict._confirmed_usage_verdict`)
+    is structurally ALWAYS either absent (no completed entry yet) or still
+    inside its confirm window, so without this re-check the "supported once
+    later confirmed" and "refuted once the window elapses unconfirmed"
+    confirmed-usage branches could never fire in production — only
+    microbench ever produced a real (non-inconclusive) verdict. This makes
+    them reachable: any reconcile pass over an ``answered`` entry whose
+    stored ``verdict`` is still ``"inconclusive"`` re-runs
+    :func:`hypothesis_verdict.classify_hypothesis_verdict` against the SAME
+    serving ``cycle_id`` (``answered_evidence``); if a measured source now
+    resolves to ``supported``/``refuted``, the entry and a
+    ``{"phase": "hypothesis", "reason": "verdict"}`` ledger event are
+    updated exactly like the original transition. If it is STILL
+    inconclusive, nothing is written and no event is appended — a
+    steady-state inconclusive entry costs one classify call per reconcile
+    pass, not a growing write/event history. Best-effort — a failure here
+    must never break the rest of reconciliation."""
+    cycle_id = entry.get("answered_evidence")
+    if not cycle_id:
+        return
+    try:
+        from nanobot.runtime.hypothesis_verdict import classify_hypothesis_verdict
+
+        verdict, evidence = classify_hypothesis_verdict(state_dir, cycle_id, entry.get("title") or "")
+    except Exception:
+        return
+    if verdict == "inconclusive":
+        return  # unchanged — no write, no event
+    entry["verdict"] = verdict
+    entry["verdict_evidence"] = evidence
+    entry["verdict_at"] = now_iso
+    try:
+        from nanobot.runtime.cycle_ledger import append_event
+
+        append_event(
+            state_dir,
+            {
+                "phase": "hypothesis",
+                "reason": "verdict",
+                "hypothesis_ref": key,
+                "verdict": verdict,
+                "cycle_id": str(cycle_id),
+                "evidence": evidence,
+            },
+        )
+    except Exception:
+        pass
+
+
 def _ref_matches_candidate(ref: str, cand: dict[str, str]) -> bool:
     ref_low = ref.lower().strip()
     if not ref_low:
@@ -266,6 +332,13 @@ def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
     since it was first observed — whichever comes first. Fail-open: never
     raises; a partial/corrupt read degrades to "no reconciliation this
     pass" rather than crashing the caller.
+
+    #878: the SAME pass that first flips a candidate to ``answered`` also
+    computes its harness-measured verdict (:func:`_apply_verdict`); every
+    LATER pass over an ``answered`` candidate whose verdict is still
+    ``"inconclusive"`` re-checks it (:func:`_maybe_upgrade_inconclusive_verdict`)
+    so a confirmed-usage signal that only arrives after day 0 can still
+    resolve the verdict.
     """
     try:
         state_dir = Path(state_dir)
@@ -325,6 +398,11 @@ def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
                 # consistent with this module's existing lazy-reconciliation
                 # design note above.
                 _apply_verdict(state_dir, entry, key, answered_keys[key], now_iso)
+            elif entry.get("status") == "answered" and entry.get("verdict") == "inconclusive":
+                # #878 opus-review N1 fix: re-check on every LATER pass too —
+                # see _maybe_upgrade_inconclusive_verdict's docstring for why
+                # the confirmed-usage source needs this to ever fire.
+                _maybe_upgrade_inconclusive_verdict(state_dir, entry, key, now_iso)
 
             if entry.get("status") == "active":
                 if key in touched_keys:
@@ -465,11 +543,13 @@ def lifecycle_counts(state_dir: Path) -> dict[str, int]:
         return {}
 
 
-def has_in_flight_experiment(state_dir: Path) -> bool:
+def has_in_flight_experiment(state_dir: Path, *, now: datetime | None = None) -> bool:
     """True iff some ``active``-status hypothesis candidate has a
     ``'proposed'`` ledger row (``serves: hypothesis <ref>``) whose
-    ``cycle_id`` has NOT YET produced a terminal ``'outcome'`` row — i.e. an
-    experiment cycle for it is currently running or awaiting its verdict.
+    ``cycle_id`` has NOT YET produced a terminal ``'outcome'`` row AND whose
+    ``proposed`` row is younger than :data:`IN_FLIGHT_TIMEOUT_DAYS` — i.e.
+    an experiment cycle for it is currently running or awaiting its
+    verdict.
 
     Used by ``demand._hypothesis_items`` to enforce the #878 "at most one
     active hypothesis experiment" rule: while this is true, no NEW
@@ -477,10 +557,22 @@ def has_in_flight_experiment(state_dir: Path) -> bool:
     presenting whatever else it has instead of stacking a second parallel
     experiment on top of the one already running). Deliberately does not
     consult ``exhausted``/``completed`` state — this is only about a cycle
-    that is currently open, not about retry bookkeeping. Fail-open: ``False``
-    on any error (never blocks demand collection)."""
+    that is currently open, not about retry bookkeeping.
+
+    #878 opus-review Y1 fix: a serving cycle that crashed on the host
+    (power loss, OOM-kill, process kill) never writes a terminal
+    ``'outcome'`` row at all — without a timeout this would read as
+    permanently in-flight, freezing the whole hypothesis demand lane until
+    the candidate separately ages into :data:`STALE_AFTER_DAYS` (14 days).
+    A ``'proposed'`` row older than :data:`IN_FLIGHT_TIMEOUT_DAYS` is
+    therefore treated as abandoned, not still-running, regardless of
+    whether it ever gets an outcome — a row with a missing/unparseable
+    ``ts`` is conservatively still counted as in-flight (cannot confirm
+    it's timed out). Fail-open: ``False`` on any error (never blocks demand
+    collection)."""
     try:
         state_dir = Path(state_dir)
+        now = now or datetime.now(timezone.utc)
         candidates = _all_candidates(state_dir)
         if not candidates:
             return False
@@ -496,7 +588,7 @@ def has_in_flight_experiment(state_dir: Path) -> bool:
 
         rows = _load_ledger_rows(state_dir)
         outcome_cycle_ids: set[str] = set()
-        proposed_cycle_ids: set[str] = set()
+        proposed_cycle_ts: dict[str, datetime | None] = {}
         for row in rows:
             cid = row.get("cycle_id")
             if not cid:
@@ -512,9 +604,17 @@ def has_in_flight_experiment(state_dir: Path) -> bool:
                 continue
             for cand in candidates:
                 if cand["key"] in active_keys and _ref_matches_candidate(ref, cand):
-                    proposed_cycle_ids.add(cid)
+                    proposed_cycle_ts[cid] = _parse_ts(row.get("ts"))
                     break
 
-        return any(cid not in outcome_cycle_ids for cid in proposed_cycle_ids)
+        for cid, prow_ts in proposed_cycle_ts.items():
+            if cid in outcome_cycle_ids:
+                continue
+            if prow_ts is not None:
+                age_days = (now - prow_ts).total_seconds() / 86400.0
+                if age_days >= IN_FLIGHT_TIMEOUT_DAYS:
+                    continue  # abandoned — no longer counts as in-flight
+            return True
+        return False
     except Exception:
         return False

--- a/nanobot/runtime/hypothesis_verdict.py
+++ b/nanobot/runtime/hypothesis_verdict.py
@@ -1,0 +1,211 @@
+"""Harness-computed hypothesis verdict (#878 — closing the RSI scientific loop).
+
+``hypothesis_backlog.reconcile`` already answers WHETHER a hypothesis's
+serving cycle integrated (``status: "answered"``). It never asked whether the
+hypothesis turned out to be TRUE — a hypothesis experiment that "succeeded"
+(the cycle integrated) and one that later proves worthless look identical in
+``lifecycle.json`` today. This module adds the missing half: a VERDICT
+(``supported`` / ``refuted`` / ``inconclusive``) derived exclusively from
+MEASURED, harness-trusted sidecars — never from anything the instance wrote
+as prose or a claimed number.
+
+Trust boundary (read before touching this module): both inputs this module
+reads are members of ``scorecard.FITNESS_SIDECARS`` (#789 spawn-boundary
+tamper detection) — ``heldout/microbench.json`` (#822, a causal, isolated
+before/after measurement the harness itself runs in a sandboxed subprocess)
+and ``demand/completed.json`` (#773/#761, whose ``confirmed`` field is set
+ONLY by ``usage_evidence.confirm_serves`` from an independently-observed
+usage signal — never from a claim). Neither ``hypotheses/lifecycle.json``
+nor ``hypotheses/backlog.json``/``research/hypotheses.json`` (the INSTANCE-
+writable state this whole feature is built on top of) is ever read for the
+number itself — a hypothesis entry's own ``evidence``/``acceptance`` text is
+informational only (``acceptance_text`` below is accepted purely for future
+context enrichment and never influences the classification).
+
+A verdict here is STEERING, never a verification gate (see the module docs
+of ``benchmark_evidence``/``heldout.microbench`` for the equivalent
+distinction on the gate side): a ``refuted`` verdict only blocks a future
+re-proposal of the same title (``llm_proposer._refuted_hypothesis_titles`,
+permanent, like #834's built-subject novelty guard); a ``supported`` verdict
+only injects a citable priority-review candidate
+(``hypothesis_backlog.supported_hypotheses`` -> ``goal_review``'s evidence
+input), which still has to pass ``goal_review.validate_priority`` and the
+full cycle gate before it can ever integrate. A forged/tampered sidecar
+therefore costs at worst a wasted retry or a rejected priority candidate —
+it can never fabricate an integration by itself.
+
+Sources tried, in order (first match wins):
+
+1. **microbench** (``heldout.microbench.load_microbench_entry``) — a causal,
+   isolated single-cycle measurement. ``improvement_pct >= 5.0`` ->
+   ``supported``; otherwise -> ``refuted``. This source, when present, is
+   authoritative and short-circuits the other two.
+2. **confirmed usage** (``demand/completed.json``) — the cycle's own
+   completed entry (matched by ``cycle_id``) touched a ``scripts/`` artifact:
+   ``confirmed is True`` -> ``supported``; ``confirmed`` still false/absent
+   after :data:`CONFIRM_WINDOW_DAYS` days since completion -> ``refuted``
+   (it had a fair window to be used and was not); still within the window ->
+   falls through to ``inconclusive`` (too early to call).
+3. **none** — no measured signal at all -> ``inconclusive``.
+
+Crude and simple, deliberately: this is a steering signal, not a scored
+metric, symmetric with the #822/#819 "only these allowlisted sidecars are
+trusted" design. Fail-open throughout: any error, missing file, or
+malformed entry degrades to ``("inconclusive", {"source": "none", ...})``,
+never raises.
+"""
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# #822 microbench: the minimum measured improvement (percent, lower baseline
+# time minus candidate time over baseline) to call a hypothesis "supported"
+# rather than "refuted". Crude, fixed threshold — this is a steering signal,
+# not a promotion gate.
+MICROBENCH_SUPPORTED_THRESHOLD_PCT = 5.0
+
+# #773/#761 confirmed-usage: how long a completed entry gets to accumulate a
+# harness usage signal before "still unconfirmed" is read as "refuted"
+# rather than "too early to tell". Mirrors the existing decay-window
+# convention (``demand._DECAY_DAYS`` / ``scorecard._DECAY_DAYS`` /
+# ``goal_review._DECAY_DAYS`` are all 14) so this module introduces no new
+# staleness constant, just reuses the established number.
+CONFIRM_WINDOW_DAYS = 14
+
+VERDICTS = ("supported", "refuted", "inconclusive")
+
+
+def _read_json(path: Path, default: Any) -> Any:
+    try:
+        if not path.is_file():
+            return default
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def _parse_ts(value: Any) -> "datetime | None":
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except Exception:
+        return None
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _microbench_verdict(state_dir: Path, cycle_id: str) -> "tuple[str, dict[str, Any]] | None":
+    """Try the microbench source; ``None`` if no well-formed entry exists for
+    ``cycle_id`` (caller falls through to the next source)."""
+    try:
+        from nanobot.runtime.heldout.microbench import load_microbench_entry
+
+        entry = load_microbench_entry(state_dir, cycle_id)
+    except Exception:
+        entry = None
+    if not isinstance(entry, dict):
+        return None
+    improvement = entry.get("improvement_pct")
+    if not _is_finite_number(improvement):
+        return None
+    verdict = "supported" if improvement >= MICROBENCH_SUPPORTED_THRESHOLD_PCT else "refuted"
+    return verdict, {
+        "source": "microbench",
+        "cycle_id": str(cycle_id),
+        "metric": "improvement_pct",
+        "value": improvement,
+        "threshold": MICROBENCH_SUPPORTED_THRESHOLD_PCT,
+    }
+
+
+def _confirmed_usage_verdict(
+    state_dir: Path, cycle_id: str, *, now: "datetime | None" = None
+) -> "tuple[str, dict[str, Any]] | None":
+    """Try the confirmed-usage source over ``demand/completed.json``
+    entries matching ``cycle_id``. ``None`` if the cycle built no
+    ``scripts/`` artifact at all (caller falls through to "inconclusive")."""
+    try:
+        now = now or datetime.now(timezone.utc)
+        completed = _read_json(Path(state_dir) / "demand" / "completed.json", None)
+        entries = completed.get("entries") if isinstance(completed, dict) else None
+        if not isinstance(entries, dict):
+            return None
+        for entry in entries.values():
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("cycle_id") or "") != str(cycle_id):
+                continue
+            files = entry.get("files_changed")
+            if not isinstance(files, list):
+                continue
+            script_files = [str(f).strip() for f in files if str(f or "").strip().startswith("scripts/")]
+            if not script_files:
+                continue
+            if entry.get("confirmed") is True:
+                return "supported", {
+                    "source": "confirmed_usage",
+                    "cycle_id": str(cycle_id),
+                    "artifact": script_files[0],
+                    "signal": str(entry.get("signal") or ""),
+                }
+            completed_ts = _parse_ts(entry.get("ts"))
+            if completed_ts is not None:
+                age_days = (now - completed_ts).total_seconds() / 86400.0
+                if age_days >= CONFIRM_WINDOW_DAYS:
+                    return "refuted", {
+                        "source": "confirmed_usage",
+                        "cycle_id": str(cycle_id),
+                        "artifact": script_files[0],
+                        "age_days": round(age_days, 1),
+                        "window_days": CONFIRM_WINDOW_DAYS,
+                    }
+            # A scripts/ artifact exists but is still within its confirm
+            # window (or has no parseable ts) — too early to call either
+            # way; fall through to the caller's "inconclusive" default.
+            return None
+        return None
+    except Exception:
+        return None
+
+
+def classify_hypothesis_verdict(
+    state_dir: Path, cycle_id: str, acceptance_text: str = "", *, now: "datetime | None" = None
+) -> "tuple[str, dict[str, Any]]":
+    """Return ``(verdict, evidence)`` for the cycle that answered a
+    hypothesis, ``verdict`` in :data:`VERDICTS`.
+
+    ``acceptance_text`` is accepted for interface symmetry with the
+    hypothesis's own recorded acceptance criteria (context for a future
+    caller/log line) but is NEVER read for the classification itself — see
+    the module docstring's trust-boundary note. ``now`` is injectable for
+    tests; defaults to the current UTC time.
+
+    Fail-open: any error, or no measured signal at all, degrades to
+    ``("inconclusive", {"source": "none", ...})`` — never raises.
+    """
+    # ``acceptance_text`` is intentionally never inspected below — see the
+    # module docstring's trust-boundary note.
+    state_dir = Path(state_dir)
+    safe_cycle_id = str(cycle_id or "").strip()
+    if not safe_cycle_id:
+        return "inconclusive", {"source": "none", "cycle_id": ""}
+    try:
+        result = _microbench_verdict(state_dir, safe_cycle_id)
+        if result is not None:
+            return result
+        result = _confirmed_usage_verdict(state_dir, safe_cycle_id, now=now)
+        if result is not None:
+            return result
+        return "inconclusive", {"source": "none", "cycle_id": safe_cycle_id}
+    except Exception:
+        return "inconclusive", {"source": "none", "cycle_id": safe_cycle_id}

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1343,6 +1343,43 @@ def _proposal_creates_new_file(selfevo_repo: Path | None, proposal: dict[str, An
     return not candidate.exists()
 
 
+def _refuted_hypothesis_titles(state_dir: Path) -> list[str]:
+    """Titles of hypotheses the harness VERDICT-marked ``"refuted"`` (#878).
+
+    Reads ``hypotheses/lifecycle.json`` directly — the harness-owned verdict
+    field written by ``hypothesis_backlog.reconcile`` from a MEASURED source
+    only (see ``hypothesis_verdict.classify_hypothesis_verdict``; never
+    anything the instance itself claimed). A refuted hypothesis must never
+    be re-proposed under the same title: unlike #716's windowed
+    ``_recent_failed_titles`` (an old failure ages out of its recency
+    window), this is PERMANENT — like #834's full-history built-subject
+    guard — because the harness already spent a measured experiment
+    disproving the idea; re-litigating it once a window happens to expire
+    would just spend another one on the same dead end. Fail-open: a
+    missing/corrupt ``lifecycle.json`` yields ``[]`` (never blocks a
+    proposal)."""
+    try:
+        path = Path(state_dir) / "hypotheses" / "lifecycle.json"
+        if not path.is_file():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8"))
+        entries = data.get("entries") if isinstance(data, dict) else None
+        if not isinstance(entries, dict):
+            return []
+        titles: list[str] = []
+        for entry in entries.values():
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("verdict") or "") != "refuted":
+                continue
+            title = str(entry.get("title") or "").strip()
+            if title:
+                titles.append(title)
+        return titles
+    except Exception:
+        return []
+
+
 def _is_duplicate_proposal(
     state_dir: Path, selfevo_repo: Path | None, proposal: dict[str, Any]
 ) -> tuple[bool, str, str]:
@@ -1363,6 +1400,12 @@ def _is_duplicate_proposal(
     recent window, so this is a temporary "don't immediately re-hit the same
     dead end" guard, not a permanent ban — an old failure ages out and a
     retry is allowed again once it exits the window.
+
+    #878: a harness-VERDICT-refuted hypothesis title (:func:`_refuted_hypothesis_titles`)
+    is checked separately, unconditionally (not gated on new-file creation
+    like the #834 check below — a refuted hypothesis experiment need not
+    have created a new file) and is a PERMANENT block, same rationale as
+    #834's full-history guard.
 
     Returns ``(True, feedback_text, matched_against)`` on a match —
     ``feedback_text`` is meant to be passed as ``propose()``'s
@@ -1404,6 +1447,30 @@ def _is_duplicate_proposal(
                 "work; propose something from a DIFFERENT area, preferring "
                 "the numbered Current priority targets"
             ), matched_against
+
+        # #878 permanent refuted-hypothesis guard: applies unconditionally
+        # (not gated on _proposal_creates_new_file — a hypothesis experiment
+        # may well have edited an existing file). ``matched_against`` is
+        # prefixed "refuted-hypothesis:" so a ``proposer_reject`` ledger row
+        # can distinguish this source at a glance while still recording
+        # which title it actually matched.
+        refuted_titles = _refuted_hypothesis_titles(state_dir)
+        if refuted_titles:
+            refuted_block = "\n".join(refuted_titles)
+            if _title_already_done_in_git_log(title, refuted_block):
+                matched_refuted = next(
+                    (
+                        t for t in refuted_titles
+                        if t.strip() and _title_already_done_in_git_log(title, t)
+                    ),
+                    "",
+                )
+                return True, (
+                    f"your proposal '{title}' re-proposes a hypothesis the "
+                    "harness already REFUTED via measured evidence (verdict: "
+                    "refuted); propose something from a DIFFERENT area, "
+                    "preferring the numbered Current priority targets"
+                ), f"refuted-hypothesis:{matched_refuted}"
 
         # #834 permanent novelty guard: for proposals that CREATE A NEW file,
         # also reject against the full commit history (not just the 14-day

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1344,7 +1344,9 @@ def _proposal_creates_new_file(selfevo_repo: Path | None, proposal: dict[str, An
 
 
 def _refuted_hypothesis_titles(state_dir: Path) -> list[str]:
-    """Titles of hypotheses the harness VERDICT-marked ``"refuted"`` (#878).
+    """Titles of hypotheses the harness VERDICT-marked ``"refuted"`` (#878),
+    newest ``verdict_at`` first, capped to
+    :data:`hypothesis_backlog.SUPPORTED_TOP_N` entries.
 
     Reads ``hypotheses/lifecycle.json`` directly — the harness-owned verdict
     field written by ``hypothesis_backlog.reconcile`` from a MEASURED source
@@ -1355,9 +1357,19 @@ def _refuted_hypothesis_titles(state_dir: Path) -> list[str]:
     window), this is PERMANENT — like #834's full-history built-subject
     guard — because the harness already spent a measured experiment
     disproving the idea; re-litigating it once a window happens to expire
-    would just spend another one on the same dead end. Fail-open: a
-    missing/corrupt ``lifecycle.json`` yields ``[]`` (never blocks a
-    proposal)."""
+    would just spend another one on the same dead end.
+
+    #878 opus-review Y2 fix: uncapped, this list only grows over a long RSI
+    run, monotonically widening the word-overlap false-positive surface
+    every future proposal is checked against. Bounded to the same small N
+    the ``supported`` side already uses (``hypothesis_backlog.SUPPORTED_TOP_N``)
+    so the surface stays flat — a title that ages out of the most-recent N
+    simply stops being permanently blocked (a live-with tradeoff, not a
+    behavior regression: it was never re-checked against anything BUT this
+    list to begin with).
+
+    Fail-open: a missing/corrupt ``lifecycle.json`` yields ``[]`` (never
+    blocks a proposal)."""
     try:
         path = Path(state_dir) / "hypotheses" / "lifecycle.json"
         if not path.is_file():
@@ -1366,16 +1378,18 @@ def _refuted_hypothesis_titles(state_dir: Path) -> list[str]:
         entries = data.get("entries") if isinstance(data, dict) else None
         if not isinstance(entries, dict):
             return []
-        titles: list[str] = []
+        ranked: list[tuple[str, str]] = []
         for entry in entries.values():
             if not isinstance(entry, dict):
                 continue
             if str(entry.get("verdict") or "") != "refuted":
                 continue
             title = str(entry.get("title") or "").strip()
-            if title:
-                titles.append(title)
-        return titles
+            if not title:
+                continue
+            ranked.append((str(entry.get("verdict_at") or ""), title))
+        ranked.sort(key=lambda pair: pair[0], reverse=True)
+        return [title for _, title in ranked[: hypothesis_backlog.SUPPORTED_TOP_N]]
     except Exception:
         return []
 

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -68,6 +68,14 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     # per the proposal — "evolution" was not added to _RUNTIME_DENY_TOKENS),
     # so this explicit entry is the only thing keeping it denied.
     'nanobot/runtime/evolution_tree.py',
+    # #878: computes the hypothesis verdict (supported/refuted/inconclusive)
+    # from the same #789-protected FITNESS_SIDECARS every other fitness-
+    # adjacent module here reads — fitness-adjacent steering logic exactly
+    # like benchmark_evidence.py/usage_evidence.py above, so it gets the
+    # same explicit deny entry (no basename token match applies: "verdict"
+    # is not in _RUNTIME_DENY_TOKENS, deliberately, so a future unrelated
+    # "*_verdict.py" module is not silently swept in by name alone).
+    'nanobot/runtime/hypothesis_verdict.py',
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -217,6 +217,23 @@ def _evolution_tree_snapshot(state_dir: 'Path | None') -> dict[str, Any]:
         return {}
 
 
+def _hypothesis_loop_snapshot(state_dir: 'Path | None') -> dict[str, Any]:
+    """#878: ``{active, answered, supported, refuted, inconclusive}`` counts
+    from ``hypotheses/lifecycle.json`` (via
+    ``hypothesis_backlog.lifecycle_counts``) — visibility only, never fed
+    into fitness/targets/gaps. Same leaf-dependency shape as
+    ``_evolution_tree_snapshot`` above. Fail-open to ``{}`` on any error or
+    when ``state_dir`` is unavailable."""
+    if state_dir is None:
+        return {}
+    try:
+        from nanobot.runtime import hypothesis_backlog
+
+        return hypothesis_backlog.lifecycle_counts(state_dir)
+    except Exception:
+        return {}
+
+
 def _control_plane_snapshot(state_dir: 'Path | None' = None) -> dict[str, Any]:
     """Active operator env values at compute time — visibility only.
 
@@ -229,6 +246,7 @@ def _control_plane_snapshot(state_dir: 'Path | None' = None) -> dict[str, Any]:
     snapshot["runtime_promotions"] = _runtime_promotions_snapshot()
     snapshot["runtime_trust_ladder"] = _runtime_trust_ladder_snapshot()
     snapshot["evolution_tree"] = _evolution_tree_snapshot(state_dir)
+    snapshot["hypothesis_loop"] = _hypothesis_loop_snapshot(state_dir)
     for key in _CONTROL_PLANE_KEYS:
         try:
             snapshot[key] = os.environ.get(key)

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -381,6 +381,72 @@ class TestHypothesisDemand:
         hyps = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"]
         assert len(hyps) == 1
 
+    # ─── #878: at most one active hypothesis experiment ────────────────────
+
+    def test_multiple_qualifying_hypotheses_capped_to_one(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        self._write_backlog(
+            state_dir,
+            [
+                {"hypothesis_id": "hypothesis-a", "task_title": "Fix widget A", "metric": "m1"},
+                {"hypothesis_id": "hypothesis-b", "task_title": "Fix widget B", "metric": "m2"},
+            ],
+        )
+        hyps = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"]
+        assert len(hyps) == 1
+
+    def test_in_flight_experiment_suppresses_new_hypothesis_demand(self, tmp_path):
+        """A hypothesis with a 'proposed' ledger row and no terminal
+        'outcome' row yet is an experiment still running — no NEW
+        hypothesis-kind demand item should be minted while it is open."""
+        state_dir = _state_dir(tmp_path)
+        self._write_backlog(
+            state_dir,
+            [{"hypothesis_id": "hypothesis-a", "task_title": "Fix widget A", "metric": "m1"}],
+        )
+        cycle_ledger.append_event(
+            state_dir,
+            {
+                "phase": "proposed",
+                "cycle_id": "c1",
+                "task_title": "Fix widget A",
+                "serves": "hypothesis hypothesis-a",
+            },
+        )
+        # No matching outcome row -> still in flight.
+        hyps = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"]
+        assert hyps == []
+
+    def test_resolved_experiment_allows_a_new_one(self, tmp_path):
+        """Once the in-flight cycle reaches a terminal outcome, a hypothesis
+        item may be minted again (subject to the usual completed-suppression
+        for the answered one specifically)."""
+        state_dir = _state_dir(tmp_path)
+        self._write_backlog(
+            state_dir,
+            [
+                {"hypothesis_id": "hypothesis-a", "task_title": "Fix widget A", "metric": "m1"},
+                {"hypothesis_id": "hypothesis-b", "task_title": "Fix widget B", "metric": "m2"},
+            ],
+        )
+        cycle_ledger.append_event(
+            state_dir,
+            {
+                "phase": "proposed",
+                "cycle_id": "c1",
+                "task_title": "Fix widget A",
+                "serves": "hypothesis hypothesis-a",
+            },
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "failed"}
+        )
+        hyps = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"]
+        # Resolved (failed, so hypothesis-a stays active) -> no in-flight
+        # experiment anymore, so the cap-to-one still applies but is no
+        # longer suppressed to zero.
+        assert len(hyps) == 1
+
 
 # ─── kind: goal-gap (#765) ──────────────────────────────────────────────────
 

--- a/tests/test_goal_review.py
+++ b/tests/test_goal_review.py
@@ -676,3 +676,79 @@ class TestDerivedPriorities:
         _write_goal_text(state_dir, shrunk)
 
         assert _derived_item_id() == id_before
+
+
+# ─── #878: supported hypotheses surface as citable evidence ────────────────
+
+
+def _write_lifecycle(state_dir: Path, entries: dict) -> None:
+    d = state_dir / "hypotheses"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "lifecycle.json").write_text(
+        json.dumps({"schema_version": "hypothesis-lifecycle-v1", "entries": entries}),
+        encoding="utf-8",
+    )
+
+
+class TestSupportedHypothesisEvidence:
+    def test_supported_hypothesis_appears_in_collected_evidence(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "verdict": "supported",
+                "verdict_at": "2026-08-01T00:00:00Z",
+                "verdict_evidence": {"source": "microbench", "value": 12.0},
+                "title": "Cache the widget lookup",
+            },
+            "hypothesis-h2": {
+                "status": "answered",
+                "verdict": "refuted",
+                "verdict_at": "2026-08-02T00:00:00Z",
+                "title": "A refuted idea",
+            },
+        })
+        evidence = goal_review._collect_evidence(state_dir, None, {}, NOW)
+        lines = list(evidence.values())
+        assert any("supported hypothesis: Cache the widget lookup" in line for line in lines)
+        assert not any("refuted" in line.lower() for line in lines)
+
+    def test_no_supported_hypotheses_adds_nothing(self, tmp_path):
+        state_dir = tmp_path / "state"
+        evidence = goal_review._collect_evidence(state_dir, None, {}, NOW)
+        assert evidence == {}
+
+    def test_supported_hypothesis_can_be_accepted_as_a_priority(
+        self, tmp_path, monkeypatch, enabled
+    ):
+        """End-to-end: a supported-hypothesis evidence line is citable by id
+        and, once cited, flows through the SAME fail-closed
+        validate_priority path as any other evidence source."""
+        state_dir = tmp_path / "state"
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [])  # no goal-gap evidence
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "verdict": "supported",
+                "verdict_at": "2026-08-01T00:00:00Z",
+                "verdict_evidence": {"source": "microbench", "value": 12.0},
+                "title": "Cache the widget lookup",
+            },
+        })
+
+        captured_context = {}
+
+        def _fake_llm(context: str):
+            captured_context["text"] = context
+            return {"priorities": [{
+                "label": "Land the widget cache",
+                "body": "Add caching to scripts/widget_lookup.py. Commit.",
+                "vector": "V1",
+                "evidence": "E1",
+            }]}
+
+        monkeypatch.setattr(goal_review, "_call_llm", _fake_llm)
+        titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
+        assert titles == ["Priority 17 — Land the widget cache"]
+        assert "supported hypothesis: Cache the widget lookup" in captured_context["text"]

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -354,6 +354,128 @@ class TestVerdictOnAnswer:
         assert len(verdict_rows) == 1
 
 
+class TestInconclusiveVerdictUpgrade:
+    """#878 opus-review N1 fix: an answered+inconclusive hypothesis is
+    re-checked on every LATER reconcile pass (the confirmed-usage source
+    needs time after completion to observe usage, so day-0 is structurally
+    always inconclusive for it)."""
+
+    def test_inconclusive_upgrades_to_supported_once_confirmed(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+        # First pass: no measured signal at all yet -> inconclusive.
+        hypothesis_backlog.reconcile(state_dir)
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["verdict"] == "inconclusive"
+
+        # Usage evidence arrives later: demand/completed.json now shows the
+        # cycle's scripts/ artifact confirmed used.
+        completed_dir = state_dir / "demand"
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        (completed_dir / "completed.json").write_text(
+            json.dumps({
+                "schema_version": "demand-completed-v1",
+                "entries": {
+                    "entry-1": {
+                        "cycle_id": "c1",
+                        "files_changed": ["scripts/widget.py"],
+                        "confirmed": True,
+                        "signal": "pycache",
+                        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    }
+                },
+            }),
+            encoding="utf-8",
+        )
+
+        # Second (later) pass: must re-check and upgrade.
+        hypothesis_backlog.reconcile(state_dir)
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["verdict"] == "supported"
+        assert entry["verdict_evidence"]["source"] == "confirmed_usage"
+
+        rows = [
+            json.loads(line)
+            for line in (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        verdict_rows = [r for r in rows if r.get("phase") == "hypothesis" and r.get("reason") == "verdict"]
+        assert [r["verdict"] for r in verdict_rows] == ["inconclusive", "supported"]
+
+    def test_still_inconclusive_produces_no_extra_writes(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+        hypothesis_backlog.reconcile(state_dir)
+        hypothesis_backlog.reconcile(state_dir)
+        hypothesis_backlog.reconcile(state_dir)
+
+        rows = [
+            json.loads(line)
+            for line in (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        verdict_rows = [r for r in rows if r.get("phase") == "hypothesis" and r.get("reason") == "verdict"]
+        # One event from the initial answered-transition only — repeated
+        # still-inconclusive passes append nothing further.
+        assert len(verdict_rows) == 1
+
+    def test_microbench_refuted_is_not_reopened_by_the_upgrade_path(self, tmp_path):
+        """A verdict that is already supported/refuted (not inconclusive)
+        must never be re-checked by the upgrade path — only inconclusive
+        entries are eligible."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_microbench(state_dir, "c1", improvement_pct=1.0)
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+        hypothesis_backlog.reconcile(state_dir)
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["verdict"] == "refuted"
+
+        # Even if usage evidence now claims confirmed use, the stored
+        # verdict must stay "refuted" -- microbench already resolved it and
+        # the entry is no longer "inconclusive".
+        completed_dir = state_dir / "demand"
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        (completed_dir / "completed.json").write_text(
+            json.dumps({
+                "schema_version": "demand-completed-v1",
+                "entries": {
+                    "entry-1": {
+                        "cycle_id": "c1",
+                        "files_changed": ["scripts/widget.py"],
+                        "confirmed": True,
+                        "signal": "pycache",
+                        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    }
+                },
+            }),
+            encoding="utf-8",
+        )
+        hypothesis_backlog.reconcile(state_dir)
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["verdict"] == "refuted"
+
+
 class TestSupportedHypotheses:
     def test_supported_hypotheses_returns_newest_first(self, tmp_path):
         state_dir = _state_dir(tmp_path)
@@ -448,3 +570,79 @@ class TestHasInFlightExperiment:
             {"phase": "proposed", "cycle_id": "c2", "task_title": "Fix widget", "serves": "hypothesis h1"},
         )
         assert hypothesis_backlog.has_in_flight_experiment(state_dir) is False
+
+    def test_timeout_releases_a_crashed_experiment(self, tmp_path):
+        """#878 opus-review Y1 fix: a proposed cycle that never got an
+        outcome (crash/kill) must NOT stay in-flight forever — once its
+        'proposed' row is older than IN_FLIGHT_TIMEOUT_DAYS, the lane
+        releases and a new hypothesis experiment may be minted."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        old_ts = (
+            datetime.now(timezone.utc)
+            - timedelta(days=hypothesis_backlog.IN_FLIGHT_TIMEOUT_DAYS + 1)
+        ).isoformat().replace("+00:00", "Z")
+        cycle_ledger.append_event(
+            state_dir,
+            {
+                "phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget",
+                "serves": "hypothesis h1", "ts": old_ts,
+            },
+        )
+        # No outcome row at all -- simulates a crashed/killed cycle.
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is False
+
+    def test_within_timeout_still_counts_as_in_flight(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        recent_ts = (
+            datetime.now(timezone.utc) - timedelta(hours=1)
+        ).isoformat().replace("+00:00", "Z")
+        cycle_ledger.append_event(
+            state_dir,
+            {
+                "phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget",
+                "serves": "hypothesis h1", "ts": recent_ts,
+            },
+        )
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is True
+
+    def test_missing_ts_conservatively_still_counts_as_in_flight(self, tmp_path):
+        """A malformed row without a parseable ts cannot be confirmed as
+        timed out, so it stays conservatively in-flight (fail-open toward
+        the existing behavior, not toward releasing the lane)."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        path = state_dir / "ledger" / "cycles.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Hand-written row with no ts at all (append_event always sets one;
+        # this simulates external/corrupt state).
+        path.write_text(
+            json.dumps({
+                "phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget",
+                "serves": "hypothesis h1",
+            }) + "\n",
+            encoding="utf-8",
+        )
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is True
+
+    def test_demand_allows_new_hypothesis_after_in_flight_timeout(self, tmp_path):
+        """End-to-end: demand.collect_demand mints a hypothesis item again
+        once the previously in-flight experiment has timed out."""
+        from nanobot.runtime import demand
+
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget", "metric": "m1"}])
+        old_ts = (
+            datetime.now(timezone.utc)
+            - timedelta(days=hypothesis_backlog.IN_FLIGHT_TIMEOUT_DAYS + 1)
+        ).isoformat().replace("+00:00", "Z")
+        cycle_ledger.append_event(
+            state_dir,
+            {
+                "phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget",
+                "serves": "hypothesis h1", "ts": old_ts,
+            },
+        )
+        hyps = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"]
+        assert len(hyps) == 1

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -244,3 +244,207 @@ class TestLifecycleReconciliation:
     def test_reconcile_is_fail_open_on_unreadable_state(self, tmp_path):
         # No exception even when nothing exists at all.
         hypothesis_backlog.reconcile(tmp_path / "does-not-exist")
+
+
+# ─── #878: verdict computed the same pass a hypothesis is answered ─────────
+
+
+def _write_microbench(state_dir: Path, cycle_id: str, *, improvement_pct: float) -> None:
+    d = state_dir / "heldout"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "microbench.json").write_text(
+        json.dumps({
+            "schema_version": "heldout-microbench-v1",
+            "entries": {
+                cycle_id: {
+                    "module": "nanobot/runtime/existence_index.py",
+                    "metric": "wall_ms_best_of_5",
+                    "baseline_ms": 100.0,
+                    "candidate_ms": 100.0 * (1 - improvement_pct / 100.0),
+                    "improvement_pct": improvement_pct,
+                    "direction": "lower",
+                    "schema": "heldout-microbench-entry-v1",
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+class TestVerdictOnAnswer:
+    def test_answered_hypothesis_gets_supported_verdict_from_microbench(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_microbench(state_dir, "c1", improvement_pct=10.0)
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["status"] == "answered"
+        assert entry["verdict"] == "supported"
+        assert entry["verdict_evidence"]["source"] == "microbench"
+        assert entry["verdict_at"]
+        assert entry["title"] == "Fix widget"
+
+    def test_answered_hypothesis_gets_inconclusive_verdict_with_no_signal(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["verdict"] == "inconclusive"
+
+    def test_verdict_ledger_event_appended(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_microbench(state_dir, "c1", improvement_pct=1.0)
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        verdict_rows = [r for r in rows if r.get("phase") == "hypothesis" and r.get("reason") == "verdict"]
+        assert len(verdict_rows) == 1
+        assert verdict_rows[0]["verdict"] == "refuted"
+        assert verdict_rows[0]["hypothesis_ref"] == "hypothesis-h1"
+        assert verdict_rows[0]["cycle_id"] == "c1"
+
+    def test_verdict_computed_only_once(self, tmp_path):
+        """A second reconcile pass over an already-answered entry must not
+        recompute/re-append the verdict (idempotent, same as the existing
+        answered-status guard)."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_microbench(state_dir, "c1", improvement_pct=10.0)
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+        hypothesis_backlog.reconcile(state_dir)
+        hypothesis_backlog.reconcile(state_dir)
+
+        path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        verdict_rows = [r for r in rows if r.get("phase") == "hypothesis" and r.get("reason") == "verdict"]
+        assert len(verdict_rows) == 1
+
+
+class TestSupportedHypotheses:
+    def test_supported_hypotheses_returns_newest_first(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered", "verdict": "supported", "verdict_at": "2026-08-01T00:00:00Z",
+                "verdict_evidence": {"source": "microbench"}, "title": "Older win",
+            },
+            "hypothesis-h2": {
+                "status": "answered", "verdict": "supported", "verdict_at": "2026-08-05T00:00:00Z",
+                "verdict_evidence": {"source": "confirmed_usage"}, "title": "Newer win",
+            },
+            "hypothesis-h3": {
+                "status": "answered", "verdict": "refuted", "verdict_at": "2026-08-06T00:00:00Z",
+                "title": "Not this one",
+            },
+        })
+        result = hypothesis_backlog.supported_hypotheses(state_dir)
+        assert [r["title"] for r in result] == ["Newer win", "Older win"]
+
+    def test_supported_hypotheses_capped_to_n(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        entries = {
+            f"hypothesis-h{i}": {
+                "status": "answered", "verdict": "supported",
+                "verdict_at": f"2026-08-0{i}T00:00:00Z", "title": f"Win {i}",
+            }
+            for i in range(1, 6)
+        }
+        _write_lifecycle(state_dir, entries)
+        result = hypothesis_backlog.supported_hypotheses(state_dir, n=3)
+        assert len(result) == 3
+
+    def test_no_lifecycle_file_returns_empty(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        assert hypothesis_backlog.supported_hypotheses(state_dir) == []
+
+
+class TestLifecycleCounts:
+    def test_counts_by_status_and_verdict(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {"status": "active"},
+            "hypothesis-h2": {"status": "answered", "verdict": "supported"},
+            "hypothesis-h3": {"status": "answered", "verdict": "refuted"},
+        })
+        assert hypothesis_backlog.lifecycle_counts(state_dir) == {
+            "active": 1, "answered": 2, "supported": 1, "refuted": 1, "inconclusive": 0,
+        }
+
+    def test_no_lifecycle_is_all_zero(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        assert hypothesis_backlog.lifecycle_counts(state_dir) == {
+            "active": 0, "answered": 0, "supported": 0, "refuted": 0, "inconclusive": 0,
+        }
+
+
+class TestHasInFlightExperiment:
+    def test_false_with_no_candidates(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is False
+
+    def test_true_when_proposed_without_outcome(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is True
+
+    def test_false_once_outcome_recorded(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "failed"}
+        )
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is False
+
+    def test_false_when_only_answered_hypothesis_has_open_cycle(self, tmp_path):
+        """An already-answered hypothesis's stale in-flight-looking row must
+        not count — only ACTIVE candidates are considered."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_lifecycle(state_dir, {"hypothesis-h1": {"status": "answered"}})
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c2", "task_title": "Fix widget", "serves": "hypothesis h1"},
+        )
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is False

--- a/tests/test_hypothesis_verdict.py
+++ b/tests/test_hypothesis_verdict.py
@@ -1,0 +1,202 @@
+"""Tests for #878: the harness-computed hypothesis verdict.
+
+Covers the two trusted measured sources (microbench, confirmed-usage), the
+inconclusive fallback when neither has a signal, and the trust boundary
+itself — a number the INSTANCE merely claims (in acceptance/evidence text)
+must never influence the verdict; only a measured sidecar can.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime import hypothesis_verdict
+
+
+def _state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    return state_dir
+
+
+def _write_microbench(state_dir: Path, cycle_id: str, *, improvement_pct: float) -> None:
+    d = state_dir / "heldout"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "microbench.json").write_text(
+        json.dumps({
+            "schema_version": "heldout-microbench-v1",
+            "entries": {
+                cycle_id: {
+                    "module": "nanobot/runtime/existence_index.py",
+                    "metric": "wall_ms_best_of_5",
+                    "baseline_ms": 100.0,
+                    "candidate_ms": 100.0 * (1 - improvement_pct / 100.0),
+                    "improvement_pct": improvement_pct,
+                    "direction": "lower",
+                    "schema": "heldout-microbench-entry-v1",
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+def _write_completed(state_dir: Path, entry_id: str, entry: dict) -> None:
+    d = state_dir / "demand"
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "completed.json"
+    data = {"schema_version": "demand-completed-v1", "entries": {}}
+    if path.is_file():
+        data = json.loads(path.read_text(encoding="utf-8"))
+    data.setdefault("entries", {})[entry_id] = entry
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestMicrobenchSource:
+    def test_supported_above_threshold(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_microbench(state_dir, "cycle-1", improvement_pct=12.5)
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-1")
+        assert verdict == "supported"
+        assert evidence["source"] == "microbench"
+        assert evidence["value"] == 12.5
+        assert evidence["threshold"] == hypothesis_verdict.MICROBENCH_SUPPORTED_THRESHOLD_PCT
+
+    def test_refuted_below_threshold(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_microbench(state_dir, "cycle-1", improvement_pct=1.0)
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-1")
+        assert verdict == "refuted"
+        assert evidence["source"] == "microbench"
+
+    def test_refuted_on_negative_improvement(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_microbench(state_dir, "cycle-1", improvement_pct=-3.0)
+        verdict, _ = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-1")
+        assert verdict == "refuted"
+
+    def test_microbench_takes_precedence_over_confirmed_usage(self, tmp_path):
+        """Both sources present for the same cycle: microbench wins (first
+        match), even though the confirmed-usage source alone would say
+        something different."""
+        state_dir = _state_dir(tmp_path)
+        _write_microbench(state_dir, "cycle-1", improvement_pct=9.0)
+        _write_completed(state_dir, "entry-1", {
+            "cycle_id": "cycle-1",
+            "files_changed": ["scripts/foo.py"],
+            "confirmed": False,
+            "ts": (datetime.now(timezone.utc) - timedelta(days=30)).isoformat().replace("+00:00", "Z"),
+        })
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-1")
+        assert verdict == "supported"
+        assert evidence["source"] == "microbench"
+
+
+class TestConfirmedUsageSource:
+    def test_supported_when_confirmed(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_completed(state_dir, "entry-1", {
+            "cycle_id": "cycle-2",
+            "files_changed": ["scripts/foo.py"],
+            "confirmed": True,
+            "signal": "pycache",
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        })
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-2")
+        assert verdict == "supported"
+        assert evidence["source"] == "confirmed_usage"
+        assert evidence["artifact"] == "scripts/foo.py"
+
+    def test_refuted_when_unused_past_window(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=hypothesis_verdict.CONFIRM_WINDOW_DAYS + 1))
+        _write_completed(state_dir, "entry-1", {
+            "cycle_id": "cycle-3",
+            "files_changed": ["scripts/foo.py"],
+            "confirmed": False,
+            "ts": old_ts.isoformat().replace("+00:00", "Z"),
+        })
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-3")
+        assert verdict == "refuted"
+        assert evidence["source"] == "confirmed_usage"
+
+    def test_inconclusive_when_still_within_window(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        recent_ts = datetime.now(timezone.utc) - timedelta(days=1)
+        _write_completed(state_dir, "entry-1", {
+            "cycle_id": "cycle-4",
+            "files_changed": ["scripts/foo.py"],
+            "confirmed": False,
+            "ts": recent_ts.isoformat().replace("+00:00", "Z"),
+        })
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-4")
+        assert verdict == "inconclusive"
+        assert evidence["source"] == "none"
+
+    def test_non_script_artifact_falls_through_to_inconclusive(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_completed(state_dir, "entry-1", {
+            "cycle_id": "cycle-5",
+            "files_changed": ["nanobot/runtime/demand.py"],
+            "confirmed": False,
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        })
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-5")
+        assert verdict == "inconclusive"
+        assert evidence["source"] == "none"
+
+
+class TestNoSignal:
+    def test_no_signal_at_all_is_inconclusive(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-none")
+        assert verdict == "inconclusive"
+        assert evidence == {"source": "none", "cycle_id": "cycle-none"}
+
+    def test_empty_cycle_id_is_inconclusive(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "")
+        assert verdict == "inconclusive"
+        assert evidence["source"] == "none"
+
+    def test_corrupt_microbench_file_is_fail_open(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        d = state_dir / "heldout"
+        d.mkdir(parents=True)
+        (d / "microbench.json").write_text("not json {{{", encoding="utf-8")
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-1")
+        assert verdict == "inconclusive"
+        assert evidence["source"] == "none"
+
+
+class TestTrustBoundary:
+    def test_forged_instance_claim_in_acceptance_text_is_ignored(self, tmp_path):
+        """A hypothesis's own acceptance/evidence text claiming a huge win
+        must NEVER move the verdict — only a measured sidecar can. With no
+        microbench/completed entry at all, the verdict must be inconclusive
+        no matter what the acceptance text says."""
+        state_dir = _state_dir(tmp_path)
+        forged_acceptance = "improvement_pct: 99.9 -- confirmed massive speedup, trust me"
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(
+            state_dir, "cycle-forged", forged_acceptance
+        )
+        assert verdict == "inconclusive"
+        assert evidence["source"] == "none"
+        assert "99.9" not in json.dumps(evidence)
+
+    def test_forged_completed_json_confirmed_field_still_requires_scripts_path(self, tmp_path):
+        """A completed entry with confirmed=True but no scripts/ artifact at
+        all must not be read as usage evidence for this cycle (a hypothesis
+        that touched no script cannot be "used")."""
+        state_dir = _state_dir(tmp_path)
+        _write_completed(state_dir, "entry-1", {
+            "cycle_id": "cycle-6",
+            "files_changed": ["nanobot/runtime/demand.py"],
+            "confirmed": True,
+            "signal": "pycache",
+            "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        })
+        verdict, evidence = hypothesis_verdict.classify_hypothesis_verdict(state_dir, "cycle-6")
+        assert verdict == "inconclusive"
+        assert evidence["source"] == "none"

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2565,3 +2565,108 @@ class TestPermanentNoveltyGuard:
         # treated as repo new-files (never probed outside the repo).
         assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "../../etc/passwd"}) is False
         assert llm_proposer._proposal_creates_new_file(repo, {"target_path": "/etc/passwd"}) is False
+
+
+# ─── #878: refuted-hypothesis permanent novelty guard ──────────────────────
+
+
+def _write_lifecycle(state_dir, entries: dict) -> None:
+    d = state_dir / "hypotheses"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "lifecycle.json").write_text(
+        json.dumps({"schema_version": "hypothesis-lifecycle-v1", "entries": entries}),
+        encoding="utf-8",
+    )
+
+
+class TestRefutedHypothesisGuard:
+    def test_refuted_hypothesis_titles_reads_lifecycle(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {"status": "answered", "verdict": "refuted", "title": "Cache the widget index"},
+            "hypothesis-h2": {"status": "answered", "verdict": "supported", "title": "Batch the writer"},
+            "hypothesis-h3": {"status": "active", "title": "Untouched idea"},
+        })
+        titles = llm_proposer._refuted_hypothesis_titles(state_dir)
+        assert titles == ["Cache the widget index"]
+
+    def test_refuted_hypothesis_titles_fail_open(self, tmp_path):
+        state_dir = tmp_path / "state"
+        assert llm_proposer._refuted_hypothesis_titles(state_dir) == []
+        d = state_dir / "hypotheses"
+        d.mkdir(parents=True)
+        (d / "lifecycle.json").write_text("not json {{{", encoding="utf-8")
+        assert llm_proposer._refuted_hypothesis_titles(state_dir) == []
+
+    def test_refuted_title_blocks_reproposal_permanently(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "verdict": "refuted",
+                "title": "cache the widget lookup index for faster reads",
+            },
+        })
+        proposal = {
+            "task_title": "cache the widget lookup index for faster reads",
+            "target_path": "nanobot/runtime/existence_index.py",
+        }
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state_dir, None, proposal)
+        assert dup is True
+        assert "REFUTED" in feedback
+        assert matched.startswith("refuted-hypothesis:")
+
+    def test_supported_title_is_not_blocked(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "verdict": "supported",
+                "title": "cache the widget lookup index for faster reads",
+            },
+        })
+        proposal = {
+            "task_title": "cache the widget lookup index for faster reads",
+            "target_path": "nanobot/runtime/existence_index.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state_dir, None, proposal)
+        assert dup is False
+
+    def test_inconclusive_title_is_not_blocked(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "verdict": "inconclusive",
+                "title": "cache the widget lookup index for faster reads",
+            },
+        })
+        proposal = {
+            "task_title": "cache the widget lookup index for faster reads",
+            "target_path": "nanobot/runtime/existence_index.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state_dir, None, proposal)
+        assert dup is False
+
+    def test_refuted_guard_applies_without_new_file_creation(self, tmp_path, monkeypatch):
+        """Unlike the #834 guard, the refuted-hypothesis guard must fire even
+        when the proposal edits an EXISTING file (a hypothesis experiment
+        need not create a new file)."""
+        state_dir = tmp_path / "state"
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "verdict": "refuted",
+                "title": "batch the ledger writer flush calls",
+            },
+        })
+        # No repo passed at all — _proposal_creates_new_file would fail-open
+        # to False anyway, but this also proves the guard doesn't depend on
+        # the #834 code path running first.
+        proposal = {
+            "task_title": "batch the ledger writer flush calls",
+            "target_path": "nanobot/runtime/existence_index.py",
+        }
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state_dir, None, proposal)
+        assert dup is True
+        assert matched.startswith("refuted-hypothesis:")

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2590,6 +2590,30 @@ class TestRefutedHypothesisGuard:
         titles = llm_proposer._refuted_hypothesis_titles(state_dir)
         assert titles == ["Cache the widget index"]
 
+    def test_refuted_hypothesis_titles_bounded_and_newest_first(self, tmp_path):
+        """#878 opus-review Y2 fix: the refuted block-list must be bounded
+        (mirrors hypothesis_backlog.SUPPORTED_TOP_N), newest verdict first —
+        an unbounded list would keep growing the false-positive surface
+        over a long RSI run."""
+        from nanobot.runtime import hypothesis_backlog
+
+        state_dir = tmp_path / "state"
+        n = hypothesis_backlog.SUPPORTED_TOP_N
+        entries = {
+            f"hypothesis-h{i}": {
+                "status": "answered",
+                "verdict": "refuted",
+                "verdict_at": f"2026-08-{i:02d}T00:00:00Z",
+                "title": f"Refuted idea {i}",
+            }
+            for i in range(1, n + 3)  # strictly more entries than the cap
+        }
+        _write_lifecycle(state_dir, entries)
+        titles = llm_proposer._refuted_hypothesis_titles(state_dir)
+        assert len(titles) == n
+        # Newest (highest day number) first.
+        assert titles[0] == f"Refuted idea {n + 2}"
+
     def test_refuted_hypothesis_titles_fail_open(self, tmp_path):
         state_dir = tmp_path / "state"
         assert llm_proposer._refuted_hypothesis_titles(state_dir) == []

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -970,7 +970,7 @@ class TestControlPlaneSnapshot:
         # keys (not env-driven), so they are asserted separately rather than
         # folded into the allowlist.
         assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {
-            "runtime_promotions", "runtime_trust_ladder", "evolution_tree",
+            "runtime_promotions", "runtime_trust_ladder", "evolution_tree", "hypothesis_loop",
         }
         assert all(control_plane[key] is None for key in scorecard._CONTROL_PLANE_KEYS)
         assert control_plane["runtime_promotions"] == {"active": 0, "soaking": 0, "rejected": 0}
@@ -981,6 +981,9 @@ class TestControlPlaneSnapshot:
         }
         assert control_plane["evolution_tree"] == {
             "nodes": 0, "current_sha": None, "switches": 0,
+        }
+        assert control_plane["hypothesis_loop"] == {
+            "active": 0, "answered": 0, "supported": 0, "refuted": 0, "inconclusive": 0,
         }
 
     def test_set_values_are_captured_others_stay_none(self, tmp_path, monkeypatch):
@@ -1008,7 +1011,7 @@ class TestControlPlaneSnapshot:
         snap = scorecard.compute_scorecard(state_dir, None, force=True)
         control_plane = snap["control_plane"]
         assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {
-            "runtime_promotions", "runtime_trust_ladder", "evolution_tree",
+            "runtime_promotions", "runtime_trust_ladder", "evolution_tree", "hypothesis_loop",
         }
 
     def test_no_secret_ever_appears_in_serialized_scorecard(self, tmp_path, monkeypatch):
@@ -1119,3 +1122,27 @@ class TestControlPlaneSnapshot:
         assert not any(
             key in scorecard._TARGETS for key in scorecard._CONTROL_PLANE_KEYS
         )
+
+    def test_hypothesis_loop_counts_from_lifecycle(self, tmp_path):
+        """#878: control_plane.hypothesis_loop reflects
+        hypotheses/lifecycle.json's status/verdict fields."""
+        state_dir = tmp_path / "state"
+        lifecycle_dir = state_dir / "hypotheses"
+        lifecycle_dir.mkdir(parents=True)
+        (lifecycle_dir / "lifecycle.json").write_text(json.dumps({
+            "schema_version": "hypothesis-lifecycle-v1",
+            "entries": {
+                "hypothesis-h1": {"status": "active"},
+                "hypothesis-h2": {"status": "answered", "verdict": "supported"},
+                "hypothesis-h3": {"status": "answered", "verdict": "refuted"},
+                "hypothesis-h4": {"status": "answered", "verdict": "inconclusive"},
+            },
+        }))
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        assert snap["control_plane"]["hypothesis_loop"] == {
+            "active": 1,
+            "answered": 3,
+            "supported": 1,
+            "refuted": 1,
+            "inconclusive": 1,
+        }


### PR DESCRIPTION
## Summary

Closes the missing half of the RSI scientific loop (#878). `hypothesis_backlog.reconcile` already answered WHETHER a hypothesis's experiment cycle integrated; it never asked whether the hypothesis was actually TRUE. This PR is a thin closing layer over machinery that already exists — no new demand lane, no report generator, no new daemon.

- **Verdict classification** (`nanobot/runtime/hypothesis_verdict.py`, new): `classify_hypothesis_verdict(state_dir, cycle_id, acceptance_text="")` derives `supported`/`refuted`/`inconclusive` from two `scorecard.FITNESS_SIDECARS` members only — `heldout/microbench.json` (#822 causal measurement, `improvement_pct >= 5.0` -> supported) then `demand/completed.json` (#773/#761 confirmed-usage; unconfirmed past a 14-day window -> refuted). `acceptance_text` is accepted for interface symmetry but never read — a claim the instance writes can never move the verdict.
- **`hypothesis_backlog.reconcile`** now computes + persists this verdict (`verdict`/`verdict_evidence`/`verdict_at`) the same pass a candidate is first marked `answered`, and appends a `{"phase": "hypothesis", "reason": "verdict", ...}` ledger row.
- **Refuted -> permanent novelty guard** (`llm_proposer._refuted_hypothesis_titles` + `_is_duplicate_proposal`): a refuted hypothesis title is blocked from re-proposal PERMANENTLY (like #834), unconditionally (unlike #834, not gated on new-file creation). `matched_against` is `"refuted-hypothesis:<title>"`.
- **Supported -> goal-review evidence candidate** (`hypothesis_backlog.supported_hypotheses` wired into `goal_review._collect_evidence`): top-3 newest-first supported hypotheses surface as citable evidence lines, exactly like decay/goal-gap evidence — still has to pass `validate_priority`'s existing fail-closed checks.
- **At most one active hypothesis experiment** (`hypothesis_backlog.has_in_flight_experiment` + `demand._hypothesis_items`): a `'proposed'` ledger row with no terminal `'outcome'` row yet suppresses minting any new hypothesis-kind demand item; otherwise the (possibly multi-candidate) result is capped to one item.
- **Scorecard visibility**: `control_plane.hypothesis_loop` = `{active, answered, supported, refuted, inconclusive}` counts from `lifecycle.json`, visibility-only (never fed into targets/gaps).
- `hypothesis_verdict.py` added to `runtime_deny._RUNTIME_DENY_ALWAYS_FILES` (fitness-adjacent steering logic, same rationale as `benchmark_evidence.py`/`usage_evidence.py`).

Full design + trust-boundary writeup: `docs/changes/878-hypothesis-loop/proposal.md`.

## Review follow-up (opus review: MERGE, 0 RED, 3 bounded fixes)

- **Y1** — `has_in_flight_experiment` never released a serving cycle that crashed/was killed before writing a terminal `outcome` row, freezing the whole hypothesis lane for up to 14 days (the stale window). Added `IN_FLIGHT_TIMEOUT_DAYS` (3d): a `proposed` row older than that no longer counts as in-flight even with no outcome row.
- **N1** — the verdict was only ever computed once, at the exact `answered` transition (day 0) — structurally always `inconclusive` for the confirmed-usage source, since usage evidence needs time to arrive. `reconcile` now re-evaluates any `answered`+`inconclusive` entry on every later pass, so a later-arriving confirmed-usage signal (or its window expiry) can actually resolve the verdict; a steady-state inconclusive entry produces no extra writes/ledger events.
- **Y2** — `_refuted_hypothesis_titles` returned every refuted title ever, unbounded, growing the word-overlap false-positive surface over a long RSI run. Bounded to the same small N `supported_hypotheses` already uses (`hypothesis_backlog.SUPPORTED_TOP_N`), newest-first.

## Trust note

`hypotheses/lifecycle.json`/`backlog.json`/`research/hypotheses.json` are INSTANCE-writable state — never trusted for the verdict number. The verdict comes exclusively from two harness-trusted, #789-protected sidecars. A verdict is STEERING, never a verification gate: `refuted` only blocks a re-proposal (worst case: a wasted retry); `supported` only injects a citable evidence candidate that still has to pass the full fail-closed validation + cycle gate before it can integrate. A forged/tampered sidecar can never fabricate an integration by itself.

## Files changed

- `nanobot/runtime/hypothesis_verdict.py` (new)
- `nanobot/runtime/hypothesis_backlog.py`
- `nanobot/runtime/llm_proposer.py`
- `nanobot/runtime/demand.py`
- `nanobot/runtime/goal_review.py`
- `nanobot/runtime/scorecard.py`
- `nanobot/runtime/runtime_deny.py`
- `tests/test_hypothesis_verdict.py` (new)
- `tests/test_hypothesis_backlog.py`
- `tests/test_llm_proposer.py`
- `tests/test_demand.py`
- `tests/test_goal_review.py`
- `tests/test_scorecard.py`
- `docs/changes/878-hypothesis-loop/proposal.md` (new)

## Test plan

- [x] `tests/test_hypothesis_verdict.py tests/test_hypothesis_backlog.py tests/test_goal_review.py tests/test_scorecard.py` (run by explicit path): **119 passed**
- [x] `tests/test_llm_proposer.py tests/test_demand.py` (run by explicit path; this dev machine has a pre-existing local site-packages `tests` package shadow that hides these two files from default collection — worked around for verification by pre-seeding `sys.modules["tests"]`, not committed): **258 passed, 2 failed** — both failures are pre-existing, unrelated Windows path-separator assertions in `TestCompileDefects` (`scripts/broken.py` vs `scripts\broken.py`), not touched by this change.
- [x] Full-suite `python -m pytest -q` (workaround-seeded to bypass a local site-packages `tests` shadow, so this run collected every file with zero collection errors): **31 failed, 2240 passed, 6 skipped in 1220.63s**. All 31 failures are pre-existing and unrelated to this change (git-provenance/symlink/rollback autoevolve tests, `flock`-is-POSIX-only bridge-locking tests, CLI branding/help-text tests, the 2 already-known Windows path-separator `TestCompileDefects` failures, and a missing `ddgs` dependency in this environment) — see the PR comment for the full breakdown.
- [x] Review-fix commit (Y1/N1/Y2 above) re-verified by explicit path: `tests/test_hypothesis_verdict.py tests/test_hypothesis_backlog.py tests/test_goal_review.py tests/test_scorecard.py` → **126 passed**; `tests/test_llm_proposer.py tests/test_demand.py` (workaround) → **259 passed, 2 failed** (same 2 pre-existing failures as above). Full-suite re-run in progress; will confirm in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

