### PR TITLE
feat(runtime): verb-invariant subject dedup + per-file edit budget (#903)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1622,21 +1622,13 @@ def _subject_dedup_enabled() -> bool:
 def _subject_tokens(text: str) -> set[str]:
     """Verb-invariant subject tokens (#903): lowercase alphabetic tokens with
     the fixed generic-verb stoplist (:data:`_SATURATED_VERB_STOPLIST`, #902)
-    and short (<=2 char) tokens removed. Applied identically to a proposal's
-    title/filename stem and a candidate script's filename stem so that a verb
-    paraphrase (check vs audit vs analyze) never changes the derived subject.
+    and short (<=2 char) tokens removed. Applied identically to the proposed
+    target's filename stem and a candidate script's filename stem so that a
+    verb paraphrase (check vs audit vs analyze) never changes the derived
+    subject key.
     """
     tokens = re.findall(r"[a-zA-Z]+", text.lower())
     return {t for t in tokens if len(t) > 2 and t not in _SATURATED_VERB_STOPLIST}
-
-
-def _proposal_subject_tokens(proposal: dict[str, Any]) -> set[str]:
-    """Subject tokens (#903) drawn from BOTH the proposal's title words and
-    its proposed filename stem — either alone could name the subject."""
-    title = str(proposal.get("task_title") or "")
-    target = str(proposal.get("target_path") or "")
-    stem = Path(target).stem if target else ""
-    return _subject_tokens(title) | _subject_tokens(stem)
 
 
 def _subject_dedup_fallback_candidates(selfevo_repo: Path) -> list[str]:
@@ -1675,29 +1667,59 @@ def _subject_duplicate_match(
     ``analyze_repeat_failures.py`` clears the lexical word-overlap threshold
     in :func:`cycle_planning._title_already_done_in_git_log` because the verb
     dilutes the overlap below `max(2, ceil(0.6*N))`. This check instead
-    compares SUBJECT tokens (title/filename words with the generic-verb
-    stoplist stripped) against candidate scripts.
+    compares SUBJECT-KEY token sets (filename words with the generic-verb
+    stoplist stripped) between the proposed target filename and candidate
+    scripts.
+
+    Scope (#903 review B1): only proposals whose ``target_path`` is under
+    ``scripts/`` with a non-``test_`` basename are in scope. ``docs/``,
+    ``memory/``, ``lessons/``, ``tests/`` targets, and ``scripts/test_*.py``
+    "tests for X" proposals, are exempt — matching a tests-for-X title
+    against the SCRIPT it tests would re-break the #757 test-for-X carve-out
+    (a test's subject legitimately overlaps the script under test; that is
+    not churn, it's coverage).
 
     Candidates come from :func:`existence_index.related_scripts` queried with
     the bare title (deliberately no ``target_path`` — passing one would
     trigger the #798 cross-target exemption, which is exactly the gap this
-    check exists to close for genuinely NEW-file proposals). When the index
-    is disabled or returns nothing, falls back to a bounded plain
-    ``scripts/*.py`` glob (:func:`_subject_dedup_fallback_candidates`).
+    check exists to close for genuinely NEW-file proposals), capped to
+    :data:`_SUBJECT_DEDUP_MAX_HITS`. When the index is disabled or returns
+    nothing, falls back to a bounded plain ``scripts/*.py`` glob
+    (:func:`_subject_dedup_fallback_candidates`, capped to
+    :data:`_SUBJECT_DEDUP_MAX_GLOB`) — the larger glob cap is safe precisely
+    BECAUSE matching is strict equality, which cannot over-block the way a
+    subset/overlap rule would.
 
-    A candidate is a subject match when its subject-token set is a subset of
-    the proposal's subject tokens, or when the two sets share >= 2 tokens.
+    #903 review M2: matching is strict, non-empty SET EQUALITY of the two
+    filename stems' subject tokens — not a subset/overlap check. A
+    subset-or->=2-overlap rule closes an entire subject after just ONE
+    existing script (e.g. "summarize_repeat_failures_weekly" would have
+    wrongly matched "repeat_failures" candidates via subset containment, and
+    two single-token subjects sharing nothing but that one token would
+    wrongly match on the ">= 2 overlap" arm once title words were folded
+    in). Equality keeps exactly the intended case
+    (``audit_repeat_failures`` == ``analyze_repeat_failures`` -> blocked)
+    while letting a genuinely broader or narrower subject through
+    (``summarize_repeat_failures_weekly`` != ``repeat_failures`` -> allowed).
+    The proposal's TITLE is no longer part of the match at all (it is only
+    used to query the FTS index above) — simpler, and the filename is the
+    only thing that actually determines what gets built.
 
-    Returns the matched candidate's repo-relative path, or ``""`` when
-    nothing matches, when disabled, or on any error (fail-open).
+    Returns the matched candidate's repo-relative path, or ``""`` when out
+    of scope, nothing matches, disabled, or on any error (fail-open).
     """
     if not selfevo_repo or not _subject_dedup_enabled():
         return ""
+    target = str(proposal.get("target_path") or "").strip()
+    if not target.startswith("scripts/"):
+        return ""
+    basename = target.rsplit("/", 1)[-1]
+    if basename.startswith("test_"):
+        return ""
     try:
-        proposal_tokens = _proposal_subject_tokens(proposal)
+        proposal_tokens = _subject_tokens(Path(target).stem)
         if not proposal_tokens:
             return ""
-        target = str(proposal.get("target_path") or "").strip()
         candidates = existence_index.related_scripts(
             state_dir, selfevo_repo, title, limit=_SUBJECT_DEDUP_MAX_HITS,
         )
@@ -1711,9 +1733,7 @@ def _subject_duplicate_match(
             candidate_tokens = _subject_tokens(Path(path).stem)
             if not candidate_tokens:
                 continue
-            if candidate_tokens.issubset(proposal_tokens) or len(
-                candidate_tokens & proposal_tokens
-            ) >= 2:
+            if candidate_tokens == proposal_tokens:
                 return path
         return ""
     except Exception:
@@ -1769,10 +1789,18 @@ def _edit_budget_match(
     the budget automatically because the count window starts at
     ``last_used`` — no extra state file is needed.
 
-    Returns ``(target_path, count, since_display)`` when the count is
-    ``>=`` the configured M (:func:`_edit_budget_m`), or ``("", 0, "")``
-    when under budget, when the check is disabled (``M <= 0``), when the
-    target is not under ``scripts/``, or on any error (fail-open).
+    #903 review m1: when the file was NEVER confirmed used, the full-history
+    count includes the file's own creation commit, which is not a "revision
+    with no confirmed usage" — it's how the file came to exist. Subtracted
+    so the reported/compared count means "edits after creation" in both
+    branches (the ``last_used`` branch's ``--since`` window already excludes
+    anything at/before that timestamp, so no adjustment is needed there).
+
+    Returns ``(target_path, count, since_display)`` when the (possibly
+    creation-commit-adjusted) count is ``>=`` the configured M
+    (:func:`_edit_budget_m`), or ``("", 0, "")`` when under budget, when the
+    check is disabled (``M <= 0``), when the target is not under
+    ``scripts/``, or on any error (fail-open).
     """
     if not selfevo_repo:
         return "", 0, ""
@@ -1790,6 +1818,8 @@ def _edit_budget_match(
         last_used_ts = _parse_inventory_ts(last_used_raw) if last_used_raw else None
         since_iso = last_used_ts.isoformat() if last_used_ts else None
         count = _git_commit_count_for_path(Path(selfevo_repo), target, since_iso)
+        if since_iso is None:
+            count = max(0, count - 1)  # exclude the creation commit itself
         if count >= m:
             return target, count, (last_used_str or "creation")
         return "", 0, ""

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -147,6 +147,18 @@ _SATURATED_VERB_STOPLIST = frozenset(
     }
 )
 
+# #903: verb-invariant subject dedup for NEW-file proposals. Default ON —
+# only "0"/"false" disable it (falls back to the pre-#903 lexical-only dedup
+# in _is_duplicate_proposal). Reuses _SATURATED_VERB_STOPLIST (#902) rather
+# than a second, drifting copy of the same stoplist.
+_SUBJECT_DEDUP_ENABLED_ENV = "SELFEVO_SUBJECT_DEDUP_ENABLED"
+_SUBJECT_DEDUP_MAX_HITS = 5
+_SUBJECT_DEDUP_MAX_GLOB = 200
+
+# #903: per-file edit budget without confirmed use. M <= 0 disables the check.
+_EDIT_BUDGET_M_ENV = "SELFEVO_EDIT_BUDGET_M"
+_DEFAULT_EDIT_BUDGET_M = 5
+
 _PROPOSER_SYSTEM_PROMPT = (
     "You are proposing exactly ONE small, bounded engineering improvement for a "
     "self-evolving codebase. Reply with ONLY a JSON object with keys "
@@ -1600,6 +1612,191 @@ def _proposal_creates_new_file(selfevo_repo: Path | None, proposal: dict[str, An
     return not candidate.exists()
 
 
+def _subject_dedup_enabled() -> bool:
+    """#903 kill switch: default ON; only "0"/"false" disable it (falls back
+    to the pre-#903 lexical-only dedup)."""
+    raw = os.environ.get(_SUBJECT_DEDUP_ENABLED_ENV, "1").strip().lower()
+    return raw not in ("0", "false")
+
+
+def _subject_tokens(text: str) -> set[str]:
+    """Verb-invariant subject tokens (#903): lowercase alphabetic tokens with
+    the fixed generic-verb stoplist (:data:`_SATURATED_VERB_STOPLIST`, #902)
+    and short (<=2 char) tokens removed. Applied identically to a proposal's
+    title/filename stem and a candidate script's filename stem so that a verb
+    paraphrase (check vs audit vs analyze) never changes the derived subject.
+    """
+    tokens = re.findall(r"[a-zA-Z]+", text.lower())
+    return {t for t in tokens if len(t) > 2 and t not in _SATURATED_VERB_STOPLIST}
+
+
+def _proposal_subject_tokens(proposal: dict[str, Any]) -> set[str]:
+    """Subject tokens (#903) drawn from BOTH the proposal's title words and
+    its proposed filename stem — either alone could name the subject."""
+    title = str(proposal.get("task_title") or "")
+    target = str(proposal.get("target_path") or "")
+    stem = Path(target).stem if target else ""
+    return _subject_tokens(title) | _subject_tokens(stem)
+
+
+def _subject_dedup_fallback_candidates(selfevo_repo: Path) -> list[str]:
+    """#903 bounded plain-glob fallback for when the FTS existence index is
+    disabled or returns no hits: top-level ``scripts/*.py`` paths only (no
+    recursion), same exclusions as the #902 saturated-themes scan
+    (``__init__.py``/``conftest.py``/``test_*.py`` are not proposable "new
+    script" targets). Bounded to :data:`_SUBJECT_DEDUP_MAX_GLOB` entries.
+    Fail-open: ``[]`` on any error.
+    """
+    try:
+        scripts_dir = Path(selfevo_repo) / "scripts"
+        if not scripts_dir.is_dir():
+            return []
+        out: list[str] = []
+        for path in sorted(scripts_dir.glob("*.py")):
+            name = path.name
+            if name in ("__init__.py", "conftest.py") or name.startswith("test_"):
+                continue
+            out.append(f"scripts/{name}")
+            if len(out) >= _SUBJECT_DEDUP_MAX_GLOB:
+                break
+        return out
+    except Exception:
+        return []
+
+
+def _subject_duplicate_match(
+    state_dir: Path, selfevo_repo: Path | None, proposal: dict[str, Any], title: str,
+) -> str:
+    """#903: verb-invariant subject dedup for NEW-file proposals.
+
+    Complements (does not replace) the #834 exact-title permanent-novelty
+    guard above: that guard only catches near-identical TITLES, so a
+    paraphrase like "audit repeat failures" vs an existing
+    ``analyze_repeat_failures.py`` clears the lexical word-overlap threshold
+    in :func:`cycle_planning._title_already_done_in_git_log` because the verb
+    dilutes the overlap below `max(2, ceil(0.6*N))`. This check instead
+    compares SUBJECT tokens (title/filename words with the generic-verb
+    stoplist stripped) against candidate scripts.
+
+    Candidates come from :func:`existence_index.related_scripts` queried with
+    the bare title (deliberately no ``target_path`` — passing one would
+    trigger the #798 cross-target exemption, which is exactly the gap this
+    check exists to close for genuinely NEW-file proposals). When the index
+    is disabled or returns nothing, falls back to a bounded plain
+    ``scripts/*.py`` glob (:func:`_subject_dedup_fallback_candidates`).
+
+    A candidate is a subject match when its subject-token set is a subset of
+    the proposal's subject tokens, or when the two sets share >= 2 tokens.
+
+    Returns the matched candidate's repo-relative path, or ``""`` when
+    nothing matches, when disabled, or on any error (fail-open).
+    """
+    if not selfevo_repo or not _subject_dedup_enabled():
+        return ""
+    try:
+        proposal_tokens = _proposal_subject_tokens(proposal)
+        if not proposal_tokens:
+            return ""
+        target = str(proposal.get("target_path") or "").strip()
+        candidates = existence_index.related_scripts(
+            state_dir, selfevo_repo, title, limit=_SUBJECT_DEDUP_MAX_HITS,
+        )
+        if not candidates:
+            candidates = _subject_dedup_fallback_candidates(Path(selfevo_repo))
+        else:
+            candidates = candidates[:_SUBJECT_DEDUP_MAX_HITS]
+        for path in candidates:
+            if not path or path == target:
+                continue
+            candidate_tokens = _subject_tokens(Path(path).stem)
+            if not candidate_tokens:
+                continue
+            if candidate_tokens.issubset(proposal_tokens) or len(
+                candidate_tokens & proposal_tokens
+            ) >= 2:
+                return path
+        return ""
+    except Exception:
+        return ""
+
+
+def _edit_budget_m() -> int:
+    """#903: ``SELFEVO_EDIT_BUDGET_M`` env override for M, default 5; unset,
+    empty, or non-numeric falls back to the default. ``M <= 0`` disables the
+    check entirely (kill switch)."""
+    raw = os.environ.get(_EDIT_BUDGET_M_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_EDIT_BUDGET_M
+    try:
+        return int(raw)
+    except Exception:
+        return _DEFAULT_EDIT_BUDGET_M
+
+
+def _git_commit_count_for_path(repo_root: Path, rel_path: str, since_iso: str | None) -> int:
+    """#903: count commits touching ``rel_path`` in ``repo_root``, since
+    ``since_iso`` (``None`` -> full history). Matches the subprocess style of
+    :func:`cycle_planning._recent_git_log` (10s timeout, stderr discarded).
+    Fail-open: ``0`` (never blocks a cycle) on any subprocess error/timeout.
+    """
+    import subprocess as _sp
+
+    git_cmd = [
+        "git", "-c", f"safe.directory={repo_root}", "-C", str(repo_root),
+        "log", "--oneline",
+    ]
+    if since_iso:
+        git_cmd.append(f"--since={since_iso}")
+    git_cmd += ["--", rel_path]
+    try:
+        out = _sp.check_output(git_cmd, stderr=_sp.DEVNULL, timeout=10).decode(errors="replace")
+    except Exception:
+        return 0
+    return sum(1 for line in out.splitlines() if line.strip())
+
+
+def _edit_budget_match(
+    state_dir: Path, selfevo_repo: Path | None, proposal: dict[str, Any],
+) -> tuple[str, int, str]:
+    """#903: per-file edit budget without confirmed use.
+
+    Applies only to EDIT proposals (the caller gates this on NOT
+    :func:`_proposal_creates_new_file`) targeting a ``scripts/`` path. Looks
+    up the target's usage-evidence sidecar entry
+    (:func:`_load_inventory_usage_entries`, #862) for a ``last_used``
+    timestamp; counts git commits touching the target since that timestamp
+    (or the full history when never confirmed used). A confirmed use resets
+    the budget automatically because the count window starts at
+    ``last_used`` — no extra state file is needed.
+
+    Returns ``(target_path, count, since_display)`` when the count is
+    ``>=`` the configured M (:func:`_edit_budget_m`), or ``("", 0, "")``
+    when under budget, when the check is disabled (``M <= 0``), when the
+    target is not under ``scripts/``, or on any error (fail-open).
+    """
+    if not selfevo_repo:
+        return "", 0, ""
+    m = _edit_budget_m()
+    if m <= 0:
+        return "", 0, ""
+    target = str(proposal.get("target_path") or "").strip()
+    if not target or not target.startswith("scripts/"):
+        return "", 0, ""
+    try:
+        usage_entries = _load_inventory_usage_entries(state_dir)
+        entry = usage_entries.get(target)
+        last_used_raw = entry.get("last_used") if isinstance(entry, dict) else None
+        last_used_str = str(last_used_raw).strip() if last_used_raw else ""
+        last_used_ts = _parse_inventory_ts(last_used_raw) if last_used_raw else None
+        since_iso = last_used_ts.isoformat() if last_used_ts else None
+        count = _git_commit_count_for_path(Path(selfevo_repo), target, since_iso)
+        if count >= m:
+            return target, count, (last_used_str or "creation")
+        return "", 0, ""
+    except Exception:
+        return "", 0, ""
+
+
 def _refuted_hypothesis_titles(state_dir: Path) -> list[str]:
     """Titles of hypotheses the harness VERDICT-marked ``"refuted"`` (#878),
     newest ``verdict_at`` first, capped to
@@ -1748,7 +1945,8 @@ def _is_duplicate_proposal(
         # window above), so a throwaway artifact is not silently rebuilt once
         # its creation commit ages out. Edits/improvements to an existing file
         # are iteration, not churn, and are never blocked here.
-        if _proposal_creates_new_file(selfevo_repo, proposal):
+        creates_new_file = _proposal_creates_new_file(selfevo_repo, proposal)
+        if creates_new_file:
             built_subjects = _all_built_subjects(selfevo_repo)
             if built_subjects and _title_already_done_in_git_log(title, built_subjects):
                 matched_built = next(
@@ -1765,6 +1963,36 @@ def _is_duplicate_proposal(
                     "improve/reuse the existing one, or propose genuinely NEW "
                     "work from the numbered Current priority targets"
                 ), matched_built
+
+            # #903: verb-invariant subject dedup. Complements the exact-title
+            # #834 guard above — a paraphrase (check/audit/analyze) clears
+            # the lexical word-overlap threshold, so this compares SUBJECT
+            # tokens (generic verbs stripped) instead. Only applies to
+            # NEW-file proposals; edits are handled by the edit-budget check
+            # below.
+            subject_match = _subject_duplicate_match(state_dir, selfevo_repo, proposal, title)
+            if subject_match:
+                return True, (
+                    f"your proposal '{title}' duplicates the subject of "
+                    f"existing script `{subject_match}`; extend "
+                    f"`{subject_match}` instead of creating a new script, or "
+                    "pick a different subject"
+                ), f"subject-duplicate:{subject_match}"
+        else:
+            # #903: per-file edit budget without confirmed use. Only applies
+            # to proposals that target an EXISTING scripts/ file (the #834
+            # permanent novelty guard above already covers new-file churn).
+            edit_path, edit_count, edit_since = _edit_budget_match(
+                state_dir, selfevo_repo, proposal,
+            )
+            if edit_path:
+                return True, (
+                    f"target `{edit_path}` already has {edit_count} "
+                    "revisions with no confirmed usage since "
+                    f"{edit_since}; do not revise it again — demonstrate "
+                    "usage of the existing version or pick a different "
+                    "target"
+                ), f"edit-budget:{edit_path}"
         return False, "", ""
     except Exception:
         return False, "", ""

--- a/tests/test_llm_proposer_dedup_budget.py
+++ b/tests/test_llm_proposer_dedup_budget.py
@@ -4,22 +4,31 @@ edit budget without confirmed use.
 Two additions to ``llm_proposer._is_duplicate_proposal``, both fail-open and
 gated on ``_proposal_creates_new_file``:
 
-1. Subject dedup (NEW-file proposals only): a verb paraphrase like "audit
-   repeat failures" vs an existing ``analyze_repeat_failures.py`` clears the
-   plain lexical word-overlap threshold in
-   ``cycle_planning._title_already_done_in_git_log`` (the verb dilutes the
-   overlap). This check instead compares SUBJECT tokens (generic verbs
-   stripped via the shared #902 ``_SATURATED_VERB_STOPLIST``) between the
-   proposal and candidate ``scripts/*.py`` files, sourced from
-   ``existence_index.related_scripts`` with a bounded plain-glob fallback
-   when the FTS index is disabled/empty.
+1. Subject dedup (NEW-file proposals only, and only when ``target_path`` is
+   under ``scripts/`` with a non-``test_`` basename — #903 review B1): a verb
+   paraphrase like "audit repeat failures" vs an existing
+   ``analyze_repeat_failures.py`` clears the plain lexical word-overlap
+   threshold in ``cycle_planning._title_already_done_in_git_log`` (the verb
+   dilutes the overlap). This check instead compares SUBJECT-KEY token sets
+   (generic verbs stripped via the shared #902 ``_SATURATED_VERB_STOPLIST``)
+   between the proposed target's filename stem and each candidate
+   ``scripts/*.py`` filename stem, sourced from
+   ``existence_index.related_scripts`` (queried by title, capped) with a
+   bounded plain-glob fallback when the FTS index is disabled/empty. Match
+   is STRICT SET EQUALITY (#903 review M2) — not subset/overlap — so e.g.
+   ``summarize_repeat_failures_weekly`` (a superset subject) does NOT match
+   ``repeat_failures``, and two single-token subjects sharing nothing else
+   do NOT falsely merge.
 2. Edit budget (EDIT proposals targeting ``scripts/`` only): a target with
    ``>= M`` git commits since its usage-sidecar ``last_used`` timestamp (or
    since creation, if never confirmed used) is rejected — demonstrate usage
-   or pick a different target. A confirmed use resets the window.
+   or pick a different target. A confirmed use resets the window. The
+   never-used (full-history) branch excludes the file's own creation commit
+   from the count (#903 review m1) — a file's creation is not itself an
+   "unconfirmed revision".
 
 See the #903 docstrings in ``llm_proposer.py`` for the full design
-rationale and the #798/#834 guards this complements without touching.
+rationale and the #798/#834/#757 guards this complements without touching.
 """
 from __future__ import annotations
 
@@ -161,11 +170,10 @@ class TestSubjectDedupGlobFallback:
         assert dup is False
 
     def test_distinct_subjects_sharing_generic_tail_do_not_merge(self, tmp_path):
-        """'usage' is not a stoplisted verb, so check_disk_usage and
-        audit_memory_usage share only the generic tail token 'usage' (1
-        overlap) — below the >=2-token-overlap bar, and neither's subject
-        set is a subset of the other's ({'disk','usage'} vs
-        {'memory','usage'})."""
+        """Equality, not overlap: check_disk_usage's subject-key set is
+        {'disk', 'usage'} (check stripped) and audit_memory_usage's is
+        {'memory', 'usage'} (audit stripped) — they share 'usage' but are
+        NOT equal sets, so they must not match."""
         repo = _init_repo_with_scripts(tmp_path, ["scripts/check_disk_usage.py"])
         state = _state_dir(tmp_path)
         proposal = {
@@ -174,6 +182,96 @@ class TestSubjectDedupGlobFallback:
         }
         dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
         assert dup is False
+
+    def test_superset_subject_not_falsely_merged(self, tmp_path):
+        """#903 review M2: a subset/overlap rule would have wrongly blocked
+        this (repeat_failures subset-of summarize_repeat_failures_weekly).
+        Strict equality correctly treats a broader subject as genuinely new."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create summarize_repeat_failures_weekly.py",
+            "target_path": "scripts/summarize_repeat_failures_weekly.py",
+        }
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("subject-duplicate:")
+
+    def test_single_token_verb_paraphrase_blocked(self, tmp_path):
+        """detect_drift and monitor_drift both key to the single-token
+        subject {'drift'} once their stoplisted verbs are stripped — equal
+        sets, so this must still be caught even though there's only one
+        subject token."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/detect_drift.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create monitor_drift.py to monitor drift",
+            "target_path": "scripts/monitor_drift.py",
+        }
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert "detect_drift.py" in feedback
+        assert matched == "subject-duplicate:scripts/detect_drift.py"
+
+    def test_unrelated_single_token_subjects_not_merged(self, tmp_path):
+        """parse_drift's subject-key set is {'parse', 'drift'} ('parse' is
+        not a stoplisted verb) and monitor_disk's is {'disk'} ('monitor'
+        stripped) — disjoint, must not match."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/parse_drift.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create monitor_disk.py to monitor disk",
+            "target_path": "scripts/monitor_disk.py",
+        }
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("subject-duplicate:")
+
+
+# ─── Feature 1 scope gate (#903 review B1): non-scripts/ and test_ targets ─
+
+
+class TestSubjectDedupScopeGate:
+    """The subject-dedup check must apply ONLY to scripts/-target, non-test_
+    proposals. A tests-for-X proposal legitimately shares subject tokens
+    with the script it tests (#757 test-for-X carve-out) — that is coverage,
+    not churn, and must never be flagged here. docs/, memory/, lessons/
+    targets are simply out of scope."""
+
+    def test_new_tests_file_targeting_existing_scripts_subject_not_blocked(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create tests for analyze_repeat_failures.py",
+            "target_path": "tests/test_analyze_repeat_failures.py",
+        }
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("subject-duplicate:")
+
+    def test_scripts_test_prefixed_target_not_blocked(self, tmp_path):
+        """Belt-and-suspenders: a scripts/test_*.py target (not under
+        tests/) is also exempt via the basename check."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create test_analyze_repeat_failures.py",
+            "target_path": "scripts/test_analyze_repeat_failures.py",
+        }
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("subject-duplicate:")
+
+    def test_new_docs_file_same_subject_not_blocked(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Document repeat failures analysis approach",
+            "target_path": "docs/repeat_failures_notes.md",
+        }
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("subject-duplicate:")
 
     def test_edit_proposal_never_hits_subject_dedup(self, tmp_path):
         """The new-file gate must be respected: an EDIT of an existing file
@@ -292,19 +390,36 @@ class TestEditBudget:
         dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
         assert dup is False
 
-    def test_never_used_counts_full_history(self, tmp_path):
+    def test_never_used_counts_full_history_minus_creation_commit(self, tmp_path):
+        """#903 review m1: the full-history count excludes the file's own
+        creation (seed) commit — seed + 5 edits = 6 raw git-log lines, but
+        the reported/compared count is 5 (>= default M=5 -> blocked)."""
         repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
         state = _state_dir(tmp_path)
-        # No usage sidecar at all -> never used -> full-history count,
-        # which already includes the seed commit + 5 more = 6 >= default M=5.
+        # No usage sidecar at all -> never used -> full-history count.
         for i in range(5):
             _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}")
 
         proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
         dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
         assert dup is True
+        assert "5 revisions" in feedback
         assert "creation" in feedback
         assert matched == "edit-budget:scripts/flaky_tool.py"
+
+    def test_never_used_below_m_after_creation_commit_excluded_passes(self, tmp_path):
+        """#903 review m1: seed + 4 edits = 5 raw git-log lines, but the
+        creation-commit-adjusted count is 4 (< default M=5 -> NOT blocked).
+        Before the fix this would have wrongly counted 5 and blocked."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        for i in range(4):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("edit-budget:")
 
     def test_m_env_override(self, tmp_path, monkeypatch):
         monkeypatch.setenv(EDIT_BUDGET_M_ENV, "2")

--- a/tests/test_llm_proposer_dedup_budget.py
+++ b/tests/test_llm_proposer_dedup_budget.py
@@ -1,0 +1,468 @@
+"""Tests for #903: verb-invariant subject dedup (existence_index) + per-file
+edit budget without confirmed use.
+
+Two additions to ``llm_proposer._is_duplicate_proposal``, both fail-open and
+gated on ``_proposal_creates_new_file``:
+
+1. Subject dedup (NEW-file proposals only): a verb paraphrase like "audit
+   repeat failures" vs an existing ``analyze_repeat_failures.py`` clears the
+   plain lexical word-overlap threshold in
+   ``cycle_planning._title_already_done_in_git_log`` (the verb dilutes the
+   overlap). This check instead compares SUBJECT tokens (generic verbs
+   stripped via the shared #902 ``_SATURATED_VERB_STOPLIST``) between the
+   proposal and candidate ``scripts/*.py`` files, sourced from
+   ``existence_index.related_scripts`` with a bounded plain-glob fallback
+   when the FTS index is disabled/empty.
+2. Edit budget (EDIT proposals targeting ``scripts/`` only): a target with
+   ``>= M`` git commits since its usage-sidecar ``last_used`` timestamp (or
+   since creation, if never confirmed used) is rejected — demonstrate usage
+   or pick a different target. A confirmed use resets the window.
+
+See the #903 docstrings in ``llm_proposer.py`` for the full design
+rationale and the #798/#834 guards this complements without touching.
+"""
+from __future__ import annotations
+
+import json
+import subprocess as sp
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import existence_index as ei
+from nanobot.runtime import llm_proposer
+from tests.test_llm_proposer import _state_dir, _write_goal_text, _write_usage_sidecar
+
+SUBJECT_DEDUP_ENV = llm_proposer._SUBJECT_DEDUP_ENABLED_ENV
+EDIT_BUDGET_M_ENV = llm_proposer._EDIT_BUDGET_M_ENV
+
+# A commit date safely before every ``last_used`` timestamp used in this
+# module's edit-budget fixtures, so the repo-creation "seed" commit (which
+# necessarily touches every fixture script) never itself counts toward a
+# budget window that starts at a LATER last_used.
+_SEED_COMMIT_DATE = "2018-01-01T00:00:00"
+
+
+@pytest.fixture(autouse=True)
+def _existence_index_disabled_by_default(monkeypatch):
+    """The FTS existence index defaults to ENABLED
+    (``existence_index.existence_index_enabled()`` is True unless the env
+    var is explicitly "0"). Disable it by default across this module so
+    most tests deterministically exercise the glob-fallback path regardless
+    of whether this Python's sqlite3 build has FTS5 compiled in.
+    ``TestSubjectDedupViaExistenceIndex`` explicitly re-enables it within
+    its own test body (same ``monkeypatch`` fixture instance, so the later
+    ``setenv`` call wins)."""
+    monkeypatch.setenv(ei.ENABLED_ENV, "0")
+
+
+# ─── repo/script fixtures ───────────────────────────────────────────────────
+
+
+def _git(repo: Path, *args: str, env: dict | None = None) -> None:
+    sp.run(["git", "-C", str(repo), *args], capture_output=True, env=env, check=False)
+
+
+def _init_repo_with_scripts(tmp_path: Path, scripts: list[str]) -> Path:
+    """Minimal git repo (one commit) with each of ``scripts`` (repo-relative
+    paths under scripts/) present as a placeholder file."""
+    import os as _os
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = dict(_os.environ)
+    env.setdefault("GIT_AUTHOR_NAME", "t")
+    env.setdefault("GIT_AUTHOR_EMAIL", "t@t")
+    env.setdefault("GIT_COMMITTER_NAME", "t")
+    env.setdefault("GIT_COMMITTER_EMAIL", "t@t")
+    _git(repo, "init", "-b", "main", env=env)
+    _git(repo, "config", "user.email", "t@t", env=env)
+    _git(repo, "config", "user.name", "t", env=env)
+    for rel in scripts:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f'"""placeholder for {rel}."""\n', encoding="utf-8")
+    _git(repo, "add", "-A", env=env)
+    # Dated safely in the past (see _SEED_COMMIT_DATE) so this seed commit —
+    # which necessarily touches every fixture script — never itself counts
+    # toward an edit-budget window that starts at a later last_used.
+    seed_env = dict(env)
+    seed_env["GIT_AUTHOR_DATE"] = _SEED_COMMIT_DATE
+    seed_env["GIT_COMMITTER_DATE"] = _SEED_COMMIT_DATE
+    sp.run(["git", "-C", str(repo), "commit", "-m", "seed"], capture_output=True, env=seed_env, check=False)
+    return repo
+
+
+def _commit_file_change(repo: Path, rel: str, message: str, iso_date: str | None = None) -> None:
+    """Append a line to rel and commit it, optionally at a fixed author/
+    committer date (so tests can control commit timestamps precisely)."""
+    import os as _os
+
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(f"# {message}\n")
+    env = dict(_os.environ)
+    env.setdefault("GIT_AUTHOR_NAME", "t")
+    env.setdefault("GIT_AUTHOR_EMAIL", "t@t")
+    env.setdefault("GIT_COMMITTER_NAME", "t")
+    env.setdefault("GIT_COMMITTER_EMAIL", "t@t")
+    if iso_date:
+        env["GIT_AUTHOR_DATE"] = iso_date
+        env["GIT_COMMITTER_DATE"] = iso_date
+    _git(repo, "add", "-A", env=env)
+    sp.run(["git", "-C", str(repo), "commit", "-m", message], capture_output=True, env=env, check=False)
+
+
+def _fts5_available(tmp_path: Path) -> bool:
+    """Best-effort probe: True when a reindex against a throwaway state/repo
+    pair succeeds without an 'error' key (FTS5 compiled into this Python's
+    sqlite3)."""
+    state_dir = tmp_path / "_fts5_probe_state"
+    repo = tmp_path / "_fts5_probe_repo"
+    repo.mkdir(parents=True)
+    try:
+        counts = ei.reindex(state_dir, repo)
+    except Exception:
+        return False
+    return "error" not in counts
+
+
+# ─── Feature 1: verb-invariant subject dedup (glob fallback) ───────────────
+
+
+class TestSubjectDedupGlobFallback:
+    """FTS index left at its default (disabled unless SELFEVO_EXISTENCE_INDEX_ENABLED
+    is set), so related_scripts() returns [] and the glob fallback path runs."""
+
+    def test_verb_paraphrase_new_file_rejected(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create audit_repeat_failures.py to audit repeat failures",
+            "target_path": "scripts/audit_repeat_failures.py",
+        }
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert "analyze_repeat_failures.py" in feedback
+        assert matched == "subject-duplicate:scripts/analyze_repeat_failures.py"
+
+    def test_genuinely_new_subject_not_rejected(self, tmp_path):
+        repo = _init_repo_with_scripts(
+            tmp_path,
+            ["scripts/analyze_repeat_failures.py", "scripts/check_repeat_failures.py"],
+        )
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "create parse_release_notes.py to parse release notes",
+            "target_path": "scripts/parse_release_notes.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_distinct_subjects_sharing_generic_tail_do_not_merge(self, tmp_path):
+        """'usage' is not a stoplisted verb, so check_disk_usage and
+        audit_memory_usage share only the generic tail token 'usage' (1
+        overlap) — below the >=2-token-overlap bar, and neither's subject
+        set is a subset of the other's ({'disk','usage'} vs
+        {'memory','usage'})."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/check_disk_usage.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "create audit_memory_usage.py to audit memory usage",
+            "target_path": "scripts/audit_memory_usage.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_edit_proposal_never_hits_subject_dedup(self, tmp_path):
+        """The new-file gate must be respected: an EDIT of an existing file
+        whose title paraphrases another existing script's subject must not
+        be flagged by the subject-dedup check (it may still be governed by
+        the (unrelated) edit-budget check, which needs >= M commits to
+        fire — a single fixture commit is far under the default M=5)."""
+        repo = _init_repo_with_scripts(
+            tmp_path,
+            ["scripts/analyze_repeat_failures.py", "scripts/audit_repeat_failures.py"],
+        )
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "audit repeat failures more thoroughly",
+            "target_path": "scripts/audit_repeat_failures.py",  # EXISTS -> edit
+        }
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+        assert not matched.startswith("subject-duplicate:")
+
+    def test_kill_switch_disables_subject_check(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(SUBJECT_DEDUP_ENV, "0")
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create audit_repeat_failures.py to audit repeat failures",
+            "target_path": "scripts/audit_repeat_failures.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_kill_switch_accepts_false_too(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(SUBJECT_DEDUP_ENV, "false")
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create audit_repeat_failures.py to audit repeat failures",
+            "target_path": "scripts/audit_repeat_failures.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_no_selfevo_repo_fails_open(self, tmp_path):
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create audit_repeat_failures.py to audit repeat failures",
+            "target_path": "scripts/audit_repeat_failures.py",
+        }
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, None, proposal)
+        assert dup is False
+
+
+# ─── Feature 1: through the real existence_index (FTS route) ───────────────
+
+
+class TestSubjectDedupViaExistenceIndex:
+    def test_verb_paraphrase_rejected_via_fts_index(self, tmp_path, monkeypatch):
+        if not _fts5_available(tmp_path / "probe"):
+            pytest.skip("sqlite3 build lacks FTS5 support")
+        monkeypatch.setenv(ei.ENABLED_ENV, "1")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        script = repo / "scripts" / "analyze_repeat_failures.py"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text('"""Analyze repeat failures across the ledger."""\n', encoding="utf-8")
+
+        state = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Create audit_repeat_failures.py to audit repeat failures",
+            "target_path": "scripts/audit_repeat_failures.py",
+        }
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert "analyze_repeat_failures.py" in feedback
+        assert matched == "subject-duplicate:scripts/analyze_repeat_failures.py"
+
+
+# ─── Feature 2: per-file edit budget without confirmed use ─────────────────
+
+
+class TestEditBudget:
+    def test_at_or_above_m_commits_since_last_used_rejected(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        _write_usage_sidecar(state, {"scripts/flaky_tool.py": {"last_used": "2020-01-01T00:00:00+00:00"}})
+        for i in range(5):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}", iso_date="2021-01-01T00:00:00")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert "5 revisions" in feedback
+        assert matched == "edit-budget:scripts/flaky_tool.py"
+
+    def test_below_m_commits_passes(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        _write_usage_sidecar(state, {"scripts/flaky_tool.py": {"last_used": "2020-01-01T00:00:00+00:00"}})
+        for i in range(4):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}", iso_date="2021-01-01T00:00:00")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_last_used_after_commits_resets_budget(self, tmp_path):
+        """A confirmed use stamped AFTER all the revision commits resets the
+        window to zero — the count since last_used is 0, well under M."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        for i in range(5):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}", iso_date="2021-01-01T00:00:00")
+        _write_usage_sidecar(state, {"scripts/flaky_tool.py": {"last_used": "2099-01-01T00:00:00+00:00"}})
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_never_used_counts_full_history(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        # No usage sidecar at all -> never used -> full-history count,
+        # which already includes the seed commit + 5 more = 6 >= default M=5.
+        for i in range(5):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert "creation" in feedback
+        assert matched == "edit-budget:scripts/flaky_tool.py"
+
+    def test_m_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(EDIT_BUDGET_M_ENV, "2")
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        _write_usage_sidecar(state, {"scripts/flaky_tool.py": {"last_used": "2020-01-01T00:00:00+00:00"}})
+        for i in range(2):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}", iso_date="2021-01-01T00:00:00")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+
+    def test_invalid_m_env_defaults_to_five(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(EDIT_BUDGET_M_ENV, "not-a-number")
+        assert llm_proposer._edit_budget_m() == 5
+
+    def test_m_zero_disables_check(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(EDIT_BUDGET_M_ENV, "0")
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        _write_usage_sidecar(state, {"scripts/flaky_tool.py": {"last_used": "2020-01-01T00:00:00+00:00"}})
+        for i in range(10):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}", iso_date="2021-01-01T00:00:00")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_new_file_proposal_never_hits_edit_budget(self, tmp_path):
+        """The edit-budget check is gated on NOT _proposal_creates_new_file
+        — a brand-new target_path (however many times some OTHER file has
+        been revised) must never be blocked by this check."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        for i in range(10):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}")
+
+        proposal = {"task_title": "create brand new helper", "target_path": "scripts/brand_new_helper.py"}
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert not matched.startswith("edit-budget:")
+
+    def test_non_scripts_target_not_checked(self, tmp_path):
+        repo = _init_repo_with_scripts(tmp_path, ["docs/notes.md"])
+        state = _state_dir(tmp_path)
+        for i in range(10):
+            _commit_file_change(repo, "docs/notes.md", f"revision {i}")
+
+        proposal = {"task_title": "update notes further", "target_path": "docs/notes.md"}
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert not matched.startswith("edit-budget:")
+
+    def test_fail_open_git_unavailable(self, tmp_path, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise RuntimeError("git not found")
+
+        import subprocess as _sp
+
+        monkeypatch.setattr(_sp, "check_output", _boom)
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_fail_open_git_timeout(self, tmp_path, monkeypatch):
+        def _timeout(*args, **kwargs):
+            raise sp.TimeoutExpired(cmd="git", timeout=10)
+
+        import subprocess as _sp
+
+        monkeypatch.setattr(_sp, "check_output", _timeout)
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_unreadable_sidecar_treated_as_never_used_but_still_fail_open_on_git_error(self, tmp_path, monkeypatch):
+        """An unreadable/malformed sidecar degrades to '{}' (never used) per
+        _load_inventory_usage_entries's own fail-open contract; separately, a
+        git failure on top of that still fails open to 'not a duplicate'."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        usage_dir = state / "usage"
+        usage_dir.mkdir(parents=True)
+        (usage_dir / "last_used.json").write_text("{not valid json", encoding="utf-8")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        import subprocess as _sp
+
+        monkeypatch.setattr(_sp, "check_output", _boom)
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is False
+
+    def test_no_selfevo_repo_fails_open(self, tmp_path):
+        state = _state_dir(tmp_path)
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, _ = llm_proposer._is_duplicate_proposal(state, None, proposal)
+        assert dup is False
+
+
+# ─── ledger contract: matched_against prefixes recorded via reject path ────
+
+
+class TestLedgerContract:
+    def test_subject_duplicate_matched_against_recorded_via_maybe_propose(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(llm_proposer.ENABLED_ENV, "1")
+        from nanobot.runtime import demand as demand_mod
+
+        monkeypatch.setenv(demand_mod.ENABLED_ENV, "0")
+        monkeypatch.setattr(llm_proposer, "_idle_recorded_this_process", False)
+
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/analyze_repeat_failures.py"])
+        state = _state_dir(tmp_path)
+        _write_goal_text(state, "no priority section, so should_propose is True")
+
+        calls = {"n": 0}
+
+        def _fake_propose(context, *, rejection_reason=None, timeout=120.0, **kwargs):
+            calls["n"] += 1
+            return {
+                "task_title": "Create audit_repeat_failures.py to audit repeat failures",
+                "rationale": "closes a gap",
+                "target_path": "scripts/audit_repeat_failures.py",
+                "serves": "priority 1",
+            }
+
+        monkeypatch.setattr(llm_proposer, "propose", _fake_propose)
+        result = llm_proposer.maybe_propose(state, repo)
+        assert result is None  # rejected both the initial try and the retry
+
+        rows = [
+            json.loads(line)
+            for line in (state / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        reject_rows = [r for r in rows if r.get("phase") == "proposer_reject" and r.get("reason") == "self_dedup"]
+        assert reject_rows
+        assert any(
+            str(r.get("matched_against", "")).startswith("subject-duplicate:") for r in reject_rows
+        )
+
+    def test_edit_budget_matched_against_recorded_via_direct_guard_call(self, tmp_path):
+        """Matches the granularity of the existing #834/#878 direct-guard
+        tests in tests/test_llm_proposer.py (they assert on
+        _is_duplicate_proposal's own return value rather than driving the
+        full maybe_propose LLM-retry loop)."""
+        repo = _init_repo_with_scripts(tmp_path, ["scripts/flaky_tool.py"])
+        state = _state_dir(tmp_path)
+        _write_usage_sidecar(state, {"scripts/flaky_tool.py": {"last_used": "2020-01-01T00:00:00+00:00"}})
+        for i in range(5):
+            _commit_file_change(repo, "scripts/flaky_tool.py", f"revision {i}", iso_date="2021-01-01T00:00:00")
+
+        proposal = {"task_title": "improve flaky tool further", "target_path": "scripts/flaky_tool.py"}
+        dup, _, matched = llm_proposer._is_duplicate_proposal(state, repo, proposal)
+        assert dup is True
+        assert matched.startswith("edit-budget:")


### PR DESCRIPTION
## Problem

The proposer's duplicate detection (`llm_proposer._is_duplicate_proposal` -> `cycle_planning._title_already_done_in_git_log`) is purely lexical: a title only counts as a duplicate when >= `max(2, ceil(0.6*N))` of its 4+-letter words appear together on one git-log/recent-titles line. A verb paraphrase clears that bar: `check_repeat_failures.py` and `audit_repeat_failures.py` were both created in one morning alongside the pre-existing `analyze_repeat_failures.py` and `prevent_repeat_failures.py` — four scripts, one concern, because verbs like check/audit/analyze/prevent dilute word overlap below threshold.

Separately, the #834 permanent novelty guard exempts edits by design ("edits are iteration, not churn"). Unbounded, that exemption lets the loop re-edit the same file indefinitely: `analyze_repeat_failures.py` has 35 commits with no confirmed usage, and `archive_old_reports.py` keeps being re-proposed as near-identical rewrites.

## What changed

Two additions to `nanobot/runtime/llm_proposer.py::_is_duplicate_proposal`, both fail-open (any exception -> `(False, "", "")`, never blocks a cycle):

1. **Verb-invariant subject dedup** (NEW-file proposals only, gated on `_proposal_creates_new_file`): strips a fixed generic-verb stoplist (reusing #902's `_SATURATED_VERB_STOPLIST` rather than duplicating it) from the proposal's title + proposed filename stem, and from each candidate script's filename stem, then flags a duplicate when the candidate's subject-token set is a subset of the proposal's, or the two share >= 2 tokens. Candidates come from `existence_index.related_scripts(state_dir, selfevo_repo, title)` — queried with the **bare title, deliberately without `target_path`** — falling back to a bounded plain `scripts/*.py` glob when the FTS index is disabled or returns nothing. Kill switch: `SELFEVO_SUBJECT_DEDUP_ENABLED` (default on; `"0"`/`"false"` disables).
2. **Per-file edit budget without confirmed use** (EDIT proposals targeting `scripts/` only): looks up the target's usage-evidence sidecar (#862) `last_used` timestamp, counts git commits touching the target since then (full history when never confirmed used), and rejects when the count is `>= M`. A confirmed use resets the window automatically — the count starts at `last_used`, so no new state file is needed. Default `M=5`, env `SELFEVO_EDIT_BUDGET_M` (invalid -> 5, `M<=0` disables).

Both checks return the same `(bool, feedback, matched_against)` shape as the existing guard, so `proposer_reject`/`self_dedup` ledger rows record `matched_against` prefixed `subject-duplicate:<path>` / `edit-budget:<path>` through the existing (unchanged) reject/ledger pipeline.

## Why the bridge's existing FTS gate doesn't already cover this

`existence_index.find_duplicate_script` (the bridge's pre-spawn gate, bridge.py:1917) is called with the proposal's own `target_path`. Per #798, when `target_path` names a concrete non-test script, hits at a **different** path are deliberately never matched — that's the cross-target precision fix from #798, and it's exactly why a new-file paraphrase proposal (`check_repeat_failures.py` targeting a path that doesn't exist yet, when `analyze_repeat_failures.py` already exists at a different path) sails through the bridge gate today. This PR's subject-dedup check queries `related_scripts` with **no `target_path`** by construction, so it isn't exempted by #798 and can catch exactly this case — without touching `bridge.py` or `existence_index.py`, so #798's behavior there is unchanged.

## Test evidence

New file `tests/test_llm_proposer_dedup_budget.py` (23 tests, all passing): verb-paraphrase rejection via the glob fallback and via a real populated FTS index, a genuinely-new subject passing, distinct subjects sharing only a generic tail not falsely merging, edit proposals never hitting subject-dedup, the subject-dedup kill switch, edit-budget rejection at/above M, below-M passing, last-used-after-commits resetting the budget to 0, never-used counting full history, the M env override (including invalid->5 and M=0 disabling), new-file proposals never hitting the edit-budget check, non-`scripts/` targets skipped, fail-open on git subprocess error/timeout and on an unreadable usage sidecar, and a ledger-contract test asserting `matched_against` prefixes flow through `maybe_propose`'s existing `proposer_reject`/`self_dedup` recording path.

Full-suite comparison (Windows sandbox; 13 test files that spawn nested pytest subprocesses excluded identically from both runs per known environment constraints — see PR discussion if needed):
- **Baseline** (clean HEAD, `git stash`): 30 failed, 2150 passed, 6 skipped
- **After this change**: 29 failed, 2174 passed, 6 skipped

The 24 additional passes are the 23 new tests plus one pre-existing flaky/order-independent test (`test_commands.py::test_runtime_state_prefers_newest_evolution_report`, unrelated to this change — an evolution-report-selection test) that flipped from fail to pass between runs. **Zero new failures** introduced; every baseline failure is still present and unrelated to `llm_proposer.py` (autoevolve git/symlink handling, CLI branding, web-search optional deps, bridge file-locking — all pre-existing Windows-sandbox environment issues).

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)