### PR TITLE
feat(host): all_local preset — fully local qwen profile (#908)

### DIFF
--- a/host/eeepc/etc/presets/all_local.env
+++ b/host/eeepc/etc/presets/all_local.env
@@ -1,0 +1,51 @@
+# Operator preset (#908): "all_local" — local qwen proposer AND local qwen
+# executor. Zero-token-cost profile: every role runs on the free local model,
+# so this preset is also the harness for A/B-ing local proposer quality
+# against `local_qwen` (which pairs the same local executor with a paid
+# gemini-3.7-flash proposer) under the same guards (rotation #902, subject
+# dedup + edit budget #903).
+#
+# What presets are: a named bundle of the knobs that together define one
+# operating profile (which models run which role, how often cycles fire, how
+# much per-cycle tool budget the executor gets). Instead of editing several
+# files across the host to switch profiles, an operator activates one preset
+# file as a unit.
+#
+# Activation: `sudo host/eeepc/scripts/apply_preset.sh all_local` (run on the
+# host). This repoints the /etc/eeepc-agent/preset.env symlink at this file,
+# materializes/removes the systemd timer drop-in derived from
+# SELFEVO_CYCLE_PAUSE, and reloads systemd.
+#
+# Precedence: the bridge service unit loads this preset file BEFORE the
+# per-instance env file (/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env).
+# systemd EnvironmentFile= entries apply in listed order and later files win
+# per-variable — so any variable set in the instance file still overrides the
+# same variable set here. This preset only fills in values the instance file
+# leaves unset. Concretely: any UNCOMMENTED model var in the instance env
+# (SUBAGENT_BRIDGE_MODEL / SELFEVO_PROPOSER_MODEL) silently overrides this
+# preset's model choice — activating this preset's models requires those
+# instance-env vars to stay commented (apply_preset.sh warns if they aren't).
+
+# Label for telemetry only (surfaces in the scorecard control_plane snapshot
+# as SELFEVO_PRESET) — not read anywhere else.
+SELFEVO_PRESET=all_local
+# Proposer role (the reasoning step that decides WHAT to improve): the local
+# qwen model instead of a paid remote model — zero token cost, and the data
+# point this preset exists to collect (proposer quality vs. `local_qwen`'s
+# gemini-3.7-flash proposer). The `openai/` prefix is kept for consistency
+# with `local_qwen.env`; model_registry already strips it for this role.
+SELFEVO_PROPOSER_MODEL=openai/un/qwen3.8-27b-gguf
+# Executor/harness role (the code-writing step, runs every cycle): the local
+# qwen model — free tokens, so it can afford deeper cycles (see the
+# iteration cap below).
+SUBAGENT_BRIDGE_MODEL=openai/un/qwen3.8-27b-gguf
+# Cycle cadence: N after the PREVIOUS cycle ENDS (translated by
+# apply_preset.sh into OnUnitActiveSec=<blank> + OnUnitInactiveSec=<this>),
+# not N after the previous cycle STARTS — self-adapting to cycle length so a
+# slow cycle never gets started_time.
+SELFEVO_CYCLE_PAUSE=3m
+# Per-spawn tool-iteration cap (read by nanobot.runtime.model_registry.
+# resolve_max_tool_iterations at both bridge spawn sites). Higher than the
+# static config default (40) because local tokens are free and cycles were
+# observed truncating at the cap.
+SELFEVO_MAX_TOOL_ITERATIONS=80

--- a/host/eeepc/etc/presets/all_local.env
+++ b/host/eeepc/etc/presets/all_local.env
@@ -42,7 +42,7 @@ SUBAGENT_BRIDGE_MODEL=openai/un/qwen3.8-27b-gguf
 # Cycle cadence: N after the PREVIOUS cycle ENDS (translated by
 # apply_preset.sh into OnUnitActiveSec=<blank> + OnUnitInactiveSec=<this>),
 # not N after the previous cycle STARTS — self-adapting to cycle length so a
-# slow cycle never gets started_time.
+# slow cycle never causes overlapping starts.
 SELFEVO_CYCLE_PAUSE=3m
 # Per-spawn tool-iteration cap (read by nanobot.runtime.model_registry.
 # resolve_max_tool_iterations at both bridge spawn sites). Higher than the


### PR DESCRIPTION
## Purpose

Adds a fully local operator preset — qwen for both the proposer AND executor
roles — to run at zero token cost and to A/B proposer quality against
`local_qwen` (local executor + paid gemini-3.7-flash proposer) under the same
guards (rotation #902, subject dedup + edit budget #903).

## File

`host/eeepc/etc/presets/all_local.env` (new):

- `SELFEVO_PRESET=all_local`
- `SELFEVO_PROPOSER_MODEL=openai/un/qwen3.8-27b-gguf`
- `SUBAGENT_BRIDGE_MODEL=openai/un/qwen3.8-27b-gguf`
- `SELFEVO_CYCLE_PAUSE=3m`
- `SELFEVO_MAX_TOOL_ITERATIONS=80`

Same header/comment conventions as `local_qwen.env`: preset ownership,
activation via `sudo apply_preset.sh all_local`, and the instance-env
override/precedence note. The `openai/` prefix is kept on the proposer model
for consistency with `local_qwen.env` — model_registry already strips it for
that role, so no runtime change is required.

No python/runtime changes. `local_qwen.env` and all other files are untouched.

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)