### PR TITLE
feat(runtime): re-close the lessons loop — proposer fills lessons_context (#912)

### DIFF
--- a/nanobot/runtime/lessons_context.py
+++ b/nanobot/runtime/lessons_context.py
@@ -1,0 +1,177 @@
+"""Re-close the lessons loop (#912): fill the proposer's ``lessons_context``.
+
+``bridge.py`` (~line 1229) has always been ready to render a
+``relevant_error`` / ``relevant_lesson`` card pair into the executor prompt
+("## Known pitfall ..." / "## Proven approach ..."), but nothing populated
+the field once the coordinator (the old writer, via
+``nanobot.runtime.lessons.LessonsDB.query_for_task``) was decommissioned —
+``llm_proposer.write_request`` hard-coded ``"lessons_context": {}``.
+
+This module is a small, standalone replacement for the read side of that
+old path. It intentionally does NOT import ``nanobot.runtime.lessons``
+(``LessonsDB`` is scheduled for deletion in #916) — it copies just the
+minimal safe-YAML-load logic it needs.
+
+Matching: every proposer request shares the same ``task_id``
+(``llm-proposed-improvement``), so ``LessonsDB.query_for_task``'s
+task_id-based lookup is useless here. Instead this module ranks cards by
+plain word overlap between the proposal's ``task_title`` (+ ``target_path``)
+and each card's ``title``/``category`` (weighted higher) and
+``root_cause``/``approach`` (weighted lower) — the same "4+ letter words,
+proportional/simple overlap" spirit as
+``cycle_planning._title_already_done_in_git_log``, just scoped to a
+handful of YAML cards instead of a git log.
+
+Fail-open everywhere: a missing lessons/ dir, missing/corrupt YAML, a
+missing ``pyyaml``, or any other exception all degrade to ``{}`` — the
+exact pre-#912 behavior (no section rendered).
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+    _YAML_OK = True
+except ImportError:
+    _YAML_OK = False
+
+ENABLED_ENV = "SELFEVO_LESSONS_CONTEXT_ENABLED"
+_FALSY = {"0", "false", "no", "off"}
+
+# Cards scanned per file, capped so a large lessons/errors.yaml can never
+# make request-writing slow. Files grow with newest entries last (plain
+# append order); when over the cap only the newest (tail) slice is scanned.
+_MAX_CARDS_SCANNED = 200
+
+# Minimum total distinct shared words (title/category + root_cause/approach
+# combined) for a card to be considered relevant at all.
+_MIN_SHARED_WORDS = 2
+
+_TITLE_CAP = 200
+_TEXT_CAP = 400
+
+_WORD_RE = re.compile(r"[A-Za-z]{4,}")
+
+
+def _extract_words(text: Any) -> set[str]:
+    return {w.lower() for w in _WORD_RE.findall(str(text or ""))}
+
+
+def _cap(text: Any, limit: int) -> str:
+    return str(text or "")[:limit]
+
+
+def _safe_load_yaml(path: Path) -> list[dict[str, Any]]:
+    """Minimal, standalone re-implementation of lessons.py's loader.
+
+    Returns ``[]`` on any problem (missing file/dir, empty file, malformed
+    YAML, non-list top level) — never raises.
+    """
+    try:
+        if not _YAML_OK or not path.exists():
+            return []
+        text = path.read_text(encoding="utf-8")
+        if not text.strip():
+            return []
+        data = yaml.safe_load(text)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _capped_entries(path: Path) -> list[dict[str, Any]]:
+    entries = [e for e in _safe_load_yaml(path) if isinstance(e, dict)]
+    if len(entries) > _MAX_CARDS_SCANNED:
+        entries = entries[-_MAX_CARDS_SCANNED:]
+    return entries
+
+
+def _score_entry(task_words: set[str], entry: dict[str, Any], secondary_field: str) -> tuple[int, int]:
+    """Return ``(score, shared_word_count)`` for one candidate card.
+
+    ``title`` + ``category`` count double; ``secondary_field``
+    (``root_cause`` for errors, ``approach`` for lessons) counts once.
+    """
+    primary_words = _extract_words(f"{entry.get('title', '')} {entry.get('category', '')}")
+    secondary_words = _extract_words(entry.get(secondary_field, ""))
+    primary_shared = task_words & primary_words
+    secondary_shared = task_words & secondary_words
+    shared_count = len(primary_shared | secondary_shared)
+    score = 2 * len(primary_shared) + len(secondary_shared)
+    return score, shared_count
+
+
+def _best_card(
+    entries: list[dict[str, Any]], task_words: set[str], secondary_field: str
+) -> dict[str, Any] | None:
+    """Highest-scoring card at/above the minimum shared-word threshold.
+
+    Ties resolve to the LAST matching entry in ``entries`` (i.e. the newest,
+    per this module's newest-last file convention) by using ``>=`` when
+    comparing to the running best.
+    """
+    if not task_words:
+        return None
+    best: dict[str, Any] | None = None
+    best_score = -1
+    for entry in entries:
+        score, shared_count = _score_entry(task_words, entry, secondary_field)
+        if shared_count < _MIN_SHARED_WORDS:
+            continue
+        if score >= best_score:
+            best_score = score
+            best = entry
+    return best
+
+
+def build_lessons_context(
+    selfevo_repo: Path | None, task_title: str, target_path: str = ""
+) -> dict[str, Any]:
+    """Return ``{}``, or up to one ``relevant_error`` + one ``relevant_lesson``
+    card selected from the instance repo's ``lessons/errors.yaml`` and
+    ``lessons/lessons.yaml``, shaped exactly as ``bridge.py``'s
+    ``build_task`` renderer expects (see module docstring).
+
+    Never raises: any failure (missing repo, missing/corrupt YAML, missing
+    ``pyyaml``, kill-switch off, etc.) returns ``{}``, matching the field's
+    behavior before #912.
+    """
+    try:
+        raw_enabled = os.environ.get(ENABLED_ENV, "1").strip().lower()
+        if raw_enabled in _FALSY:
+            return {}
+        if not selfevo_repo:
+            return {}
+        task_words = _extract_words(f"{task_title} {target_path}")
+        if not task_words:
+            return {}
+
+        lessons_dir = Path(selfevo_repo) / "lessons"
+
+        result: dict[str, Any] = {}
+
+        err = _best_card(_capped_entries(lessons_dir / "errors.yaml"), task_words, "root_cause")
+        if err:
+            result["relevant_error"] = {
+                "id": err.get("id"),
+                "title": _cap(err.get("title"), _TITLE_CAP),
+                "root_cause": _cap(err.get("root_cause"), _TEXT_CAP),
+                "prevention": _cap(err.get("prevention"), _TEXT_CAP),
+            }
+
+        less = _best_card(_capped_entries(lessons_dir / "lessons.yaml"), task_words, "approach")
+        if less:
+            result["relevant_lesson"] = {
+                "id": less.get("id"),
+                "title": _cap(less.get("title"), _TITLE_CAP),
+                "approach": _cap(less.get("approach"), _TEXT_CAP),
+                "reusable_insight": _cap(less.get("reusable_insight"), _TEXT_CAP),
+            }
+
+        return result
+    except Exception:
+        return {}

--- a/nanobot/runtime/lessons_context.py
+++ b/nanobot/runtime/lessons_context.py
@@ -22,9 +22,20 @@ proportional/simple overlap" spirit as
 ``cycle_planning._title_already_done_in_git_log``, just scoped to a
 handful of YAML cards instead of a git log.
 
-Fail-open everywhere: a missing lessons/ dir, missing/corrupt YAML, a
-missing ``pyyaml``, or any other exception all degrade to ``{}`` — the
-exact pre-#912 behavior (no section rendered).
+On-disk shapes handled (#912 review): ``errors.yaml`` legacy/manual cards
+are a bare top-level YAML list with ``title``/``root_cause``/``prevention``
+fields directly. The LIVE per-cycle writer, ``bridge._write_structured_lesson``
+(bridge.py ~3807-3882), instead writes ``lessons.yaml`` as a top-level
+DICT — ``{'lessons': [...]}`` — and its entries carry NO ``title``/
+``category``/``approach``/``reusable_insight`` at all, only
+``hypothesis``/``result``/``generalized_insight``/``task_id`` (see
+``_normalize_entry``, which maps those onto the canonical fields so
+scoring/rendering can treat every card uniformly). Both writers prepend
+new entries with ``list.insert(0, ...)`` — the list is newest-FIRST.
+
+Fail-open everywhere: a missing lessons/ dir, missing/corrupt YAML, an
+oversized file, a missing ``pyyaml``, or any other exception all degrade
+to ``{}`` — the exact pre-#912 behavior (no section rendered).
 """
 from __future__ import annotations
 
@@ -43,9 +54,14 @@ ENABLED_ENV = "SELFEVO_LESSONS_CONTEXT_ENABLED"
 _FALSY = {"0", "false", "no", "off"}
 
 # Cards scanned per file, capped so a large lessons/errors.yaml can never
-# make request-writing slow. Files grow with newest entries last (plain
-# append order); when over the cap only the newest (tail) slice is scanned.
+# make request-writing slow. Both writers prepend (``insert(0, ...)``), so
+# the file is newest-FIRST — when over the cap, the HEAD slice (the newest
+# entries) is kept, not the tail.
 _MAX_CARDS_SCANNED = 200
+
+# Size guard so "can never slow request-writing" is an honest claim even if
+# lessons/errors.yaml somehow grows huge outside the normal cadence.
+_MAX_FILE_BYTES = 2 * 1024 * 1024
 
 # Minimum total distinct shared words (title/category + root_cause/approach
 # combined) for a card to be considered relevant at all.
@@ -68,33 +84,81 @@ def _cap(text: Any, limit: int) -> str:
 def _safe_load_yaml(path: Path) -> list[dict[str, Any]]:
     """Minimal, standalone re-implementation of lessons.py's loader.
 
-    Returns ``[]`` on any problem (missing file/dir, empty file, malformed
-    YAML, non-list top level) — never raises.
+    Accepts three on-disk shapes: a bare top-level list (legacy manual
+    cards, e.g. today's ``errors.yaml``); a top-level dict wrapping the
+    list under a ``'lessons'`` key or an ``'errors'`` key (the LIVE
+    ``bridge._write_structured_lesson`` shape for ``lessons.yaml``, and a
+    defensive match for any future errors-side writer using the same
+    convention). Any other dict shape, or anything that isn't a list once
+    unwrapped, is treated as unrecognized -> ``[]``.
+
+    Returns ``[]`` on any problem (missing file/dir, empty file, oversized
+    file, malformed YAML, unrecognized top level) — never raises.
     """
     try:
         if not _YAML_OK or not path.exists():
+            return []
+        try:
+            if path.stat().st_size > _MAX_FILE_BYTES:
+                return []
+        except OSError:
             return []
         text = path.read_text(encoding="utf-8")
         if not text.strip():
             return []
         data = yaml.safe_load(text)
-        return data if isinstance(data, list) else []
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("lessons", "errors"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    return value
+            return []
+        return []
     except Exception:
         return []
 
 
+def _normalize_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Fill canonical title/approach/reusable_insight/id fields from the
+    LIVE bridge writer's shape when they're absent.
+
+    ``bridge._write_structured_lesson`` entries carry
+    ``hypothesis``/``result``/``generalized_insight``/``task_id`` and NO
+    ``title``/``category``/``approach``/``reusable_insight`` at all.
+    Legacy ``LessonsDB``-authored cards (today's ``errors.yaml``, and any
+    pre-#912 coordinator-written ``lessons.yaml``) already carry the
+    canonical fields directly and pass through unchanged — this only fills
+    gaps, never overwrites an existing value.
+    """
+    normalized = dict(entry)
+    if not normalized.get("title") and normalized.get("hypothesis"):
+        normalized["title"] = _cap(normalized["hypothesis"], _TITLE_CAP)
+    if not normalized.get("approach") and normalized.get("result"):
+        normalized["approach"] = normalized["result"]
+    if not normalized.get("reusable_insight") and normalized.get("generalized_insight"):
+        normalized["reusable_insight"] = normalized["generalized_insight"]
+    if not normalized.get("id") and normalized.get("task_id"):
+        normalized["id"] = normalized["task_id"]
+    return normalized
+
+
 def _capped_entries(path: Path) -> list[dict[str, Any]]:
     entries = [e for e in _safe_load_yaml(path) if isinstance(e, dict)]
+    # Both writers prepend (insert(0, ...)) -> newest-FIRST. Keep the HEAD
+    # slice (the newest entries), not the tail, when over the scan cap.
     if len(entries) > _MAX_CARDS_SCANNED:
-        entries = entries[-_MAX_CARDS_SCANNED:]
-    return entries
+        entries = entries[:_MAX_CARDS_SCANNED]
+    return [_normalize_entry(e) for e in entries]
 
 
 def _score_entry(task_words: set[str], entry: dict[str, Any], secondary_field: str) -> tuple[int, int]:
     """Return ``(score, shared_word_count)`` for one candidate card.
 
     ``title`` + ``category`` count double; ``secondary_field``
-    (``root_cause`` for errors, ``approach`` for lessons) counts once.
+    (``root_cause`` for errors, ``approach`` for lessons, already
+    normalized onto the entry by ``_normalize_entry``) counts once.
     """
     primary_words = _extract_words(f"{entry.get('title', '')} {entry.get('category', '')}")
     secondary_words = _extract_words(entry.get(secondary_field, ""))
@@ -110,9 +174,10 @@ def _best_card(
 ) -> dict[str, Any] | None:
     """Highest-scoring card at/above the minimum shared-word threshold.
 
-    Ties resolve to the LAST matching entry in ``entries`` (i.e. the newest,
-    per this module's newest-last file convention) by using ``>=`` when
-    comparing to the running best.
+    ``entries`` is newest-first (see ``_capped_entries``). Ties resolve to
+    the EARLIEST matching entry, i.e. the newest card, via a strict ``>``
+    comparison that never lets a later (older) same-score entry replace an
+    earlier (newer) one.
     """
     if not task_words:
         return None
@@ -122,7 +187,7 @@ def _best_card(
         score, shared_count = _score_entry(task_words, entry, secondary_field)
         if shared_count < _MIN_SHARED_WORDS:
             continue
-        if score >= best_score:
+        if score > best_score:
             best_score = score
             best = entry
     return best

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -46,6 +46,7 @@ from nanobot.runtime.cycle_planning import (
     _title_already_done_in_git_log,
     filter_completed_priorities_from_goal_text,
 )
+from nanobot.runtime.lessons_context import build_lessons_context
 from nanobot.runtime.model_registry import resolve_model
 
 ENABLED_ENV = "SELFEVO_LLM_PROPOSER_ENABLED"
@@ -2161,7 +2162,9 @@ def _consecutive_self_dedup_rejects(state_dir: Path) -> int:
         return 0
 
 
-def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
+def write_request(
+    state_dir: Path, proposal: dict[str, Any], selfevo_repo: Path | None = None
+) -> str:
     """Write the request JSON in the ``subagent-request-v1`` shape the
     subagent bridge consumes (#707 C1) — same keys, ``request_status:
     "queued"`` — so the bridge's ``find_pending_request`` picks it up. Since
@@ -2180,6 +2183,13 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
     :func:`validate_sizing` before this is ever called) so the report can
     compute a per-serves-class distribution; deliberately NOT added to the
     request ``payload`` itself, to keep the C1 request-schema stable.
+
+    #912: ``selfevo_repo`` (optional — ``None`` from any caller that lacks
+    it, e.g. legacy tests) is used to select up to one relevant error card
+    and one relevant lesson card via :func:`build_lessons_context`, filling
+    the ``lessons_context`` field that ``bridge.py``'s executor-prompt
+    renderer has always been ready to consume. Fully fail-open: any
+    lookup failure degrades to ``{}``, identical to the pre-#912 hardcode.
     """
     state_dir = Path(state_dir)
     cycle_id = f"cycle-{uuid.uuid4().hex[:12]}"
@@ -2205,6 +2215,8 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
         "recommended_next_action": f"Implement and commit: {task_title} (target: {target_path})",
     }
     artifact_path.write_text(json.dumps(artifact_payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    lessons_context = build_lessons_context(selfevo_repo, task_title, target_path)
 
     request_id = f"llm-proposer-{cycle_id}"
     request_dir = _requests_dir(state_dir)
@@ -2237,7 +2249,7 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
         "budget": "standard",
         "source_artifact": str(artifact_path),
         "feedback_decision": None,
-        "lessons_context": {},
+        "lessons_context": lessons_context,
     }
     request_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
@@ -2255,6 +2267,18 @@ def write_request(state_dir: Path, proposal: dict[str, Any]) -> str:
     demand_id = _demand_id_from_serves(serves)
     if demand_id:
         proposed_event["demand_id"] = demand_id
+    # #912: telemetry for the lessons-context re-close — record WHICH cards
+    # (if any) were injected into this request, so effectiveness is
+    # auditable from the ledger alone. Absent entirely when nothing matched
+    # (today's exact ledger shape), never an empty list.
+    if lessons_context:
+        injected = []
+        if lessons_context.get("relevant_error"):
+            injected.append(f"error:{lessons_context['relevant_error'].get('id')}")
+        if lessons_context.get("relevant_lesson"):
+            injected.append(f"lesson:{lessons_context['relevant_lesson'].get('id')}")
+        if injected:
+            proposed_event["lessons_context"] = injected
     append_event(state_dir, proposed_event)
 
     return str(request_path)
@@ -2489,7 +2513,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             )
             return None
 
-        write_request(state_dir, proposal)
+        write_request(state_dir, proposal, selfevo_repo)
         return _display_title(str(proposal.get("task_title") or ""))
     except Exception as exc:
         # #762: the catch-all safety net now leaves a trace. The recorder is

--- a/tests/test_lessons_context.py
+++ b/tests/test_lessons_context.py
@@ -1,0 +1,284 @@
+"""Tests for nanobot.runtime.lessons_context (#912): re-close the lessons
+loop by filling ``lessons_context`` for the executor prompt.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from nanobot.runtime.bridge import build_task
+from nanobot.runtime.lessons_context import build_lessons_context
+
+
+def _write_yaml(path: Path, entries: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(entries, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+
+def _repo_with_lessons(tmp_path: Path, errors: list[dict] | None = None,
+                        lessons: list[dict] | None = None) -> Path:
+    repo = tmp_path / "instance_repo"
+    if errors is not None:
+        _write_yaml(repo / "lessons" / "errors.yaml", errors)
+    if lessons is not None:
+        _write_yaml(repo / "lessons" / "lessons.yaml", lessons)
+    return repo
+
+
+class TestErrorMatching:
+    def test_title_relevant_error_card_selected(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config, not a cached default.",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Fix subagent timeout guard misconfiguration")
+
+        assert set(result.keys()) == {"relevant_error"}
+        err = result["relevant_error"]
+        # Bridge-compatible keys exactly.
+        assert set(err.keys()) == {"id", "title", "root_cause", "prevention"}
+        assert err["id"] == "ERR-AUTO-timeout-guard"
+        assert err["title"] == "Subagent timeout guard misconfigured"
+
+    def test_no_relevant_card_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config.",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Document the ledger digest helper for operators")
+
+        assert result == {}
+
+
+class TestLessonMatching:
+    def test_lesson_and_error_both_matched_from_separate_files(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-dashboard-crash",
+                    "category": "dashboard",
+                    "title": "Dashboard render crash on empty ledger",
+                    "root_cause": "Ledger digest helper assumed non-empty rows.",
+                    "prevention": "Guard the digest helper against empty ledger input.",
+                },
+            ],
+            lessons=[
+                {
+                    "id": "LESS-AUTO-dashboard-digest",
+                    "category": "successful-improvement",
+                    "title": "Dashboard ledger digest helper works well",
+                    "approach": "Added a small digest helper summarizing ledger rows.",
+                    "reusable_insight": "Digest helpers keep dashboards fast for large ledgers.",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Improve the dashboard ledger digest helper")
+
+        assert "relevant_error" in result
+        assert "relevant_lesson" in result
+        assert result["relevant_error"]["id"] == "ERR-AUTO-dashboard-crash"
+        assert result["relevant_lesson"]["id"] == "LESS-AUTO-dashboard-digest"
+        assert set(result["relevant_lesson"].keys()) == {
+            "id", "title", "approach", "reusable_insight",
+        }
+
+
+class TestFailOpen:
+    def test_missing_repo_dir_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        missing_repo = tmp_path / "does-not-exist"
+
+        assert build_lessons_context(missing_repo, "Any task title here") == {}
+
+    def test_missing_files_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = tmp_path / "instance_repo"
+        repo.mkdir()
+
+        assert build_lessons_context(repo, "Any task title here") == {}
+
+    def test_corrupt_yaml_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = tmp_path / "instance_repo"
+        errors_path = repo / "lessons" / "errors.yaml"
+        errors_path.parent.mkdir(parents=True)
+        errors_path.write_text("title: [unterminated flow\n  - not valid yaml: [", encoding="utf-8")
+
+        assert build_lessons_context(repo, "Fix the unterminated flow bug in the parser") == {}
+
+    def test_none_repo_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        assert build_lessons_context(None, "Any task title here") == {}
+
+
+class TestKillSwitch:
+    def test_kill_switch_off_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_LESSONS_CONTEXT_ENABLED", "0")
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config.",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Fix subagent timeout guard misconfiguration")
+
+        assert result == {}
+
+    def test_kill_switch_false_string_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SELFEVO_LESSONS_CONTEXT_ENABLED", "false")
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config.",
+                },
+            ],
+        )
+
+        assert build_lessons_context(repo, "Fix subagent timeout guard misconfiguration") == {}
+
+    def test_kill_switch_unset_defaults_to_on(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config.",
+                },
+            ],
+        )
+
+        assert build_lessons_context(repo, "Fix subagent timeout guard misconfiguration") != {}
+
+
+class TestCaps:
+    def test_long_root_cause_truncated_to_400(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        long_root_cause = "stale config default value " * 30  # well over 400 chars
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": long_root_cause,
+                    "prevention": "Always read timeout from live config.",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Fix subagent timeout guard misconfiguration")
+
+        assert len(result["relevant_error"]["root_cause"]) == 400
+        assert result["relevant_error"]["root_cause"] == long_root_cause[:400]
+
+    def test_long_title_truncated_to_200(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        long_title = "Subagent timeout guard misconfigured " * 10  # well over 200 chars
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "category": "timeout",
+                    "title": long_title,
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config.",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Fix subagent timeout guard misconfiguration")
+
+        assert len(result["relevant_error"]["title"]) == 200
+
+
+class TestBridgeIntegration:
+    def test_non_empty_lessons_context_renders_known_pitfall_section(self):
+        """Integration: a request with a populated lessons_context renders
+        the '## Known pitfall' / '## Proven approach' sections via bridge's
+        build_task — the bridge-side renderer (#912 recon) already existed
+        unchanged; this proves the producer side now actually feeds it."""
+        req = {
+            "task_title": "some task",
+            "request_id": "r1",
+            "cycle_id": "c1",
+            "goal_id": "g1",
+            "lessons_context": {
+                "relevant_error": {
+                    "id": "ERR-AUTO-timeout-guard",
+                    "title": "Subagent timeout guard misconfigured",
+                    "root_cause": "Timeout value read from stale config default.",
+                    "prevention": "Always read timeout from live config.",
+                },
+                "relevant_lesson": {
+                    "id": "LESS-AUTO-dashboard-digest",
+                    "title": "Dashboard ledger digest helper works well",
+                    "approach": "Added a small digest helper summarizing ledger rows.",
+                    "reusable_insight": "Digest helpers keep dashboards fast.",
+                },
+            },
+        }
+
+        task = build_task(req, "mission text", "report_source.json")
+
+        assert "## Known pitfall for this task (from lessons/errors.yaml)" in task
+        assert "ERR-AUTO-timeout-guard" in task
+        assert "## Proven approach for this task (from lessons/lessons.yaml)" in task
+        assert "LESS-AUTO-dashboard-digest" in task
+
+    def test_empty_lessons_context_omits_sections(self):
+        """No regression: an empty lessons_context (today's pre-#912
+        behavior when nothing matches) renders no section at all."""
+        req = {
+            "task_title": "some task",
+            "request_id": "r1",
+            "cycle_id": "c1",
+            "goal_id": "g1",
+            "lessons_context": {},
+        }
+
+        task = build_task(req, "mission text", "report_source.json")
+
+        assert "Known pitfall" not in task
+        assert "Proven approach" not in task

--- a/tests/test_lessons_context.py
+++ b/tests/test_lessons_context.py
@@ -7,8 +7,14 @@ from pathlib import Path
 
 import yaml
 
-from nanobot.runtime.bridge import build_task
-from nanobot.runtime.lessons_context import build_lessons_context
+from nanobot.runtime.bridge import _write_structured_lesson, build_task
+from nanobot.runtime.lessons_context import (
+    _MAX_FILE_BYTES,
+    _capped_entries,
+    _normalize_entry,
+    _safe_load_yaml,
+    build_lessons_context,
+)
 
 
 def _write_yaml(path: Path, entries: list[dict]) -> None:
@@ -231,6 +237,182 @@ class TestCaps:
         result = build_lessons_context(repo, "Fix subagent timeout guard misconfiguration")
 
         assert len(result["relevant_error"]["title"]) == 200
+
+
+class TestLiveWriterRoundTrip:
+    """#912 review (MAJOR): the reader must be able to read what the LIVE
+    per-cycle writer actually produces. ``bridge._write_structured_lesson``
+    (bridge.py ~3807) writes ``lessons.yaml`` as a top-level dict
+    (``{'lessons': [...]}``) with entries shaped
+    hypothesis/result/generalized_insight/task_id — NOT
+    title/category/approach/reusable_insight. This exercises the real
+    writer function directly (its keyword-only signature is small and
+    self-contained: repo_root/cycle_id/backlog_title/files_changed/
+    commits_pushed/artifact_data/budget_used) rather than a hand-copied
+    fixture, so a future change to the writer's on-disk shape breaks this
+    test instead of silently reintroducing the same read/write mismatch.
+    """
+
+    def test_round_trip_through_real_bridge_writer(self, tmp_path):
+        repo = tmp_path / "instance_repo"
+        repo.mkdir()
+
+        wrote = _write_structured_lesson(
+            repo_root=repo,
+            cycle_id="cycle-abc123def456",
+            backlog_title="Improve dashboard ledger digest helper",
+            files_changed=["scripts/eeebot_dashboard.py"],
+            commits_pushed=1,
+            artifact_data={
+                "hypothesis": "Improve dashboard ledger digest helper for faster reads",
+            },
+            budget_used={"tool_calls": 5, "elapsed_seconds": 30},
+        )
+        assert wrote is True
+
+        # Sanity: confirm the writer really did produce the dict-wrapped,
+        # title-less shape this test is meant to guard against silently
+        # regressing (fails loudly here, not just inside build_lessons_context).
+        written = yaml.safe_load((repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+        assert isinstance(written, dict) and "lessons" in written
+        raw_entry = written["lessons"][0]
+        assert "title" not in raw_entry
+        assert "hypothesis" in raw_entry and "generalized_insight" in raw_entry
+
+        result = build_lessons_context(
+            repo, "Improve dashboard ledger digest helper for faster reads"
+        )
+
+        assert "relevant_lesson" in result
+        less = result["relevant_lesson"]
+        assert set(less.keys()) == {"id", "title", "approach", "reusable_insight"}
+        assert less["id"]
+        assert less["title"]  # non-blank: derived from hypothesis
+        assert "dashboard ledger digest helper" in less["title"].lower()
+        assert less["approach"]  # non-blank: derived from result
+        assert less["reusable_insight"]  # non-blank: derived from generalized_insight
+
+
+class TestOnDiskShapes:
+    def test_safe_load_yaml_accepts_bare_list(self, tmp_path):
+        path = tmp_path / "errors.yaml"
+        _write_yaml(path, [{"id": "E1", "title": "x"}])
+
+        assert _safe_load_yaml(path) == [{"id": "E1", "title": "x"}]
+
+    def test_safe_load_yaml_accepts_lessons_dict_wrapper(self, tmp_path):
+        path = tmp_path / "lessons.yaml"
+        path.write_text(
+            yaml.dump({"lessons": [{"id": "L1", "hypothesis": "x"}]}, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        assert _safe_load_yaml(path) == [{"id": "L1", "hypothesis": "x"}]
+
+    def test_safe_load_yaml_accepts_errors_dict_wrapper(self, tmp_path):
+        path = tmp_path / "errors.yaml"
+        path.write_text(
+            yaml.dump({"errors": [{"id": "E1", "title": "x"}]}, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        assert _safe_load_yaml(path) == [{"id": "E1", "title": "x"}]
+
+    def test_safe_load_yaml_unrecognized_dict_returns_empty(self, tmp_path):
+        path = tmp_path / "lessons.yaml"
+        path.write_text(yaml.dump({"something_else": [1, 2]}), encoding="utf-8")
+
+        assert _safe_load_yaml(path) == []
+
+    def test_normalize_entry_fills_gaps_without_overwriting(self):
+        live = _normalize_entry({
+            "id": "L1",
+            "hypothesis": "Do the thing",
+            "result": "Did it",
+            "generalized_insight": "It worked",
+            "task_id": "fallback-id",
+        })
+        assert live["title"] == "Do the thing"
+        assert live["approach"] == "Did it"
+        assert live["reusable_insight"] == "It worked"
+
+        legacy = _normalize_entry({
+            "id": "L2",
+            "title": "Already has a title",
+            "approach": "Already has an approach",
+            "reusable_insight": "Already has an insight",
+            "hypothesis": "should be ignored",
+        })
+        assert legacy["title"] == "Already has a title"
+        assert legacy["approach"] == "Already has an approach"
+        assert legacy["reusable_insight"] == "Already has an insight"
+
+    def test_normalize_entry_id_falls_back_to_task_id(self):
+        normalized = _normalize_entry({"task_id": "some-task", "hypothesis": "x"})
+        assert normalized["id"] == "some-task"
+
+
+class TestNewestFirstOrdering:
+    """#912 review (MINOR): both writers prepend (insert(0, ...)), so the
+    file is newest-first. A large file must be capped by keeping the HEAD
+    slice, and tied scores must resolve to the earliest (newest) entry."""
+
+    def test_capped_entries_keeps_head_slice_when_over_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("nanobot.runtime.lessons_context._MAX_CARDS_SCANNED", 3)
+        path = tmp_path / "errors.yaml"
+        # Index 0 is newest per both writers' insert(0, ...) convention.
+        entries = [{"id": f"E{i}", "title": f"card {i}"} for i in range(5)]
+        _write_yaml(path, entries)
+
+        capped = _capped_entries(path)
+
+        assert [e["id"] for e in capped] == ["E0", "E1", "E2"]
+
+    def test_tied_score_prefers_earliest_newest_entry(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = _repo_with_lessons(
+            tmp_path,
+            errors=[
+                {
+                    "id": "ERR-2-newest",
+                    "category": "timeout",
+                    "title": "Timeout guard fails again",
+                    "root_cause": "x",
+                    "prevention": "y",
+                },
+                {
+                    "id": "ERR-1-older",
+                    "category": "timeout",
+                    "title": "Timeout guard fails today",
+                    "root_cause": "x",
+                    "prevention": "y",
+                },
+            ],
+        )
+
+        result = build_lessons_context(repo, "Fix timeout guard fails issue")
+
+        assert result["relevant_error"]["id"] == "ERR-2-newest"
+
+
+class TestSizeGuard:
+    def test_oversized_file_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        repo = tmp_path / "instance_repo"
+        errors_path = repo / "lessons" / "errors.yaml"
+        errors_path.parent.mkdir(parents=True)
+        # A single valid-YAML entry padded past the size cap.
+        padding = "x" * (_MAX_FILE_BYTES + 1024)
+        _write_yaml(errors_path, [{
+            "id": "ERR-1",
+            "category": "timeout",
+            "title": "Timeout guard fails",
+            "root_cause": padding,
+            "prevention": "y",
+        }])
+        assert errors_path.stat().st_size > _MAX_FILE_BYTES
+
+        assert build_lessons_context(repo, "Fix timeout guard fails issue") == {}
 
 
 class TestBridgeIntegration:

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1578,6 +1578,83 @@ class TestWriteRequestSchemaEquality:
         assert proposed_rows[0]["serves"] == ""
 
 
+# ─── write_request — #912 lessons_context wiring ───────────────────────────
+
+
+class TestWriteRequestLessonsContext:
+    """#912: write_request fills the request's lessons_context field (via
+    build_lessons_context) instead of the pre-#912 hardcoded {}, and
+    annotates the ledger 'proposed' row with which cards were injected."""
+
+    def test_no_selfevo_repo_writes_empty_lessons_context(self, tmp_path):
+        """Legacy call shape (no selfevo_repo arg, e.g. existing callers/
+        tests) must keep writing '{}' — identical to pre-#912 behavior."""
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+
+        assert written["lessons_context"] == {}
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert "lessons_context" not in proposed_rows[0]
+
+    def test_matching_selfevo_repo_populates_request_and_ledger(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        state_dir = _state_dir(tmp_path)
+        repo = tmp_path / "instance_repo"
+        errors_path = repo / "lessons" / "errors.yaml"
+        errors_path.parent.mkdir(parents=True)
+        errors_path.write_text(
+            "- id: ERR-AUTO-timeout-guard\n"
+            "  category: timeout\n"
+            "  title: Subagent timeout guard misconfigured\n"
+            "  root_cause: Timeout value read from stale config default.\n"
+            "  prevention: Always read timeout from live config.\n",
+            encoding="utf-8",
+        )
+        proposal = {
+            "task_title": "Fix subagent timeout guard misconfiguration",
+            "rationale": "closes a recorded pitfall",
+            "target_path": "nanobot/runtime/bridge.py",
+        }
+
+        path = llm_proposer.write_request(state_dir, proposal, repo)
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+
+        assert written["lessons_context"]["relevant_error"]["id"] == "ERR-AUTO-timeout-guard"
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert proposed_rows[0]["lessons_context"] == ["error:ERR-AUTO-timeout-guard"]
+
+    def test_no_match_leaves_ledger_row_without_key(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SELFEVO_LESSONS_CONTEXT_ENABLED", raising=False)
+        state_dir = _state_dir(tmp_path)
+        repo = tmp_path / "instance_repo"  # lessons/ dir doesn't exist at all
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+        }
+
+        path = llm_proposer.write_request(state_dir, proposal, repo)
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert written["lessons_context"] == {}
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert "lessons_context" not in proposed_rows[0]
+
+
 # ─── integration: maybe_propose -> bridge.find_pending_request handoff ─────
 
 


### PR DESCRIPTION
## Problem

The runtime writes structured lessons (`bridge.py`'s `_write_structured_lesson`, per-cycle) but never fed them back to the executor. The bridge's executor-prompt renderer (`bridge.py` ~1229) has always been ready to consume a `lessons_context` dict and render `## Known pitfall for this task (from lessons/errors.yaml)` / `## Proven approach for this task (from lessons/lessons.yaml)` sections — but `llm_proposer.write_request` hard-coded `"lessons_context": {}`. The only prior reader, `nanobot.runtime.lessons.LessonsDB.query_for_task`, was only reachable via a decommissioned coordinator call chain, and matches by `task_id` — useless here since every proposer request shares the same `task_id` (`llm-proposed-improvement`). Net effect: the loop never surfaced its own recorded pitfalls/approaches at execution time.

## What changed

- New standalone module `nanobot/runtime/lessons_context.py` (deliberately does **not** import `nanobot.runtime.lessons`, which #916 is slated to delete). `build_lessons_context(selfevo_repo, task_title, target_path="")`:
  - Loads `lessons/errors.yaml` and `lessons/lessons.yaml` from the instance repo (own minimal, standalone `_safe_load_yaml`, same fail-open shape as `lessons.py`'s).
  - Ranks cards by **word overlap** between the proposal's `task_title` (+ `target_path`) and each card's `title`+`category` (weighted 2x) and `root_cause`/`approach` (weighted 1x) — same "4+ letter words" spirit as `cycle_planning._title_already_done_in_git_log`, since task_id-based matching doesn't work here. A card needs ≥2 total shared words to be eligible; highest score wins; ties resolve to the last (newest) matching entry.
  - Returns at most one `relevant_error` + one `relevant_lesson`, in the exact keys `bridge.py`'s renderer expects (`id/title/root_cause/prevention` and `id/title/approach/reusable_insight`), text fields capped to 400 chars (200 for titles).
  - Bounded: scans at most the newest 200 cards per file.
  - Fail-open: missing repo/dir/files, corrupt YAML, missing `pyyaml`, or any other exception all return `{}` — the exact pre-#912 behavior.
  - Kill switch: `SELFEVO_LESSONS_CONTEXT_ENABLED` (default on; `"0"`/`"false"` disables).
- `llm_proposer.write_request` gains an optional `selfevo_repo` parameter (threaded from `maybe_propose`, which already has it in scope), calls `build_lessons_context` instead of writing `{}`, and — when non-empty — annotates the `proposed` ledger row with `lessons_context: ["error:<id>", "lesson:<id>"]` (key omitted entirely when nothing matched) for auditability.

## Out of scope (per issue)

`lessons.py` / coordinator modules are untouched; `lesson_policy.json` is unchanged.

## Test evidence

New `tests/test_lessons_context.py` (14 tests): relevant-error match with bridge-compatible keys, error+lesson matched from separate files, no-match → `{}`, missing repo dir / missing files / corrupt YAML → `{}`, `None` repo → `{}`, kill-switch `0`/`false`/unset-defaults-on, 400-char and 200-char caps, and two bridge-integration tests (`build_task` renders the "Known pitfall"/"Proven approach" sections when populated, omits them when empty).

Extended `tests/test_llm_proposer.py` with `TestWriteRequestLessonsContext` (3 tests): legacy no-`selfevo_repo` call still writes `{}` and omits the ledger key, a matching repo populates both the request payload and the ledger annotation, and a repo with no `lessons/` dir still writes `{}` with no ledger key.

All 4 designated suites pass together:
```
tests/test_lessons_context.py tests/test_llm_proposer.py tests/test_llm_proposer_rotation.py tests/test_llm_proposer_dedup_budget.py tests/test_bridge_recent_activity_context.py
247 passed
```

`python -c "import nanobot.runtime.llm_proposer, nanobot.runtime.lessons_context, nanobot.runtime.bridge"` — clean.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)