### PR TITLE
feat(runtime): #879 tech-tree of improvement directions — plateau-switching bandit ranking

### DIFF
--- a/docs/changes/879-tech-tree/proposal.md
+++ b/docs/changes/879-tech-tree/proposal.md
@@ -1,0 +1,270 @@
+# Change: tech-tree of improvement DIRECTIONS (RSI stage 5)
+
+- **change-id:** 879-tech-tree
+- **issue:** #879
+- **capability:** self-evolving-runtime (scorecard #765/#789/#865, demand
+  #760/#815, goal-review #768/#860, hypothesis loop #878, evolution tree
+  #877)
+- **role / workstream:** RSI (recursive self-improvement) — a soft ranking
+  input over capability domains, layered on the EXISTING demand/goal-review
+  pipeline
+
+## Strict product simplicity (the issue's own words)
+
+"2GB-simple, NO heavy bandit machinery, NO MAP-Elites, NO new scheduler."
+This is a RANKING INPUT to the existing demand/goal-review pipeline —
+exactly the same shape as the #815 V1-over-V2 soft vector bias in
+`demand.py` — never a scheduler, never a gate. The entire "bandit" is
+epsilon-greedy over five product-seeded nodes plus whatever a supported
+hypothesis mints; there is no grid, no population, no new daemon or timer.
+
+## Two DIFFERENT trees — do not conflate
+
+- **#877 `evolution_tree.py`** = STATE space: WHERE the code has been (git
+  shas, branches, generations). Already built; untouched by this change.
+- **THIS (#879) `tech_tree.py`** = DIRECTION space: WHICH capability
+  domain the loop invests its next cycles in. A Civ-style tech tree:
+  invest in one direction while it keeps yielding measured gains; when a
+  direction PLATEAUS (no net improvement over a trailing window), shift
+  investment to the best other direction. The instance can MINT a new
+  direction from a supported hypothesis (#878) whose domain isn't already
+  mapped.
+
+## Design
+
+### 1. `nanobot/runtime/tech_tree.py` (new, harness-owned, stdlib-only, deny-set)
+
+A sidecar at `<state_dir>/tech_tree/portfolio.json`:
+
+```json
+{
+  "schema_version": "tech-tree-v1",
+  "current": "proposer-quality",
+  "nodes": {
+    "proposer-quality": {
+      "lever_metric": "loop.repeat_failure_rate",
+      "direction": "lower",
+      "gain_history": [0.02, -0.01, 0.0],
+      "status": "active",
+      "cooldown_until_ts": null,
+      "minted_by": "product",
+      "created_ts": "2026-08-17T00:00:00Z",
+      "last_lever_value": 0.31
+    }
+  },
+  "switches": [
+    {"ts": "...", "from": "proposer-quality", "to": "cycle-cost", "reason": "plateau_switch", "floor": 0.0}
+  ],
+  "last_mint_ts": null
+}
+```
+
+**Five product-seeded nodes** (`SEED_NODES`), each naming one EXISTING
+scorecard metric (dotted `section.metric` path) as its lever, and which
+direction of that metric counts as improvement:
+
+| node | lever_metric | direction |
+|---|---|---|
+| `proposer-quality` | `loop.repeat_failure_rate` | lower |
+| `cycle-cost` | `cost.tokens_per_integration` | lower |
+| `tool-reuse` | `loop.confirmed_integration_ratio` | higher |
+| `heldout-robustness` | `heldout.heldout_gap` | lower |
+| `compile-health` | `quality.compile_clean_ratio` | higher |
+
+Public functions (all fail-open: any error degrades to `None`/no-op/empty
+— a tech-tree bug must NEVER block a cycle or the scorecard):
+
+- `ensure_seeded(state_dir)` — create the portfolio from `SEED_NODES` if
+  absent; add any MISSING seed nodes idempotently to an existing
+  portfolio. Never deletes or overwrites an existing entry (product or
+  instance-minted alike).
+- `record_gains(state_dir, scorecard_result)` — for each node, reads its
+  lever's CURRENT value from the harness-computed scorecard result (dotted
+  lookup, skip if absent/non-numeric) and appends one signed marginal-gain
+  observation vs. the node's own prior value, oriented by `direction`:
+  lower-better → `gain = last - current`; higher-better →
+  `gain = current - last`. The FIRST observation for a node records no
+  gain (nothing to compare yet), only the baseline. Bounded to a trailing
+  window of `GAIN_HISTORY_MAX = 8`. **Harness-computed ONLY** — this never
+  reads an instance-authored "gain" field, only the scorecard result it is
+  handed and the node's own previously-recorded baseline.
+- `node_mean_gain(node)` — mean of `gain_history` (`0.0` when empty).
+- `is_plateaued(node, floor=PLATEAU_FLOOR)` — `True` once a node has a
+  FULL window (8 observations) whose mean is at or below `floor`.
+  `PLATEAU_FLOOR = 0.0` — see "The plateau floor choice" below.
+- `select_current_direction(state_dir, *, epsilon=0.15, now=None, rng=None)`
+  — epsilon-greedy over non-plateaued, non-cooldown nodes: with
+  probability `epsilon` pick a random eligible node (explore), else the
+  highest-mean-gain node (exploit; ties → fewest attempts, so a
+  freshly-seeded/reactivated node isn't starved by an established
+  leader). If the PREVIOUSLY current node just plateaued this pass, it is
+  retired (`status: "plateaued"`, a 72h cooldown) and — if the pick
+  differs — the forced switch is recorded both in the sidecar's own
+  bounded `switches` list and as a `{"phase": "tech_tree", "reason":
+  "plateau_switch"}` ledger event. A plateaued node re-enters the
+  eligible pool once its cooldown elapses, OR immediately if a
+  newly-mintable hypothesis maps back onto it.
+- `maybe_mint_node(state_dir, supported)` — given
+  `hypothesis_backlog.supported_hypotheses` output (harness-verdicted,
+  #878, never an instance claim), a simple normalized-token overlap
+  between the hypothesis text and each node's name/lever-metric-tail
+  tokens decides whether its domain is already mapped. Mapped → no mint
+  (a matched-but-plateaued node is instead reactivated). Unmapped → mint
+  ONE new node, rate-limited to at most one per 24h and name-deduped. The
+  new node's lever defaults to `loop.confirmed_integration_ratio`
+  (higher) unless the hypothesis's own evidence names a metric this
+  module recognizes — documented crude v1 behavior.
+- `portfolio_snapshot(state_dir)` — `{current, nodes: {name: {status,
+  mean_gain, attempts, lever_metric}}, switches: <count>}` for
+  control-plane visibility.
+- `current_direction(state_dir)` / `direction_for_metric(state_dir,
+  metric)` / `matches_direction(text, state_dir, name)` — small read-only
+  accessors used by the wiring below.
+
+### 2. Wiring — SOFT ranking, no starvation (mirrors #815)
+
+**`scorecard.compute_scorecard`** — after computing `snapshot["gaps"]`
+and before persisting `latest.json`/`history.jsonl`, one fail-open block
+calls `tech_tree.ensure_seeded`, `tech_tree.record_gains(state_dir,
+snapshot)`, `tech_tree.maybe_mint_node(state_dir,
+hypothesis_backlog.supported_hypotheses(state_dir))`, then
+`tech_tree.select_current_direction(state_dir)`, and overwrites
+`snapshot["control_plane"]["tech_tree"]` with the freshly-updated
+`portfolio_snapshot` (so a reader of THIS cycle's snapshot sees this
+cycle's pick, not the pre-update one `_control_plane_snapshot` captured
+when the section was first assembled). Wrapped as its OWN try/except,
+separate from the module's outer fail-open wrapper — a tech_tree bug must
+never discard the sections already computed above it.
+
+**`goal_review.maybe_goal_review`** — after the LLM reply is parsed into
+candidates, `tech_tree.current_direction(state_dir)` is consulted; if set,
+the candidate list is stable-sorted so direction-aligned candidates
+(token-overlap with the current node's name/lever) are validated FIRST —
+nothing is dropped here, only reordered; the pre-existing
+`_MAX_PRIORITIES` cap is the only thing that can ever leave a non-aligned
+candidate unaccepted, exactly like #815's V1-over-V2 bias. An accepted
+priority whose own text matches the current direction is tagged
+`direction: "<name>"` in `derived_priorities.json` (attribution only,
+additive — omitted entirely for entries that don't match, so an older
+entry's exact shape is unaffected).
+
+**`demand._goal_gap_items`** — each goal-gap item is tagged via
+`tech_tree.direction_for_metric` (an EXACT string match between the
+gap's bare metric name and a node's lever-metric TAIL — the one place
+this module has a precise, non-fuzzy correspondence to demand, so it's
+the only demand kind wired with a domain tag in this v1). Within the
+kind, items whose `direction` equals the CURRENT investment direction are
+stable-sorted to lead WITHIN their existing vector class — `_vector_rank`
+(#815, V1-before-V2) stays the PRIMARY sort key; the direction boost is a
+secondary tiebreak only, so neither invariant fights the other and
+nothing is ever dropped. `_make_item` gained an optional `direction=""`
+parameter (additive; every existing caller is unaffected).
+
+## The plateau floor choice
+
+`PLATEAU_FLOOR = 0.0` — "no net improvement over the window" — using
+`mean_gain <= floor` rather than strict `<`: a node oscillating exactly
+around zero net change (a metric that has fully saturated) reads as
+plateaued, not perpetually "not yet plateaued" by a hair's-width
+technicality. Recorded explicitly per the issue's own request to document
+this choice, since a stricter `<` would leave an exactly-flat metric
+stuck "active" forever, quietly starving every OTHER direction of a
+chance to be tried.
+
+## The minted-node lever mapping (crude v1, documented)
+
+A hypothesis-minted node's lever defaults to
+`loop.confirmed_integration_ratio` (higher-better) unless the
+hypothesis's own verdict-evidence names a `metric` string that exactly
+matches one of the five known seed-node levers. There is no general
+metric-discovery here — recognizing an arbitrary new dotted scorecard
+path from free text would need actual schema introspection, well past
+"2GB-simple". This is flagged as an explicit v1 simplification: worst
+case, an organically-minted node measures the wrong (but still real and
+harness-computed) lever, which the epsilon-greedy selection will simply
+deprioritize once its gains don't materialize — never a correctness or
+trust problem, just a possibly-uninformative direction.
+
+## Trust boundary (do not weaken)
+
+`tech_tree/portfolio.json` lives under `state/` and is therefore
+**instance-writable**, exactly like every other bridge sidecar
+(`demand/completed.json`, `scorecard/latest.json`, `evolution/tree.json`,
+...). It is added to `scorecard.FITNESS_SIDECARS` (#789) so tampering is
+**detected** (spawn-boundary hash mismatch → an `integrity` ledger row)
+the same generic way every other fitness-input sidecar is — nothing new
+to build, just tuple membership.
+
+But selecting a direction is a **steering** decision, not a
+**verification** one (the same argument `evolution_tree.py` makes for its
+own sidecar, #877). A forged portfolio can, at worst, re-order which
+domain the loop *prefers* to work on next:
+
+- **No gain number is ever instance-authored.** `record_gains` is the
+  ONLY place a `gain_history` entry is ever appended, and it always
+  computes that entry from (a) the node's own prior `last_lever_value`
+  and (b) the CURRENT scorecard result the harness's own
+  `compute_scorecard` hands it — never from any other field.
+- Every cycle still passes the full, unweakened gate (smoke tests +
+  deny-set/mutation-surface check + held-out pack); promotions are still
+  root-verified (#875); priorities still pass
+  `goal_review.validate_priority` — a tech-tree bias can shift WHICH
+  priority gets minted/accepted first, never bypass validation.
+- `nanobot/runtime/tech_tree.py` is added to
+  `runtime_deny._RUNTIME_DENY_ALWAYS_FILES` — fitness-adjacent steering,
+  same tier as `evolution_tree.py`/`hypothesis_verdict.py`. No
+  basename-token match applies ("tech"/"tree" are not in
+  `_RUNTIME_DENY_TOKENS`), so the explicit file entry is the only thing
+  keeping it denied — called out per this repo's convention of only
+  relying on a token match when it already naturally fires.
+- New-node minting is rate-limited (one per 24h) and name-deduped, so an
+  instance cannot flood the portfolio with junk nodes to dilute
+  selection.
+
+## Non-negotiable invariants
+
+- No MAP-Elites grid, no population manager, no new daemon/scheduler —
+  every write happens inline on the existing scorecard recompute path.
+- `select_current_direction` has exactly ONE selection mechanism
+  (epsilon-greedy over mean gain); no second heuristic was added.
+- `tech_tree.py` is deny-set (never promotable/loadable via the
+  runtime-slice/trust-ladder path).
+- The demand/goal-review direction bias is a STABLE REORDER only —
+  nothing is ever dropped or starved because of it; every existing
+  gap/hypothesis/vector input keeps working exactly as before.
+- Every gain number traces back to a harness-computed scorecard value;
+  no instance-authored number can ever enter `gain_history`.
+
+## Tests
+
+- `tests/test_tech_tree.py` (new): seed idempotency (missing nodes
+  added, existing ones — including instance-minted — never touched);
+  `record_gains` marginal-delta sign for both lower-better and
+  higher-better nodes, first-observation-records-no-gain, bounded window;
+  `is_plateaued` at/under/over the floor and under a full vs. partial
+  window; `select_current_direction` exploit (best mean-gain, tie →
+  fewest attempts) and explore (patched `rng`) paths, plateau → cooldown
+  → forced switch + ledger event, plateaued/cooldown nodes excluded from
+  selection, cooldown-expiry reactivation; `maybe_mint_node` mints an
+  unmapped hypothesis, dedups (and reactivates a plateaued match for) a
+  mapped one, rate-limits a second mint within the window; a forged
+  `gain_history`/`last_lever_value` written directly to the sidecar is
+  never itself trusted as a "claimed gain" — the next `record_gains` call
+  still appends only the value it computes from the real scorecard
+  result. Wiring: `scorecard.compute_scorecard`'s `control_plane.tech_tree`
+  is present and reflects the seeded portfolio; `demand`'s goal-gap
+  direction tag/boost never drops an item; `goal_review`'s direction bias
+  lets an aligned candidate win a capped slot without starving unaligned
+  ones when the cap isn't hit.
+- `tests/test_scorecard.py` (extended): the two existing
+  `control_plane` exact-key-set assertions gained `"tech_tree"`; a new
+  assertion pins the freshly-seeded `tech_tree` snapshot's shape (5 nodes,
+  all active, zero gain/attempts — the exact `current` pick is left
+  unasserted since real epsilon-greedy randomness is in play there).
+
+Run explicitly by path (site-packages shadow gotcha, per this repo's
+convention): `python -m pytest tests/test_tech_tree.py
+tests/test_scorecard.py tests/test_demand.py tests/test_goal_review.py
+tests/test_runtime_slice.py -q`, then the full suite with
+`--continue-on-collection-errors`. See the PR description for the
+verbatim final lines of both runs.

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -80,8 +80,15 @@ Demand kinds, in trust order (see ``docs/changes/760-demand-driven-proposer/``):
   watermark-cheap) so the evidence layer stays current without a separate
   scheduler hook.
 
-Each item is ``{kind, id, summary, evidence, affected_path}`` with a stable
-``id`` (hash of kind+summary) used for exhaustion tracking: once a demand
+Each item is ``{kind, id, summary, evidence, affected_path, vector,
+direction}`` with a stable ``id`` (hash of kind+summary) used for
+exhaustion tracking. ``vector`` (#815) is the goal vector the item serves;
+``direction`` (#879) is the tech-tree improvement DOMAIN it corresponds
+to when one can be determined (currently only ``goal-gap`` items, via an
+exact metric<->lever match — see ``_goal_gap_items``) — items whose
+``direction`` matches the tech-tree's current investment pick are
+stable-sorted to lead within their existing vector class, a purely
+cosmetic reordering that never drops or exhausts anything. Once a demand
 item's proposals have been self-dedup-rejected 2+ times (matched via the
 ``demand_id`` recorded on ``proposer_reject`` ledger rows, #762/#760), the
 item is marked exhausted in ``<state_dir>/demand/exhausted.json``
@@ -212,7 +219,12 @@ def item_id(kind: str, summary: str) -> str:
 
 
 def _make_item(
-    kind: str, summary: str, evidence: str, affected_path: str = "", vector: str = ""
+    kind: str,
+    summary: str,
+    evidence: str,
+    affected_path: str = "",
+    vector: str = "",
+    direction: str = "",
 ) -> dict[str, str]:
     summary = (summary or "").strip()[:_MAX_SUMMARY_CHARS]
     return {
@@ -227,6 +239,13 @@ def _make_item(
         # "" (unknown) otherwise. Additive-only: existing callers that omit
         # this arg get "" and are unaffected.
         "vector": (vector or "").strip(),
+        # #879: which tech-tree improvement DOMAIN this item corresponds
+        # to (e.g. "proposer-quality"), "" (unknown/unmapped) otherwise —
+        # a SEPARATE axis from ``vector`` above. Currently only
+        # ``_goal_gap_items`` populates this (an exact metric<->lever
+        # correspondence; see its own docstring). Additive-only: existing
+        # callers that omit this arg get "" and are unaffected.
+        "direction": (direction or "").strip(),
     }
 
 
@@ -772,9 +791,31 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
     ``repeat_failure_rate`` at 0.4731 vs 0.4681), defeating the completed
     fold (#773) and per-id exhaustion alike. Current/target/window detail
     goes in ``evidence`` only. Fail-open: any error yields no goal-gap
-    demand."""
+    demand.
+
+    #879: each item is tagged with the tech-tree DOMAIN whose lever_metric
+    tail matches this gap's bare metric name (``tech_tree.direction_for_
+    metric`` — an EXACT string correspondence, the one place this item's
+    domain is unambiguous rather than a fuzzy text match). Within this
+    kind, items whose ``direction`` equals the tech-tree's CURRENT
+    investment direction are stable-sorted to lead WITHIN their existing
+    vector class (#815's V1-before-V2 ordering is the primary key,
+    unchanged; the direction boost is a secondary tiebreak only) — nothing
+    is ever dropped, and a gap whose domain isn't the current direction (or
+    isn't mapped to any node at all) is simply presented in its original
+    relative order, never suppressed. Both lookups are wrapped fail-open:
+    a tech_tree bug degrades to no tagging/no reordering, never fewer
+    items."""
     try:
         from nanobot.runtime import scorecard
+
+        try:
+            from nanobot.runtime import tech_tree
+
+            current_direction = tech_tree.current_direction(state_dir)
+        except Exception:
+            tech_tree = None  # type: ignore[assignment]
+            current_direction = None
 
         items: list[dict[str, str]] = []
         for gap in scorecard.goal_gaps(state_dir, selfevo_repo)[:_MAX_GOAL_GAP_ITEMS]:
@@ -791,12 +832,26 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
                 # therefore the id) stays untouched so exhaustion/dedup
                 # identity (#778) is unaffected by this addition.
                 rationale = f"{rationale} | lever: {lever_hint}"
+            direction = ""
+            if tech_tree is not None:
+                try:
+                    direction = tech_tree.direction_for_metric(state_dir, metric) or ""
+                except Exception:
+                    direction = ""
             items.append(
                 _make_item(
                     "goal-gap",
                     f"goal gap: {metric} ({vector})",
                     rationale,
                     vector=vector,
+                    direction=direction,
+                )
+            )
+        if current_direction:
+            items.sort(
+                key=lambda it: (
+                    _vector_rank(it.get("vector", "")),
+                    0 if it.get("direction") == current_direction else 1,
                 )
             )
         return items

--- a/nanobot/runtime/goal_review.py
+++ b/nanobot/runtime/goal_review.py
@@ -52,6 +52,16 @@ Wiring: invoked from ``scorecard.compute_scorecard``'s recompute path
 review bug must never break the scorecard or demand collection. Everything
 here is fail-open/fail-closed by design and never raises into the caller.
 
+**#879 tech-tree soft bias.** ``tech_tree.current_direction`` (the loop's
+current preferred improvement domain, e.g. "proposer-quality") is
+consulted to softly REORDER the LLM's own candidate list before
+validation — a stable sort, nothing dropped, mirroring the #815
+V1-over-V2 demand bias exactly: only the ``_MAX_PRIORITIES`` cap can ever
+leave a non-aligned candidate unaccepted. An accepted priority whose own
+text matches the current direction's tokens is tagged
+``direction: "<name>"`` in ``derived_priorities.json`` (attribution only;
+untagged/no match is the common case and is never penalized).
+
 **Canon split (#860).** ``goal_text.json`` is the OPERATOR's canon — every
 release's ``deploy_release.sh`` unconditionally reseeds it from the repo,
 which used to erase every accepted priority this module ever appended (the
@@ -254,15 +264,22 @@ def read_derived_priorities(state_dir: Path) -> list[dict[str, Any]]:
             number = 0
         if not label or not body or vector not in ("V1", "V2") or number <= 0:
             continue  # number is required (#860 review: stable demand ids)
-        out.append(
-            {
-                "label": label,
-                "body": body,
-                "vector": vector,
-                "number": number,
-                "added_utc": str(entry.get("added_utc") or ""),
-            }
-        )
+        item: dict[str, Any] = {
+            "label": label,
+            "body": body,
+            "vector": vector,
+            "number": number,
+            "added_utc": str(entry.get("added_utc") or ""),
+        }
+        # #879: which tech-tree investment direction was current at mint
+        # time, when the priority's own text matched it — additive,
+        # OMITTED entirely (not just "") for any entry that predates this
+        # field or never matched one, so existing exact-shape comparisons
+        # of older entries are unaffected.
+        direction = str(entry.get("direction") or "").strip()
+        if direction:
+            item["direction"] = direction
+        out.append(item)
     return out
 
 
@@ -659,6 +676,32 @@ def maybe_goal_review(
             _record_review(state_dir, "invalid_reply", inputs_hash=inputs_hash)
             return []
 
+        # #879: consult the tech-tree for the CURRENT investment direction
+        # and softly prefer candidates aimed at it — a stable reorder of
+        # the LLM's own candidate list (nothing dropped here; the
+        # _MAX_PRIORITIES cap below is the only thing that can ever leave
+        # a non-aligned candidate out, exactly like #815's V1-over-V2
+        # demand bias). Fail-open: any tech_tree trouble degrades to "no
+        # preference" (original candidate order, no direction tags).
+        current_direction: str | None = None
+        try:
+            from nanobot.runtime import tech_tree
+
+            current_direction = tech_tree.current_direction(state_dir)
+        except Exception:
+            current_direction = None
+        if current_direction:
+            def _direction_rank(cand: Any) -> int:
+                if not isinstance(cand, dict):
+                    return 1
+                text = f"{cand.get('label', '')} {cand.get('body', '')}"
+                try:
+                    return 0 if tech_tree.matches_direction(text, state_dir, current_direction) else 1
+                except Exception:
+                    return 1
+
+            candidates = sorted(candidates, key=_direction_rank)
+
         existing_labels = _existing_priority_labels(merged_text)
         accepted: list[dict[str, str]] = []
         rejected: list[dict[str, str]] = []
@@ -682,6 +725,19 @@ def maybe_goal_review(
             }:
                 _reject(candidate, "duplicate")
                 continue
+            # #879: tag with the direction it was minted under ONLY when
+            # its own text actually matches the current direction's
+            # tokens — an attribution, not a blanket stamp (a priority
+            # that landed despite not matching stays untagged).
+            direction_tag = ""
+            if current_direction:
+                text = f"{normalized['label']} {normalized['body']}"
+                try:
+                    if tech_tree.matches_direction(text, state_dir, current_direction):
+                        direction_tag = current_direction
+                except Exception:
+                    direction_tag = ""
+            normalized["direction"] = direction_tag
             accepted.append(normalized)
 
         if not accepted:
@@ -704,15 +760,21 @@ def maybe_goal_review(
             cand["number"] = base_number + offset
         _, titles = append_priorities(merged_text, accepted)
         now_iso = _iso(now)
-        derived_entries = read_derived_priorities(state_dir) + [
-            {
+
+        def _derived_entry(cand: dict[str, Any]) -> dict[str, Any]:
+            entry: dict[str, Any] = {
                 "label": cand["label"],
                 "vector": cand["vector"],
                 "body": cand["body"],
                 "number": cand["number"],
                 "added_utc": now_iso,
             }
-            for cand in accepted
+            if cand.get("direction"):
+                entry["direction"] = cand["direction"]
+            return entry
+
+        derived_entries = read_derived_priorities(state_dir) + [
+            _derived_entry(cand) for cand in accepted
         ]
         _write_derived_priorities(state_dir, derived_entries)
 

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -76,6 +76,15 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     # is not in _RUNTIME_DENY_TOKENS, deliberately, so a future unrelated
     # "*_verdict.py" module is not silently swept in by name alone).
     'nanobot/runtime/hypothesis_verdict.py',
+    # #879: steers WHICH improvement direction (proposer-quality,
+    # cycle-cost, ...) the loop prefers to invest its next cycles in from
+    # the same #789-protected scorecard-derived gains every other
+    # fitness-adjacent module here reads — same steering tier as
+    # evolution_tree.py right above (no basename token match applies:
+    # "tree" alone is too broad a token to add here, and "tech" is not in
+    # _RUNTIME_DENY_TOKENS, deliberately, so this explicit entry is the
+    # only thing keeping it denied).
+    'nanobot/runtime/tech_tree.py',
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -914,10 +914,13 @@ FITNESS_SIDECARS = (
     # #879: the tech-tree portfolio steers WHICH improvement direction the
     # loop prefers next (see tech_tree.py's module docstring for the full
     # trust argument) — same steering-not-verification tier as
-    # evolution/tree.json above; tampering is DETECTED here, never
-    # prevented, and can never fabricate a gain number (record_gains is
-    # the only writer of gain_history, and it only ever reads the harness's
-    # own freshly-computed scorecard result).
+    # evolution/tree.json above. A directly-edited gain_history/
+    # last_lever_value CAN persist here for up to GAIN_HISTORY_MAX cycles
+    # (until the next record_gains call overwrites last_lever_value) — this
+    # is a SOFT RANKING bias only, never a gate/verifier bypass and never
+    # starvation of another direction; tampering is DETECTED (never
+    # prevented) via this sidecar's FITNESS_SIDECARS membership, the same
+    # spawn-boundary #789 integrity check every other sidecar here gets.
     "tech_tree/portfolio.json",
 )
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -234,6 +234,26 @@ def _hypothesis_loop_snapshot(state_dir: 'Path | None') -> dict[str, Any]:
         return {}
 
 
+def _tech_tree_snapshot(state_dir: 'Path | None') -> dict[str, Any]:
+    """#879: read-only ``tech_tree.portfolio_snapshot`` at the time
+    ``_control_plane_snapshot`` is assembled — BEFORE this cycle's
+    ``record_gains``/``select_current_direction`` run (see
+    ``compute_scorecard``, which overwrites ``control_plane.tech_tree``
+    with the freshly-updated snapshot right before persisting). Kept here
+    too so the key is never simply absent if the later fail-open update
+    block errors out. Same leaf-dependency shape as
+    ``_evolution_tree_snapshot``/``_hypothesis_loop_snapshot`` above.
+    Fail-open to ``{}`` on any error or when ``state_dir`` is unavailable."""
+    if state_dir is None:
+        return {}
+    try:
+        from nanobot.runtime import tech_tree
+
+        return tech_tree.portfolio_snapshot(state_dir)
+    except Exception:
+        return {}
+
+
 def _control_plane_snapshot(state_dir: 'Path | None' = None) -> dict[str, Any]:
     """Active operator env values at compute time — visibility only.
 
@@ -247,6 +267,7 @@ def _control_plane_snapshot(state_dir: 'Path | None' = None) -> dict[str, Any]:
     snapshot["runtime_trust_ladder"] = _runtime_trust_ladder_snapshot()
     snapshot["evolution_tree"] = _evolution_tree_snapshot(state_dir)
     snapshot["hypothesis_loop"] = _hypothesis_loop_snapshot(state_dir)
+    snapshot["tech_tree"] = _tech_tree_snapshot(state_dir)
     for key in _CONTROL_PLANE_KEYS:
         try:
             snapshot[key] = os.environ.get(key)
@@ -890,6 +911,14 @@ FITNESS_SIDECARS = (
     # any other fitness-adjacent sidecar is, even though it is a steering
     # input, not a verification one.
     "evolution/tree.json",
+    # #879: the tech-tree portfolio steers WHICH improvement direction the
+    # loop prefers next (see tech_tree.py's module docstring for the full
+    # trust argument) — same steering-not-verification tier as
+    # evolution/tree.json above; tampering is DETECTED here, never
+    # prevented, and can never fabricate a gain number (record_gains is
+    # the only writer of gain_history, and it only ever reads the harness's
+    # own freshly-computed scorecard result).
+    "tech_tree/portfolio.json",
 )
 
 
@@ -1190,6 +1219,29 @@ def compute_scorecard(
         # window never compares the snapshot against itself.
         history = _read_history(state_dir)
         snapshot["gaps"] = _compute_gaps(snapshot, history, now)
+
+        # #879: tech-tree of improvement directions — a RANKING INPUT to
+        # demand/goal-review (mirrors the #815 soft vector bias), never a
+        # scheduler. Runs against THIS snapshot (the harness-computed
+        # result, never an instance claim) and updates the portfolio
+        # sidecar; the control-plane key is overwritten with the
+        # POST-update snapshot so a reader sees this cycle's fresh
+        # current-direction pick, not the stale pre-update one
+        # ``_control_plane_snapshot`` captured above. Wrapped fail-open as
+        # ONE block, separate from the module's own per-function fail-open
+        # guards: a tech_tree bug must never break the scorecard or lose
+        # the sections already computed above.
+        try:
+            from nanobot.runtime import hypothesis_backlog as _hyp_backlog
+            from nanobot.runtime import tech_tree
+
+            tech_tree.ensure_seeded(state_dir)
+            tech_tree.record_gains(state_dir, snapshot)
+            tech_tree.maybe_mint_node(state_dir, _hyp_backlog.supported_hypotheses(state_dir))
+            tech_tree.select_current_direction(state_dir)
+            snapshot["control_plane"]["tech_tree"] = tech_tree.portfolio_snapshot(state_dir)
+        except Exception:
+            pass
 
         _write_json(_latest_path(state_dir), snapshot)
         try:

--- a/nanobot/runtime/tech_tree.py
+++ b/nanobot/runtime/tech_tree.py
@@ -70,22 +70,30 @@ Mechanics, all crude-and-cheap by design:
 Trust boundary (read before wiring this in anywhere else): the sidecar,
 ``<state_dir>/tech_tree/portfolio.json``, is instance-writable state
 exactly like every other bridge sidecar (``demand/completed.json``,
-``scorecard/latest.json``, ``evolution/tree.json``, ...). It is listed in
-``scorecard.FITNESS_SIDECARS`` (#789) so tampering with it is DETECTED
-(spawn-boundary hash mismatch -> an ``integrity`` ledger row) the same
-generic way tampering with any other fitness-input sidecar is detected —
-nothing new to build here, just membership in that tuple. But selecting a
+``scorecard/latest.json``, ``evolution/tree.json``, ...). Selecting a
 direction is a STEERING decision, not a verification one (the same
 argument ``evolution_tree.py`` makes for its own sidecar): a forged
 portfolio can, at worst, re-order which domain the loop *prefers* to work
-on next — it can never fabricate a gain number out of thin air, because
-:func:`record_gains` is the ONLY place a ``gain_history`` entry is ever
-appended, and it always computes that entry from (a) the node's own prior
+on next — never bypass the gate, never skip root-verified promotion,
+never starve another direction of a turn. This module's OWN write path
+(:func:`record_gains`) never fabricates anything: it only ever appends a
+``gain_history`` entry computed from (a) the node's own prior
 ``last_lever_value`` and (b) the CURRENT scorecard result handed to it by
-the harness's own ``compute_scorecard`` recompute — never from any other
-instance-authored field. A gate/promotion/priority-validation bypass is
-never possible through this module; see ``nanobot/runtime/tech_tree.py``'s
-entry in ``runtime_deny._RUNTIME_DENY_ALWAYS_FILES`` for the matching
+the harness's own ``compute_scorecard`` recompute. But a direct edit to
+the sidecar file itself — bypassing this module's API entirely — CAN
+write an arbitrary ``gain_history``/``last_lever_value`` value, and that
+forged value persists in the eligible-node ranking for up to
+:data:`GAIN_HISTORY_MAX` observations, until the next :func:`record_gains`
+call overwrites ``last_lever_value`` with the real scorecard reading (a
+stale forged entry inside ``gain_history`` itself ages out of the window
+the same way any other entry does). This is exactly why the sidecar is
+listed in ``scorecard.FITNESS_SIDECARS`` (#789): such tampering is
+DETECTED (spawn-boundary hash mismatch -> an ``integrity`` ledger row) —
+never silently trusted, and never able to reach further than "which
+direction gets preferred next," since a gate/promotion/priority-validation
+bypass is never possible through this module. See
+``nanobot/runtime/tech_tree.py``'s entry in
+``runtime_deny._RUNTIME_DENY_ALWAYS_FILES`` for the matching
 mutation-surface hardening (fitness-adjacent steering, same tier as
 ``evolution_tree.py``/``hypothesis_verdict.py``).
 

--- a/nanobot/runtime/tech_tree.py
+++ b/nanobot/runtime/tech_tree.py
@@ -1,0 +1,727 @@
+"""Tech-tree of improvement DIRECTIONS — RSI stage 5 (#879).
+
+Two DIFFERENT trees exist in this codebase; do not conflate them:
+
+- ``evolution_tree.py`` (#877) is the STATE-space tree — where the code has
+  BEEN (git shas, branches, generations). Already built.
+- THIS module is the DIRECTION-space tree — which capability DOMAIN the
+  loop invests its next cycles in. A Civ-style tech tree: invest in one
+  direction while it keeps yielding measured gains; when that direction
+  PLATEAUS (no net improvement over a trailing window), shift investment
+  to the best other direction. The instance may also MINT a new direction
+  from a supported hypothesis (#878) whose domain isn't already mapped.
+
+STRICT product simplicity (the issue's own words): 2GB-simple, NO heavy
+bandit machinery, NO MAP-Elites, NO new scheduler. This module is a
+RANKING INPUT to the EXISTING demand/goal-review pipeline — the same shape
+as the #815 V1-over-V2 soft vector bias in ``demand.py`` — never a
+scheduler, never a gate. A forged/absent/corrupt sidecar can only ever
+change which direction the loop *prefers*; every cycle still passes the
+full unweakened gate, promotions are still root-verified, priorities still
+pass ``goal_review.validate_priority``.
+
+Mechanics, all crude-and-cheap by design:
+
+- **Seed nodes** (:data:`SEED_NODES`): five product-authored domains, each
+  naming one existing scorecard metric (a dotted ``section.metric`` path,
+  e.g. ``"loop.repeat_failure_rate"``) as its lever, and which DIRECTION of
+  that metric counts as improvement (``"lower"``/``"higher"``).
+- **Marginal gain** (:func:`record_gains`): every scorecard recompute, each
+  node's lever value is read from the freshly-computed scorecard result
+  (harness-owned, never an instance claim) and compared to the node's own
+  previous value, oriented by its direction, to produce one signed "gain"
+  observation appended to a bounded trailing window
+  (:data:`GAIN_HISTORY_MAX`). The FIRST observation for a node records no
+  gain (there is nothing yet to compare against) — only sets the
+  baseline.
+- **Plateau** (:func:`is_plateaued`): once a node has a FULL window of
+  observations, a mean gain at or below :data:`PLATEAU_FLOOR` (0.0 — "no
+  net improvement over the window", see the constant's own docstring for
+  why ``<=`` was chosen over strict ``<``) marks it plateaued.
+- **Selection** (:func:`select_current_direction`): epsilon-greedy
+  (:data:`EPSILON`) over non-plateaued, non-cooldown nodes — explore a
+  random eligible node with probability epsilon, otherwise exploit the
+  highest mean-gain node (ties broken toward the least-tried node, so a
+  freshly-seeded/reactivated node with zero attempts is not permanently
+  starved by an established leader). When the PREVIOUSLY current node
+  just plateaued this pass, it is retired into a cooldown window
+  (:data:`COOLDOWN_HOURS`) and the forced switch is recorded (both in the
+  sidecar's own bounded ``switches`` list and as a
+  ``{"phase": "tech_tree", "reason": "plateau_switch"}`` ledger event).
+  A plateaued node re-enters the eligible pool once its cooldown elapses,
+  OR immediately if a newly-mintable hypothesis maps back onto it (see
+  :func:`maybe_mint_node`).
+- **Minting** (:func:`maybe_mint_node`): given
+  ``hypothesis_backlog.supported_hypotheses`` output (harness-verdicted,
+  never an instance claim), a simple normalized-token overlap between the
+  hypothesis text and each existing node's name/lever-metric tokens
+  decides whether its domain is already mapped. Mapped -> no mint (and a
+  matched-but-plateaued node is reactivated instead, so a hypothesis can
+  pull a domain back into rotation early). Unmapped -> mint ONE new node,
+  rate-limited to at most one mint per :data:`MINT_MIN_INTERVAL_HOURS`
+  (a wall-clock approximation of "at most 1 mint per M cycles" — this
+  module has no direct cycle counter of its own, see the constant's
+  docstring) and name-deduped against existing nodes. The new node's lever
+  defaults to ``loop.confirmed_integration_ratio`` (higher-better) unless
+  the hypothesis's own verdict-evidence names a metric this module already
+  recognizes (:data:`_KNOWN_LEVER_DIRECTIONS`) — a deliberately crude v1
+  mapping, documented as such.
+
+Trust boundary (read before wiring this in anywhere else): the sidecar,
+``<state_dir>/tech_tree/portfolio.json``, is instance-writable state
+exactly like every other bridge sidecar (``demand/completed.json``,
+``scorecard/latest.json``, ``evolution/tree.json``, ...). It is listed in
+``scorecard.FITNESS_SIDECARS`` (#789) so tampering with it is DETECTED
+(spawn-boundary hash mismatch -> an ``integrity`` ledger row) the same
+generic way tampering with any other fitness-input sidecar is detected —
+nothing new to build here, just membership in that tuple. But selecting a
+direction is a STEERING decision, not a verification one (the same
+argument ``evolution_tree.py`` makes for its own sidecar): a forged
+portfolio can, at worst, re-order which domain the loop *prefers* to work
+on next — it can never fabricate a gain number out of thin air, because
+:func:`record_gains` is the ONLY place a ``gain_history`` entry is ever
+appended, and it always computes that entry from (a) the node's own prior
+``last_lever_value`` and (b) the CURRENT scorecard result handed to it by
+the harness's own ``compute_scorecard`` recompute — never from any other
+instance-authored field. A gate/promotion/priority-validation bypass is
+never possible through this module; see ``nanobot/runtime/tech_tree.py``'s
+entry in ``runtime_deny._RUNTIME_DENY_ALWAYS_FILES`` for the matching
+mutation-surface hardening (fitness-adjacent steering, same tier as
+``evolution_tree.py``/``hypothesis_verdict.py``).
+
+Everything here is stdlib-only and FAIL-OPEN: a missing/corrupt sidecar,
+a bad argument, or any unexpected exception degrades to a no-op / empty
+snapshot / ``None`` — never raises into the caller. A bug in this module
+must NEVER block a cycle or the scorecard recompute it rides.
+"""
+from __future__ import annotations
+
+import json
+import random
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "tech-tree-v1"
+_PORTFOLIO_SUBPATH = "tech_tree/portfolio.json"
+
+# ─── seed nodes (product-authored, #879) ────────────────────────────────────
+#
+# Each names one existing scorecard metric (dotted "section.metric" path,
+# see nanobot.runtime.scorecard's snapshot shape) as its lever, and which
+# direction of that metric counts as an improvement.
+SEED_NODES: tuple[dict[str, str], ...] = (
+    {"name": "proposer-quality", "lever_metric": "loop.repeat_failure_rate", "direction": "lower"},
+    {"name": "cycle-cost", "lever_metric": "cost.tokens_per_integration", "direction": "lower"},
+    {"name": "tool-reuse", "lever_metric": "loop.confirmed_integration_ratio", "direction": "higher"},
+    {"name": "heldout-robustness", "lever_metric": "heldout.heldout_gap", "direction": "lower"},
+    {"name": "compile-health", "lever_metric": "quality.compile_clean_ratio", "direction": "higher"},
+)
+
+# Metrics + directions this module can recognize when a minted-from-
+# hypothesis node's verdict evidence names one (crude v1 mapping, #879 —
+# anything else falls back to DEFAULT_MINT_LEVER below). Kept in sync with
+# SEED_NODES' own lever/direction pairs; a future seed addition should
+# extend this too if it wants hypothesis-minted nodes to ever reuse it.
+_KNOWN_LEVER_DIRECTIONS: dict[str, str] = {spec["lever_metric"]: spec["direction"] for spec in SEED_NODES}
+
+# Crude v1 default lever for a hypothesis-minted node whose evidence names
+# no metric this module recognizes (documented in the issue itself as a
+# deliberate simplification — a mint should never be blocked for lack of a
+# perfect metric mapping).
+DEFAULT_MINT_LEVER = "loop.confirmed_integration_ratio"
+
+# Trailing marginal-gain window per node (K). Chosen to match the
+# hypothesis-lifecycle's own small-N conventions elsewhere in this
+# codebase (e.g. hypothesis_backlog.SUPPORTED_TOP_N) — small enough that a
+# node reaches a plateau verdict within a handful of scorecard recomputes,
+# large enough that one noisy observation cannot single-handedly plateau
+# or un-plateau it.
+GAIN_HISTORY_MAX = 8
+
+# Epsilon-greedy explore probability (#879: "NO heavy bandit machinery" —
+# this is the entire exploration mechanism, no UCB/Thompson sampling).
+EPSILON = 0.15
+
+# PLATEAU_FLOOR = 0.0: a node's trailing mean marginal gain at or BELOW
+# zero over a full GAIN_HISTORY_MAX window counts as plateaued — "no net
+# improvement". Deliberately "<=" rather than strict "<": a node
+# oscillating exactly around zero net change (a metric that has fully
+# saturated) should read as plateaued, not perpetually "not yet plateaued"
+# by a hair's-width technicality. Documented per the issue's own request
+# to record this choice explicitly.
+PLATEAU_FLOOR = 0.0
+
+# How long a just-plateaued node sits out of the eligible pool before it
+# can be reselected. 72h (3 days) mirrors hypothesis_backlog's own
+# IN_FLIGHT_TIMEOUT_DAYS=3 "short but not thrashy" timescale — long enough
+# that the loop does not immediately re-pick the direction it just left,
+# short enough that a metric which later moves (e.g. after unrelated work
+# shifts it) is not locked out for a goal_review-scale 14-day decay window.
+COOLDOWN_HOURS = 72
+
+# Rate limit for maybe_mint_node's NEW-node path. The issue asks for "at
+# most 1 mint per M cycles"; this module has no direct cycle counter of
+# its own (it is invoked from the scorecard recompute path, itself
+# time-watermarked, not cycle-counted) so a wall-clock interval is used as
+# the simplest faithful approximation — one calendar day, matching
+# goal_review's own once-per-day review cadence this shares a call site
+# with.
+MINT_MIN_INTERVAL_HOURS = 24
+
+# Bounded audit trail of forced plateau switches kept inside the sidecar
+# itself (mirrors evolution_tree.MAX_SWITCHES) — the durable record is the
+# cycle-ledger "phase": "tech_tree" rows; this is just a small in-sidecar
+# summary for portfolio_snapshot/debugging.
+MAX_SWITCHES = 20
+
+# Token-matching hygiene (maybe_mint_node domain-mapping / goal_review's
+# soft direction bias): ignore very short tokens and a tiny stopword set
+# so generic connective words never register as a "match".
+_MIN_TOKEN_LEN = 3
+_STOPWORDS = frozenset({
+    "the", "a", "an", "of", "to", "in", "on", "for", "and", "or", "is",
+    "are", "this", "that", "it", "its", "use", "using", "via", "one",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+# ─── small shared helpers (same shapes as demand.py / scorecard.py) ─────────
+
+
+def _portfolio_path(state_dir: Any) -> Path:
+    return Path(state_dir) / _PORTFOLIO_SUBPATH
+
+
+def _iso(dt: 'datetime | None' = None) -> str:
+    dt = dt or datetime.now(timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_ts(value: Any) -> 'datetime | None':
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except Exception:
+        return None
+
+
+def _empty_portfolio() -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "current": None,
+        "nodes": {},
+        "switches": [],
+        "last_mint_ts": None,
+    }
+
+
+def read_portfolio(state_dir: Any) -> dict[str, Any]:
+    """Parsed ``tech_tree/portfolio.json``, normalized to the v1 schema
+    shape (same defensive-read pattern as ``evolution_tree.read_tree``).
+    Any trouble at all (missing file, corrupt json, wrong top-level type,
+    malformed sub-fields) degrades to a fresh empty portfolio — never
+    raises. Read-only: never writes."""
+    try:
+        path = _portfolio_path(state_dir)
+        if not path.is_file():
+            return _empty_portfolio()
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return _empty_portfolio()
+        portfolio = _empty_portfolio()
+        current = raw.get("current")
+        portfolio["current"] = current if isinstance(current, str) and current else None
+        nodes = raw.get("nodes")
+        if isinstance(nodes, dict):
+            portfolio["nodes"] = {str(k): v for k, v in nodes.items() if isinstance(v, dict)}
+        switches = raw.get("switches")
+        if isinstance(switches, list):
+            portfolio["switches"] = [s for s in switches if isinstance(s, dict)]
+        last_mint = raw.get("last_mint_ts")
+        portfolio["last_mint_ts"] = last_mint if isinstance(last_mint, str) and last_mint else None
+        return portfolio
+    except Exception:
+        return _empty_portfolio()
+
+
+def _write_portfolio(state_dir: Any, portfolio: dict[str, Any]) -> None:
+    path = _portfolio_path(state_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(portfolio, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _dotted_get(data: Any, dotted: str) -> 'float | None':
+    """Numeric value at a dotted ``section.metric`` path inside a nested
+    dict (the scorecard result's own shape), or ``None`` if absent/not a
+    plain number. Booleans are excluded (``bool`` is an ``int`` subclass in
+    Python but is never a metric value here)."""
+    try:
+        cur = data
+        for part in dotted.split("."):
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(part)
+        if isinstance(cur, bool) or not isinstance(cur, (int, float)):
+            return None
+        return float(cur)
+    except Exception:
+        return None
+
+
+def _tokens(text: Any) -> set[str]:
+    try:
+        raw = _TOKEN_RE.findall(str(text or "").lower())
+        return {t for t in raw if len(t) >= _MIN_TOKEN_LEN and t not in _STOPWORDS}
+    except Exception:
+        return set()
+
+
+def _node_tokens(name: str, node: dict[str, Any]) -> set[str]:
+    """Matchable tokens for one node: its own name plus ONLY the tail
+    (metric, not section) component of its lever_metric — the section
+    prefix (``loop``/``cost``/``quality``/...) is far too generic a word
+    (it means "the whole self-evolving loop" in ordinary prose) to ever
+    count as a meaningful domain match, so it is deliberately excluded."""
+    lever = str(node.get("lever_metric") or "")
+    tail = lever.rsplit(".", 1)[-1] if lever else ""
+    return _tokens(name.replace("-", " ")) | _tokens(tail.replace("_", " "))
+
+
+def _match_existing_node(text: str, nodes: dict[str, Any]) -> 'str | None':
+    """Best node whose tokens overlap ``text``'s tokens (simple normalized
+    token-overlap match — deliberately crude, #879 v1), or ``None`` when
+    there is no overlap with any node. Ties broken by node insertion order
+    (dict iteration order) — good enough for a soft, non-verification
+    steering decision."""
+    try:
+        text_toks = _tokens(text)
+        if not text_toks:
+            return None
+        best_name: 'str | None' = None
+        best_score = 0
+        for name, node in nodes.items():
+            score = len(_node_tokens(name, node) & text_toks)
+            if score > best_score:
+                best_score = score
+                best_name = name
+        return best_name if best_score > 0 else None
+    except Exception:
+        return None
+
+
+def _slugify(text: str) -> str:
+    try:
+        return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")[:40]
+    except Exception:
+        return ""
+
+
+# ─── seeding ─────────────────────────────────────────────────────────────────
+
+
+def _seed_node_entry(spec: dict[str, str], now_iso: str) -> dict[str, Any]:
+    return {
+        "lever_metric": spec["lever_metric"],
+        "direction": spec["direction"],
+        "gain_history": [],
+        "status": "active",
+        "cooldown_until_ts": None,
+        "minted_by": "product",
+        "created_ts": now_iso,
+        "last_lever_value": None,
+    }
+
+
+def ensure_seeded(state_dir: Any, *, now: 'datetime | None' = None) -> None:
+    """Create ``portfolio.json`` from :data:`SEED_NODES` if absent, or add
+    any MISSING seed nodes idempotently to an existing portfolio — never
+    deletes or overwrites an existing entry (product or instance-minted
+    alike). Calling this repeatedly is a no-op once every seed node
+    exists. Fail-open: any error is swallowed silently."""
+    try:
+        portfolio = read_portfolio(state_dir)
+        now_iso = _iso(now)
+        changed = False
+        for spec in SEED_NODES:
+            name = spec["name"]
+            if name not in portfolio["nodes"]:
+                portfolio["nodes"][name] = _seed_node_entry(spec, now_iso)
+                changed = True
+        if changed:
+            _write_portfolio(state_dir, portfolio)
+    except Exception:
+        pass
+
+
+# ─── marginal gain ───────────────────────────────────────────────────────────
+
+
+def record_gains(state_dir: Any, scorecard_result: dict[str, Any]) -> None:
+    """For each node, read its lever_metric's CURRENT value from
+    ``scorecard_result`` (the harness-computed snapshot dict — dotted
+    lookup, fail-open skip if absent/non-numeric) and append one signed
+    marginal-gain observation, oriented by the node's own ``direction``:
+    lower-better -> ``gain = last - current``; higher-better ->
+    ``gain = current - last``. The FIRST observation for a node (no stored
+    ``last_lever_value`` yet) records no gain, only the baseline. Bounded
+    to the trailing :data:`GAIN_HISTORY_MAX` observations. Harness-computed
+    ONLY — this never reads any instance-authored "gain" field, only the
+    scorecard result it is handed and the node's own previously-recorded
+    baseline. Fail-open: any error is swallowed silently."""
+    try:
+        ensure_seeded(state_dir)
+        portfolio = read_portfolio(state_dir)
+        nodes = portfolio["nodes"]
+        changed = False
+        for node in nodes.values():
+            lever = node.get("lever_metric")
+            if not lever:
+                continue
+            current = _dotted_get(scorecard_result, str(lever))
+            if current is None:
+                continue
+            last = node.get("last_lever_value")
+            if isinstance(last, (int, float)) and not isinstance(last, bool):
+                direction = node.get("direction")
+                gain = (float(last) - current) if direction == "lower" else (current - float(last))
+                history = node.get("gain_history")
+                history = list(history) if isinstance(history, list) else []
+                history.append(round(gain, 6))
+                if len(history) > GAIN_HISTORY_MAX:
+                    history = history[-GAIN_HISTORY_MAX:]
+                node["gain_history"] = history
+            node["last_lever_value"] = current
+            changed = True
+        if changed:
+            portfolio["nodes"] = nodes
+            _write_portfolio(state_dir, portfolio)
+    except Exception:
+        pass
+
+
+def node_mean_gain(node: dict[str, Any]) -> float:
+    """Mean of ``node``'s ``gain_history`` (0.0 when empty). Fail-open."""
+    try:
+        history = node.get("gain_history") or []
+        nums = [float(x) for x in history if isinstance(x, (int, float)) and not isinstance(x, bool)]
+        if not nums:
+            return 0.0
+        return sum(nums) / len(nums)
+    except Exception:
+        return 0.0
+
+
+def is_plateaued(node: dict[str, Any], floor: float = PLATEAU_FLOOR) -> bool:
+    """True iff ``node`` has a FULL trailing window
+    (:data:`GAIN_HISTORY_MAX` observations) whose mean is at or below
+    ``floor``. A node with fewer observations is never plateaued — there
+    is not yet enough evidence to call it. Fail-open to ``False``."""
+    try:
+        history = node.get("gain_history") or []
+        if len(history) < GAIN_HISTORY_MAX:
+            return False
+        return node_mean_gain(node) <= floor
+    except Exception:
+        return False
+
+
+# ─── selection (epsilon-greedy over non-plateaued, non-cooldown nodes) ──────
+
+
+def _cooldown_active(node: dict[str, Any], now: datetime) -> bool:
+    until = _parse_ts(node.get("cooldown_until_ts"))
+    return until is not None and now < until
+
+
+def select_current_direction(
+    state_dir: Any,
+    *,
+    epsilon: float = EPSILON,
+    now: 'datetime | None' = None,
+    rng: Any = None,
+) -> 'str | None':
+    """Pick the current investment direction, epsilon-greedy over eligible
+    (non-plateaued, non-cooldown) nodes: with probability ``epsilon`` pick
+    a random eligible node (explore), otherwise the highest
+    :func:`node_mean_gain` node (exploit); ties broken toward the node
+    with the FEWEST attempts (``len(gain_history)``) so a freshly-seeded
+    or just-reactivated node is not starved by an established leader.
+
+    If the PREVIOUSLY current node just crossed into :func:`is_plateaued`
+    this pass, it is retired (``status: "plateaued"``, a
+    :data:`COOLDOWN_HOURS` cooldown) and — if the new pick differs — the
+    forced switch is recorded both in the sidecar's own bounded
+    ``switches`` list and as a ``{"phase": "tech_tree", "reason":
+    "plateau_switch"}`` ledger event. A plateaued node whose cooldown has
+    elapsed is reactivated back into the eligible pool before selection
+    runs (the OTHER re-entry path — a hypothesis targeting it — lives in
+    :func:`maybe_mint_node`).
+
+    ``rng`` defaults to the stdlib ``random`` module; tests may pass a
+    fake object exposing ``.random()``/``.choice()`` for determinism.
+    Returns the chosen node name, or ``None`` if there is no eligible node
+    at all. Fail-open to ``None`` on any error."""
+    try:
+        ensure_seeded(state_dir, now=now)
+        now = now or datetime.now(timezone.utc)
+        rng = rng or random
+        portfolio = read_portfolio(state_dir)
+        nodes = portfolio["nodes"]
+        if not nodes:
+            return None
+
+        prev_current = portfolio.get("current")
+        switched_off_plateau = False
+        if prev_current and prev_current in nodes:
+            prev_node = nodes[prev_current]
+            if prev_node.get("status") != "plateaued" and is_plateaued(prev_node):
+                prev_node["status"] = "plateaued"
+                prev_node["cooldown_until_ts"] = _iso(now + timedelta(hours=COOLDOWN_HOURS))
+                switched_off_plateau = True
+
+        # Cooldown-expired plateaued nodes re-enter the eligible pool.
+        for node in nodes.values():
+            if node.get("status") == "plateaued" and not _cooldown_active(node, now):
+                node["status"] = "active"
+                node["cooldown_until_ts"] = None
+
+        eligible = sorted(name for name, node in nodes.items() if node.get("status") == "active")
+        if not eligible:
+            portfolio["current"] = None
+            portfolio["nodes"] = nodes
+            _write_portfolio(state_dir, portfolio)
+            return None
+
+        if rng.random() < epsilon:
+            new_current = rng.choice(eligible)
+        else:
+            def _exploit_key(name: str) -> tuple[float, int]:
+                node = nodes[name]
+                return (-node_mean_gain(node), len(node.get("gain_history") or []))
+
+            new_current = sorted(eligible, key=_exploit_key)[0]
+
+        if switched_off_plateau and new_current != prev_current:
+            switches = portfolio.get("switches")
+            switches = list(switches) if isinstance(switches, list) else []
+            switches.append({
+                "ts": _iso(now),
+                "from": prev_current,
+                "to": new_current,
+                "reason": "plateau_switch",
+                "floor": PLATEAU_FLOOR,
+            })
+            if len(switches) > MAX_SWITCHES:
+                switches = switches[-MAX_SWITCHES:]
+            portfolio["switches"] = switches
+            try:
+                from nanobot.runtime.cycle_ledger import append_event
+
+                append_event(state_dir, {
+                    "phase": "tech_tree",
+                    "reason": "plateau_switch",
+                    "from": prev_current,
+                    "to": new_current,
+                    "floor": PLATEAU_FLOOR,
+                })
+            except Exception:
+                pass
+
+        portfolio["current"] = new_current
+        portfolio["nodes"] = nodes
+        _write_portfolio(state_dir, portfolio)
+        return new_current
+    except Exception:
+        return None
+
+
+def current_direction(state_dir: Any) -> 'str | None':
+    """Read-only view of the portfolio's current investment direction (or
+    ``None``). Never seeds/mutates state — a pure read for
+    ``goal_review``/``demand`` wiring, same shape as
+    ``hypothesis_backlog.supported_hypotheses``. Fail-open to ``None``."""
+    try:
+        current = read_portfolio(state_dir).get("current")
+        return current if isinstance(current, str) and current else None
+    except Exception:
+        return None
+
+
+def direction_for_metric(state_dir: Any, metric: str) -> 'str | None':
+    """Name of the node whose lever_metric's TAIL component (the bare
+    metric name, e.g. ``"repeat_failure_rate"`` for
+    ``"loop.repeat_failure_rate"``) equals ``metric``, or ``None``. Used by
+    ``demand._goal_gap_items`` to tag a goal-gap item with the domain it
+    naturally corresponds to (an exact string match — the one place this
+    module has a precise, non-fuzzy correspondence to demand). Read-only.
+    Fail-open to ``None``."""
+    try:
+        for name, node in (read_portfolio(state_dir).get("nodes") or {}).items():
+            lever = str(node.get("lever_metric") or "")
+            tail = lever.rsplit(".", 1)[-1] if lever else ""
+            if tail and tail == metric:
+                return name
+        return None
+    except Exception:
+        return None
+
+
+def matches_direction(text: str, state_dir: Any, direction_name: str) -> bool:
+    """True iff ``text``'s normalized tokens overlap ``direction_name``'s
+    node tokens (name + lever-metric tail) — the same crude token-overlap
+    match :func:`maybe_mint_node` uses for hypothesis domain-mapping,
+    reused by ``goal_review``'s soft candidate-ordering bias. Read-only.
+    Fail-open to ``False``."""
+    try:
+        if not direction_name:
+            return False
+        node = (read_portfolio(state_dir).get("nodes") or {}).get(direction_name)
+        if not isinstance(node, dict):
+            return False
+        return bool(_node_tokens(direction_name, node) & _tokens(text))
+    except Exception:
+        return False
+
+
+# ─── minting from a supported hypothesis (#878 organic new-node source) ────
+
+
+def maybe_mint_node(state_dir: Any, supported: 'list[dict[str, Any]] | None') -> 'str | None':
+    """Given ``hypothesis_backlog.supported_hypotheses`` output, mint ONE
+    new node for the first hypothesis whose domain is UNMAPPED (no token
+    overlap with any existing node — :func:`_match_existing_node`),
+    subject to a rate limit of one mint per :data:`MINT_MIN_INTERVAL_HOURS`
+    and name-deduping against existing nodes.
+
+    A hypothesis whose domain IS mapped to an existing node never mints a
+    duplicate; if that matched node happens to be plateaued, it is instead
+    reactivated (a hypothesis "targeting" it is itself evidence the
+    direction may be worth another look — the other plateau re-entry path
+    besides cooldown expiry).
+
+    The minted node's lever defaults to ``loop.confirmed_integration_ratio``
+    (higher-better) unless the hypothesis's own ``evidence`` names a
+    ``metric`` this module recognizes (:data:`_KNOWN_LEVER_DIRECTIONS`) —
+    documented crude v1 behavior, see the module docstring.
+
+    Returns the minted node's name, or ``None`` if nothing was minted
+    (nothing supported, everything mapped, or rate-limited). Fail-open."""
+    try:
+        if not supported:
+            return None
+        ensure_seeded(state_dir)
+        portfolio = read_portfolio(state_dir)
+        nodes = portfolio["nodes"]
+        now = datetime.now(timezone.utc)
+        now_iso = _iso(now)
+        changed = False
+        minted_name: 'str | None' = None
+
+        last_mint = _parse_ts(portfolio.get("last_mint_ts"))
+        rate_limited = last_mint is not None and (now - last_mint) < timedelta(hours=MINT_MIN_INTERVAL_HOURS)
+
+        for hyp in supported:
+            if not isinstance(hyp, dict):
+                continue
+            title = str(hyp.get("title") or "").strip()
+            if not title:
+                continue
+            evidence = hyp.get("evidence") if isinstance(hyp.get("evidence"), dict) else {}
+            metric_hint = str(evidence.get("metric") or "").strip() if evidence else ""
+
+            # Domain-mapping matches on the TITLE only, deliberately NOT
+            # the metric_hint: every metric this module currently
+            # recognizes (_KNOWN_LEVER_DIRECTIONS) already belongs to an
+            # existing seed node, so folding metric_hint into the match
+            # text would make it self-defeating — a hypothesis naming a
+            # known metric would always "match" that metric's OWNING node
+            # via the metric name's own tokens, before the mint path could
+            # ever use it as a fresh node's lever. metric_hint is used
+            # ONLY below, to pick the lever for a genuinely new mint.
+            matched = _match_existing_node(title, nodes)
+            if matched:
+                node = nodes[matched]
+                if node.get("status") == "plateaued":
+                    node["status"] = "active"
+                    node["cooldown_until_ts"] = None
+                    changed = True
+                continue  # domain already mapped — no mint
+
+            if minted_name is not None or rate_limited:
+                continue  # already minted this pass, or rate-limited
+
+            name = _slugify(title)
+            if not name:
+                continue
+            base_name, suffix = name, 2
+            while name in nodes:
+                name = f"{base_name}-{suffix}"
+                suffix += 1
+
+            lever_metric = metric_hint if metric_hint in _KNOWN_LEVER_DIRECTIONS else DEFAULT_MINT_LEVER
+            direction = _KNOWN_LEVER_DIRECTIONS.get(lever_metric, "higher")
+            nodes[name] = {
+                "lever_metric": lever_metric,
+                "direction": direction,
+                "gain_history": [],
+                "status": "active",
+                "cooldown_until_ts": None,
+                "minted_by": "hypothesis",
+                "created_ts": now_iso,
+                "last_lever_value": None,
+            }
+            portfolio["last_mint_ts"] = now_iso
+            minted_name = name
+            changed = True
+            try:
+                from nanobot.runtime.cycle_ledger import append_event
+
+                append_event(state_dir, {
+                    "phase": "tech_tree",
+                    "reason": "node_minted",
+                    "name": name,
+                    "lever_metric": lever_metric,
+                })
+            except Exception:
+                pass
+
+        if changed:
+            portfolio["nodes"] = nodes
+            _write_portfolio(state_dir, portfolio)
+        return minted_name
+    except Exception:
+        return None
+
+
+# ─── control-plane / demand visibility ───────────────────────────────────────
+
+
+def portfolio_snapshot(state_dir: Any) -> dict[str, Any]:
+    """``{current, nodes: {name: {status, mean_gain, attempts,
+    lever_metric}}, switches: count}`` — read by
+    ``scorecard._control_plane_snapshot``-style visibility wiring. Fail-open
+    to ``{}``."""
+    try:
+        portfolio = read_portfolio(state_dir)
+        nodes_out: dict[str, Any] = {}
+        for name, node in (portfolio.get("nodes") or {}).items():
+            nodes_out[name] = {
+                "status": node.get("status"),
+                "mean_gain": round(node_mean_gain(node), 6),
+                "attempts": len(node.get("gain_history") or []),
+                "lever_metric": node.get("lever_metric"),
+            }
+        return {
+            "current": portfolio.get("current"),
+            "nodes": nodes_out,
+            "switches": len(portfolio.get("switches") or []),
+        }
+    except Exception:
+        return {}

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -971,6 +971,7 @@ class TestControlPlaneSnapshot:
         # folded into the allowlist.
         assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {
             "runtime_promotions", "runtime_trust_ladder", "evolution_tree", "hypothesis_loop",
+            "tech_tree",
         }
         assert all(control_plane[key] is None for key in scorecard._CONTROL_PLANE_KEYS)
         assert control_plane["runtime_promotions"] == {"active": 0, "soaking": 0, "rejected": 0}
@@ -985,6 +986,20 @@ class TestControlPlaneSnapshot:
         assert control_plane["hypothesis_loop"] == {
             "active": 0, "answered": 0, "supported": 0, "refuted": 0, "inconclusive": 0,
         }
+        # #879: a fresh recompute seeds all 5 tech-tree nodes and always
+        # picks SOME current direction from among them (epsilon-greedy is
+        # real/unseeded here, so which one is non-deterministic — assert
+        # shape, not the exact pick).
+        from nanobot.runtime import tech_tree as _tech_tree
+
+        tt_snap = control_plane["tech_tree"]
+        assert set(tt_snap["nodes"].keys()) == {spec["name"] for spec in _tech_tree.SEED_NODES}
+        assert tt_snap["current"] in tt_snap["nodes"]
+        assert tt_snap["switches"] == 0
+        assert all(
+            node == {"status": "active", "mean_gain": 0.0, "attempts": 0, "lever_metric": node["lever_metric"]}
+            for node in tt_snap["nodes"].values()
+        )
 
     def test_set_values_are_captured_others_stay_none(self, tmp_path, monkeypatch):
         for key in scorecard._CONTROL_PLANE_KEYS:
@@ -1012,6 +1027,7 @@ class TestControlPlaneSnapshot:
         control_plane = snap["control_plane"]
         assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {
             "runtime_promotions", "runtime_trust_ladder", "evolution_tree", "hypothesis_loop",
+            "tech_tree",
         }
 
     def test_no_secret_ever_appears_in_serialized_scorecard(self, tmp_path, monkeypatch):

--- a/tests/test_tech_tree.py
+++ b/tests/test_tech_tree.py
@@ -1,0 +1,742 @@
+"""Tests for #879: tech-tree of improvement DIRECTIONS.
+
+Covers the pure sidecar module (nanobot/runtime/tech_tree.py) in isolation
+— seeding idempotency, marginal-gain sign/window/trust behavior, plateau
+detection, epsilon-greedy selection with cooldown/reactivation, hypothesis
+minting with domain-mapping/rate-limit/dedup, and portfolio visibility —
+plus the three SOFT wiring points: scorecard's control-plane snapshot,
+demand's goal-gap direction tag/boost, and goal_review's candidate-
+ordering bias. Every LLM/randomness dependency is monkeypatched or
+injected — no test reaches a provider or real ``random``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from nanobot.runtime import tech_tree
+
+NOW = datetime(2026, 8, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _set_node(tmp_path, name: str, **overrides) -> None:
+    portfolio = tech_tree.read_portfolio(tmp_path)
+    portfolio["nodes"][name].update(overrides)
+    tech_tree._write_portfolio(tmp_path, portfolio)
+
+
+class _FakeRng:
+    """Deterministic stand-in for the ``random`` module — tests inject this
+    via ``select_current_direction(..., rng=...)`` instead of patching the
+    stdlib module globally."""
+
+    def __init__(self, random_value: float, choice_value=None):
+        self._random_value = random_value
+        self._choice_value = choice_value
+
+    def random(self) -> float:
+        return self._random_value
+
+    def choice(self, seq):
+        return self._choice_value if self._choice_value is not None else seq[0]
+
+
+# ─── seeding ─────────────────────────────────────────────────────────────────
+
+
+class TestEnsureSeeded:
+    def test_creates_all_seed_nodes(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        assert set(portfolio["nodes"].keys()) == {s["name"] for s in tech_tree.SEED_NODES}
+        for spec in tech_tree.SEED_NODES:
+            node = portfolio["nodes"][spec["name"]]
+            assert node["lever_metric"] == spec["lever_metric"]
+            assert node["direction"] == spec["direction"]
+            assert node["status"] == "active"
+            assert node["gain_history"] == []
+            assert node["minted_by"] == "product"
+            assert node["last_lever_value"] is None
+            assert node["cooldown_until_ts"] is None
+
+    def test_idempotent_never_touches_existing_entry(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(tmp_path, "proposer-quality", gain_history=[0.5], status="plateaued")
+
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        reread = tech_tree.read_portfolio(tmp_path)
+        assert reread["nodes"]["proposer-quality"]["gain_history"] == [0.5]
+        assert reread["nodes"]["proposer-quality"]["status"] == "plateaued"
+
+    def test_adds_missing_seed_node_without_deleting_instance_minted(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        del portfolio["nodes"]["compile-health"]
+        portfolio["nodes"]["custom-domain"] = {
+            "lever_metric": "loop.confirmed_integration_ratio",
+            "direction": "higher",
+            "gain_history": [],
+            "status": "active",
+            "cooldown_until_ts": None,
+            "minted_by": "hypothesis",
+            "created_ts": _iso(NOW),
+            "last_lever_value": None,
+        }
+        tech_tree._write_portfolio(tmp_path, portfolio)
+
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        reread = tech_tree.read_portfolio(tmp_path)
+        assert "compile-health" in reread["nodes"]  # re-added
+        assert "custom-domain" in reread["nodes"]  # never deleted
+
+
+class TestReadPortfolioFailOpen:
+    def test_missing_file_returns_empty_schema(self, tmp_path):
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        assert portfolio == {
+            "schema_version": tech_tree.SCHEMA_VERSION,
+            "current": None,
+            "nodes": {},
+            "switches": [],
+            "last_mint_ts": None,
+        }
+
+    def test_corrupt_json_fails_open_to_empty(self, tmp_path):
+        path = tmp_path / "tech_tree" / "portfolio.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert tech_tree.read_portfolio(tmp_path)["nodes"] == {}
+
+    def test_non_dict_top_level_fails_open(self, tmp_path):
+        path = tmp_path / "tech_tree" / "portfolio.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        assert tech_tree.read_portfolio(tmp_path)["nodes"] == {}
+
+
+# ─── marginal gain ───────────────────────────────────────────────────────────
+
+
+class TestRecordGains:
+    def test_auto_seeds_when_called_first(self, tmp_path):
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.5}})
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        assert "proposer-quality" in portfolio["nodes"]
+
+    def test_first_observation_sets_baseline_no_gain(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4}})
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["gain_history"] == []
+        assert node["last_lever_value"] == 0.4
+
+    def test_lower_better_gain_sign(self, tmp_path):
+        """proposer-quality (loop.repeat_failure_rate, lower-better)."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4}})
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3}})  # improved
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["gain_history"] == [pytest.approx(0.1)]
+        assert node["last_lever_value"] == 0.3
+
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.5}})  # worsened
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["gain_history"][-1] == pytest.approx(-0.2)
+
+    def test_higher_better_gain_sign(self, tmp_path):
+        """tool-reuse (loop.confirmed_integration_ratio, higher-better)."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.5}})
+        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.7}})  # improved
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["tool-reuse"]
+        assert node["gain_history"] == [pytest.approx(0.2)]
+
+        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.6}})  # worsened
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["tool-reuse"]
+        assert node["gain_history"][-1] == pytest.approx(-0.1)
+
+    def test_missing_or_non_numeric_metric_skipped(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": "not-a-number"}})
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["last_lever_value"] is None
+        assert node["gain_history"] == []
+
+        tech_tree.record_gains(tmp_path, {})  # section absent entirely
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["last_lever_value"] is None
+
+    def test_window_bounded_to_max(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        value = 1.0
+        for _ in range(tech_tree.GAIN_HISTORY_MAX + 3):
+            value -= 0.01
+            tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": value}})
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert len(node["gain_history"]) == tech_tree.GAIN_HISTORY_MAX
+
+    def test_forged_gain_history_not_trusted_next_gain_is_honest(self, tmp_path):
+        """#879 trust note: even with a forged sidecar (bypassing this
+        module's own API entirely), the NEXT record_gains call only ever
+        appends a value it computes from the node's own last_lever_value +
+        the REAL scorecard result it is handed — never a "claimed" gain."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(tmp_path, "proposer-quality", last_lever_value=0.5, gain_history=[999.0])
+
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3}})
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["gain_history"] == [999.0, pytest.approx(0.2)]
+        assert node["last_lever_value"] == 0.3
+
+
+class TestNodeMeanGain:
+    def test_empty_history_is_zero(self):
+        assert tech_tree.node_mean_gain({"gain_history": []}) == 0.0
+        assert tech_tree.node_mean_gain({}) == 0.0
+
+    def test_mean_of_history(self):
+        assert tech_tree.node_mean_gain({"gain_history": [0.1, 0.3, -0.2]}) == pytest.approx(0.0666667)
+
+
+class TestIsPlateaued:
+    def test_false_when_window_not_full(self):
+        node = {"gain_history": [0.0] * (tech_tree.GAIN_HISTORY_MAX - 1)}
+        assert tech_tree.is_plateaued(node) is False
+
+    def test_true_at_floor_with_full_window(self):
+        node = {"gain_history": [0.0] * tech_tree.GAIN_HISTORY_MAX}
+        assert tech_tree.is_plateaued(node) is True
+
+    def test_false_above_floor(self):
+        node = {"gain_history": [0.01] * tech_tree.GAIN_HISTORY_MAX}
+        assert tech_tree.is_plateaued(node) is False
+
+    def test_true_below_floor(self):
+        node = {"gain_history": [-0.05] * tech_tree.GAIN_HISTORY_MAX}
+        assert tech_tree.is_plateaued(node) is True
+
+    def test_custom_floor_argument(self):
+        node = {"gain_history": [0.05] * tech_tree.GAIN_HISTORY_MAX}
+        assert tech_tree.is_plateaued(node, floor=0.1) is True
+        assert tech_tree.is_plateaued(node, floor=0.01) is False
+
+
+# ─── selection (epsilon-greedy) ──────────────────────────────────────────────
+
+
+class TestSelectCurrentDirection:
+    def test_exploit_picks_highest_mean_gain(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(tmp_path, "compile-health", gain_history=[0.5, 0.5])
+        _set_node(tmp_path, "cycle-cost", gain_history=[0.1, 0.1])
+        picked = tech_tree.select_current_direction(tmp_path, now=NOW, rng=_FakeRng(1.0))
+        assert picked == "compile-health"
+
+    def test_exploit_tie_break_by_fewest_attempts(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(tmp_path, "compile-health", gain_history=[0.5, 0.5, 0.5])  # mean 0.5, 3 attempts
+        _set_node(tmp_path, "cycle-cost", gain_history=[0.5])  # mean 0.5, 1 attempt -> wins tie
+        picked = tech_tree.select_current_direction(tmp_path, now=NOW, rng=_FakeRng(1.0))
+        assert picked == "cycle-cost"
+
+    def test_explore_takes_forced_choice_over_exploit_winner(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(tmp_path, "compile-health", gain_history=[0.9, 0.9])  # clear exploit winner
+        picked = tech_tree.select_current_direction(
+            tmp_path, epsilon=0.15, now=NOW,
+            rng=_FakeRng(random_value=0.0, choice_value="heldout-robustness"),
+        )
+        assert picked == "heldout-robustness"  # NOT the exploit winner -> explore path taken
+
+    def test_at_or_above_epsilon_never_explores(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(tmp_path, "compile-health", gain_history=[0.9, 0.9])
+        picked = tech_tree.select_current_direction(
+            tmp_path, epsilon=0.15, now=NOW,
+            rng=_FakeRng(random_value=0.15, choice_value="heldout-robustness"),
+        )
+        assert picked == "compile-health"  # 0.15 is NOT < epsilon -> exploit
+
+    def test_plateaued_and_cooldown_nodes_excluded(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(
+            tmp_path, "compile-health",
+            gain_history=[0.9] * tech_tree.GAIN_HISTORY_MAX,
+            status="plateaued",
+            cooldown_until_ts=_iso(NOW + timedelta(hours=1)),
+        )
+        picked = tech_tree.select_current_direction(tmp_path, now=NOW, rng=_FakeRng(1.0))
+        assert picked != "compile-health"
+
+    def test_previously_current_node_plateaus_and_switch_recorded(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        portfolio["current"] = "proposer-quality"
+        portfolio["nodes"]["proposer-quality"]["gain_history"] = [0.0] * tech_tree.GAIN_HISTORY_MAX
+        tech_tree._write_portfolio(tmp_path, portfolio)
+
+        picked = tech_tree.select_current_direction(tmp_path, now=NOW, rng=_FakeRng(1.0))
+        assert picked != "proposer-quality"
+
+        updated = tech_tree.read_portfolio(tmp_path)
+        node = updated["nodes"]["proposer-quality"]
+        assert node["status"] == "plateaued"
+        assert node["cooldown_until_ts"] is not None
+        assert len(updated["switches"]) == 1
+        assert updated["switches"][0] == {
+            "ts": _iso(NOW), "from": "proposer-quality", "to": picked,
+            "reason": "plateau_switch", "floor": tech_tree.PLATEAU_FLOOR,
+        }
+
+        ledger_path = tmp_path / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text().splitlines() if line.strip()]
+        matches = [r for r in rows if r.get("phase") == "tech_tree" and r.get("reason") == "plateau_switch"]
+        assert len(matches) == 1
+        assert matches[0]["from"] == "proposer-quality"
+        assert matches[0]["to"] == picked
+
+    def test_cooldown_expiry_reactivates_node(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(
+            tmp_path, "compile-health",
+            status="plateaued", cooldown_until_ts=_iso(NOW - timedelta(hours=1)),
+        )
+        tech_tree.select_current_direction(tmp_path, now=NOW, rng=_FakeRng(1.0))
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["compile-health"]
+        assert node["status"] == "active"
+        assert node["cooldown_until_ts"] is None
+
+    def test_cooldown_not_yet_expired_stays_plateaued(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(
+            tmp_path, "compile-health",
+            status="plateaued", cooldown_until_ts=_iso(NOW + timedelta(hours=1)),
+        )
+        tech_tree.select_current_direction(tmp_path, now=NOW, rng=_FakeRng(1.0))
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["compile-health"]
+        assert node["status"] == "plateaued"
+
+
+# ─── minting from a supported hypothesis ────────────────────────────────────
+
+
+class TestMaybeMintNode:
+    def test_nothing_supported_no_mint(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert tech_tree.maybe_mint_node(tmp_path, []) is None
+        assert tech_tree.maybe_mint_node(tmp_path, None) is None
+
+    def test_unmapped_hypothesis_mints_new_node(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        supported = [{"title": "Totally novel widget caching subsystem", "evidence": {}}]
+        minted = tech_tree.maybe_mint_node(tmp_path, supported)
+        assert minted is not None
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        node = portfolio["nodes"][minted]
+        assert node["minted_by"] == "hypothesis"
+        assert node["lever_metric"] == tech_tree.DEFAULT_MINT_LEVER
+        assert node["direction"] == "higher"
+        assert node["status"] == "active"
+        assert portfolio["last_mint_ts"]
+
+    def test_mapped_hypothesis_does_not_mint_duplicate(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        supported = [{"title": "Reduce proposer repeat failure rate churn", "evidence": {}}]
+        minted = tech_tree.maybe_mint_node(tmp_path, supported)
+        assert minted is None
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        assert set(portfolio["nodes"].keys()) == {s["name"] for s in tech_tree.SEED_NODES}
+
+    def test_mapped_hypothesis_reactivates_plateaued_node(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        _set_node(
+            tmp_path, "proposer-quality",
+            status="plateaued", cooldown_until_ts=_iso(NOW + timedelta(hours=10)),
+        )
+        supported = [{"title": "Reduce proposer repeat failure rate churn", "evidence": {}}]
+        minted = tech_tree.maybe_mint_node(tmp_path, supported)
+        assert minted is None
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["status"] == "active"
+        assert node["cooldown_until_ts"] is None
+
+    def test_rate_limited_second_mint_within_window(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        first = tech_tree.maybe_mint_node(tmp_path, [{"title": "Alpha novel domain one", "evidence": {}}])
+        assert first is not None
+        second = tech_tree.maybe_mint_node(tmp_path, [{"title": "Beta novel domain two", "evidence": {}}])
+        assert second is None
+        # Only the first mint's node exists — the rate-limited attempt left
+        # nothing behind.
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        assert len(portfolio["nodes"]) == len(tech_tree.SEED_NODES) + 1
+
+    def test_mint_allowed_again_after_window_elapses(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        portfolio["last_mint_ts"] = _iso(NOW - timedelta(hours=tech_tree.MINT_MIN_INTERVAL_HOURS + 1))
+        tech_tree._write_portfolio(tmp_path, portfolio)
+
+        minted = tech_tree.maybe_mint_node(tmp_path, [{"title": "Gamma novel domain three", "evidence": {}}])
+        assert minted is not None
+
+    def test_name_dedup_on_collision(self, tmp_path, monkeypatch):
+        """Directly exercises the slug-collision suffix path: force every
+        hypothesis to read as domain-UNMAPPED (monkeypatching the matcher)
+        so a pre-existing node occupying the exact target slug forces the
+        "-2" fallback, independent of the (structurally hard to
+        decouple-from-slug) token-overlap check."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        portfolio["nodes"]["widget-cache-thing"] = {
+            "lever_metric": tech_tree.DEFAULT_MINT_LEVER, "direction": "higher",
+            "gain_history": [], "status": "active", "cooldown_until_ts": None,
+            "minted_by": "hypothesis", "created_ts": _iso(NOW), "last_lever_value": None,
+        }
+        tech_tree._write_portfolio(tmp_path, portfolio)
+        monkeypatch.setattr(tech_tree, "_match_existing_node", lambda *a, **k: None)
+
+        minted = tech_tree.maybe_mint_node(tmp_path, [{"title": "Widget cache thing", "evidence": {}}])
+        assert minted == "widget-cache-thing-2"
+
+    def test_known_metric_hint_used_for_lever(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        minted = tech_tree.maybe_mint_node(
+            tmp_path,
+            [{"title": "Totally new domain area", "evidence": {"metric": "heldout.heldout_gap"}}],
+        )
+        node = tech_tree.read_portfolio(tmp_path)["nodes"][minted]
+        assert node["lever_metric"] == "heldout.heldout_gap"
+        assert node["direction"] == "lower"
+
+    def test_unknown_metric_hint_falls_back_to_default(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        minted = tech_tree.maybe_mint_node(
+            tmp_path,
+            [{"title": "Totally new domain area", "evidence": {"metric": "made.up.metric"}}],
+        )
+        node = tech_tree.read_portfolio(tmp_path)["nodes"][minted]
+        assert node["lever_metric"] == tech_tree.DEFAULT_MINT_LEVER
+
+    def test_malformed_entries_skipped_fail_open(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert tech_tree.maybe_mint_node(tmp_path, ["not-a-dict", {"title": ""}, {}]) is None
+
+
+# ─── portfolio visibility / read-only accessors ─────────────────────────────
+
+
+class TestPortfolioSnapshot:
+    def test_shape(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        snap = tech_tree.portfolio_snapshot(tmp_path)
+        assert set(snap.keys()) == {"current", "nodes", "switches"}
+        assert set(snap["nodes"].keys()) == {s["name"] for s in tech_tree.SEED_NODES}
+        for node in snap["nodes"].values():
+            assert set(node.keys()) == {"status", "mean_gain", "attempts", "lever_metric"}
+            assert node["status"] == "active"
+            assert node["mean_gain"] == 0.0
+            assert node["attempts"] == 0
+
+    def test_fail_open_on_corrupt_sidecar(self, tmp_path):
+        path = tmp_path / "tech_tree" / "portfolio.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert tech_tree.portfolio_snapshot(tmp_path) == {"current": None, "nodes": {}, "switches": 0}
+
+
+class TestCurrentDirection:
+    def test_none_when_absent(self, tmp_path):
+        assert tech_tree.current_direction(tmp_path) is None
+
+    def test_reads_set_value(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        portfolio["current"] = "cycle-cost"
+        tech_tree._write_portfolio(tmp_path, portfolio)
+        assert tech_tree.current_direction(tmp_path) == "cycle-cost"
+
+
+class TestDirectionForMetric:
+    def test_exact_tail_match(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert tech_tree.direction_for_metric(tmp_path, "repeat_failure_rate") == "proposer-quality"
+        assert tech_tree.direction_for_metric(tmp_path, "compile_clean_ratio") == "compile-health"
+
+    def test_no_match_returns_none(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert tech_tree.direction_for_metric(tmp_path, "totally_unknown_metric") is None
+
+
+class TestMatchesDirection:
+    def test_token_overlap_true(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert tech_tree.matches_direction(
+            "Cut the proposer repeat failure rate", tmp_path, "proposer-quality"
+        )
+
+    def test_no_overlap_false(self, tmp_path):
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert not tech_tree.matches_direction("Update the readme wording", tmp_path, "proposer-quality")
+
+    def test_generic_section_word_never_matches(self, tmp_path):
+        """'loop' is the SECTION prefix shared by several levers — it must
+        never register as a domain match on its own (too generic a word)."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        assert not tech_tree.matches_direction(
+            "the self-evolving loop keeps running", tmp_path, "proposer-quality"
+        )
+
+    def test_unknown_direction_name_false(self, tmp_path):
+        assert not tech_tree.matches_direction("anything", tmp_path, "no-such-node")
+
+
+class TestDenySetAndFitnessSidecar:
+    def test_tech_tree_module_is_deny_set(self):
+        from nanobot.runtime import runtime_deny
+
+        assert runtime_deny._is_runtime_deny("nanobot/runtime/tech_tree.py")
+
+    def test_fitness_sidecar_membership(self):
+        from nanobot.runtime import scorecard
+
+        assert "tech_tree/portfolio.json" in scorecard.FITNESS_SIDECARS
+
+
+# ─── wiring: scorecard control-plane ─────────────────────────────────────────
+
+
+class TestScorecardWiring:
+    def test_control_plane_tech_tree_present(self, tmp_path):
+        from nanobot.runtime import scorecard
+
+        snap = scorecard.compute_scorecard(tmp_path, None, force=True)
+        tt = snap["control_plane"]["tech_tree"]
+        assert set(tt["nodes"].keys()) == {s["name"] for s in tech_tree.SEED_NODES}
+        assert tt["current"] in tt["nodes"]
+
+    def test_tech_tree_exception_never_breaks_scorecard(self, tmp_path, monkeypatch):
+        from nanobot.runtime import scorecard
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("tech_tree bug")
+
+        monkeypatch.setattr(tech_tree, "record_gains", _boom)
+        snap = scorecard.compute_scorecard(tmp_path, None, force=True)
+        assert snap["schema_version"] == scorecard.SCORECARD_SCHEMA
+        assert isinstance(snap["loop"], dict)  # sections computed before the
+        # tech_tree block are NOT discarded by its failure
+
+
+# ─── wiring: demand goal-gap direction tag/boost ────────────────────────────
+
+
+class TestDemandWiring:
+    def test_goal_gap_direction_boost_does_not_drop_items(self, tmp_path):
+        from nanobot.runtime import demand
+
+        state_dir = tmp_path / "state"
+        (state_dir / "goals").mkdir(parents=True)
+        tech_tree.ensure_seeded(state_dir, now=NOW)
+        portfolio = tech_tree.read_portfolio(state_dir)
+        portfolio["current"] = "compile-health"
+        tech_tree._write_portfolio(state_dir, portfolio)
+
+        # #765: scorecard.goal_gaps -> compute_scorecard has its own
+        # 30-min watermark and calls datetime.now() internally (no `now=`
+        # plumbed through demand.collect_demand) — computed_at_utc must be
+        # close to REAL wall-clock time for the watermark short-circuit to
+        # return this injected snapshot as-is, unlike the fixed NOW used
+        # elsewhere in this file for the pure tech_tree unit tests.
+        scorecard_dir = state_dir / "scorecard"
+        scorecard_dir.mkdir(parents=True)
+        real_now = datetime.now(timezone.utc)
+        (scorecard_dir / "latest.json").write_text(
+            json.dumps({
+                "schema_version": "scorecard-v1",
+                "computed_at_utc": _iso(real_now - timedelta(minutes=1)),
+                "window_days": 7,
+                "loop": {}, "cost": {}, "quality": {}, "value": {},
+                "gaps": [
+                    {"metric": "repeat_failure_rate", "vector": "V1", "current": 0.6, "target": 0.3, "evidence": "e1"},
+                    {"metric": "compile_clean_ratio", "vector": "V1", "current": 0.5, "target": 0.95, "evidence": "e2"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+        items = demand.collect_demand(state_dir, None)
+        gap_items = [i for i in items if i["kind"] == "goal-gap"]
+        assert len(gap_items) == 2  # nothing dropped
+        summaries = {i["summary"] for i in gap_items}
+        assert "goal gap: repeat_failure_rate (V1)" in summaries
+        assert "goal gap: compile_clean_ratio (V1)" in summaries
+        # the compile-health-tagged item (the current direction) leads
+        # within this V1-only batch.
+        assert gap_items[0]["direction"] == "compile-health"
+        assert gap_items[0]["summary"] == "goal gap: compile_clean_ratio (V1)"
+
+    def test_no_current_direction_preserves_original_order(self, tmp_path):
+        from nanobot.runtime import demand
+
+        state_dir = tmp_path / "state"
+        (state_dir / "goals").mkdir(parents=True)
+        # No tech_tree state at all -> current_direction() is None.
+        scorecard_dir = state_dir / "scorecard"
+        scorecard_dir.mkdir(parents=True)
+        real_now = datetime.now(timezone.utc)
+        (scorecard_dir / "latest.json").write_text(
+            json.dumps({
+                "schema_version": "scorecard-v1",
+                "computed_at_utc": _iso(real_now - timedelta(minutes=1)),
+                "window_days": 7,
+                "loop": {}, "cost": {}, "quality": {}, "value": {},
+                "gaps": [
+                    {"metric": "repeat_failure_rate", "vector": "V1", "current": 0.6, "target": 0.3, "evidence": "e1"},
+                    {"metric": "confirmed_ratio", "vector": "V2", "current": 0.1, "target": 0.5, "evidence": "e2"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+        items = demand.collect_demand(state_dir, None)
+        gap_items = [i for i in items if i["kind"] == "goal-gap"]
+        assert len(gap_items) == 2
+        assert "(V1)" in gap_items[0]["summary"]
+        assert "(V2)" in gap_items[1]["summary"]
+
+
+# ─── wiring: goal_review candidate-ordering bias ────────────────────────────
+
+
+GOAL_TEXT = (
+    "eeebot purpose. Vector 1 (PRIMARY) — Self-Improvement of the Agent "
+    "System.\n\nVector 2 (SECONDARY) — Operator Interface.\n\n"
+    "Current priority targets:\n"
+    "(A) Priority 5 — Existing entry: do the existing thing. Commit.\n"
+)
+
+GAP = {
+    "metric": "repeat_failure_rate",
+    "vector": "V1",
+    "current": 0.5,
+    "target": 0.3,
+    "evidence": "repeat_failure_rate=0.5 is above max target 0.3 over the last 7d window (goal vector V1)",
+}
+
+
+def _write_goal_text(state_dir, text: str = GOAL_TEXT) -> None:
+    path = state_dir / "goals" / "goal_text.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"text": text}), encoding="utf-8")
+
+
+def _write_snapshot(state_dir, gaps: list[dict]) -> None:
+    path = state_dir / "scorecard" / "latest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "schema_version": "scorecard-v1",
+            "window_days": 7,
+            "loop": {"integrations": 1, "repeat_failure_rate": 0.5},
+            "gaps": gaps,
+        }),
+        encoding="utf-8",
+    )
+
+
+ALIGNED_PRIORITY = {
+    "label": "Cut proposer repeat failure rate",
+    "body": "Add a guard reducing proposer repeat failure rate in scripts/x.py. Commit.",
+    "vector": "V1",
+    "evidence": "E1",
+}
+
+
+class TestGoalReviewWiring:
+    def test_direction_aligned_candidate_wins_capped_slot(self, tmp_path, monkeypatch):
+        from nanobot.runtime import goal_review
+
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv(goal_review.ENABLED_ENV, "1")
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        tech_tree.ensure_seeded(state_dir, now=NOW)
+        portfolio = tech_tree.read_portfolio(state_dir)
+        portfolio["current"] = "proposer-quality"
+        tech_tree._write_portfolio(state_dir, portfolio)
+
+        unrelated = [
+            {
+                "label": f"Bounded dashboard tweak {i}",
+                "body": "Add a widget to scripts/dashboard_widget.py showing a counter. Commit.",
+                "vector": "V1",
+                "evidence": "E1",
+            }
+            for i in range(3)
+        ]
+        # The aligned candidate is LAST in the raw LLM order — the
+        # _MAX_PRIORITIES=3 cap would normally drop it; the direction bias
+        # must reorder it to the front instead.
+        monkeypatch.setattr(
+            goal_review, "_call_llm", lambda ctx: {"priorities": unrelated + [ALIGNED_PRIORITY]}
+        )
+
+        titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
+        assert len(titles) == 3
+        assert any("Cut proposer repeat failure rate" in t for t in titles)
+        derived = goal_review.read_derived_priorities(state_dir)
+        aligned_entry = next(d for d in derived if d["label"] == "Cut proposer repeat failure rate")
+        assert aligned_entry.get("direction") == "proposer-quality"
+
+    def test_non_aligned_not_starved_when_cap_not_hit(self, tmp_path, monkeypatch):
+        from nanobot.runtime import goal_review
+
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv(goal_review.ENABLED_ENV, "1")
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        tech_tree.ensure_seeded(state_dir, now=NOW)
+        portfolio = tech_tree.read_portfolio(state_dir)
+        portfolio["current"] = "proposer-quality"
+        tech_tree._write_portfolio(state_dir, portfolio)
+
+        unrelated = {
+            "label": "Dashboard usage ping",
+            "body": "Add a function to scripts/dashboard_widget.py logging a usage timestamp. Commit.",
+            "vector": "V1",
+            "evidence": "E1",
+        }
+        monkeypatch.setattr(
+            goal_review, "_call_llm", lambda ctx: {"priorities": [unrelated, ALIGNED_PRIORITY]}
+        )
+
+        titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
+        assert len(titles) == 2
+        derived = goal_review.read_derived_priorities(state_dir)
+        assert {d["label"] for d in derived} == {
+            "Cut proposer repeat failure rate", "Dashboard usage ping",
+        }
+        unrelated_entry = next(d for d in derived if d["label"] == "Dashboard usage ping")
+        assert not unrelated_entry.get("direction")  # never tagged — didn't match
+
+    def test_no_current_direction_no_reordering_no_tagging(self, tmp_path, monkeypatch):
+        """With no tech-tree state at all, behavior is byte-identical to
+        pre-#879: original candidate order, no direction key added."""
+        from nanobot.runtime import goal_review
+
+        state_dir = tmp_path / "state"
+        monkeypatch.setenv(goal_review.ENABLED_ENV, "1")
+        _write_goal_text(state_dir)
+        _write_snapshot(state_dir, [GAP])
+        monkeypatch.setattr(goal_review, "_call_llm", lambda ctx: {"priorities": [ALIGNED_PRIORITY]})
+
+        titles = goal_review.maybe_goal_review(state_dir, None, now=NOW)
+        assert titles == ["Priority 6 — Cut proposer repeat failure rate"]
+        derived = goal_review.read_derived_priorities(state_dir)
+        assert "direction" not in derived[0]


### PR DESCRIPTION
## Concept

Two DIFFERENT trees exist in this codebase; do not conflate them:

- **#877 `evolution_tree.py`** = STATE space — WHERE the code has been (git shas/branches/generations). Already built, untouched here.
- **THIS (#879) `tech_tree.py`** = DIRECTION space — WHICH capability domain the loop invests its next cycles in. A Civ-style tech tree: invest in one direction while it keeps yielding measured gains; when a direction PLATEAUS (no net improvement over a trailing window), shift investment to the best other direction. The instance can MINT a new direction from a supported hypothesis (#878) whose domain isn't already mapped.

**Strict product simplicity** (the issue's own words): "2GB-simple, NO heavy bandit machinery, NO MAP-Elites, NO new scheduler." This is a RANKING INPUT to the EXISTING demand/goal-review pipeline — exactly the same shape as the #815 V1-over-V2 soft vector bias in `demand.py` — never a scheduler, never a gate.

## Seed nodes

Five product-seeded domains (`SEED_NODES`), each naming one existing scorecard metric (dotted `section.metric` path) as its lever, and which direction of that metric counts as improvement:

| node | lever_metric | direction |
|---|---|---|
| `proposer-quality` | `loop.repeat_failure_rate` | lower |
| `cycle-cost` | `cost.tokens_per_integration` | lower |
| `tool-reuse` | `loop.confirmed_integration_ratio` | higher |
| `heldout-robustness` | `heldout.heldout_gap` | lower |
| `compile-health` | `quality.compile_clean_ratio` | higher |

## Marginal gain / plateau / selection

- `record_gains` computes one signed marginal-gain observation per node each scorecard recompute, from the harness's own freshly-computed scorecard result vs. the node's own prior value (oriented by direction). Bounded to a trailing window of 8. The first observation for a node sets only a baseline (no gain yet).
- `is_plateaued`: once a node has a FULL window whose mean gain is at or below `PLATEAU_FLOOR = 0.0` ("no net improvement"), it's plateaued. `<=` rather than strict `<` was chosen deliberately — an exactly-flat metric should read as plateaued, not perpetually "not yet" by a hair's-width technicality.
- `select_current_direction`: epsilon-greedy (0.15) over non-plateaued, non-cooldown nodes — explore a random eligible node, else exploit the highest-mean-gain node (ties broken by fewest attempts). A node that just plateaued is retired into a 72h cooldown and the forced switch is recorded (sidecar `switches` list + a `{"phase": "tech_tree", "reason": "plateau_switch"}` ledger event).
- `maybe_mint_node`: a supported hypothesis (#878) whose domain has no token overlap with any existing node mints ONE new node (rate-limited to 1/24h, name-deduped). A mapped-but-plateaued node is reactivated instead of minting a duplicate. Lever defaults to `loop.confirmed_integration_ratio` unless the hypothesis's evidence names one of the 5 known metrics — documented crude v1 behavior.

## Wiring (soft, no starvation — mirrors #815)

- **`scorecard.compute_scorecard`**: seeds/updates the portfolio each recompute (its own fail-open block, separate from the module's outer wrapper so a tech_tree bug can never discard already-computed sections); exposes `control_plane.tech_tree`.
- **`demand._goal_gap_items`**: tags each item with the domain whose lever_metric TAIL exactly matches the gap's bare metric name; direction-aligned items are stable-sorted to lead WITHIN their existing `_vector_rank` (#815) class — V1-before-V2 stays the primary key, direction is only a secondary tiebreak. Nothing is ever dropped.
- **`goal_review.maybe_goal_review`**: softly reorders the LLM's own candidate list toward the current direction (token-overlap match) before the existing `_MAX_PRIORITIES` cap runs — only the cap can ever leave a non-aligned candidate unaccepted. An accepted priority whose text matches the current direction is tagged `direction: "<name>"` in `derived_priorities.json` (additive, omitted when it doesn't match).

## Trust note

`tech_tree/portfolio.json` is instance-writable state, exactly like every other bridge sidecar. It's added to `scorecard.FITNESS_SIDECARS` (#789) so tampering is DETECTED — nothing new to build, just tuple membership. Selecting a direction is a STEERING decision, not a verification one (same argument as `evolution_tree.py`): a forged portfolio can at most re-order which domain the loop prefers next. **No gain number is ever instance-authored** — `record_gains` is the ONLY writer of `gain_history`, and it always computes from (a) the node's own prior value and (b) the harness's own current scorecard result, never any other field (test-pinned: a forged `gain_history`/`last_lever_value` written directly to the sidecar doesn't affect the next honestly-computed appended value). Every cycle still passes the full gate; promotions are still root-verified; priorities still pass `validate_priority`. `nanobot/runtime/tech_tree.py` is added to `_RUNTIME_DENY_ALWAYS_FILES` (fitness-adjacent steering, same tier as `evolution_tree.py`/`hypothesis_verdict.py`).

## Files changed

- `nanobot/runtime/tech_tree.py` (new)
- `nanobot/runtime/scorecard.py` (control-plane snapshot, FITNESS_SIDECARS, recompute-path wiring)
- `nanobot/runtime/demand.py` (`_make_item` direction param, `_goal_gap_items` tagging + within-kind boost)
- `nanobot/runtime/goal_review.py` (candidate reordering bias, `direction` tag on derived priorities)
- `nanobot/runtime/runtime_deny.py` (deny-set entry)
- `tests/test_tech_tree.py` (new — unit + wiring tests)
- `tests/test_scorecard.py` (extended — control_plane exact-key-set assertions + shape pin)
- `docs/changes/879-tech-tree/proposal.md` (new)

## Test results

Touched files by path:

```
tests/test_tech_tree.py, tests/test_scorecard.py, tests/test_runtime_slice.py, tests/test_runtime_trust_ladder.py
130 passed (test_tech_tree.py alone: 57 passed)
```

`tests/test_demand.py` hits a PRE-EXISTING, unrelated environment issue on this Windows dev machine: a stray `tests` package installed in system `site-packages` shadows the local `tests/` package for its internal `from tests.test_goal_backlog_routing import ...` cross-module import (confirmed present on a clean `origin/main` checkout too, same import line, untouched by this diff). Verified via a diagnostic `sys.modules` shim that bypasses the shadow without touching any repo file:

```
2 failed, 229 passed in 44.52s
```

(the 2 failures are pre-existing Windows path-separator (`\` vs `/`) assertions in `TestCompileDefects`, unrelated to this change). `tests/test_goal_review.py` passed cleanly as part of the 130-passed run above.

Full suite (`python -m pytest -q --continue-on-collection-errors`):

```
28 failed, 1917 passed, 6 skipped, 10 warnings, 11 errors in 1013.78s (0:16:53)
```

Matches the documented baseline (~27-31 pre-existing Windows failures + ~11 shadow collection errors) — none of the failures/errors touch `tech_tree`/`scorecard`/`demand`/`goal_review`; all are pre-existing `autoevolve`/bridge-locking/CLI/web-search-tool issues plus the same `tests`-package-shadow collection errors (`test_demand.py`, `test_llm_proposer.py`, etc.).

## Uncertain / judgment calls (flagging per review request)

1. **`goal_review` integration point**: I reorder the LLM's own returned candidate list by token-overlap with the current direction, then tag accepted priorities that match — rather than injecting the direction into the LLM prompt itself. Kept deterministic/measurement-driven (consistent with the module's own "inputs are measurements, not vibes" philosophy) rather than adding another vibe-based prompt instruction.
2. **Plateau floor**: `PLATEAU_FLOOR = 0.0` with `mean_gain <= floor` (not strict `<`) — documented in the module docstring; an exactly-flat metric should count as plateaued.
3. **Minted-node lever mapping**: domain-mapping (is this hypothesis about an existing node?) uses the hypothesis TITLE only, deliberately excluding the evidence's `metric` field from that check — including it would make every currently-known metric self-defeating (it would always "match" its own owning node before the mint path could ever reuse that metric for a new node). The metric field is still used, separately, to pick a NEW node's lever when unmapped.
4. **Demand direction tagging scope**: only `goal-gap` items get a `direction` tag in this v1 (the one demand kind with an exact, non-fuzzy metric-to-lever correspondence) — priority/hypothesis/decay/defect stay untagged rather than extending the fuzzy token-match everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
