### PR TITLE
chore(host): bridge model back to gemini-3.7-flash-high

### DIFF
--- a/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
+++ b/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
@@ -11,9 +11,13 @@ NANOBOT_CONFIG_PATH=/run/user/1001/nanobot-eeepc/config.json
 SUBAGENT_BRIDGE_STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state/subagent_bridge
 # Bridge proposer model. openai/ prefix is REQUIRED: the litellm
 # materializer path needs it, the raw-client proposer strips it.
-SUBAGENT_BRIDGE_MODEL=openai/an/gemini-3-flash
-# Reasoning effort passed to the bridge's tool-harness calls (#832).
-SUBAGENT_BRIDGE_REASONING_EFFORT=high
+# 2026-08-18 operator decision: gemini-3.7-flash-high (the baked -high
+# name encodes the reasoning tier; proven transformative on this loop,
+# see #828 era notes).
+SUBAGENT_BRIDGE_MODEL=openai/an/gemini-3.7-flash-high
+# Reasoning effort for models WITHOUT a baked tier in the name (#832).
+# Leave unset for baked -high model names to avoid double-specification.
+#SUBAGENT_BRIDGE_REASONING_EFFORT=high
 SUBAGENT_BRIDGE_FORCE_BUDGET=extended
 
 # LLM-driven proposer loop kill switch, default OFF upstream (#739).


### PR DESCRIPTION
Operator decision 2026-08-18: return the bridge to `openai/an/gemini-3.7-flash-high` (was switched to gemini-3-flash on 2026-08-16 — miscommunication). Template-only sync per #865; the baked `-high` name encodes the reasoning tier so `SUBAGENT_BRIDGE_REASONING_EFFORT` is commented out (#832 — it exists for tier-less model names). Live /etc applied separately with backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)