### PR TITLE
fix(runtime): #893 tech-tree gains paced by integrations + #894 legacy verdict re-eval

### DIFF
--- a/docs/changes/893-tech-tree-pacing/proposal.md
+++ b/docs/changes/893-tech-tree-pacing/proposal.md
@@ -1,0 +1,86 @@
+# Change: tech-tree gains paced by integrations, not scorecard recompute ticks
+
+- **change-id:** 893-tech-tree-pacing
+- **issue:** #893 (+ #894 one-liner rider, same PR)
+- **capability:** self-evolving-runtime (tech-tree #879, hypothesis loop
+  #878, scorecard #765/#789/#865)
+- **role / workstream:** RSI (recursive self-improvement) — pacing fix to
+  an existing ranking input, no new machinery
+
+## Live finding
+
+`tech_tree.record_gains` (`nanobot/runtime/tech_tree.py`) is invoked from
+`scorecard.compute_scorecard`'s recompute path — a timer-driven tick, observed
+firing ~27 times over a ~14h window on the live instance. Its lever metrics
+(`loop.repeat_failure_rate`, `cost.tokens_per_integration`,
+`loop.confirmed_integration_ratio`, `heldout.heldout_gap`,
+`quality.compile_clean_ratio`) are all 7-day rolling aggregates computed over
+the cycle ledger — over that same ~14h window, the loop only recorded ~5
+actual integrations, so the underlying aggregates barely moved between
+consecutive recomputes.
+
+Recording one gain observation per recompute regardless of whether any real
+work had landed meant each node accumulated a full `GAIN_HISTORY_MAX=8`
+window of near-zero-delta observations in a matter of hours — with zero
+cycles' worth of real integration progress behind most of them — and
+`is_plateaued` correctly (given the data it was fed) called every node
+plateaued. All five seed nodes plateaued overnight; `current` read `None`
+because `select_current_direction` found no eligible (non-plateaued,
+non-cooldown) node left to pick.
+
+This is not a bug in the plateau/selection math — it is a pacing bug:
+`record_gains` was measuring *ticks*, not *progress*.
+
+## Fix
+
+`record_gains(state_dir, scorecard_result)` now gates on the harness's own
+cycle-progress counter, `loop.integrations` (read via the existing
+`_dotted_get` dotted-path helper, same as every lever lookup):
+
+- **Absent / non-numeric** `loop.integrations` → fail open: record nothing
+  this call. This never falls back to the old per-tick behavior — a missing
+  counter is treated as "no signal," not "assume progress."
+- **Present but not advanced** past the portfolio's own `last_integrations`
+  watermark (a new single top-level field on the portfolio sidecar — global,
+  not per-node, since it paces every node identically) → record nothing this
+  call: no gain observation and no `last_lever_value` update, for any node.
+- **Present and advanced** → proceed exactly as before: each node's lever
+  value is read from the scorecard result, compared to its own prior
+  `last_lever_value`, and one signed gain observation is appended (bounded to
+  `GAIN_HISTORY_MAX`); `last_integrations` is then advanced to this call's
+  value.
+- **First-ever observation** (no `last_integrations` watermark yet) sets the
+  baseline — `last_integrations` and each node's `last_lever_value` — but
+  appends no gain observations, matching the pre-existing per-node
+  first-observation convention.
+
+No change to `PLATEAU_FLOOR`, `GAIN_HISTORY_MAX` (K), `COOLDOWN_HOURS`, or the
+epsilon-greedy selection logic in `select_current_direction` — this is a
+pacing fix to the gain-recording input those consume, not a change to how
+they interpret it. With this fix, a plateau verdict now means "K
+observations, each backed by real integration progress, showed no
+improvement" rather than "K scorecard-recompute ticks fired, most with
+nothing to measure."
+
+## #894 rider (same PR) — hypothesis re-eval misses legacy no-verdict entries
+
+`hypothesis_backlog.reconcile`'s re-evaluation branch for already-`answered`
+entries checked `entry.get("verdict") == "inconclusive"`. Any `answered`
+lifecycle entry that predates #878 (the verdict feature) has no `verdict`
+key at all — `None`, not the string `"inconclusive"` — so those legacy
+entries were silently excluded from ever getting a first verdict computed.
+Changed the condition to `entry.get("verdict") in (None, "inconclusive")`.
+The existing guard (`answered_evidence` / serving `cycle_id` required, else
+skip quietly) is unchanged — an answered entry with neither a verdict nor a
+recorded serving cycle is left alone rather than raising.
+
+## Rollout note (operator does this by hand after merge, not part of this PR)
+
+The live portfolio's `gain_history`/plateau state was built entirely under
+the broken per-tick pacing and is meaningless. On deploy, the operator will
+reset the live `tech_tree/portfolio.json`: every node back to `status:
+"active"` with cooldown cleared and `gain_history` cleared, and the new
+`last_integrations` field set to `null` so the very next scorecard recompute
+is treated as the first-ever (baseline-only) observation under the corrected
+pacing. No script for this is included in this PR — it's a one-time manual
+state heal on the live host, not machinery this change should ship.

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -254,7 +254,10 @@ def _maybe_upgrade_inconclusive_verdict(
     state_dir: Path, entry: dict[str, Any], key: str, now_iso: str
 ) -> None:
     """#878 opus-review N1 fix: re-evaluate an already-answered hypothesis's
-    verdict on a LATER reconcile pass if it is still ``"inconclusive"``.
+    verdict on a LATER reconcile pass if it is still ``"inconclusive"`` —
+    and, per #894, also if it has NO verdict at all (``None``), which is
+    the shape of any ``answered`` entry that predates #878 entirely and so
+    never got a first classify pass.
 
     ``_apply_verdict`` originally only ran once, at the exact moment a
     candidate flips to ``answered`` — day 0. At that instant the
@@ -398,10 +401,15 @@ def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
                 # consistent with this module's existing lazy-reconciliation
                 # design note above.
                 _apply_verdict(state_dir, entry, key, answered_keys[key], now_iso)
-            elif entry.get("status") == "answered" and entry.get("verdict") == "inconclusive":
+            elif entry.get("status") == "answered" and entry.get("verdict") in (None, "inconclusive"):
                 # #878 opus-review N1 fix: re-check on every LATER pass too —
                 # see _maybe_upgrade_inconclusive_verdict's docstring for why
                 # the confirmed-usage source needs this to ever fire.
+                # #894: also catches legacy "answered" entries that predate
+                # #878 entirely and so have NO verdict field at all (verdict
+                # is None, not the string "inconclusive") — those never got
+                # a first classify pass and would otherwise sit unevaluated
+                # forever.
                 _maybe_upgrade_inconclusive_verdict(state_dir, entry, key, now_iso)
 
             if entry.get("status") == "active":

--- a/nanobot/runtime/tech_tree.py
+++ b/nanobot/runtime/tech_tree.py
@@ -26,16 +26,31 @@ Mechanics, all crude-and-cheap by design:
   naming one existing scorecard metric (a dotted ``section.metric`` path,
   e.g. ``"loop.repeat_failure_rate"``) as its lever, and which DIRECTION of
   that metric counts as improvement (``"lower"``/``"higher"``).
-- **Marginal gain** (:func:`record_gains`): every scorecard recompute, each
-  node's lever value is read from the freshly-computed scorecard result
+- **Marginal gain** (:func:`record_gains`): PACED BY INTEGRATION PROGRESS
+  (#893), not by how often the caller (the scorecard recompute path) happens
+  to invoke this function. The lever metrics are 7-day rolling aggregates
+  that barely move between back-to-back recomputes — a timer-driven
+  recompute tick can fire many times per hour while the underlying
+  integration count crawls forward by only a handful over the same window;
+  recording an observation on every tick regardless produced a wall of
+  near-zero "gains" that plateaued every node within hours despite almost
+  no real work having landed. So each call reads the harness's own
+  cycle-progress counter, ``loop.integrations``, from the scorecard result;
+  if it has not advanced past the portfolio's own last-observed watermark,
+  the call records NOTHING (no gain observation, no ``last_lever_value``
+  update, for any node) and returns. Only once ``loop.integrations`` has
+  advanced does each node's lever value get read from the scorecard result
   (harness-owned, never an instance claim) and compared to the node's own
   previous value, oriented by its direction, to produce one signed "gain"
   observation appended to a bounded trailing window
-  (:data:`GAIN_HISTORY_MAX`). The FIRST observation for a node records no
-  gain (there is nothing yet to compare against) — only sets the
-  baseline.
+  (:data:`GAIN_HISTORY_MAX`). The FIRST-EVER observation (no stored
+  integration watermark yet) records no gain for any node (there is
+  nothing yet to compare against) — only sets the baseline. A missing/
+  non-numeric ``loop.integrations`` fails open to "record nothing" — it
+  never falls back to the old per-tick recording.
 - **Plateau** (:func:`is_plateaued`): once a node has a FULL window of
-  observations, a mean gain at or below :data:`PLATEAU_FLOOR` (0.0 — "no
+  observations — each now backed by real integration progress, not a bare
+  recompute tick — a mean gain at or below :data:`PLATEAU_FLOOR` (0.0 — "no
   net improvement over the window", see the constant's own docstring for
   why ``<=`` was chosen over strict ``<``) marks it plateaued.
 - **Selection** (:func:`select_current_direction`): epsilon-greedy
@@ -227,6 +242,12 @@ def _empty_portfolio() -> dict[str, Any]:
         "nodes": {},
         "switches": [],
         "last_mint_ts": None,
+        # #893: global (not per-node) watermark of the harness's own
+        # cycle-progress counter (``loop.integrations``) last observed by
+        # record_gains — the pacing gate that keeps gain observations tied
+        # to real integration progress rather than scorecard recompute
+        # ticks. ``None`` means no observation has ever been recorded.
+        "last_integrations": None,
     }
 
 
@@ -254,6 +275,12 @@ def read_portfolio(state_dir: Any) -> dict[str, Any]:
             portfolio["switches"] = [s for s in switches if isinstance(s, dict)]
         last_mint = raw.get("last_mint_ts")
         portfolio["last_mint_ts"] = last_mint if isinstance(last_mint, str) and last_mint else None
+        last_integrations = raw.get("last_integrations")
+        portfolio["last_integrations"] = (
+            last_integrations
+            if isinstance(last_integrations, (int, float)) and not isinstance(last_integrations, bool)
+            else None
+        )
         return portfolio
     except Exception:
         return _empty_portfolio()
@@ -372,22 +399,49 @@ def ensure_seeded(state_dir: Any, *, now: 'datetime | None' = None) -> None:
 
 
 def record_gains(state_dir: Any, scorecard_result: dict[str, Any]) -> None:
-    """For each node, read its lever_metric's CURRENT value from
-    ``scorecard_result`` (the harness-computed snapshot dict — dotted
-    lookup, fail-open skip if absent/non-numeric) and append one signed
-    marginal-gain observation, oriented by the node's own ``direction``:
-    lower-better -> ``gain = last - current``; higher-better ->
-    ``gain = current - last``. The FIRST observation for a node (no stored
-    ``last_lever_value`` yet) records no gain, only the baseline. Bounded
-    to the trailing :data:`GAIN_HISTORY_MAX` observations. Harness-computed
-    ONLY — this never reads any instance-authored "gain" field, only the
-    scorecard result it is handed and the node's own previously-recorded
-    baseline. Fail-open: any error is swallowed silently."""
+    """PACED BY INTEGRATION PROGRESS (#893), not by how often this is
+    called. Reads the harness's own cycle-progress counter,
+    ``loop.integrations``, from ``scorecard_result`` (dotted lookup via
+    :func:`_dotted_get`):
+
+    - Absent/non-numeric -> FAIL OPEN: record nothing this call (never
+      falls back to the old per-tick recording).
+    - Present but NOT strictly greater than the portfolio's own
+      ``last_integrations`` watermark -> record nothing this call: no gain
+      observation and no ``last_lever_value`` update for ANY node (the
+      lever metrics are 7-day aggregates that barely move between
+      back-to-back scorecard recompute ticks, so a tick with no new
+      integration progress carries no signal worth recording).
+    - Present and ADVANCED (or this is the first-ever observation, i.e.
+      no ``last_integrations`` watermark yet) -> for each node, read its
+      ``lever_metric``'s CURRENT value from ``scorecard_result`` (fail-open
+      skip if absent/non-numeric) and append one signed marginal-gain
+      observation, oriented by the node's own ``direction``: lower-better
+      -> ``gain = last - current``; higher-better -> ``gain = current -
+      last``. The FIRST-EVER observation (no stored ``last_integrations``
+      watermark yet) records no gain for any node, only sets the baseline
+      (matches each node's own pre-existing first-observation convention).
+      Bounded to the trailing :data:`GAIN_HISTORY_MAX` observations, then
+      ``last_integrations`` is advanced to this call's value.
+
+    Harness-computed ONLY — this never reads any instance-authored "gain"
+    field, only the scorecard result it is handed and the node's own
+    previously-recorded baseline. Fail-open: any error is swallowed
+    silently."""
     try:
         ensure_seeded(state_dir)
         portfolio = read_portfolio(state_dir)
+
+        integrations = _dotted_get(scorecard_result, "loop.integrations")
+        if integrations is None:
+            return  # no pacing signal at all -- fail open, record nothing
+
+        last_integrations = portfolio.get("last_integrations")
+        has_watermark = isinstance(last_integrations, (int, float)) and not isinstance(last_integrations, bool)
+        if has_watermark and integrations <= float(last_integrations):
+            return  # no integration progress since the last observation
+
         nodes = portfolio["nodes"]
-        changed = False
         for node in nodes.values():
             lever = node.get("lever_metric")
             if not lever:
@@ -406,10 +460,10 @@ def record_gains(state_dir: Any, scorecard_result: dict[str, Any]) -> None:
                     history = history[-GAIN_HISTORY_MAX:]
                 node["gain_history"] = history
             node["last_lever_value"] = current
-            changed = True
-        if changed:
-            portfolio["nodes"] = nodes
-            _write_portfolio(state_dir, portfolio)
+
+        portfolio["nodes"] = nodes
+        portfolio["last_integrations"] = integrations
+        _write_portfolio(state_dir, portfolio)
     except Exception:
         pass
 

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -433,6 +433,68 @@ class TestInconclusiveVerdictUpgrade:
         # still-inconclusive passes append nothing further.
         assert len(verdict_rows) == 1
 
+    def test_legacy_answered_entry_with_no_verdict_field_gets_evaluated(self, tmp_path):
+        """#894: an "answered" lifecycle entry that predates #878 entirely
+        has NO "verdict" key at all (not the string "inconclusive" — simply
+        absent). The reconcile re-eval branch used to check
+        ``verdict == "inconclusive"`` and so never touched this legacy
+        shape; it must now also catch ``verdict is None``."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_microbench(state_dir, "c1", improvement_pct=10.0)
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "title": "Fix widget",
+                "first_seen": "2026-01-01T00:00:00Z",
+                "cycles_untouched": 0,
+                "answered_evidence": "c1",
+                "answered_at": "2026-01-01T00:00:00Z",
+                # no "verdict" / "verdict_evidence" / "verdict_at" at all.
+            },
+        })
+
+        entry_before = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert "verdict" not in entry_before
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert entry["verdict"] == "supported"
+        assert entry["verdict_evidence"]["source"] == "microbench"
+        assert entry["verdict_at"]
+
+        rows = [
+            json.loads(line)
+            for line in (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        verdict_rows = [r for r in rows if r.get("phase") == "hypothesis" and r.get("reason") == "verdict"]
+        assert len(verdict_rows) == 1
+        assert verdict_rows[0]["verdict"] == "supported"
+
+    def test_legacy_answered_entry_without_answered_evidence_skipped_quietly(self, tmp_path):
+        """Guard: the re-eval path requires ``answered_evidence`` (the
+        serving cycle_id) — a legacy entry missing that too must be left
+        alone rather than raising or fabricating a cycle_id."""
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        _write_lifecycle(state_dir, {
+            "hypothesis-h1": {
+                "status": "answered",
+                "title": "Fix widget",
+                "first_seen": "2026-01-01T00:00:00Z",
+                "cycles_untouched": 0,
+                # no answered_evidence, no verdict at all.
+            },
+        })
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        entry = _read_lifecycle(state_dir)["entries"]["hypothesis-h1"]
+        assert "verdict" not in entry
+        assert entry["status"] == "answered"
+
     def test_microbench_refuted_is_not_reopened_by_the_upgrade_path(self, tmp_path):
         """A verdict that is already supported/refuted (not inconclusive)
         must never be re-checked by the upgrade path — only inconclusive

--- a/tests/test_tech_tree.py
+++ b/tests/test_tech_tree.py
@@ -105,6 +105,7 @@ class TestReadPortfolioFailOpen:
             "nodes": {},
             "switches": [],
             "last_mint_ts": None,
+            "last_integrations": None,
         }
 
     def test_corrupt_json_fails_open_to_empty(self, tmp_path):
@@ -131,53 +132,101 @@ class TestRecordGains:
 
     def test_first_observation_sets_baseline_no_gain(self, tmp_path):
         tech_tree.ensure_seeded(tmp_path, now=NOW)
-        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4}})
-        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4, "integrations": 1}})
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        node = portfolio["nodes"]["proposer-quality"]
         assert node["gain_history"] == []
         assert node["last_lever_value"] == 0.4
+        assert portfolio["last_integrations"] == 1
+
+    def test_missing_loop_integrations_records_nothing(self, tmp_path):
+        """#893: no pacing signal at all -> fail open, never falls back to
+        per-tick recording."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4}})
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        node = portfolio["nodes"]["proposer-quality"]
+        assert node["last_lever_value"] is None
+        assert node["gain_history"] == []
+        assert portfolio["last_integrations"] is None
+
+        tech_tree.record_gains(tmp_path, {})  # loop section absent entirely
+        node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
+        assert node["last_lever_value"] is None
+
+    def test_same_integrations_records_nothing(self, tmp_path):
+        """#893 core pacing fix: a recompute tick with NO new integration
+        progress must append no gain observation and must not even move
+        last_lever_value — the whole point is that a same-window recompute
+        carries no real signal."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4, "integrations": 3}})
+        # Same integrations count -> a plain tick, no new observation.
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.1, "integrations": 3}})
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        node = portfolio["nodes"]["proposer-quality"]
+        assert node["gain_history"] == []
+        assert node["last_lever_value"] == 0.4  # untouched by the second call
+        assert portfolio["last_integrations"] == 3
+
+    def test_advanced_integrations_records_gain(self, tmp_path):
+        """#893: only once loop.integrations has advanced does a new gain
+        observation land."""
+        tech_tree.ensure_seeded(tmp_path, now=NOW)
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4, "integrations": 3}})
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3, "integrations": 3}})  # no progress
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.2, "integrations": 5}})  # progressed
+        portfolio = tech_tree.read_portfolio(tmp_path)
+        node = portfolio["nodes"]["proposer-quality"]
+        # Only ONE observation recorded (from the 3 -> 5 advance), computed
+        # against the baseline (0.4) — the intervening same-integrations
+        # call at 0.3 never touched last_lever_value.
+        assert node["gain_history"] == [pytest.approx(0.2)]
+        assert node["last_lever_value"] == 0.2
+        assert portfolio["last_integrations"] == 5
 
     def test_lower_better_gain_sign(self, tmp_path):
         """proposer-quality (loop.repeat_failure_rate, lower-better)."""
         tech_tree.ensure_seeded(tmp_path, now=NOW)
-        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4}})
-        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3}})  # improved
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.4, "integrations": 1}})
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3, "integrations": 2}})  # improved
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
         assert node["gain_history"] == [pytest.approx(0.1)]
         assert node["last_lever_value"] == 0.3
 
-        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.5}})  # worsened
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.5, "integrations": 3}})  # worsened
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
         assert node["gain_history"][-1] == pytest.approx(-0.2)
 
     def test_higher_better_gain_sign(self, tmp_path):
         """tool-reuse (loop.confirmed_integration_ratio, higher-better)."""
         tech_tree.ensure_seeded(tmp_path, now=NOW)
-        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.5}})
-        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.7}})  # improved
+        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.5, "integrations": 1}})
+        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.7, "integrations": 2}})  # improved
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["tool-reuse"]
         assert node["gain_history"] == [pytest.approx(0.2)]
 
-        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.6}})  # worsened
+        tech_tree.record_gains(tmp_path, {"loop": {"confirmed_integration_ratio": 0.6, "integrations": 3}})  # worsened
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["tool-reuse"]
         assert node["gain_history"][-1] == pytest.approx(-0.1)
 
     def test_missing_or_non_numeric_metric_skipped(self, tmp_path):
         tech_tree.ensure_seeded(tmp_path, now=NOW)
-        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": "not-a-number"}})
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": "not-a-number", "integrations": 1}})
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
         assert node["last_lever_value"] is None
         assert node["gain_history"] == []
 
-        tech_tree.record_gains(tmp_path, {})  # section absent entirely
+        tech_tree.record_gains(tmp_path, {})  # section absent entirely -> no integrations either
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
         assert node["last_lever_value"] is None
 
     def test_window_bounded_to_max(self, tmp_path):
         tech_tree.ensure_seeded(tmp_path, now=NOW)
         value = 1.0
-        for _ in range(tech_tree.GAIN_HISTORY_MAX + 3):
+        for i in range(tech_tree.GAIN_HISTORY_MAX + 3):
             value -= 0.01
-            tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": value}})
+            tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": value, "integrations": i + 1}})
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
         assert len(node["gain_history"]) == tech_tree.GAIN_HISTORY_MAX
 
@@ -189,7 +238,7 @@ class TestRecordGains:
         tech_tree.ensure_seeded(tmp_path, now=NOW)
         _set_node(tmp_path, "proposer-quality", last_lever_value=0.5, gain_history=[999.0])
 
-        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3}})
+        tech_tree.record_gains(tmp_path, {"loop": {"repeat_failure_rate": 0.3, "integrations": 1}})
         node = tech_tree.read_portfolio(tmp_path)["nodes"]["proposer-quality"]
         assert node["gain_history"] == [999.0, pytest.approx(0.2)]
         assert node["last_lever_value"] == 0.3


### PR DESCRIPTION
## Live finding (#893)

`tech_tree.record_gains` (`nanobot/runtime/tech_tree.py`) runs on every
`scorecard` recompute tick — observed firing ~27 times over a ~14h window on
the live instance. Its lever metrics (`loop.repeat_failure_rate`,
`cost.tokens_per_integration`, `loop.confirmed_integration_ratio`,
`heldout.heldout_gap`, `quality.compile_clean_ratio`) are all 7-day rolling
aggregates — over that same window only ~5 real integrations landed, so the
aggregates barely moved between consecutive ticks. Recording one gain
observation per tick regardless meant every node filled its full
`GAIN_HISTORY_MAX=8` window with near-zero-delta observations — with almost
no real integration progress behind them — and plateaued overnight; all five
seed nodes ended up plateaued, `current=None`.

This was a pacing bug, not a plateau/selection bug: `record_gains` was
measuring ticks, not progress.

## Fix

`record_gains(state_dir, scorecard_result)` now gates on the harness's own
cycle-progress counter, `loop.integrations` (via the existing `_dotted_get`
dotted-path lookup):

- Absent/non-numeric → fail open: record nothing this call (never falls back
  to the old per-tick recording).
- Present but not advanced past the portfolio's own new `last_integrations`
  watermark (a single top-level field on the portfolio sidecar — global, not
  per-node) → record nothing this call: no gain observation, no
  `last_lever_value` update, for any node.
- Present and advanced → proceed exactly as before: append one signed gain
  observation per node (bounded to `GAIN_HISTORY_MAX`), then advance
  `last_integrations`.
- First-ever observation (no `last_integrations` watermark yet) → set the
  baseline (`last_integrations` + each node's `last_lever_value`) but append
  no gains — same convention as the existing per-node first-observation rule.

No change to `PLATEAU_FLOOR`, `GAIN_HISTORY_MAX` (K), `COOLDOWN_HOURS`, or
`select_current_direction`'s epsilon-greedy logic — pacing fix only. Module
docstring's pacing paragraph updated to match: a plateau verdict now means "K
observations, each backed by real integration progress, showed no
improvement."

## #894 rider (same PR, one-liner)

`hypothesis_backlog.reconcile`'s re-eval branch for already-`answered`
entries checked `entry.get("verdict") == "inconclusive"`. Any `answered`
entry that predates #878 has no `verdict` key at all (`None`), so legacy
entries never got evaluated. Changed to
`entry.get("verdict") in (None, "inconclusive")`. The existing guard
(`answered_evidence`/serving `cycle_id` required, else skip quietly) is
unchanged.

## Rollout note

Documented in `docs/changes/893-tech-tree-pacing/proposal.md`: on deploy,
the operator will manually reset the live `tech_tree/portfolio.json`
(`status: "active"`, cooldown cleared, `gain_history` cleared,
`last_integrations: null`) since observations recorded under the broken
pacing are meaningless. No script for this ships in this PR.

## Test results

Targeted:
```
python -m pytest tests/test_tech_tree.py tests/test_hypothesis_backlog.py tests/test_scorecard.py -q
........................................................................ [ 50%]
........................................................................ [100%]
144 passed in 5.95s
```

Full suite (run explicitly by path, `--continue-on-collection-errors`):
```
27 failed, 1923 passed, 6 skipped, 10 warnings, 11 errors in 923.74s (0:15:23)
```
27 pre-existing Windows-environment failures (autoevolve/bridge-locking/CLI
help/web-search-tool/etc.) + 11 pre-existing shadow-package collection
errors — matches the documented baseline, no new failures introduced by this
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)