### PR TITLE
feat(host): all_gemini preset — move executor off the local model (#917)

### DIFF
--- a/host/eeepc/etc/presets/all_gemini.env
+++ b/host/eeepc/etc/presets/all_gemini.env
@@ -1,0 +1,46 @@
+# Operator preset (#917): "all_gemini" — gemini-3.7-flash-high for BOTH the
+# proposer and the executor. Frees the local qwen model/host entirely for
+# operator-driven test runs; the self-evolving loop makes no local-model
+# calls under this profile.
+#
+# Cost posture: the executor is a PAID model here, so cadence and the
+# per-cycle tool budget deliberately revert to near-original pacing
+# (12m pause after each cycle END, stock 40-iteration cap) instead of
+# local_qwen's free-token 3m/80 profile.
+#
+# What presets are: a named bundle of the knobs that together define one
+# operating profile (which models run which role, how often cycles fire, how
+# much per-cycle tool budget the executor gets). An operator activates one
+# preset file as a unit instead of editing several files across the host.
+#
+# Activation: `sudo host/eeepc/scripts/apply_preset.sh all_gemini` (run on the
+# host). This repoints the /etc/eeepc-agent/preset.env symlink at this file,
+# materializes/removes the systemd timer drop-in derived from
+# SELFEVO_CYCLE_PAUSE, and reloads systemd.
+#
+# Precedence: the bridge service unit loads this preset file BEFORE the
+# per-instance env file (/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env).
+# systemd EnvironmentFile= entries apply in listed order and later files win
+# per-variable — any UNCOMMENTED model var in the instance env silently
+# overrides this preset's model choice; activating this preset's models
+# requires those instance-env vars to stay commented (apply_preset.sh warns
+# if they aren't).
+
+# Label for telemetry only (surfaces in the scorecard control_plane snapshot
+# as SELFEVO_PRESET) — not read anywhere else.
+SELFEVO_PRESET=all_gemini
+# Proposer role (the reasoning step that decides WHAT to improve). The
+# `openai/` prefix is kept for consistency with sibling presets;
+# model_registry already strips it for this role.
+SELFEVO_PROPOSER_MODEL=openai/an/gemini-3.7-flash-high
+# Executor/harness role (the code-writing step, runs every cycle) — the same
+# paid remote model; the local qwen backend is intentionally NOT used.
+SUBAGENT_BRIDGE_MODEL=openai/an/gemini-3.7-flash-high
+# Cycle cadence: N after the PREVIOUS cycle ENDS (translated by
+# apply_preset.sh into OnUnitActiveSec=<blank> + OnUnitInactiveSec=<this>).
+# 12m ~= the original 15m start-to-start tempo — paid tokens, bounded spend.
+SELFEVO_CYCLE_PAUSE=12m
+# Per-spawn tool-iteration cap (read by nanobot.runtime.model_registry.
+# resolve_max_tool_iterations at both bridge spawn sites). Stock config
+# default — deeper 80-iteration cycles are a free-local-token luxury.
+SELFEVO_MAX_TOOL_ITERATIONS=40


### PR DESCRIPTION
New operator preset `all_gemini`: proposer AND executor on `an/gemini-3.7-flash-high`, freeing the local qwen backend for operator test runs. Deliberately conservative profile for a paid executor: `SELFEVO_CYCLE_PAUSE=12m`, `SELFEVO_MAX_TOOL_ITERATIONS=40` (vs local_qwen's free-token 3m/80). Single env template, same conventions as sibling presets, no runtime changes.

Sourcing sanity-checked; activation on the host follows after merge+deploy via `apply_preset.sh all_gemini`.

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)