### PR TITLE
feat(runtime): operator status surface reads live ledger/scorecard (#914)

### DIFF
--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import time
+from collections import deque
 from pathlib import Path
 from typing import Any, Iterator, Tuple
 
@@ -902,6 +903,158 @@ def _subagent_rollup_snapshot_uncached(
     return result
 
 
+# ─── live status surface (#914) ──────────────────────────────────────────
+#
+# The sections below repoint the operator status/health surface at sources
+# that the CURRENT (post-coordinator-decommission, #900/#910) loop actually
+# updates every cycle: the goal registry, the cycle ledger, and the
+# scorecard — instead of ``goals/current.json``/``outbox/``/``promotions/``/
+# ``experiments/``/``credits/``, which froze when the coordinator was
+# retired. Every helper here is independently fail-open: a missing or
+# corrupt source file yields ``None``/``[]`` for just that field, never an
+# exception, so one bad artifact can never blank out the rest of the
+# surface (or crash the CLI/health check that reads it).
+
+_LIVE_LEDGER_TAIL_LINES = 200
+_LIVE_RECENT_OUTCOMES_LIMIT = 5
+
+
+def _live_active_goal_id(state_root: Path) -> str | None:
+    """Active goal id from the live goal registry.
+
+    ``goals/registry.json`` is rewritten every cycle by the current loop
+    (see ``coordinator._write_goal_registry`` / ``bridge``'s equivalent) —
+    unlike ``goals/current.json``/``active.json``, which stopped updating
+    when the coordinator was decommissioned. Fail-open to ``None``.
+    """
+    data = _safe_read_json(state_root / "goals" / "registry.json")
+    if not isinstance(data, dict):
+        return None
+    goal_id = data.get("active_goal_id")
+    if isinstance(goal_id, str) and goal_id.strip():
+        return goal_id.strip()
+    return None
+
+
+def _live_recent_outcomes(
+    state_root: Path, limit: int = _LIVE_RECENT_OUTCOMES_LIMIT
+) -> list[dict[str, Any]]:
+    """Last ``limit`` terminal ledger outcomes, newest first.
+
+    Reads ``ledger/cycles.jsonl`` with a bounded tail — lines are streamed
+    into a ``deque(maxlen=_LIVE_LEDGER_TAIL_LINES)`` one at a time, capping
+    memory even if the ledger is unexpectedly large (same bounded-tail
+    pattern as ``backlog_snapshot._last_cycle_id``). Each ``phase:
+    "outcome"`` row is enriched with the ``task_title`` carried by its
+    matching ``phase: "proposed"`` row (same ``cycle_id``) when one is
+    present in the tail window — the outcome row itself never carries a
+    title (see ``cycle_ledger.record_cycle_outcome``). Fail-open to ``[]``.
+    """
+    path = state_root / "ledger" / "cycles.jsonl"
+    if not path.is_file():
+        return []
+    try:
+        tail: 'deque[str]' = deque(maxlen=_LIVE_LEDGER_TAIL_LINES)
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                tail.append(line)
+    except Exception:
+        return []
+
+    records: list[dict[str, Any]] = []
+    for line in tail:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(rec, dict):
+            records.append(rec)
+
+    proposed_titles: dict[str, str] = {}
+    for rec in records:
+        if rec.get("phase") == "proposed" and rec.get("cycle_id") and rec.get("task_title"):
+            proposed_titles[str(rec["cycle_id"])] = str(rec["task_title"])
+
+    outcomes: list[dict[str, Any]] = []
+    for rec in reversed(records):
+        if rec.get("phase") != "outcome":
+            continue
+        cycle_id = rec.get("cycle_id")
+        outcomes.append(
+            {
+                "cycle_id": cycle_id or None,
+                "outcome": rec.get("outcome"),
+                "ts": rec.get("ts"),
+                "files_changed": rec.get("files_changed"),
+                "task_title": proposed_titles.get(str(cycle_id)) if cycle_id else None,
+            }
+        )
+        if len(outcomes) >= limit:
+            break
+    return outcomes
+
+
+def _live_scorecard_snapshot(state_root: Path) -> dict[str, Any] | None:
+    """Key fitness metrics + active preset/models from the live scorecard.
+
+    Reads ``scorecard/latest.json`` (persisted by
+    ``nanobot.runtime.scorecard.compute_scorecard``) — never a coordinator
+    artifact. Fail-open to ``None`` when the file is missing/corrupt or not
+    a dict; individual metrics are fail-open to ``None`` within it.
+    """
+    data = _safe_read_json(state_root / "scorecard" / "latest.json")
+    if not isinstance(data, dict):
+        return None
+    loop = data.get("loop") if isinstance(data.get("loop"), dict) else {}
+    quality = data.get("quality") if isinstance(data.get("quality"), dict) else {}
+    control_plane = data.get("control_plane") if isinstance(data.get("control_plane"), dict) else {}
+    models = control_plane.get("models")
+    return {
+        "computed_at_utc": data.get("computed_at_utc"),
+        "confirmed_integration_ratio": loop.get("confirmed_integration_ratio"),
+        "repeat_failure_rate": loop.get("repeat_failure_rate"),
+        "idle_share": loop.get("idle_share"),
+        "compile_clean_ratio": quality.get("compile_clean_ratio"),
+        "preset": control_plane.get("SELFEVO_PRESET"),
+        "models": models if isinstance(models, dict) else None,
+    }
+
+
+def _live_state_snapshot(state_root: Path) -> dict[str, Any] | None:
+    """Assemble the `live` operator-status section (#914).
+
+    Returns ``None`` only when goal registry, ledger, and scorecard all
+    yield nothing at all — a clean "nothing live to show" signal rather
+    than a dict of all-``None`` fields. Each of the three sources is
+    independently fail-open, so one missing/corrupt file never blanks the
+    other two.
+    """
+    try:
+        active_goal_id = _live_active_goal_id(state_root)
+    except Exception:
+        active_goal_id = None
+    try:
+        recent_outcomes = _live_recent_outcomes(state_root)
+    except Exception:
+        recent_outcomes = []
+    try:
+        scorecard = _live_scorecard_snapshot(state_root)
+    except Exception:
+        scorecard = None
+
+    if active_goal_id is None and not recent_outcomes and scorecard is None:
+        return None
+
+    return {
+        "active_goal_id": active_goal_id,
+        "recent_outcomes": recent_outcomes,
+        "scorecard": scorecard,
+    }
+
+
 def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace_state") -> dict[str, Any]:
     """Load canonical runtime state from an explicit state root if present."""
     reports_dir = state_root / "reports"
@@ -1506,6 +1659,17 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         "credits_balance": credits_balance,
         "credits_delta": credits_delta,
         "credits_path": credits_path,
+        # #914: these four flags mark data actually loaded from the frozen
+        # coordinator-era artifact directories (outbox/, promotions/,
+        # experiments/, credits/ — see module docstring above
+        # `load_runtime_state_from_root`) so a consumer/renderer can label
+        # it "decommissioned" instead of presenting it as current. True
+        # only when the corresponding file was found AND parsed as a dict
+        # — an absent file is just absent, not an error.
+        "outbox_decommissioned": isinstance(outbox_data, dict),
+        "promotion_decommissioned": isinstance(promotion_data, dict),
+        "experiment_decommissioned": isinstance(experiment_data, dict),
+        "credits_decommissioned": isinstance(credits_data, dict),
         "subagent_telemetry_root": str(subagents_dir) if subagents_dir.exists() else None,
         "subagent_telemetry_count": subagent_telemetry_count,
         "subagent_telemetry_path": subagent_telemetry_latest_path,
@@ -1542,6 +1706,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         runtime["action_registry"] = build_action_registry_snapshot(workspace)
     except Exception:
         runtime["action_registry"] = None
+    runtime["live"] = _live_state_snapshot(state_root)
     return runtime
 
 
@@ -1551,8 +1716,20 @@ def load_runtime_state(workspace: Path) -> dict[str, Any]:
     return load_runtime_state_from_root(workspace / "state", source_kind="workspace_state")
 
 
+_DECOMMISSIONED_SUFFIX = " (decommissioned — frozen data)"
+
+
 def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
-    """Format the canonical runtime state into stable user-facing lines."""
+    """Format the canonical runtime state into stable user-facing lines.
+
+    #914: the `live` section (goal registry, recent ledger outcomes,
+    scorecard metrics/preset) is rendered FIRST — it is what the current
+    loop actually keeps fresh. The legacy coordinator-era sections that
+    follow are unchanged in content, except that their *source* line is
+    suffixed "(decommissioned — frozen data)" when that section's data was
+    actually loaded, so a reader can never mistake a frozen artifact for
+    current state.
+    """
     lines = ["Runtime:"]
 
     def _render(label: str, value: Any) -> None:
@@ -1564,6 +1741,49 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
         else:
             lines.append(f"  {label}: {value}")
 
+    def _render_source(label: str, value: Any, decommissioned: bool) -> None:
+        if value in (None, ""):
+            lines.append(f"  {label}: unknown")
+        else:
+            lines.append(f"  {label}: {value}{_DECOMMISSIONED_SUFFIX if decommissioned else ''}")
+
+    live = runtime.get("live") if isinstance(runtime.get("live"), dict) else None
+    lines.append("Live status:")
+    if live:
+        _render("Active goal (live)", live.get("active_goal_id"))
+        outcomes = live.get("recent_outcomes") if isinstance(live.get("recent_outcomes"), list) else []
+        if outcomes:
+            lines.append("  Recent outcomes (live):")
+            for item in outcomes:
+                if not isinstance(item, dict):
+                    continue
+                bits = [
+                    f"cycle={item.get('cycle_id') or 'unknown'}",
+                    f"outcome={item.get('outcome') or 'unknown'}",
+                ]
+                if item.get("task_title"):
+                    bits.append(f"title={item.get('task_title')}")
+                if item.get("ts"):
+                    bits.append(f"ts={item.get('ts')}")
+                lines.append(f"    {' '.join(bits)}")
+        else:
+            lines.append("  Recent outcomes (live): unknown")
+        scorecard = live.get("scorecard") if isinstance(live.get("scorecard"), dict) else None
+        if scorecard:
+            _render("Scorecard confirmed integration ratio", scorecard.get("confirmed_integration_ratio"))
+            _render("Scorecard repeat failure rate", scorecard.get("repeat_failure_rate"))
+            _render("Scorecard compile clean ratio", scorecard.get("compile_clean_ratio"))
+            _render("Scorecard idle share", scorecard.get("idle_share"))
+            _render("Active preset (live)", scorecard.get("preset"))
+            _render("Active models (live)", scorecard.get("models"))
+        else:
+            lines.append("  Scorecard (live): unknown")
+    else:
+        lines.append("  Active goal (live): unknown")
+        lines.append("  Recent outcomes (live): unknown")
+        lines.append("  Scorecard (live): unknown")
+
+    lines.append("Legacy runtime detail:")
     _render("Runtime state source", runtime.get("runtime_state_source"))
     _render("Runtime state root", runtime.get("runtime_state_root"))
     _render("Runtime status", runtime.get("runtime_status"))
@@ -1578,9 +1798,10 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
     _render("Experiment current", runtime.get("experiment_metric_current"))
     _render("Experiment frontier", runtime.get("experiment_metric_frontier"))
     _render("Experiment contract", runtime.get("experiment_contract_path"))
+    _render_source("Experiment source", runtime.get("experiment_path"), bool(runtime.get("experiment_decommissioned")))
     _render("Credits balance", runtime.get("credits_balance"))
     _render("Credits delta", runtime.get("credits_delta"))
-    _render("Credits source", runtime.get("credits_path"))
+    _render_source("Credits source", runtime.get("credits_path"), bool(runtime.get("credits_decommissioned")))
     _render("Subagent telemetry root", runtime.get("subagent_telemetry_root"))
     _render("Subagent telemetry path", runtime.get("subagent_telemetry_path"))
     _render("Subagent telemetry count", runtime.get("subagent_telemetry_count"))
@@ -1654,7 +1875,7 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
             _render("Artifacts", ", ".join(str(item) for item in artifacts))
         else:
             _render("Artifacts", artifacts)
-    _render("Promotion source", runtime.get("promotion_path"))
+    _render_source("Promotion source", runtime.get("promotion_path"), bool(runtime.get("promotion_decommissioned")))
     _render("Approval gate", runtime.get("approval_gate"))
     _render("Gate state", runtime.get("approval_gate_state"))
     if runtime.get("approval_gate_ttl_minutes") is not None:
@@ -1671,5 +1892,5 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
             _render("Goal rotation artifacts", trigger_artifacts)
     _render("Report source", runtime.get("report_path"))
     _render("Goal source", runtime.get("goal_path"))
-    _render("Outbox source", runtime.get("outbox_path"))
+    _render_source("Outbox source", runtime.get("outbox_path"), bool(runtime.get("outbox_decommissioned")))
     return lines

--- a/tests/test_runtime_state_live.py
+++ b/tests/test_runtime_state_live.py
@@ -1,0 +1,188 @@
+"""Tests for the #914 live operator-status surface.
+
+Covers ``nanobot.runtime.state.load_runtime_state_from_root``'s new `live`
+section (goal registry, ledger tail, scorecard) and ``format_runtime_state``'s
+live-first rendering with decommissioned labeling of coordinator-era
+(outbox/promotions/experiments/credits) artifacts. See issue #914: the
+status surface previously showed only frozen coordinator-era data.
+"""
+
+import json
+from pathlib import Path
+
+from nanobot.runtime.state import format_runtime_state, load_runtime_state_from_root
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_ledger(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def test_live_section_populated_from_full_live_state_dir(tmp_path: Path):
+    state_root = tmp_path / "state"
+    _write_json(state_root / "goals" / "registry.json", {"active_goal_id": "goal-live-1"})
+    _write_ledger(
+        state_root / "ledger" / "cycles.jsonl",
+        [
+            {"phase": "proposed", "cycle_id": "cycle-1", "task_title": "Fix the thing"},
+            {
+                "phase": "outcome",
+                "cycle_id": "cycle-1",
+                "outcome": "success",
+                "ts": "2026-08-01T00:00:00Z",
+                "files_changed": ["a.py"],
+            },
+            {"phase": "proposed", "cycle_id": "cycle-2", "task_title": "Add the feature"},
+            {
+                "phase": "outcome",
+                "cycle_id": "cycle-2",
+                "outcome": "failed",
+                "ts": "2026-08-02T00:00:00Z",
+            },
+        ],
+    )
+    _write_json(
+        state_root / "scorecard" / "latest.json",
+        {
+            "schema_version": "scorecard-v1",
+            "computed_at_utc": "2026-08-02T00:05:00Z",
+            "loop": {
+                "confirmed_integration_ratio": 0.5,
+                "repeat_failure_rate": 0.25,
+                "idle_share": 0.1,
+            },
+            "quality": {"compile_clean_ratio": 0.9},
+            "control_plane": {
+                "SELFEVO_PRESET": "balanced",
+                "models": {"proposer": "gpt-x"},
+            },
+        },
+    )
+
+    runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
+    live = runtime["live"]
+    assert live is not None
+    assert live["active_goal_id"] == "goal-live-1"
+
+    outcomes = live["recent_outcomes"]
+    assert len(outcomes) == 2
+    # newest first
+    assert outcomes[0]["cycle_id"] == "cycle-2"
+    assert outcomes[0]["outcome"] == "failed"
+    assert outcomes[0]["task_title"] == "Add the feature"
+    assert outcomes[1]["cycle_id"] == "cycle-1"
+    assert outcomes[1]["outcome"] == "success"
+    assert outcomes[1]["task_title"] == "Fix the thing"
+    assert outcomes[1]["files_changed"] == ["a.py"]
+
+    scorecard = live["scorecard"]
+    assert scorecard["confirmed_integration_ratio"] == 0.5
+    assert scorecard["repeat_failure_rate"] == 0.25
+    assert scorecard["idle_share"] == 0.1
+    assert scorecard["compile_clean_ratio"] == 0.9
+    assert scorecard["preset"] == "balanced"
+    assert scorecard["models"] == {"proposer": "gpt-x"}
+
+    formatted = format_runtime_state(runtime)
+    live_idx = next(i for i, line in enumerate(formatted) if line == "Live status:")
+    legacy_idx = next(i for i, line in enumerate(formatted) if line == "Legacy runtime detail:")
+    assert live_idx < legacy_idx
+    assert any("Active goal (live): goal-live-1" in line for line in formatted)
+    assert any("cycle=cycle-2" in line and "title=Add the feature" in line for line in formatted)
+    assert any("Scorecard confirmed integration ratio: 0.5" in line for line in formatted)
+    assert any("Active preset (live): balanced" in line for line in formatted)
+
+
+def test_live_section_partial_when_scorecard_missing(tmp_path: Path):
+    state_root = tmp_path / "state"
+    _write_json(state_root / "goals" / "registry.json", {"active_goal_id": "goal-live-2"})
+    _write_ledger(
+        state_root / "ledger" / "cycles.jsonl",
+        [
+            {
+                "phase": "outcome",
+                "cycle_id": "cycle-9",
+                "outcome": "success",
+                "ts": "2026-08-03T00:00:00Z",
+            },
+        ],
+    )
+    # no scorecard/ directory at all
+
+    runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
+    live = runtime["live"]
+    assert live is not None
+    assert live["active_goal_id"] == "goal-live-2"
+    assert len(live["recent_outcomes"]) == 1
+    assert live["scorecard"] is None
+
+    # fail-open: no exception, and format still renders cleanly.
+    formatted = format_runtime_state(runtime)
+    assert any("Scorecard (live): unknown" in line for line in formatted)
+
+
+def test_live_section_empty_for_fully_empty_state_dir(tmp_path: Path):
+    state_root = tmp_path / "state"
+    state_root.mkdir(parents=True)
+
+    runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
+
+    assert runtime["live"] is None
+
+    formatted = format_runtime_state(runtime)
+    assert any("Active goal (live): unknown" in line for line in formatted)
+    assert any("Recent outcomes (live): unknown" in line for line in formatted)
+    assert any("Scorecard (live): unknown" in line for line in formatted)
+
+
+def test_legacy_artifacts_present_are_marked_decommissioned(tmp_path: Path):
+    state_root = tmp_path / "state"
+    _write_json(state_root / "outbox" / "latest.json", {"status": "PASS"})
+    _write_json(state_root / "credits" / "latest.json", {"balance": 5, "delta": -1})
+    _write_json(state_root / "experiments" / "latest.json", {"outcome": "keep"})
+    _write_json(state_root / "promotions" / "latest.json", {"promotion_candidate_id": "promo-1"})
+
+    runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
+
+    assert runtime["outbox_decommissioned"] is True
+    assert runtime["credits_decommissioned"] is True
+    assert runtime["experiment_decommissioned"] is True
+    assert runtime["promotion_decommissioned"] is True
+
+    formatted = format_runtime_state(runtime)
+    assert any(
+        line.startswith("  Outbox source:") and "(decommissioned — frozen data)" in line
+        for line in formatted
+    )
+    assert any(
+        line.startswith("  Credits source:") and "(decommissioned — frozen data)" in line
+        for line in formatted
+    )
+    assert any(
+        line.startswith("  Experiment source:") and "(decommissioned — frozen data)" in line
+        for line in formatted
+    )
+    assert any(
+        line.startswith("  Promotion source:") and "(decommissioned — frozen data)" in line
+        for line in formatted
+    )
+
+
+def test_legacy_artifacts_absent_are_not_marked_and_do_not_error(tmp_path: Path):
+    state_root = tmp_path / "state"
+    state_root.mkdir(parents=True)
+
+    runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
+
+    assert runtime["outbox_decommissioned"] is False
+    assert runtime["credits_decommissioned"] is False
+    assert runtime["experiment_decommissioned"] is False
+    assert runtime["promotion_decommissioned"] is False
+
+    formatted = format_runtime_state(runtime)
+    assert not any("decommissioned" in line for line in formatted)


### PR DESCRIPTION
## Problem

The operator status surface (`nanobot/cli/commands.py`'s `status` command, `nanobot/runtime/health.py`) reads `nanobot/runtime/state.py:load_runtime_state_from_root`, which sources its fields from `goals/current.json`, `outbox/latest.json`, `promotions/*`, `experiments/*`, `credits/*` — all frozen since the coordinator was decommissioned (#900/#910). The actual live activity (goal registry, cycle ledger, scorecard) was never surfaced, leaving operators looking at a permanently stale snapshot.

## What changed

`nanobot/runtime/state.py`:
- Added a `live` section, assembled by three new fail-open helpers and attached to the return of `load_runtime_state_from_root`:
  - `_live_active_goal_id` — active goal id from `goals/registry.json` (rewritten every cycle by the current loop, unlike `goals/current.json`/`active.json`).
  - `_live_recent_outcomes` — last 5 terminal `ledger/cycles.jsonl` outcomes, newest first, via a bounded tail read (`deque(maxlen=200)`, same pattern as `backlog_snapshot._last_cycle_id`). Each outcome row is enriched with the `task_title` from its matching `phase: "proposed"` row (same `cycle_id`).
  - `_live_scorecard_snapshot` — `confirmed_integration_ratio`, `repeat_failure_rate`, `idle_share`, `compile_clean_ratio`, active `preset` (`SELFEVO_PRESET`), and `models` from `scorecard/latest.json` (`nanobot.runtime.scorecard.compute_scorecard`'s persisted shape).
  - `_live_state_snapshot` combines the three; returns `None` only when all three are empty.
- Every field is independently fail-open: a missing/corrupt source file omits just that field, never raises.
- Four new boolean flags (`outbox_decommissioned`, `promotion_decommissioned`, `experiment_decommissioned`, `credits_decommissioned`) mark when data was actually loaded from the frozen coordinator-era directories. **Nothing was deleted** — all existing keys/fields other code (`health.py`, callers of `format_runtime_state`) depends on are preserved unchanged.
- `format_runtime_state` now renders the `Live status:` section **first** (goal, recent outcomes, scorecard metrics, preset/models), then `Legacy runtime detail:` with the existing content unchanged, except the `Outbox source` / `Promotion source` / `Credits source` lines (and a new `Experiment source` line) are suffixed `(decommissioned — frozen data)` whenever that artifact was actually present.

`nanobot/runtime/health.py`: verified (no code change needed) — it already fails open on an empty/coordinator-absent state dir; confirmed via a direct empty-state-dir run that `build_cycle_health_summary` still returns a well-formed summary with no exception.

## Sample output (workspace with live goal registry + ledger + scorecard, no coordinator artifacts)

```
Runtime:
Live status:
  Active goal (live): goal-abc
  Recent outcomes (live):
    cycle=c1 outcome=success title=Fix thing ts=2026-08-01T00:00:00Z
  Scorecard confirmed integration ratio: 0.5
  Scorecard repeat failure rate: 0.1
  Scorecard compile clean ratio: 0.9
  Scorecard idle share: 0.2
  Active preset (live): balanced
  Active models (live): proposer=gpt-x
Legacy runtime detail:
  Runtime state source: workspace_state
  ...
  Outbox source: unknown
```

With a legacy `outbox/latest.json` also present:
```
  Outbox source: /state/outbox/latest.json (decommissioned — frozen data)
```

## Tests

New `tests/test_runtime_state_live.py` (5 tests, all passing):
- `test_live_section_populated_from_full_live_state_dir` — full live dir (registry + ledger + scorecard) → `live` populated (goal id, outcome ordering/content incl. task_title join, scorecard metrics, preset/models); `format_runtime_state` renders live section before legacy.
- `test_live_section_partial_when_scorecard_missing` — registry + ledger only → `live` has goal + outcomes, `scorecard` is `None`, no error.
- `test_live_section_empty_for_fully_empty_state_dir` — empty state dir → `load_runtime_state_from_root` doesn't raise, `runtime["live"]` is `None`, formatted output renders "unknown" cleanly.
- `test_legacy_artifacts_present_are_marked_decommissioned` — outbox/promotions/experiments/credits present → all four flags `True`, all four "source" lines carry the decommissioned suffix.
- `test_legacy_artifacts_absent_are_not_marked_and_do_not_error` — none present → all flags `False`, no "decommissioned" text anywhere, no error.

Existing coverage re-verified green (unchanged behavior preserved):
- `tests/test_commands.py`, `tests/test_capability_reporting.py`, `tests/test_host_resource_sensing.py`, `tests/test_promotion_workflow.py`, `tests/test_heartbeat_service.py`, `tests/test_eeebot_imports.py`, `tests/test_telegram_channel.py`, `tests/test_runtime_coordinator.py` (76 tests), `tests/test_scorecard.py` (49 tests), `tests/test_cycle_health_summary.py` (7 tests).
- 3 unrelated pre-existing failures confirmed present identically on `main` (verified via `git stash`) before any of this branch's changes: two `--help` CLI tests broken by a `typer`/`click` version mismatch, one Windows-filesystem-mtime-resolution flaky test (`test_runtime_state_prefers_newest_evolution_report`), and one subagent-executor test unrelated to `state.py`. None touch the code this PR changes.
- `python -c "import nanobot.runtime.state, nanobot.runtime.health, nanobot.cli.commands"` — clean.

## Out of scope (per issue)

Ops dashboard (separate repo); writing any state files (read-only surface); deleting any `state.py` field consumed elsewhere.

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)