### PR TITLE
fix(host): import archive-subagent-requests units into repo templates (#915)

### DIFF
--- a/host/eeepc/scripts/install.sh
+++ b/host/eeepc/scripts/install.sh
@@ -255,6 +255,7 @@ enable_timers() {
   local timers=(
     eeepc-self-evolving-subagent-bridge.timer
     eeepc-promotion-verifier.timer
+    eeebot-archive-subagent-requests.timer
   )
   for t in "${timers[@]}"; do
     run systemctl enable "$t"

--- a/host/eeepc/systemd/eeebot-archive-subagent-requests.service
+++ b/host/eeepc/systemd/eeebot-archive-subagent-requests.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Archive stale eeebot subagent requests (older than 24h)
+After=network.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+ExecStart=/opt/eeepc-agent/venv/bin/python /opt/eeepc-agent/runtimes/self-evolving-agent/current/scripts/cleanup_subagent_queue.py --state-root /var/lib/eeepc-agent/self-evolving-agent/state

--- a/host/eeepc/systemd/eeebot-archive-subagent-requests.timer
+++ b/host/eeepc/systemd/eeebot-archive-subagent-requests.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run eeebot subagent request archiver hourly
+
+[Timer]
+OnBootSec=10m
+OnUnitActiveSec=1h
+Unit=eeebot-archive-subagent-requests.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Imports the host-only `eeebot-archive-subagent-requests.{service,timer}` verbatim from the live eeepc host into `host/eeepc/systemd/` (they were configuration drift — enabled and running on the host, absent from the repo). `install.sh` enables the timer on fresh installs alongside its sibling timers; `deploy_release.sh` picks the templates up automatically via its existing `*.service`/`*.timer` sync glob.

Verbatim parity with the host was taken from `systemctl cat` output today. No python changes.

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)