### PR TITLE
fix(runtime): drop phantom trust-ladder rung for deleted cycle_planning.py (#924)

### DIFF
--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -142,7 +142,7 @@ def _is_runtime_deny(path: str) -> bool:
 # part of the ladder's own unlock logic — it is the operator-seeded base
 # module, reachable only through the existing ``SELFEVO_RUNTIME_SLICE`` env
 # allow-list (``runtime_deny.runtime_slice_paths``), exactly as before #876.
-# The ladder only ever ADDS rungs on top of that: rung ``i+1`` unlocks once
+# The ladder only ever ADDS rungs 1-2 on top of that: rung ``i+1`` unlocks once
 # rung ``i`` has an ACTIVE root-verified promotion — consecutive-from-bottom
 # only, so a higher rung being promoted (e.g. an operator manually widening
 # ``SELFEVO_RUNTIME_SLICE`` directly) can never skip over an unproven lower
@@ -154,13 +154,13 @@ def _is_runtime_deny(path: str) -> bool:
 # Ordering rationale (ascending blast radius): existence_index.py is a small,
 # already-microbenched (#822) read-mostly indexer; demand.py shapes what the
 # proposer sees but does not itself decide/act; llm_proposer.py decides WHAT
-# to propose next (no direct execution power); cycle_planning.py shapes
-# planning/curriculum across cycles — the widest-reaching of the four.
+# to propose next (no direct execution power) — the widest-reaching of the
+# three. (#924: the former rung 3, cycle_planning.py, was dropped — that
+# module was deleted in #916/#923 and the entry was inert.)
 RUNTIME_TRUST_LADDER: 'tuple[str, ...]' = (
     'nanobot/runtime/existence_index.py',
     'nanobot/runtime/demand.py',
     'nanobot/runtime/llm_proposer.py',
-    'nanobot/runtime/cycle_planning.py',
 )
 # Invariant assertion (#876): the ladder must never contain a deny-set path —
 # the verification kernel stays constitutionally unmodifiable (#603) no

--- a/tests/test_runtime_trust_ladder.py
+++ b/tests/test_runtime_trust_ladder.py
@@ -17,15 +17,16 @@ from nanobot.runtime import runtime_deny
 _RUNG0 = runtime_deny.RUNTIME_TRUST_LADDER[0]
 _RUNG1 = runtime_deny.RUNTIME_TRUST_LADDER[1]
 _RUNG2 = runtime_deny.RUNTIME_TRUST_LADDER[2]
-_RUNG3 = runtime_deny.RUNTIME_TRUST_LADDER[3]
 
 
-def test_ladder_is_the_expected_four_modules_in_ascending_blast_radius_order():
+def test_ladder_is_the_expected_three_modules_in_ascending_blast_radius_order():
+    # #924: the former rung 3 (cycle_planning.py) was dropped — that module
+    # was deleted in #916/#923 and the entry was inert (allow-listing a
+    # nonexistent file).
     assert runtime_deny.RUNTIME_TRUST_LADDER == (
         "nanobot/runtime/existence_index.py",
         "nanobot/runtime/demand.py",
         "nanobot/runtime/llm_proposer.py",
-        "nanobot/runtime/cycle_planning.py",
     )
 
 
@@ -37,7 +38,7 @@ def test_no_ladder_module_is_ever_in_the_deny_set():
 # ─── earned_ladder_slice ──────────────────────────────────────────────────────
 # rung 0 (existence_index.py) is NEVER part of earned_ladder_slice's output —
 # it is the operator-seeded base rung, reachable only via the env allow-list
-# (runtime_slice_paths). The ladder only ever ADDS rungs 1-3 on top of that.
+# (runtime_slice_paths). The ladder only ever ADDS rungs 1-2 on top of that.
 
 
 def test_earned_slice_zero_active_is_empty():
@@ -55,10 +56,6 @@ def test_earned_slice_rung0_and_rung1_active_unlocks_rung2():
     assert runtime_deny.earned_ladder_slice({_RUNG0, _RUNG1}) == {_RUNG1, _RUNG2}
 
 
-def test_earned_slice_rung0_rung1_rung2_active_unlocks_rung3():
-    assert runtime_deny.earned_ladder_slice({_RUNG0, _RUNG1, _RUNG2}) == {_RUNG1, _RUNG2, _RUNG3}
-
-
 def test_earned_slice_non_consecutive_active_does_not_skip():
     # rung1 active but rung0 NOT — the walk starts at rung0, finds it
     # missing, and stops immediately. rung1 being active does not unlock
@@ -69,13 +66,13 @@ def test_earned_slice_non_consecutive_active_does_not_skip():
 
 def test_earned_slice_all_active_is_the_ladder_minus_rung0():
     all_active = set(runtime_deny.RUNTIME_TRUST_LADDER)
-    assert runtime_deny.earned_ladder_slice(all_active) == {_RUNG1, _RUNG2, _RUNG3}
+    assert runtime_deny.earned_ladder_slice(all_active) == {_RUNG1, _RUNG2}
 
 
 def test_earned_slice_top_rung_active_alone_unlocks_nothing():
-    # rung3 (the top) active alone, with nothing below it active, unlocks
+    # rung2 (the top) active alone, with nothing below it active, unlocks
     # nothing at all — consecutive-from-bottom only.
-    assert runtime_deny.earned_ladder_slice({_RUNG3}) == set()
+    assert runtime_deny.earned_ladder_slice({_RUNG2}) == set()
 
 
 def test_earned_slice_fails_open_to_empty_on_bad_input():


### PR DESCRIPTION
## What

`RUNTIME_TRUST_LADDER` in `nanobot/runtime/runtime_deny.py` still listed `nanobot/runtime/cycle_planning.py` as rung 3 (the top earn-able mutation rung) even though that module was deleted in #916/#923. This drops the phantom rung:

- `RUNTIME_TRUST_LADDER` is now a 3-tuple: `existence_index.py`, `demand.py`, `llm_proposer.py` (which becomes the new top rung).
- Updated the ordering-rationale comment and the "rungs 1-3"/"widest-reaching of the four" prose that referenced the dropped rung.
- Updated `tests/test_runtime_trust_ladder.py`'s pinned tuple, removed the now-redundant "rung0/1/2 active unlocks rung3" test (identical to the existing "all active" test once the ladder has only 3 rungs), and repointed the "top rung active alone unlocks nothing" test at the new top rung (`llm_proposer.py`).

## Why

The entry was functionally inert today — `earned_ladder_slice`/`effective_runtime_slice` are pure string-set operations, so allow-listing a nonexistent file grants nothing, and the import-time `ladder ⊄ deny-set` assert already passed. But it left a phantom top-rung allow-entry in a deny-set-protected security module: if a file named `cycle_planning.py` were ever recreated (e.g. by mistake or a future refactor reusing the name), it would silently inherit top-rung mutability without anyone deliberately re-granting it. The trust-ladder allow-list should not carry references to files that no longer exist.

## Diff summary

```
 nanobot/runtime/runtime_deny.py    |  8 ++++----
 tests/test_runtime_trust_ladder.py | 19 ++++++++-----------
 2 files changed, 12 insertions(+), 15 deletions(-)
```

No changes to deny-set semantics for any existing file; no new rungs added; no change to earned-rung mechanics.

## Test evidence

- `python -c "import nanobot.runtime.runtime_deny, nanobot.runtime.promoted_overlay, nanobot.runtime.bridge, nanobot.runtime.llm_proposer"` — succeeds (import-time `ladder ⊄ deny-set` assert still passes).
- `pytest tests/test_runtime_trust_ladder.py tests/test_runtime_slice.py tests/test_promoted_overlay.py tests/test_scorecard.py tests/test_tech_tree.py tests/test_heldout.py` — **230 passed**.
- Verified via grep that no remaining reference to `cycle_planning.py` exists anywhere under `nanobot/` or `tests/` except historical docstring/comment mentions of the already-deleted module's old API (unrelated pre-existing documentation, out of scope here) — none of the ladder/deny-set logic itself references it anymore.
- Note: `tests/test_llm_proposer.py` (and several other unrelated test files) fail to *collect* in this environment due to a pre-existing, unrelated issue — a stale `tests` package installed in global site-packages shadows the repo's local `tests/` directory for `from tests.X import Y` style intra-test imports. Confirmed via `git stash` that this collection failure is present on the unmodified `main` tree too, so it is not a regression from this change.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)