### PR TITLE
fix(runtime): stop silencing 14 live validators; classify EROFS, arg and timeout failures (#934)

### DIFF
--- a/docs/INITIAL_VALIDATOR_ROADMAP.md
+++ b/docs/INITIAL_VALIDATOR_ROADMAP.md
@@ -155,13 +155,16 @@ contract:
   finding worth surfacing to the loop as demand — write real errors to
   stderr/stdout, since that text becomes the evidence attached to the item.
 - **Decay self-declaration excludes a script.** A script whose source
-  carries, on a single line, both `is deprecated and marked as archived` (or
-  `is deprecated and scheduled for removal`) and its own `scripts/<name>.py`
-  path is treated as having declared itself decayed, and is never selected
-  again. Do not use that phrasing on one line with your own path for
-  anything other than a genuine decay declaration — a validator that audits
-  decay declarations can hold the phrase as a constant safely, as long as it
-  is not on the same line as its own path.
+  contains both `is deprecated and marked as archived` (or `is deprecated and
+  scheduled for removal`) and its own `scripts/<name>.py` path is treated as
+  having declared itself decayed, and is never selected again. The two do not
+  have to be on the same line, because real declarations are not written that
+  way. **So if you are writing a validator that audits decay declarations,
+  do not put your own path in the same file as the phrase** — refer to the
+  scripts you check by variable, not by quoting your own name next to the
+  marker you search for. A pattern cannot tell "quotes the phrase" from
+  "declares the phrase", and guessing wrong in the exclude direction is what
+  silenced 14 validators before #934.
 - **Declare `--json`, don't just mention it.** The harness appends `--json`
   only when your source declares the option (an `add_argument("--json")`
   call, or a `"--json" in sys.argv` test). Naming the string in a docstring

--- a/docs/INITIAL_VALIDATOR_ROADMAP.md
+++ b/docs/INITIAL_VALIDATOR_ROADMAP.md
@@ -132,3 +132,31 @@ Start with the checks that prevent loss of provenance, ownership confusion, and
 unsafe promotion.
 Only after those are solid should the validator layer expand into richer runtime
 quality checks.
+
+## Harness Invocation Contract
+
+Once a validator lands under `scripts/(check|validate|audit|analyze|verify)_*.py`
+it is picked up automatically by `nanobot.runtime.validator_harness` and run on a
+rotation. That harness invokes every script the same way, so a script that wants
+to be exercised (and to have its findings become real demand) must fit this
+contract:
+
+- **No arguments.** The harness runs `<python> <script>` (or `<script> --json`
+  when the script's own source mentions `--json`). A script whose `argparse`
+  requires a flag will exit non-zero on every single run; offer a no-argument
+  default or a `--test` mode.
+- **A per-script timeout and a total budget.** Each run gets 60s; the whole
+  rotation gets 240s. A script that cannot finish in that window on the
+  target hardware produces no verdict at all, and the harness surfaces that
+  as its own demand item ("cannot finish within the harness's per-script
+  time budget"). Make the work incremental, or decay-declare the script.
+  It is deliberately not dropped from the rotation automatically.
+- **What a non-zero exit means.** The harness treats a non-zero exit as a
+  finding worth surfacing to the loop as demand — write real errors to
+  stderr/stdout, since that text becomes the evidence attached to the item.
+- **Decay self-declaration excludes a script.** A script that prints, in its
+  own source near the top, something matching `is deprecated and marked as
+  archived` or `is deprecated and scheduled for removal` — together with its
+  own `scripts/<name>.py` path — is treated as having declared itself
+  decayed and is never selected again. Do not use that phrasing for anything
+  other than a genuine decay declaration.

--- a/docs/INITIAL_VALIDATOR_ROADMAP.md
+++ b/docs/INITIAL_VALIDATOR_ROADMAP.md
@@ -142,7 +142,7 @@ to be exercised (and to have its findings become real demand) must fit this
 contract:
 
 - **No arguments.** The harness runs `<python> <script>` (or `<script> --json`
-  when the script's own source mentions `--json`). A script whose `argparse`
+  when the script's own source declares `--json`). A script whose `argparse`
   requires a flag will exit non-zero on every single run; offer a no-argument
   default or a `--test` mode.
 - **A per-script timeout and a total budget.** Each run gets 60s; the whole
@@ -154,9 +154,16 @@ contract:
 - **What a non-zero exit means.** The harness treats a non-zero exit as a
   finding worth surfacing to the loop as demand — write real errors to
   stderr/stdout, since that text becomes the evidence attached to the item.
-- **Decay self-declaration excludes a script.** A script that prints, in its
-  own source near the top, something matching `is deprecated and marked as
-  archived` or `is deprecated and scheduled for removal` — together with its
-  own `scripts/<name>.py` path — is treated as having declared itself
-  decayed and is never selected again. Do not use that phrasing for anything
-  other than a genuine decay declaration.
+- **Decay self-declaration excludes a script.** A script whose source
+  carries, on a single line, both `is deprecated and marked as archived` (or
+  `is deprecated and scheduled for removal`) and its own `scripts/<name>.py`
+  path is treated as having declared itself decayed, and is never selected
+  again. Do not use that phrasing on one line with your own path for
+  anything other than a genuine decay declaration — a validator that audits
+  decay declarations can hold the phrase as a constant safely, as long as it
+  is not on the same line as its own path.
+- **Declare `--json`, don't just mention it.** The harness appends `--json`
+  only when your source declares the option (an `add_argument("--json")`
+  call, or a `"--json" in sys.argv` test). Naming the string in a docstring
+  or a pattern list does not count — which means a script that searches
+  other files for `--json` will not be handed a flag it cannot parse.

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -709,11 +709,20 @@ def _validator_defect_items(state_dir: Path) -> list[dict[str, str]]:
     presented — a since-fixed failure must not linger as demand forever).
 
     One item per script, priority order when more than one condition holds:
-    a non-zero exit ("validator X fails when run"), then a positive findings
-    count ("validator X reports N findings"). A clean run (exit 0, no
-    findings) yields nothing — only a validator that surfaced a
-    real problem becomes demand. Bounded to :data:`_MAX_VALIDATOR_DEFECTS`;
-    fail-open: any error or a missing sidecar yields no validator demand."""
+    a non-zero exit ("validator X fails when run" — or, when the harness
+    marked the run ``harness_contract: "requires_arguments"`` (#934 Class
+    B), "validator X cannot run under the harness: it requires
+    command-line arguments" — a truthful relabeling, NOT a suppression:
+    the harness invokes every script with no arguments, so a validator
+    whose argparse requires a flag would otherwise be misreported as
+    crashing on every run forever), then a run the harness killed at its
+    per-script timeout (``harness_contract: "exceeds_time_budget"``, #934 —
+    such a run has no exit code at all, so before #934 it produced no
+    demand and no signal of any kind), then a positive findings count
+    ("validator X reports N findings"). A clean run (exit 0, no findings)
+    yields nothing — only a validator that surfaced a real problem becomes
+    demand. Bounded to :data:`_MAX_VALIDATOR_DEFECTS`; fail-open: any error
+    or a missing sidecar yields no validator demand."""
     items: list[dict[str, str]] = []
     try:
         path = Path(state_dir) / "validator_harness" / "last_runs.jsonl"
@@ -785,11 +794,46 @@ def _validator_defect_items(state_dir: Path) -> list[dict[str, str]]:
             findings = row.get("findings_count")
             if isinstance(exit_code, int) and exit_code != 0:
                 stderr_tail = _sanitize_stderr_tail(str(row.get("stderr_tail") or ""))
+                if row.get("harness_contract") == "requires_arguments":
+                    # #934 Class B: the harness invokes every script with NO
+                    # arguments, so a validator whose argparse requires a
+                    # flag exits 2 on every run forever. "fails when run"
+                    # would send the loop chasing a crash that does not
+                    # exist; this names the real, fixable contract mismatch
+                    # instead. Same affected_path/sanitisation/allowlist
+                    # gating/cap as any other exit-code defect below — this
+                    # is a relabeling, not a new suppression path.
+                    summary = (
+                        f"validator {rel} cannot run under the harness: it "
+                        "requires command-line arguments"
+                    )
+                else:
+                    summary = f"validator {rel} fails when run"
                 items.append(
                     _make_item(
                         "defect",
-                        f"validator {rel} fails when run",
+                        summary,
                         f"exit code {exit_code}" + (f": {stderr_tail[:300]}" if stderr_tail else ""),
+                        affected_path=rel,
+                    )
+                )
+            elif row.get("harness_contract") == "exceeds_time_budget":
+                # #934: a run the harness killed at _PER_SCRIPT_TIMEOUT has
+                # exit_code None, so before this it produced NOTHING here —
+                # the script silently burned a quarter of the invocation's
+                # budget every rotation and never yielded a verdict or a
+                # signal. This is the honest, fixable framing: the script
+                # does not fit the harness's time contract. Checked as an
+                # elif on the exit-code branch above because a timed-out run
+                # has no exit code to report by construction.
+                items.append(
+                    _make_item(
+                        "defect",
+                        f"validator {rel} cannot finish within the harness's "
+                        "per-script time budget",
+                        f"validator harness run at {row.get('finished_at') or '?'} "
+                        f"was killed at the per-script timeout: "
+                        f"{_sanitize_stderr_tail(str(row.get('stderr_tail') or ''))[:300]}",
                         affected_path=rel,
                     )
                 )

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -16,11 +16,14 @@ Design, one call to :func:`run_validator_harness` per invocation:
 1. Select up to :func:`_max_k` (env ``SELFEVO_VALIDATOR_HARNESS_MAX``,
    default 5) scripts matching the allowlist
    ``scripts/(check|validate|audit|analyze|verify)_*.py``, least-recently-run
-   first, excluding any script whose own source declares it archived/decayed
-   (#928: see :data:`_ARCHIVED_RE` — there is no machine-readable decay
-   registry, so the marker text is the only signal; an archived script's
-   refusal to run is correct behaviour, not a defect, and must never be
-   selected in the first place). Rotation state persists in
+   first, excluding any script whose own source SELF-DECLARES decay (#934:
+   see :data:`_DECAY_DECL_RE` — there is no machine-readable decay registry,
+   so the declaration text is the only signal, and it must be a
+   self-declaration — the phrase together with the script's OWN path — not
+   merely a mention, or scripts that implement decay detection get silently
+   excluded from ever running; a decayed script's refusal to run is correct
+   behaviour, not a defect, and must never be selected in the first place).
+   Rotation state persists in
    ``<state_dir>/validator_harness/rotation.json`` (same served-map schema
    style as ``llm_proposer``'s #902 demand rotation: ``{"served":
    {"<rel_path>": "<iso-ts>"}}``, pruned to the current candidate set on
@@ -114,6 +117,30 @@ success while recording nothing. This module's own writes are confined to
 ``<state_dir>/validator_harness/`` — never a fitness sidecar, never a git
 commit, never a mutation of the instance repo (which the sandbox mounts
 read-only anyway).
+
+INVOCATION CONTRACT (#934), for the instance's script authors — nowhere
+else documents this, and every point below has produced a live false
+defect when a script did not anticipate it:
+
+- No arguments: every script is run as ``<python> <script>`` (or with a
+  trailing ``--json`` when the script's own text mentions that flag). A
+  script whose ``argparse`` requires a flag will exit non-zero on EVERY
+  run; offer a no-argument default or a ``--test`` mode. Detected and
+  RECLASSIFIED (``harness_contract: "requires_arguments"``, still visible
+  demand, never suppressed) rather than silently reported as a crash — see
+  :func:`_is_argparse_usage_error`.
+- Bounded time: :data:`_PER_SCRIPT_TIMEOUT` (60s) per run. A script that
+  cannot finish inside it produces no verdict, so it is RECLASSIFIED
+  (``harness_contract: "exceeds_time_budget"``) into visible demand —
+  make it incremental, or decay-declare it. It is deliberately NOT
+  dropped from rotation; see the marker in :func:`_run_one` for why an
+  auto-exclusion driven by sidecar history would be a silencing channel.
+- Non-zero exit = a finding worth surfacing: it becomes ``defect`` demand
+  with your stderr/stdout as evidence (see
+  ``demand._validator_defect_items``).
+- Decay self-declaration excludes a script from ever running again: see
+  :data:`_DECAY_DECL_RE` for the exact phrasing and the own-path
+  requirement.
 """
 from __future__ import annotations
 
@@ -162,40 +189,81 @@ _MAX_SCAN_BYTES = 200_000  # bounded read for the cheap "--json" text check
 # scripts/(check|validate|audit|analyze|verify)_*.py — the built-validator class
 _ALLOWLIST_RE = re.compile(r"^(check|validate|audit|analyze|verify)_.*\.py$")
 
-# #928: there is NO machine-readable decay registry anywhere in this repo —
-# whether a script has been archived/decayed exists only as text the script
-# prints (or the marker its own body carries) at run time, e.g.
+# #934: there is NO machine-readable decay registry anywhere in this repo —
+# whether a script has declared itself decayed exists only as text it prints
+# at run time, e.g.
 #   "WARNING: scripts/analyze_repo_size.py is deprecated and marked as
 #    archived (decay-36bd86468443) as unused."
-#   "Error: Execution is disabled because this script is archived."
-# An archived script's declared contract is "do not run me"; running it and
-# then scoring its (correct) refusal as a crash manufactures a false defect.
-# On the live host 11 of 42 allowlisted validators carried this marker, 6 of
-# them still exiting non-zero (counted 2026-08-23; the scripts live in the
-# INSTANCE repo, not here — this repo has two allowlisted scripts and no
-# marker hits). Matched against the SOURCE TEXT: the marker is the script's
-# own self-declaration, not something we have to execute it to observe.
+#   "WARNING: scripts/verify_eeepc_..._guard.py is deprecated and scheduled
+#    for removal after 14+ days of disuse."
+# A script that SELF-DECLARES this way has a contract of "do not run me";
+# running it and scoring its (correct) refusal as a crash manufactures a
+# false defect.
+#
+# #928's original rule matched either alternative phrase ANYWHERE in the
+# source head — a MENTION test, not a self-declaration test. That was wrong:
+# a copy-pasted helper docstring shared by 14 of the 42 allowlisted
+# validators on the live host —
+#   '"""Check if a script is archived/deprecated by reading its content."""'
+# — tripped the "script is archived" alternative, silently excluding every
+# one of those 14 from ever being selected. They implement decay DETECTION;
+# they are not decayed. Measured 2026-08-23: the mention rule excluded 25 of
+# 42; only 13 genuinely self-declare.
+#
+# The rule is now two conditions, both required: the phrase below AND the
+# script's OWN repo-relative path (``scripts/<filename>``) appearing
+# together in the source head. Requiring the own path is what turns a
+# "mentions decay somewhere" test into a "declares ITSELF decayed" test, and
+# it also closes the near-miss #928 left open (issue #934 Class C): the
+# "scheduled for removal" rung — the step before "marked as archived" — used
+# to slip through this pattern entirely.
 #
 # The wording is LLM-authored — nothing in this repo generates it — so it
-# will drift, and a variant this pattern misses lands back in the false-defect
-# path. Be honest about that cost: it is NOT one wasted cycle and the
-# sandbox-denial marker in _run_one does not cover it (an archived refusal is a
-# plain non-zero exit, nothing resembling a PermissionError). The script stays
-# a candidate, so it is re-selected and re-fails every rotation, and the 7-day
-# completed-TTL re-presents it as demand every week until the pattern is
-# widened or the script is deleted. The fail-open direction is still "treat as
-# a candidate", because assuming archival on an unreadable file would silently
-# stop running a real validator — a worse trade than a visible recurring
-# false defect.
-_ARCHIVED_RE = re.compile(r"marked as archived|script is archived")
+# will drift, and a variant this pattern misses lands back in the
+# false-defect path. Be honest about that cost: it is NOT one wasted cycle
+# and the sandbox-denial marker in _run_one does not cover it (a decay
+# refusal is a plain non-zero exit, nothing resembling a PermissionError).
+# The script stays a candidate, so it is re-selected and re-fails every
+# rotation, and the 7-day completed-TTL re-presents it as demand every week
+# until the pattern is widened or the script is deleted.
+#
+# The own-path requirement fails open the SAME direction as an unreadable
+# file: a genuine declaration that happens to omit its own path stays a
+# candidate rather than being silently excluded on an unverifiable claim —
+# it will go on to produce a visible false defect when it refuses to run,
+# which is the honest outcome, not a fabricated one, and strictly better
+# than silencing a real validator that never actually declared itself
+# decayed at all.
+_DECAY_DECL_RE = re.compile(
+    r"is deprecated and (?:marked as archived|scheduled for removal)"
+)
 
 # #928: the ONE error that makes main() exit non-zero (see its comment).
 _NOT_WRITABLE_ERROR = "state_dir_not_writable"
 
-# #928: a run that failed because THIS unit's sandbox denied it a read is not
-# a defect in the script. Matched against the child's stderr; see the marker
-# in _run_one for why the exception name alone is the right signal here.
-_SANDBOX_DENIAL_RE = re.compile(r"PermissionError|Errno 13|Permission denied")
+# #928/#934: a run that failed because THIS unit's sandbox denied it a
+# read/write is not a defect in the script. #934 adds EROFS (Errno 30,
+# "Read-only file system") alongside the original EACCES alternatives —
+# same class as the PermissionError case #928 fixed: a validator (e.g.
+# verify_and_proof.py) that writes its own report into state/reports, which
+# the sandbox makes read-only, crashes with ``OSError: [Errno 30]
+# Read-only file system: ...`` through no fault of its own.
+#
+# Matched against the TERMINAL non-empty line of the child's stderr only
+# (see :func:`_terminal_stderr_line`), NOT the whole stream — #934: a
+# validator can log a non-fatal, mid-run warning that happens to mention a
+# read-only path (e.g. a failed export into memory/*.json) and then go on
+# to report a genuine, unrelated failure on its last line
+# (analyze_repeat_failures.py's live shape). Whole-stderr matching would
+# suppress that genuine finding — a silencing channel, and not a
+# hypothetical one. The exception name/errno alone, without a path check,
+# is still the right signal for what IS on the terminal line: under this
+# sandbox the whole instance tree is read-only and several subtrees are
+# unreadable, so EACCES/EROFS there is far more likely to be the sandbox
+# than the script.
+_SANDBOX_DENIAL_RE = re.compile(
+    r"PermissionError|Errno 13|Permission denied|Errno 30|Read-only file system"
+)
 
 # Tiny, deliberately narrow findings-count heuristic (#925 design: "keep the
 # parse heuristic tiny and fail-open to raw exit code"). Only a top-level
@@ -247,24 +315,30 @@ def _scan_head(script: Path) -> str:
         return handle.read(_MAX_SCAN_BYTES)
 
 
-def _is_archived(script: Path) -> bool:
-    """#928: does the script's own source declare itself archived/decayed
-    (see :data:`_ARCHIVED_RE`)? Bounded read, same pattern as
-    :func:`_accepts_json_flag` — this scans text, it does not execute
-    anything. Fail-open to ``False`` (NOT archived, i.e. still a candidate)
-    on any read error: an unreadable script will simply fail to run on its
-    own, which is an honest outcome, not a fabricated one."""
+def _is_decay_declared(script: Path) -> bool:
+    """#934: does the script's own source SELF-DECLARE decay (see
+    :data:`_DECAY_DECL_RE`) — the phrase AND the script's own repo-relative
+    path (``scripts/<filename>``) both present in its source head? Bounded
+    read, same pattern as :func:`_accepts_json_flag` — this scans text, it
+    does not execute anything. Fail-open to ``False`` (not declared, i.e.
+    still a candidate) on any read error, AND when the phrase matches but
+    the script's own path is absent: an unreadable file or an unverifiable
+    claim must not silently stop a script from running — see the long
+    comment on :data:`_DECAY_DECL_RE` for why that direction is safe."""
     try:
-        return bool(_ARCHIVED_RE.search(_scan_head(script)))
+        head = _scan_head(script)
+        own_path = f"scripts/{script.name}"
+        return bool(_DECAY_DECL_RE.search(head)) and own_path in head
     except Exception:
         return False
 
 
 def _candidate_scripts(selfevo_repo: Path) -> list[Path]:
     """Allowlisted validator-class scripts in the instance repo, sorted for
-    determinism, excluding any that declare themselves archived/decayed
-    (#928: an archived script's refusal to run is correct behaviour, not a
-    defect). Fail-open: no ``scripts/`` dir or any error yields ``[]``."""
+    determinism, excluding any that SELF-DECLARE decay (#934: see
+    :data:`_DECAY_DECL_RE` — a decayed script's refusal to run is correct
+    behaviour, not a defect). Fail-open: no ``scripts/`` dir or any error
+    yields ``[]``."""
     try:
         scripts_dir = Path(selfevo_repo) / "scripts"
         if not scripts_dir.is_dir():
@@ -272,7 +346,7 @@ def _candidate_scripts(selfevo_repo: Path) -> list[Path]:
         return sorted(
             p
             for p in scripts_dir.glob("*.py")
-            if _ALLOWLIST_RE.match(p.name) and not _is_archived(p)
+            if _ALLOWLIST_RE.match(p.name) and not _is_decay_declared(p)
         )
     except Exception:
         return []
@@ -395,6 +469,42 @@ def _parse_findings_count(stdout: str) -> int | None:
     return None
 
 
+def _terminal_stderr_line(stderr: str) -> str:
+    """#934: the last non-empty line of ``stderr`` — what the
+    sandbox-denial marker is matched against, rather than the whole stream.
+    A validator's mid-run, non-fatal noise (e.g. a failed best-effort
+    export logging a read-only path) must not suppress a genuine failure
+    it reports afterward; keying on the terminal line is what keeps that
+    genuine failure visible. Empty/whitespace-only input yields ``""``."""
+    for line in reversed(stderr.splitlines()):
+        if line.strip():
+            return line
+    return ""
+
+
+# #934 Class B: argparse's own usage-error shape, e.g.
+#   usage: validate_cycle_handoff.py [-h] [--manifest MANIFEST] ...
+#   validate_cycle_handoff.py: error: --manifest is required unless --test is used
+# Both lines are required — a validator that legitimately exits 2 while
+# printing ordinary findings text must not be caught by a looser check (e.g.
+# exit_code == 2 alone, or "usage:" alone without the paired "prog: error:"
+# line argparse always emits alongside it).
+_ARGPARSE_USAGE_LINE_RE = re.compile(r"^usage:\s", re.IGNORECASE | re.MULTILINE)
+_ARGPARSE_ERROR_LINE_RE = re.compile(r"^\S+:\s*error:\s", re.MULTILINE)
+
+
+def _is_argparse_usage_error(stderr: str) -> bool:
+    """#934: does ``stderr`` carry argparse's own usage-error shape — a
+    ``usage:`` line AND a ``<prog>: error: ...`` line? Called only when
+    ``exit_code == 2`` (see the caller in :func:`_run_one`); checked here as
+    a pure text shape so a validator that happens to exit 2 for its own
+    reasons (e.g. reporting findings) is not misclassified merely because it
+    shares that exit code."""
+    return bool(_ARGPARSE_USAGE_LINE_RE.search(stderr)) and bool(
+        _ARGPARSE_ERROR_LINE_RE.search(stderr)
+    )
+
+
 def _process_group_id(proc: "subprocess.Popen[str] | None") -> int | None:
     """The process-group id of a just-spawned child (POSIX only; ``None``
     elsewhere or on any error).
@@ -501,6 +611,7 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         cmd.append("--json")
 
     exit_code: int | None = None
+    timed_out = False
     stdout = ""
     stderr = ""
     proc: "subprocess.Popen[str] | None" = None
@@ -563,6 +674,7 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
             pass
         for t in reader_threads:
             t.join(timeout=5)
+        timed_out = True
         stderr = f"timeout after {timeout:.0f}s"
     except Exception as exc:
         _kill_process_group(proc, pgid)
@@ -602,24 +714,79 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         "findings_count": _parse_findings_count(stdout),
         "stderr_tail": stderr[-2000:],
     }
-    if isinstance(exit_code, int) and exit_code != 0 and _SANDBOX_DENIAL_RE.search(stderr):
-        # #928: this run did not fail because the script is broken — it failed
-        # because THIS unit's sandbox denied it a read. Two of the three false
-        # defects from the harness's first production run were exactly that
-        # (validators whose purpose is reading state/ledger, which was in
-        # InaccessiblePaths=). Removing ledger from that list fixes those two;
-        # this marker closes the class, because demand/, scorecard/, goals/,
-        # promotions/ and usage/ are still inaccessible and a validator has
-        # every reason to read some of them.
+    if (
+        isinstance(exit_code, int)
+        and exit_code != 0
+        and _SANDBOX_DENIAL_RE.search(_terminal_stderr_line(stderr))
+    ):
+        # #928/#934: this run did not fail because the script is broken — it
+        # failed because THIS unit's sandbox denied it a read or a write. Two
+        # of the three false defects from the harness's first production run
+        # were exactly this shape (validators whose purpose is reading
+        # state/ledger, which was in InaccessiblePaths=). Removing ledger
+        # from that list fixed those two; this marker closes the class,
+        # because demand/, scorecard/, goals/, promotions/ and usage/ are
+        # still inaccessible, state/reports is read-only, and a validator has
+        # every reason to touch some of them.
         #
-        # Deliberately keyed on the exception name alone, not on the denied
-        # path: under this sandbox the whole instance tree is read-only and
-        # several subtrees are unreadable, so EACCES is far more likely to be
-        # the sandbox than the script. The trade is explicit — a genuine
-        # script bug that surfaces only as EACCES stops becoming demand — and
-        # it is the right way round, because a false defect actively poisons
-        # the loop while a missed one merely goes unreported.
+        # Keyed on the exception name/errno alone, not on the denied path:
+        # under this sandbox the whole instance tree is read-only and
+        # several subtrees are unreadable, so EACCES/EROFS is far more
+        # likely to be the sandbox than the script. The trade is explicit —
+        # a genuine script bug that surfaces only as EACCES/EROFS stops
+        # becoming demand — and it is the right way round, because a false
+        # defect actively poisons the loop while a missed one merely goes
+        # unreported.
+        #
+        # Matched against the TERMINAL line only (#934), not the whole
+        # stream: see the comment on :data:`_SANDBOX_DENIAL_RE` for why a
+        # whole-stderr scan is itself a silencing channel for a genuine
+        # failure a validator reports after unrelated, non-fatal noise.
         record["harness_env_error"] = "permission_denied"
+    if exit_code == 2 and _is_argparse_usage_error(stderr):
+        # #934 Class B: the harness invokes every script with NO arguments
+        # (see the module docstring's invocation contract). A validator
+        # whose argparse requires a flag therefore exits 2 on EVERY run,
+        # forever, and without this the false-defect summary
+        # "validator X fails when run" sends the loop chasing a script that
+        # is not broken. This is a DISTINCT field from harness_env_error on
+        # purpose: that field means "suppress, this is not the script's
+        # fault"; this one means the opposite — the script genuinely does
+        # not conform to the harness's no-argument contract, which the loop
+        # CAN fix (the script already offers a --test mode in the observed
+        # live case), so it must stay visible, just correctly labelled.
+        record["harness_contract"] = "requires_arguments"
+    elif timed_out:
+        # #934: a script that cannot finish inside _PER_SCRIPT_TIMEOUT
+        # produces no verdict at all (exit_code None), so before this it
+        # yielded NOTHING anywhere — not demand, not an operator signal —
+        # while still burning a quarter of _TOTAL_BUDGET_SECONDS on every
+        # rotation. Measured live: check_style.py AST-parses 456 files on
+        # i386/2GB hardware and times out every single run.
+        #
+        # This is deliberately a RECLASSIFICATION and not an exclusion from
+        # selection, and the reason is worth stating plainly, because the
+        # obvious design is the dangerous one. Any auto-exclusion has to
+        # decide "has this script timed out N times running?" from the only
+        # history that exists — last_runs.jsonl — and EVERY validator
+        # subprocess can append to that file (it is the harness's one
+        # writable carve-out, shared by every child). A row's path,
+        # exit_code, stderr_tail and any mtime stamp are all forgeable, and
+        # the instance tree is readable, so three appended lines naming ANY
+        # allowlisted validator would drop it from selection — permanently,
+        # because a script that never runs never produces a real row to
+        # break its own streak. That is a capability the sidecar does not
+        # otherwise grant: forging a clean newest row already suppresses a
+        # script's DEMAND, but the script still runs and its next real
+        # verdict supersedes the forgery.
+        #
+        # So the budget is not reclaimed automatically. Instead the waste
+        # becomes visible, truthful, fixable demand: the loop can make the
+        # script incremental, or decay-declare it (which excludes it through
+        # the one mechanism that reads the script's OWN source rather than
+        # attacker-writable state). Forging THIS marker only fabricates a
+        # defect, which forging an exit_code already did — no new capability.
+        record["harness_contract"] = "exceeds_time_budget"
     return record
 
 
@@ -856,8 +1023,9 @@ def run_validator_harness(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]
     """Run one bounded validator-harness invocation. See the module
     docstring for the full design. Returns
     ``{"selected": [...], "ran": [...], "skipped_birth_window": [...],
-    "errors": [...]}`` (repo-relative ``scripts/*.py`` paths). Fail-open for
-    everything EXCEPT the writable-directory probe below (#928): a broken
+    "errors": [...]}`` (repo-relative
+    ``scripts/*.py`` paths). Fail-open for everything EXCEPT the
+    writable-directory probe below (#928): a broken
     ``state/validator_harness`` carve-out must be reported loudly, not
     swallowed into an empty-but-successful-looking result. Any other
     unexpected error yields whatever was collected so far plus an

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -446,7 +446,7 @@ def _write_rotation(state_dir: Path, data: dict[str, Any]) -> None:
         pass
 
 
-def _rotation_key(script: Path, served: dict[str, str]) -> tuple[int, str, str]:
+def _rotation_key(script: Path, served: dict[str, str]) -> tuple[int, float, str]:
     """Sort key for least-recently-run-first: never-run scripts (no
     rotation entry) sort before any run one; among run ones, oldest
     timestamp first; ties broken by path for determinism.
@@ -460,12 +460,31 @@ def _rotation_key(script: Path, served: dict[str, str]) -> tuple[int, str, str]:
     of any allowlisted validator from one JSON write, and it is exactly the
     capability #934 refused to add via a timeout streak. Clamping makes the
     forgery self-heal within one rotation: an impossible stamp buys the
-    attacker priority, not silence."""
+    attacker priority, not silence.
+
+    Sorted on a NUMERIC timestamp, and every failure returns the never-run
+    key (#934 review round 2). The previous version formatted the stamp with
+    :func:`_iso`, whose ``astimezone`` raises ``OverflowError`` when the
+    result leaves ``datetime``'s range — reachable from one forged line,
+    e.g. ``0001-01-01T00:00:00+14:00``, which parses fine, is not in the
+    future, and then underflows. That raise propagated out of
+    ``eligible.sort(key=...)`` into ``run_validator_harness``'s outer
+    handler, so the WHOLE invocation aborted before either
+    ``_write_rotation`` call — meaning the poison was never overwritten and
+    the entire validator fleet was dead permanently, while ``main()``
+    (which only exits non-zero for ``_NOT_WRITABLE_ERROR``) still reported
+    success to systemd. That is the same durable, attacker-writable-state
+    silencing class this clamp exists to close, except total rather than
+    per-script. ``.timestamp()`` on an aware datetime is plain arithmetic
+    against the epoch, safe across the full year 1..9999 range."""
     rel = f"scripts/{script.name}"
-    parsed = _parse_ts(served.get(rel))
-    if parsed is None or parsed > datetime.now(timezone.utc):
-        return (0, "", rel)
-    return (1, _iso(parsed), rel)
+    try:
+        parsed = _parse_ts(served.get(rel))
+        if parsed is None or parsed > datetime.now(timezone.utc):
+            return (0, 0.0, rel)
+        return (1, parsed.timestamp(), rel)
+    except Exception:
+        return (0, 0.0, rel)
 
 
 # ─── execution ───────────────────────────────────────────────────────────
@@ -476,8 +495,8 @@ def _rotation_key(script: Path, served: dict[str, str]) -> tuple[int, str, str]:
 # and the hand-rolled ``"--json" in sys.argv`` idiom. See
 # :func:`_accepts_json_flag` for why a mention test was wrong.
 _JSON_FLAG_DECL_RE = re.compile(
-    r"""add_argument\(\s*(?:['"][^'"]*['"]\s*,\s*)*['"]--json['"]"""
-    r"""|['"]--json['"]\s*(?:not\s+)?in\s+sys\.argv"""
+    r"""(?:add_argument|add_option|option)\(\s*(?:['"][^'"]*['"]\s*,\s*)*['"]--json['"]"""
+    r"""|['"]--json['"]\s*(?:not\s+)?in\s+(?:sys\.)?argv"""
 )
 
 
@@ -496,9 +515,26 @@ def _accepts_json_flag(script: Path) -> bool:
     rejected it with ``unrecognized arguments``, and the run failed for a
     reason the script had no part in.
 
-    Fail-open direction here is "do not pass the flag": a missed ``--json``
-    only costs the findings-count heuristic a parse, whereas passing a flag
-    the script rejects breaks the run outright.
+    Fail-open direction here is "do not pass the flag", because passing one
+    the script rejects breaks the run outright. But a miss is NOT free, and
+    an earlier version of this docstring understated it (#934 review round
+    2): for a validator that reports findings while exiting 0 — precisely
+    what ``demand._validator_defect_items``' findings-count branch exists to
+    serve — no ``--json`` means no JSON on stdout, ``findings_count`` None,
+    exit 0, and therefore no demand item at all. Its findings stop reaching
+    the loop entirely. So the pattern covers ``add_argument``/``add_option``/
+    ``option`` (argparse, optparse, click/typer decorators) and both
+    ``sys.argv`` spellings. A declaration built indirectly — ``NAMES =
+    ["-j", "--json"]`` then ``add_argument(*NAMES)`` — is not matchable by
+    any source pattern and will be missed; that is the residual, and it
+    costs that script's exit-0 findings.
+
+    Measured against the live instance repo (2026-08-23, 43 allowlisted):
+    the old mention test matched 38, this declaration test matches 37, and
+    the single difference is a script whose only ``--json`` occurrence is a
+    usage example in its docstring with no option declared anywhere — i.e.
+    the one change is a fix, not a regression. Widening to the non-argparse
+    forms regains none of the 43 today; it is there for the next author.
 
     #928: reads a BOUNDED prefix rather than the whole file. These scripts are
     instance-authored, so their size is not ours to trust, and this runs once
@@ -624,7 +660,7 @@ def _kill_process_group(
         pass
 
 
-def _drain_capped(stream: Any, sink: list[str], cap: int, truncated: list[bool] | None = None) -> None:
+def _drain_capped(stream: Any, sink: list[str], cap: int) -> None:
     """Reader-thread body (#928): read ``stream`` in a loop until EOF,
     keeping only the first ``cap`` chars in ``sink`` and discarding
     everything read beyond that. This is the piece that makes the output
@@ -641,12 +677,14 @@ def _drain_capped(stream: Any, sink: list[str], cap: int, truncated: list[bool] 
     from under it during a kill) — this is a background drain, never the
     source of truth for ``exit_code``.
 
-    ``truncated``, when given, is a one-element sink set to ``True`` if
-    anything was discarded (#934 review). What is kept is the HEAD of the
-    stream, so on truncation the last line of ``sink`` is NOT the last line
-    the script wrote — it is whatever sat at the cap boundary, at an offset
-    the script itself chooses. :func:`_run_one` needs to know that before it
-    classifies anything from the "terminal" line."""
+    What is kept is the HEAD of the stream, so on truncation the last line
+    of ``sink`` is NOT the last line the script wrote — it is whatever sat
+    at the cap boundary, at an offset the script itself chooses.
+    :func:`_run_one` detects that as ``len(stderr) >= cap`` and refuses to
+    classify anything from the "terminal" line (#934 review); deriving it
+    from the length rather than a flag the reader thread sets is race-free
+    by construction, which matters because that thread may still be running
+    after its ``join`` timeout expires."""
     total = 0
     try:
         while True:
@@ -657,12 +695,7 @@ def _drain_capped(stream: Any, sink: list[str], cap: int, truncated: list[bool] 
                 keep = chunk[: cap - total]
                 sink.append(keep)
                 total += len(keep)
-                if len(keep) < len(chunk) and truncated is not None:
-                    truncated[0] = True
-            else:
-                # Deliberately discarded -- still consumed to keep draining.
-                if truncated is not None:
-                    truncated[0] = True
+            # else: deliberately discarded -- still consumed to keep draining
     except Exception:
         pass
 
@@ -698,10 +731,6 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
     pgid: int | None = None
     stdout_chunks: list[str] = []
     stderr_chunks: list[str] = []
-    # #934 review: one-element sink, set by the stderr reader thread if it
-    # had to discard anything. See the marker below for why classification
-    # must not trust a truncated stream's last line.
-    stderr_truncated: list[bool] = [False]
     reader_threads: list[threading.Thread] = []
     try:
         proc = subprocess.Popen(
@@ -724,7 +753,7 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
             ),
             threading.Thread(
                 target=_drain_capped,
-                args=(proc.stderr, stderr_chunks, _MAX_OUTPUT_BYTES, stderr_truncated),
+                args=(proc.stderr, stderr_chunks, _MAX_OUTPUT_BYTES),
                 daemon=True,
             ),
         ]
@@ -803,7 +832,7 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         isinstance(exit_code, int)
         and exit_code != 0
         and not usage_error
-        and not stderr_truncated[0]
+        and len(stderr) < _MAX_OUTPUT_BYTES
         and _SANDBOX_DENIAL_RE.search(_terminal_stderr_line(stderr))
     ):
         # #928/#934: this run did not fail because the script is broken — it
@@ -825,9 +854,10 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         # defect actively poisons the loop while a missed one merely goes
         # unreported.
         #
-        # NOT applied when the stderr capture was TRUNCATED (#934 review).
-        # _drain_capped keeps the HEAD of the stream, so once a script writes
-        # more than _MAX_OUTPUT_BYTES the last captured line is not the last
+        # NOT applied when the stderr capture was TRUNCATED (#934 review),
+        # detected as len(stderr) >= _MAX_OUTPUT_BYTES. _drain_capped keeps
+        # the HEAD of the stream, so once a script writes more than
+        # _MAX_OUTPUT_BYTES the last captured line is not the last
         # line the script wrote — it is whatever sat at the cap boundary, at
         # an offset the script chooses. A hostile validator could therefore
         # pad its stderr so that a line mentioning a read-only path lands on
@@ -1192,7 +1222,7 @@ def run_validator_harness(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]
             deadline = time.monotonic() + _TOTAL_BUDGET_SECONDS
             for script in selected:
                 remaining = deadline - time.monotonic()
-                if remaining < _PER_SCRIPT_TIMEOUT:
+                if result["ran"] and remaining < _PER_SCRIPT_TIMEOUT:
                     # #934 review: NEVER start a run that cannot be given the
                     # full per-script contract. This used to pass
                     # min(_PER_SCRIPT_TIMEOUT, remaining), so the last script
@@ -1213,6 +1243,20 @@ def run_validator_harness(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]
                     # about the script, so the budget it consumes buys
                     # nothing, and the script keeps its rotation position
                     # (nothing is stamped) so it runs first next time.
+                    #
+                    # The result["ran"] guard above is a
+                    # forward-progress floor (#934 review round 2):
+                    # the FIRST selected script always gets its run.
+                    # Without it, a configuration where
+                    # _PER_SCRIPT_TIMEOUT >= _TOTAL_BUDGET_SECONDS
+                    # would select scripts, run none, report
+                    # errors: [] and exit 0 -- a silently dead unit
+                    # that systemd calls successful. Not reachable
+                    # with today's hard-coded 60/240, but K is
+                    # already env-tunable and these two are the
+                    # obvious next knobs. The first run is still
+                    # bounded by _PER_SCRIPT_TIMEOUT, so total wall
+                    # time stays bounded either way.
                     break
                 record = _run_one(script, selfevo_repo, _PER_SCRIPT_TIMEOUT)
                 rel = record["path"]

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -19,7 +19,7 @@ Design, one call to :func:`run_validator_harness` per invocation:
    first, excluding any script whose own source SELF-DECLARES decay (#934:
    see :data:`_DECAY_DECL_RE` — there is no machine-readable decay registry,
    so the declaration text is the only signal, and it must be a
-   self-declaration — the phrase and the script's OWN path on one line — not
+   self-declaration — the phrase and the script's OWN path together — not
    merely a mention, or scripts that implement decay detection get silently
    excluded from ever running; a decayed script's refusal to run is correct
    behaviour, not a defect, and must never be selected in the first place).
@@ -211,9 +211,9 @@ _ALLOWLIST_RE = re.compile(r"^(check|validate|audit|analyze|verify)_.*\.py$")
 # they are not decayed. Measured 2026-08-23: the mention rule excluded 25 of
 # 42; only 13 genuinely self-declare.
 #
-# The rule is now two conditions, both required ON THE SAME LINE: the phrase
-# below AND the script's OWN repo-relative path (``scripts/<filename>``).
-# Requiring the own path is what turns a
+# The rule is now two conditions, both required: the phrase below AND the
+# script's OWN repo-relative path (``scripts/<filename>``), anywhere in the
+# scanned head. Requiring the own path is what turns a
 # "mentions decay somewhere" test into a "declares ITSELF decayed" test, and
 # it also closes the near-miss #928 left open (issue #934 Class C): the
 # "scheduled for removal" rung — the step before "marked as archived" — used
@@ -319,7 +319,7 @@ def _scan_head(script: Path) -> str:
 def _is_decay_declared(script: Path) -> bool:
     """#934: does the script's own source SELF-DECLARE decay (see
     :data:`_DECAY_DECL_RE`) — the phrase AND the script's own repo-relative
-    path (``scripts/<filename>``) on the SAME line of its source head? Bounded
+    path (``scripts/<filename>``) both present in its source head? Bounded
     read, same pattern as :func:`_accepts_json_flag` — this scans text, it
     does not execute anything. Fail-open to ``False`` (not declared, i.e.
     still a candidate) on any read error, AND when the phrase matches but
@@ -329,18 +329,30 @@ def _is_decay_declared(script: Path) -> bool:
     try:
         head = _scan_head(script)
         own_path = f"scripts/{script.name}"
-        # Both conditions on the SAME line (#934 review). Co-occurrence
-        # anywhere in the 200KB head is too loose now that
-        # docs/INITIAL_VALIDATOR_ROADMAP.md publishes the canonical phrase
-        # verbatim: the next decay-auditing validator will hold it as a
-        # constant to search for AND name its own path in its usage text,
-        # and would silence itself — the same bug this replaced, one rung
-        # narrower. Both real declarations on the host are single-line
-        # ``WARNING: scripts/<name>.py is deprecated and ...`` strings.
-        return any(
-            _DECAY_DECL_RE.search(line) and own_path in line
-            for line in head.splitlines()
-        )
+        # Co-occurrence anywhere in the head, NOT on the same line.
+        #
+        # The #934 review argued for a same-line rule, on the grounds that
+        # co-occurrence is loose now that docs/INITIAL_VALIDATOR_ROADMAP.md
+        # publishes the canonical phrase verbatim, so a future decay-auditing
+        # validator could hold the phrase as a constant, name its own path in
+        # its usage text, and silence itself. The concern is right. The fix
+        # was wrong, and measuring it against the live instance repo is what
+        # showed that: same-line excludes 11 of 43 where co-occurrence
+        # excludes 13, and the two it loses are precisely the "scheduled for
+        # removal" pair this issue set out to start excluding (Class C).
+        # Their declarations are not single-line —
+        # verify_eeepc_self_evolving_service_guard.py carries the phrase in
+        # its module docstring and its own path four lines later, and its
+        # runtime WARNING string is split across two adjacent literals so the
+        # phrase spans a line break there too.
+        #
+        # So the residual is handled where it can be handled honestly: the
+        # roadmap doc tells authors not to put the phrase and their own path
+        # in the same file unless they mean it. A pattern cannot distinguish
+        # "quotes the phrase" from "declares the phrase" when both appear in
+        # one file, and guessing wrong in the exclude direction is what
+        # silenced 14 validators in the first place.
+        return bool(_DECAY_DECL_RE.search(head)) and own_path in head
     except Exception:
         return False
 

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -208,8 +208,11 @@ _ALLOWLIST_RE = re.compile(r"^(check|validate|audit|analyze|verify)_.*\.py$")
 #   '"""Check if a script is archived/deprecated by reading its content."""'
 # — tripped the "script is archived" alternative, silently excluding every
 # one of those 14 from ever being selected. They implement decay DETECTION;
-# they are not decayed. Measured 2026-08-23: the mention rule excluded 25 of
-# 42; only 13 genuinely self-declare.
+# they are not decayed. Measured on the live instance repo 2026-08-23: the
+# mention rule excluded 25 of the 42 allowlisted validators, while only 13
+# genuinely self-declare. (A later measurement the same day counted 43
+# allowlisted — the loop authored one more in between. Both numbers are real;
+# the ratios are what matter, and they did not move.)
 #
 # The rule is now two conditions, both required: the phrase below AND the
 # script's OWN repo-relative path (``scripts/<filename>``), anywhere in the

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -498,8 +498,8 @@ def _rotation_key(script: Path, served: dict[str, str]) -> tuple[int, float, str
 # and the hand-rolled ``"--json" in sys.argv`` idiom. See
 # :func:`_accepts_json_flag` for why a mention test was wrong.
 _JSON_FLAG_DECL_RE = re.compile(
-    r"""(?:add_argument|add_option|option)\(\s*(?:['"][^'"]*['"]\s*,\s*)*['"]--json['"]"""
-    r"""|['"]--json['"]\s*(?:not\s+)?in\s+(?:sys\.)?argv"""
+    r"""\b(?:add_argument|add_option|option)\(\s*(?:['"][^'"]*['"]\s*,\s*)*['"]--json['"]"""
+    r"""|['"]--json['"]\s*(?:not\s+)?in\s+(?:sys\.)?argv\b"""
 )
 
 
@@ -526,11 +526,26 @@ def _accepts_json_flag(script: Path) -> bool:
     serve — no ``--json`` means no JSON on stdout, ``findings_count`` None,
     exit 0, and therefore no demand item at all. Its findings stop reaching
     the loop entirely. So the pattern covers ``add_argument``/``add_option``/
-    ``option`` (argparse, optparse, click/typer decorators) and both
-    ``sys.argv`` spellings. A declaration built indirectly — ``NAMES =
-    ["-j", "--json"]`` then ``add_argument(*NAMES)`` — is not matchable by
-    any source pattern and will be missed; that is the residual, and it
-    costs that script's exit-0 findings.
+    ``option`` (argparse, optparse, click-style decorators) and both
+    ``sys.argv`` spellings, each anchored on a word boundary so it cannot
+    match inside a longer identifier (#934 review round 3: without ``\\b``,
+    ``foption("--json"`` and ``in argv_names_the_auditor_checks`` both
+    matched, and a script handed a flag it cannot parse produces a plain
+    "fails when run" false defect every rotation — the exact class this
+    issue removes).
+
+    Three residuals, all costing that script's exit-0 findings and none
+    matchable by any source pattern:
+
+    * an indirectly built declaration — ``NAMES = ["-j", "--json"]`` then
+      ``add_argument(*NAMES)``;
+    * typer's idiomatic ``Option(False, "--json")``, where the default comes
+      before the flag, so the alias-skipping group above does not reach it;
+    * the mirror case, a validator holding the literal ``'option("--json"'``
+      as a needle to search other files for. It gets the flag it may not
+      accept, and the ``unrecognized arguments`` veto in
+      :func:`_is_argparse_usage_error` then keeps the row honest ("fails
+      when run" with the usage text as evidence) rather than mislabelling it.
 
     Measured against the live instance repo (2026-08-23, 43 allowlisted):
     the old mention test matched 38, this declaration test matches 37, and

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -19,7 +19,7 @@ Design, one call to :func:`run_validator_harness` per invocation:
    first, excluding any script whose own source SELF-DECLARES decay (#934:
    see :data:`_DECAY_DECL_RE` — there is no machine-readable decay registry,
    so the declaration text is the only signal, and it must be a
-   self-declaration — the phrase together with the script's OWN path — not
+   self-declaration — the phrase and the script's OWN path on one line — not
    merely a mention, or scripts that implement decay detection get silently
    excluded from ever running; a decayed script's refusal to run is correct
    behaviour, not a defect, and must never be selected in the first place).
@@ -40,7 +40,7 @@ Design, one call to :func:`run_validator_harness` per invocation:
    something whose age is unknown), matching the module's overall
    skip-means-not-run discipline.
 3. Each selected script is run with ``<venv python> <script> --json`` when
-   the script's own text mentions ``--json`` (cheap textual check — this is
+   the script's own text DECLARES ``--json`` (cheap textual check — this is
    a SELECTION heuristic, not a security boundary), else a plain invocation.
    ``subprocess`` with ``cwd=selfevo_repo``, a per-script timeout
    (:data:`_PER_SCRIPT_TIMEOUT`, 60s) and a total per-invocation budget
@@ -123,7 +123,8 @@ else documents this, and every point below has produced a live false
 defect when a script did not anticipate it:
 
 - No arguments: every script is run as ``<python> <script>`` (or with a
-  trailing ``--json`` when the script's own text mentions that flag). A
+  trailing ``--json`` when the script's own text DECLARES that flag —
+  an ``add_argument`` call or a ``sys.argv`` test, not a bare mention). A
   script whose ``argparse`` requires a flag will exit non-zero on EVERY
   run; offer a no-argument default or a ``--test`` mode. Detected and
   RECLASSIFIED (``harness_contract: "requires_arguments"``, still visible
@@ -210,9 +211,9 @@ _ALLOWLIST_RE = re.compile(r"^(check|validate|audit|analyze|verify)_.*\.py$")
 # they are not decayed. Measured 2026-08-23: the mention rule excluded 25 of
 # 42; only 13 genuinely self-declare.
 #
-# The rule is now two conditions, both required: the phrase below AND the
-# script's OWN repo-relative path (``scripts/<filename>``) appearing
-# together in the source head. Requiring the own path is what turns a
+# The rule is now two conditions, both required ON THE SAME LINE: the phrase
+# below AND the script's OWN repo-relative path (``scripts/<filename>``).
+# Requiring the own path is what turns a
 # "mentions decay somewhere" test into a "declares ITSELF decayed" test, and
 # it also closes the near-miss #928 left open (issue #934 Class C): the
 # "scheduled for removal" rung — the step before "marked as archived" — used
@@ -318,7 +319,7 @@ def _scan_head(script: Path) -> str:
 def _is_decay_declared(script: Path) -> bool:
     """#934: does the script's own source SELF-DECLARE decay (see
     :data:`_DECAY_DECL_RE`) — the phrase AND the script's own repo-relative
-    path (``scripts/<filename>``) both present in its source head? Bounded
+    path (``scripts/<filename>``) on the SAME line of its source head? Bounded
     read, same pattern as :func:`_accepts_json_flag` — this scans text, it
     does not execute anything. Fail-open to ``False`` (not declared, i.e.
     still a candidate) on any read error, AND when the phrase matches but
@@ -328,7 +329,18 @@ def _is_decay_declared(script: Path) -> bool:
     try:
         head = _scan_head(script)
         own_path = f"scripts/{script.name}"
-        return bool(_DECAY_DECL_RE.search(head)) and own_path in head
+        # Both conditions on the SAME line (#934 review). Co-occurrence
+        # anywhere in the 200KB head is too loose now that
+        # docs/INITIAL_VALIDATOR_ROADMAP.md publishes the canonical phrase
+        # verbatim: the next decay-auditing validator will hold it as a
+        # constant to search for AND name its own path in its usage text,
+        # and would silence itself — the same bug this replaced, one rung
+        # narrower. Both real declarations on the host are single-line
+        # ``WARNING: scripts/<name>.py is deprecated and ...`` strings.
+        return any(
+            _DECAY_DECL_RE.search(line) and own_path in line
+            for line in head.splitlines()
+        )
     except Exception:
         return False
 
@@ -425,27 +437,62 @@ def _write_rotation(state_dir: Path, data: dict[str, Any]) -> None:
 def _rotation_key(script: Path, served: dict[str, str]) -> tuple[int, str, str]:
     """Sort key for least-recently-run-first: never-run scripts (no
     rotation entry) sort before any run one; among run ones, oldest
-    timestamp first; ties broken by path for determinism."""
+    timestamp first; ties broken by path for determinism.
+
+    A stamp in the FUTURE is treated as never-run (#934 review).
+    ``rotation.json`` lives in the same writable carve-out every validator
+    subprocess shares, and ``served[rel]`` is only overwritten for scripts
+    that actually RUN — so a single forged entry dated far ahead used to sort
+    its target last forever, meaning it was never selected, never ran, and so
+    never replaced the forgery. That is durable, self-maintaining exclusion
+    of any allowlisted validator from one JSON write, and it is exactly the
+    capability #934 refused to add via a timeout streak. Clamping makes the
+    forgery self-heal within one rotation: an impossible stamp buys the
+    attacker priority, not silence."""
     rel = f"scripts/{script.name}"
     parsed = _parse_ts(served.get(rel))
-    if parsed is None:
+    if parsed is None or parsed > datetime.now(timezone.utc):
         return (0, "", rel)
     return (1, _iso(parsed), rel)
 
 
 # ─── execution ───────────────────────────────────────────────────────────
 
+# #934 review: a script DECLARING a --json option, not merely naming the
+# string. Covers argparse (``add_argument("--json"``, any quoting/spacing,
+# including a short alias before it as in ``add_argument("-j", "--json"``)
+# and the hand-rolled ``"--json" in sys.argv`` idiom. See
+# :func:`_accepts_json_flag` for why a mention test was wrong.
+_JSON_FLAG_DECL_RE = re.compile(
+    r"""add_argument\(\s*(?:['"][^'"]*['"]\s*,\s*)*['"]--json['"]"""
+    r"""|['"]--json['"]\s*(?:not\s+)?in\s+sys\.argv"""
+)
+
 
 def _accepts_json_flag(script: Path) -> bool:
     """Cheap textual check (not a security boundary): does the script's own
-    source mention ``--json`` anywhere in its first :data:`_MAX_SCAN_BYTES`
-    characters? Fail-open to ``False`` (plain invocation) on any read error.
+    source DECLARE a ``--json`` option — an ``add_argument("--json")``-shaped
+    call, or a direct ``sys.argv`` membership test — within its first
+    :data:`_MAX_SCAN_BYTES` characters? Fail-open to ``False`` (plain
+    invocation) on any read error.
+
+    #934 review: this used to be ``"--json" in head``, a bare MENTION test —
+    the same defect shape ``_ARCHIVED_RE`` had, one function away. A script
+    that merely names the string (a decay/pattern auditor looking FOR
+    ``--json`` in other files is the obvious case, and the 14 validators #934
+    returns to service are exactly that class) got the flag appended, argparse
+    rejected it with ``unrecognized arguments``, and the run failed for a
+    reason the script had no part in.
+
+    Fail-open direction here is "do not pass the flag": a missed ``--json``
+    only costs the findings-count heuristic a parse, whereas passing a flag
+    the script rejects breaks the run outright.
 
     #928: reads a BOUNDED prefix rather than the whole file. These scripts are
     instance-authored, so their size is not ours to trust, and this runs once
     per candidate inside a unit capped at ``MemoryMax=512M``."""
     try:
-        return "--json" in _scan_head(script)
+        return bool(_JSON_FLAG_DECL_RE.search(_scan_head(script)))
     except Exception:
         return False
 
@@ -494,12 +541,21 @@ _ARGPARSE_ERROR_LINE_RE = re.compile(r"^\S+:\s*error:\s", re.MULTILINE)
 
 
 def _is_argparse_usage_error(stderr: str) -> bool:
-    """#934: does ``stderr`` carry argparse's own usage-error shape — a
-    ``usage:`` line AND a ``<prog>: error: ...`` line? Called only when
-    ``exit_code == 2`` (see the caller in :func:`_run_one`); checked here as
-    a pure text shape so a validator that happens to exit 2 for its own
-    reasons (e.g. reporting findings) is not misclassified merely because it
-    shares that exit code."""
+    """#934: does ``stderr`` carry argparse's own UNDER-supply usage-error
+    shape — a ``usage:`` line AND a ``<prog>: error: ...`` line, and NOT
+    argparse's over-supply wording? Called only when ``exit_code == 2`` (see
+    the caller in :func:`_run_one`); checked here as a pure text shape so a
+    validator that happens to exit 2 for its own reasons (e.g. reporting
+    findings) is not misclassified merely because it shares that exit code.
+
+    The ``unrecognized arguments`` exclusion (#934 review) matters because
+    the harness itself supplies ``--json`` whenever
+    :func:`_accepts_json_flag` says so. A script that gets that flag and
+    rejects it produces the same two lines — and labelling it "requires
+    command-line arguments" would assert the exact opposite of the truth:
+    it requires NONE, and the harness passed one too many."""
+    if "unrecognized arguments" in stderr:
+        return False
     return bool(_ARGPARSE_USAGE_LINE_RE.search(stderr)) and bool(
         _ARGPARSE_ERROR_LINE_RE.search(stderr)
     )
@@ -556,7 +612,7 @@ def _kill_process_group(
         pass
 
 
-def _drain_capped(stream: Any, sink: list[str], cap: int) -> None:
+def _drain_capped(stream: Any, sink: list[str], cap: int, truncated: list[bool] | None = None) -> None:
     """Reader-thread body (#928): read ``stream`` in a loop until EOF,
     keeping only the first ``cap`` chars in ``sink`` and discarding
     everything read beyond that. This is the piece that makes the output
@@ -571,7 +627,14 @@ def _drain_capped(stream: Any, sink: list[str], cap: int) -> None:
     it — turning a merely chatty (but otherwise fine) validator into a
     bogus timeout record. Swallows any read error (e.g. the pipe closing
     from under it during a kill) — this is a background drain, never the
-    source of truth for ``exit_code``."""
+    source of truth for ``exit_code``.
+
+    ``truncated``, when given, is a one-element sink set to ``True`` if
+    anything was discarded (#934 review). What is kept is the HEAD of the
+    stream, so on truncation the last line of ``sink`` is NOT the last line
+    the script wrote — it is whatever sat at the cap boundary, at an offset
+    the script itself chooses. :func:`_run_one` needs to know that before it
+    classifies anything from the "terminal" line."""
     total = 0
     try:
         while True:
@@ -582,7 +645,12 @@ def _drain_capped(stream: Any, sink: list[str], cap: int) -> None:
                 keep = chunk[: cap - total]
                 sink.append(keep)
                 total += len(keep)
-            # else: deliberately discarded -- still consumed to keep draining
+                if len(keep) < len(chunk) and truncated is not None:
+                    truncated[0] = True
+            else:
+                # Deliberately discarded -- still consumed to keep draining.
+                if truncated is not None:
+                    truncated[0] = True
     except Exception:
         pass
 
@@ -618,6 +686,10 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
     pgid: int | None = None
     stdout_chunks: list[str] = []
     stderr_chunks: list[str] = []
+    # #934 review: one-element sink, set by the stderr reader thread if it
+    # had to discard anything. See the marker below for why classification
+    # must not trust a truncated stream's last line.
+    stderr_truncated: list[bool] = [False]
     reader_threads: list[threading.Thread] = []
     try:
         proc = subprocess.Popen(
@@ -640,7 +712,7 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
             ),
             threading.Thread(
                 target=_drain_capped,
-                args=(proc.stderr, stderr_chunks, _MAX_OUTPUT_BYTES),
+                args=(proc.stderr, stderr_chunks, _MAX_OUTPUT_BYTES, stderr_truncated),
                 daemon=True,
             ),
         ]
@@ -714,9 +786,12 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         "findings_count": _parse_findings_count(stdout),
         "stderr_tail": stderr[-2000:],
     }
+    usage_error = exit_code == 2 and _is_argparse_usage_error(stderr)
     if (
         isinstance(exit_code, int)
         and exit_code != 0
+        and not usage_error
+        and not stderr_truncated[0]
         and _SANDBOX_DENIAL_RE.search(_terminal_stderr_line(stderr))
     ):
         # #928/#934: this run did not fail because the script is broken — it
@@ -737,6 +812,26 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         # becoming demand — and it is the right way round, because a false
         # defect actively poisons the loop while a missed one merely goes
         # unreported.
+        #
+        # NOT applied when the stderr capture was TRUNCATED (#934 review).
+        # _drain_capped keeps the HEAD of the stream, so once a script writes
+        # more than _MAX_OUTPUT_BYTES the last captured line is not the last
+        # line the script wrote — it is whatever sat at the cap boundary, at
+        # an offset the script chooses. A hostile validator could therefore
+        # pad its stderr so that a line mentioning a read-only path lands on
+        # the boundary, get this marker, and have demand skip the genuine
+        # failure it reported afterwards. That is self-maintaining (driven by
+        # its own source, no sidecar write needed), so it would hold every
+        # rotation. Refusing to classify a truncated stream fails open toward
+        # a VISIBLE defect, the direction this module already prefers.
+        #
+        # NOT applied to an argparse usage error either: that is a contract
+        # mismatch the loop can fix, and this marker would make demand skip
+        # the row entirely. Reachable in practice — argparse.FileType on a
+        # required flag reports EACCES as its terminal line — so without the
+        # exclusion the "never suppressed" property of harness_contract would
+        # be untrue and the script would sit in the rotation forever with no
+        # signal at all.
         #
         # Matched against the TERMINAL line only (#934), not the whole
         # stream: see the comment on :data:`_SANDBOX_DENIAL_RE` for why a
@@ -775,10 +870,18 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         # the instance tree is readable, so three appended lines naming ANY
         # allowlisted validator would drop it from selection — permanently,
         # because a script that never runs never produces a real row to
-        # break its own streak. That is a capability the sidecar does not
-        # otherwise grant: forging a clean newest row already suppresses a
-        # script's DEMAND, but the script still runs and its next real
-        # verdict supersedes the forgery.
+        # break its own streak. Forging a clean newest row is much weaker:
+        # it suppresses a script's DEMAND, but the script still runs and its
+        # next real verdict supersedes the forgery.
+        #
+        # An earlier version of this comment claimed durable exclusion was a
+        # capability the carve-out "does not otherwise grant". That was
+        # false, and the #934 review proved it: rotation.json is in the same
+        # carve-out, and a forged far-future `served` stamp used to sort its
+        # target last forever, so it never ran and never overwrote the
+        # forgery. _rotation_key now clamps future stamps to never-run,
+        # closing that one. The argument for not ADDING another such channel
+        # stands on its own either way.
         #
         # So the budget is not reclaimed automatically. Instead the waste
         # becomes visible, truthful, fixable demand: the loop can make the
@@ -1077,9 +1180,29 @@ def run_validator_harness(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]
             deadline = time.monotonic() + _TOTAL_BUDGET_SECONDS
             for script in selected:
                 remaining = deadline - time.monotonic()
-                if remaining <= 0:
+                if remaining < _PER_SCRIPT_TIMEOUT:
+                    # #934 review: NEVER start a run that cannot be given the
+                    # full per-script contract. This used to pass
+                    # min(_PER_SCRIPT_TIMEOUT, remaining), so the last script
+                    # of a rotation got whatever the budget had left — and
+                    # once a timeout became demand (the "exceeds_time_budget"
+                    # marker in _run_one), a perfectly conformant validator
+                    # that needs 2s could be handed 1s, time out, and be
+                    # reported as unable to finish within a 60s budget it
+                    # never received. That is the harness blaming a script
+                    # for the harness's own scheduling, i.e. exactly the
+                    # false-defect class #928/#934 exist to remove, and it
+                    # was guaranteed to fire on the live host, where
+                    # check_style.py eats 60s of the 240s every rotation.
+                    #
+                    # The cost is up to _PER_SCRIPT_TIMEOUT-1 seconds of
+                    # budget left unspent at the tail. That is the right
+                    # trade: a squeezed run's timeout carries no information
+                    # about the script, so the budget it consumes buys
+                    # nothing, and the script keeps its rotation position
+                    # (nothing is stamped) so it runs first next time.
                     break
-                record = _run_one(script, selfevo_repo, min(_PER_SCRIPT_TIMEOUT, remaining))
+                record = _run_one(script, selfevo_repo, _PER_SCRIPT_TIMEOUT)
                 rel = record["path"]
                 served[rel] = record["finished_at"]
                 _append_last_run(state_dir, record, all_rels)

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1731,6 +1731,72 @@ class TestValidatorSandboxDenialIsNotDemand:
         assert len(demand._validator_defect_items(state_dir)) == 1
 
 
+# ─── #934 Class B: argparse usage errors are reclassified, not suppressed ──
+
+
+class TestValidatorHarnessContractReclassified:
+    """#934: the harness invokes every script with NO arguments, so a
+    validator whose argparse requires a flag exits 2 on every run forever.
+    ``harness_contract: "requires_arguments"`` must relabel the summary so
+    the loop is told the real, fixable problem instead of chasing a
+    nonexistent crash -- it is a RECLASSIFICATION, distinct from
+    ``harness_env_error``, which suppresses entirely."""
+
+    def _write_run(self, state_dir: Path, *rows: dict) -> None:
+        d = state_dir / "validator_harness"
+        d.mkdir(parents=True, exist_ok=True)
+        with (d / "last_runs.jsonl").open("a", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row) + "\n")
+
+    def test_requires_arguments_is_reclassified_not_suppressed(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        self._write_run(
+            state_dir,
+            {"path": "scripts/validate_cycle_handoff.py", "exit_code": 2,
+             "findings_count": None, "harness_contract": "requires_arguments",
+             "stderr_tail": (
+                 "usage: validate_cycle_handoff.py [-h] [--manifest MANIFEST] "
+                 "[--repo-root REPO_ROOT] [--json] [--test]\n"
+                 "validate_cycle_handoff.py: error: --manifest is required "
+                 "unless --test is used"
+             ),
+             "finished_at": _now_iso()},
+        )
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == 1
+        assert items[0]["kind"] == "defect"
+        assert items[0]["summary"] == (
+            "validator scripts/validate_cycle_handoff.py cannot run under "
+            "the harness: it requires command-line arguments"
+        )
+        assert "error" in items[0]["evidence"]
+        assert items[0]["affected_path"] == "scripts/validate_cycle_handoff.py"
+
+    def test_ordinary_failure_without_contract_field_is_unaffected(self, tmp_path):
+        """Existing behaviour for a plain non-zero exit must not change."""
+        state_dir = _state_dir(tmp_path)
+        self._write_run(
+            state_dir,
+            {"path": "scripts/check_x.py", "exit_code": 1, "findings_count": None,
+             "stderr_tail": "boom", "finished_at": _now_iso()},
+        )
+        items = demand._validator_defect_items(state_dir)
+        assert items[0]["summary"] == "validator scripts/check_x.py fails when run"
+
+    def test_contract_field_does_not_suppress_like_env_error_does(self, tmp_path):
+        """harness_contract and harness_env_error must not be conflated:
+        one relabels (still demand), the other suppresses entirely."""
+        state_dir = _state_dir(tmp_path)
+        self._write_run(
+            state_dir,
+            {"path": "scripts/validate_cycle_handoff.py", "exit_code": 2,
+             "findings_count": None, "harness_contract": "requires_arguments",
+             "finished_at": _now_iso()},
+        )
+        assert len(demand._validator_defect_items(state_dir)) == 1
+
+
 # ─── #789: tamper defect demand ─────────────────────────────────────────────
 
 

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -502,17 +502,21 @@ class TestProcessGroupKill:
 
 class TestTotalBudget:
     def test_budget_cap_stops_further_runs(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(validator_harness, "_TOTAL_BUDGET_SECONDS", 1.0)
+        # Re-tuned (#934 review round 2). With budget 1.0 and per-script 5.0
+        # the loop now breaks on the FIRST iteration, so `ran` was empty and
+        # `0 < 3` held whether or not the loop guard worked at all — the only
+        # test named for that guard had stopped discriminating in either
+        # direction. Budget 7.0 against three ~1.5s runs makes it exercise
+        # the real shape again: some run, then the cap stops the rest.
+        monkeypatch.setattr(validator_harness, "_TOTAL_BUDGET_SECONDS", 7.0)
         monkeypatch.setattr(validator_harness, "_PER_SCRIPT_TIMEOUT", 5.0)
         repo = _init_repo(tmp_path)
         for i in range(3):
-            _add_script(repo, f"check_{i}.py", "import time\ntime.sleep(0.9)\n", days_ago=2)
+            _add_script(repo, f"check_{i}.py", "import time\ntime.sleep(1.5)\n", days_ago=2)
         state_dir = _state_dir(tmp_path)
         result = validator_harness.run_validator_harness(state_dir, repo)
-        # The budget (1s) cannot fit 3 * ~0.9s runs plus overhead -- at least
-        # one selected script must be left un-run.
-        assert len(result["ran"]) < len(result["selected"])
         assert len(result["selected"]) == 3
+        assert 0 < len(result["ran"]) < len(result["selected"])
 
 
 # ─── #934: a script that always times out is reclassified, not excluded ──
@@ -1850,3 +1854,168 @@ class TestUsageErrorIsNeverSuppressedByTheEnvMarker:
         items = demand._validator_defect_items(state_dir)
         assert len(items) == 1
         assert "requires command-line arguments" in items[0]["summary"]
+
+
+# ─── #934 review round 2 fixes ───────────────────────────────────────────
+
+
+class TestRotationKeyCannotKillTheHarness:
+    """#934 review round 2 RED: ``_rotation_key`` formatted the stamp with
+    ``_iso``, whose ``astimezone`` raises ``OverflowError`` outside
+    ``datetime``'s range. One forged line reached it — the value parses, is
+    not in the future, and then underflows — and the raise propagated out of
+    ``eligible.sort(key=...)`` into the outer handler, aborting the whole
+    invocation BEFORE either ``_write_rotation`` call. So the poison was
+    never overwritten: the entire validator fleet was dead permanently while
+    ``main()`` still reported success to systemd. Total silencing from one
+    line, strictly worse than the per-script class #934 closes."""
+
+    POISON = "0001-01-01T00:00:00+14:00"
+
+    def _seed_poison(self, state_dir: Path, rel: str) -> Path:
+        path = state_dir / "validator_harness" / "rotation.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": validator_harness._ROTATION_SCHEMA,
+                    "served": {rel: self.POISON},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_key_does_not_raise_and_sorts_the_script_first(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = _add_script(repo, "check_ok.py", "print('fine')\n", days_ago=2)
+        other = _add_script(repo, "check_recent.py", "print('fine')\n", days_ago=2)
+        served = {
+            "scripts/check_ok.py": self.POISON,
+            "scripts/check_recent.py": _iso(datetime.now(timezone.utc)),
+        }
+
+        # The point is that this returns at all: `_iso` raised OverflowError
+        # here. A year-1 stamp is a legitimately ancient one, so it sorts
+        # ahead of a just-run script rather than being clamped away — the
+        # same practical outcome as never-run, and it gets overwritten by the
+        # real stamp as soon as the script runs.
+        poisoned = validator_harness._rotation_key(script, served)
+        recent = validator_harness._rotation_key(other, served)
+        assert poisoned < recent
+
+    def test_a_poisoned_stamp_does_not_kill_the_invocation(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        _add_script(repo, "check_ok.py", "print('fine')\n", days_ago=2)
+        self._seed_poison(state_dir, "scripts/check_ok.py")
+
+        result = validator_harness.run_validator_harness(state_dir, repo)
+
+        assert result["errors"] == []
+        assert result["ran"] == ["scripts/check_ok.py"]
+        # And the poison is gone, so it cannot be permanent.
+        assert _rotation(state_dir)["served"]["scripts/check_ok.py"] != self.POISON
+
+    def test_it_does_not_survive_repeated_invocations(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        _add_script(repo, "check_ok.py", "print('fine')\n", days_ago=2)
+        self._seed_poison(state_dir, "scripts/check_ok.py")
+
+        runs = [
+            validator_harness.run_validator_harness(state_dir, repo)
+            for _ in range(3)
+        ]
+
+        assert all(r["ran"] == ["scripts/check_ok.py"] for r in runs)
+        assert all(r["errors"] == [] for r in runs)
+
+
+class TestFutureStampsBuyDelayNotSilence:
+    """#934 review round 2: the single-entry future-stamp test cannot detect
+    the reverse channel — forging future stamps for MANY candidates to starve
+    them out of the K-sized selection. The clamp's claimed property is that
+    priority buys at most delay, never exclusion, so pin it: every candidate
+    must still run within ceil(N/K) invocations."""
+
+    def test_every_candidate_still_runs_within_a_full_sweep(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validator_harness, "_DEFAULT_MAX_K", 2)
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        names = [f"check_s{i}.py" for i in range(6)]
+        for name in names:
+            _add_script(repo, name, "print('ok')\n", days_ago=2)
+        # Every candidate forged into the future, not just one.
+        path = state_dir / "validator_harness" / "rotation.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": validator_harness._ROTATION_SCHEMA,
+                    "served": {f"scripts/{n}": "3000-01-01T00:00:00+00:00" for n in names},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        ran: set[str] = set()
+        for _ in range(3):  # ceil(6 / 2)
+            ran.update(validator_harness.run_validator_harness(state_dir, repo)["ran"])
+
+        assert ran == {f"scripts/{n}" for n in names}
+
+
+class TestJsonFlagDeclarationForms:
+    """#934 review round 2: the declaration test must not miss real
+    non-argparse declarations. A miss is not a lost parse — for a validator
+    that reports findings while exiting 0, no ``--json`` means no JSON on
+    stdout, ``findings_count`` None, exit 0, and therefore no demand item at
+    all: its findings stop reaching the loop entirely."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            'p.add_argument("--json", action="store_true")\n',
+            "p.add_argument('-j', '--json')\n",
+            'p.add_argument(\n    "--json",\n    action="store_true",\n)\n',
+            '@click.option("--json", is_flag=True)\n',
+            'parser.add_option("--json", dest="as_json")\n',
+            'if "--json" in sys.argv:\n',
+            'argv = sys.argv[1:]\nif "--json" in argv:\n',
+        ],
+    )
+    def test_declaration_forms_are_matched(self, source):
+        assert validator_harness._JSON_FLAG_DECL_RE.search(source)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            'PATTERNS = ["--json", "--verbose"]\n',
+            '"""Usage: python scripts/x.py --json"""\n',
+            'p.add_argument("--json-output")\n',
+            'p.add_argument("--no-json")\n',
+        ],
+    )
+    def test_mentions_and_near_misses_are_not_matched(self, source):
+        assert not validator_harness._JSON_FLAG_DECL_RE.search(source)
+
+
+class TestForwardProgressFloor:
+    """#934 review round 2: without a floor, a configuration where the
+    per-script timeout meets or exceeds the total budget would select
+    scripts, run none, report no errors, and exit 0 — a silently dead unit
+    that systemd calls successful, the same signature as the RED above."""
+
+    def test_the_first_script_always_runs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validator_harness, "_PER_SCRIPT_TIMEOUT", 10.0)
+        monkeypatch.setattr(validator_harness, "_TOTAL_BUDGET_SECONDS", 1.0)
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        _add_script(repo, "check_one.py", "print('ok')\n", days_ago=2)
+        _add_script(repo, "check_two.py", "print('ok')\n", days_ago=2)
+
+        result = validator_harness.run_validator_harness(state_dir, repo)
+
+        assert result["ran"] == ["scripts/check_one.py"]
+        assert result["errors"] == []

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -1767,26 +1767,47 @@ class TestJsonFlagMustBeDeclaredNotMentioned:
         assert validator_harness._is_argparse_usage_error(stderr) is True
 
 
-class TestDecayDeclarationMustBeOnOneLine:
-    """#934 review YELLOW: co-occurrence anywhere in the 200KB head is too
-    loose now that docs/INITIAL_VALIDATOR_ROADMAP.md publishes the canonical
-    phrase verbatim — the next decay auditor will hold it as a constant AND
-    name its own path in its usage text, and would silence itself. Both real
-    declarations on the host are single-line ``WARNING:`` strings."""
+class TestDecayDeclarationSpanningLines:
+    """#934 review round 2: the review asked for a same-line rule (phrase and
+    own path on one line), because co-occurrence anywhere in the head is loose
+    now that the roadmap doc publishes the phrase verbatim. Measured against
+    the live instance repo, that rule excludes 11 of 43 where co-occurrence
+    excludes 13 — and the two it loses are exactly the "scheduled for removal"
+    pair this issue set out to START excluding. Their declarations are not
+    single-line: the guard script carries the phrase in its module docstring
+    and its own path four lines later, and its runtime WARNING string is split
+    across two adjacent literals so the phrase itself spans a line break.
 
-    def test_phrase_and_own_path_on_separate_lines_stays_a_candidate(self, tmp_path):
+    These two tests pin the real shapes, so a future tightening cannot quietly
+    regress Class C again."""
+
+    def test_docstring_phrase_with_the_path_lines_later_is_excluded(self, tmp_path):
         repo = _init_repo(tmp_path)
+        # The live verify_eeepc_self_evolving_service_guard.py shape.
         script = (
-            '"""Audit decay declarations.\n'
+            '"""Guard check.\n'
             "\n"
-            "Usage: python scripts/validate_decay_audit.py\n"
+            "This script is deprecated and scheduled for removal after 14+ days"
+            " of disuse.\n"
+            "\n"
+            "Replacement:\n"
+            "        scripts/verify_eeepc_self_evolving_service_guard.py\n"
             '"""\n'
-            'MARKER = "is deprecated and marked as archived"\n'
-            "print(MARKER)\n"
+            "import warnings\n"
+            "warnings.warn(\n"
+            '    "WARNING: scripts/verify_eeepc_self_evolving_service_guard.py '
+            'is deprecated "\n'
+            '    "and scheduled for removal after 14+ days of disuse.",\n'
+            "    DeprecationWarning,\n"
+            "    stacklevel=1,\n"
+            ")\n"
+            "raise SystemExit(2)\n"
         )
-        _add_script(repo, "validate_decay_audit.py", script, days_ago=2)
+        _add_script(
+            repo, "verify_eeepc_self_evolving_service_guard.py", script, days_ago=2
+        )
         names = {p.name for p in validator_harness._candidate_scripts(repo)}
-        assert "validate_decay_audit.py" in names
+        assert "verify_eeepc_self_evolving_service_guard.py" not in names
 
     def test_a_real_single_line_declaration_is_still_excluded(self, tmp_path):
         repo = _init_repo(tmp_path)

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -109,9 +110,14 @@ class TestCandidateSelection:
         names = sorted(p.name for p in validator_harness._candidate_scripts(repo))
         assert names == ["check_ok.py"]
 
-    def test_archived_marker_other_form_excludes_script(self, tmp_path):
-        """The second observed marker form ('script is archived') must also
-        be excluded, not just the 'marked as archived' wording."""
+    def test_bare_mention_without_self_declaration_stays_a_candidate(self, tmp_path):
+        """#934: the pre-#934 rule matched the bare phrase 'script is
+        archived' anywhere in the source head -- a MENTION test. This text
+        mentions archival but is neither the canonical self-declaration
+        phrase ('is deprecated and marked as archived'/'scheduled for
+        removal') nor paired with the script's own path, so under the
+        current self-declaration rule it must stay a candidate. See
+        TestDecayDeclarationExclusion for the properties this replaced."""
         repo = _init_repo(tmp_path)
         _add_script(
             repo,
@@ -121,7 +127,7 @@ class TestCandidateSelection:
             days_ago=2,
         )
         names = [p.name for p in validator_harness._candidate_scripts(repo)]
-        assert "check_disabled.py" not in names
+        assert "check_disabled.py" in names
 
     def test_unreadable_script_is_still_a_candidate(self, tmp_path):
         """Fail-open direction (#928): when the archived-marker scan cannot
@@ -204,6 +210,156 @@ class TestCandidateSelection:
         assert "scripts/long_gone.py" not in rotation["served"]
 
 
+# ─── #934: self-declaration, not mention, excludes a script ──────────────
+
+
+class TestDecayDeclarationExclusion:
+    """#934: the old ``_ARCHIVED_RE`` matched any MENTION of the archival
+    phrases anywhere in a script's source head, not a self-declaration --
+    so the copy-pasted helper docstring
+
+        \"\"\"Check if a script is archived/deprecated by reading its
+        content.\"\"\"
+
+    (present verbatim in many validators that IMPLEMENT decay detection)
+    tripped the ``script is archived`` alternative and silently excluded
+    them from ever running. Measured live: the old rule excluded 25 of 42
+    allowlisted validators; only 13 genuinely self-declare. This class
+    reproduces that shape with a synthetic 42-script fixture and also pins
+    the two properties individually."""
+
+    def test_mention_only_stays_a_candidate(self, tmp_path):
+        """A script whose head merely MENTIONS archival (the copy-pasted
+        helper docstring) must remain a candidate -- it is not declaring
+        itself archived, it is looking for scripts that are."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "validate_decay_helper.py",
+            '    """Check if a script is archived/deprecated by reading '
+            'its content."""\n'
+            "def helper():\n    pass\n",
+            days_ago=2,
+        )
+        names = [p.name for p in validator_harness._candidate_scripts(repo)]
+        assert "validate_decay_helper.py" in names
+
+    def test_self_declaration_with_own_path_is_excluded(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "analyze_repo_size.py",
+            "print('WARNING: scripts/analyze_repo_size.py is deprecated "
+            "and marked as archived (decay-36bd86468443) as unused.')\n",
+            days_ago=2,
+        )
+        names = [p.name for p in validator_harness._candidate_scripts(repo)]
+        assert "analyze_repo_size.py" not in names
+
+    def test_scheduled_for_removal_rung_is_excluded(self, tmp_path):
+        """Class C in #934: the rung BEFORE 'marked as archived' -- a
+        script declining to run for exactly the same reason, which the old
+        rule missed entirely (it does not contain either old alternative)."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "verify_eeepc_self_evolving_service_guard.py",
+            "print('WARNING: scripts/verify_eeepc_self_evolving_service_"
+            "guard.py is deprecated and scheduled for removal after 14+ "
+            "days of disuse.')\n",
+            days_ago=2,
+        )
+        names = [
+            p.name for p in validator_harness._candidate_scripts(repo)
+        ]
+        assert "verify_eeepc_self_evolving_service_guard.py" not in names
+
+    def test_self_declaration_missing_own_path_fails_open(self, tmp_path):
+        """The own-path requirement fails open the same direction as an
+        unreadable file: a genuine declaration that omits its own path
+        stays a candidate (and will go on to produce a VISIBLE false
+        defect when it refuses to run) rather than being silently
+        silenced on an unverifiable claim."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_vague.py",
+            "print('WARNING: this script is deprecated and marked as "
+            "archived as unused.')\n",
+            days_ago=2,
+        )
+        names = [p.name for p in validator_harness._candidate_scripts(repo)]
+        assert "check_vague.py" in names
+
+    def test_old_rule_over_excludes_new_rule_does_not_synthetic_42(self, tmp_path):
+        """Reproduces the measured live shape: 42 allowlisted scripts, 13 of
+        which genuinely self-declare (11 'marked as archived' + 2 'scheduled
+        for removal', each naming its own path) and 14 of which merely carry
+        the copy-pasted mention-only docstring. The OLD (mention) rule
+        excludes 25 (13 - 2 genuine 'scheduled for removal' misses it
+        entirely + 14 false positives = 11 + 14); the NEW (self-declaration)
+        rule excludes exactly the 13 genuine ones."""
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+
+        # 11 genuine self-declarations, "marked as archived" rung.
+        for i in range(11):
+            name = f"check_archived_{i:02d}.py"
+            (scripts_dir / name).write_text(
+                f"print('WARNING: scripts/{name} is deprecated and marked "
+                "as archived (decay-deadbeef) as unused.')\n",
+                encoding="utf-8",
+            )
+
+        # 2 genuine self-declarations, "scheduled for removal" rung.
+        for i in range(2):
+            name = f"verify_removal_{i:02d}.py"
+            (scripts_dir / name).write_text(
+                f"print('WARNING: scripts/{name} is deprecated and "
+                "scheduled for removal after 14+ days of disuse.')\n",
+                encoding="utf-8",
+            )
+
+        # 14 mention-only scripts: the copy-pasted helper docstring, which
+        # implements decay DETECTION rather than declaring itself decayed.
+        for i in range(14):
+            name = f"validate_decay_helper_{i:02d}.py"
+            (scripts_dir / name).write_text(
+                '    """Check if a script is archived/deprecated by '
+                'reading its content."""\n'
+                "def helper():\n    pass\n",
+                encoding="utf-8",
+            )
+
+        # 15 plain scripts, no marker at all.
+        for i in range(15):
+            name = f"analyze_plain_{i:02d}.py"
+            (scripts_dir / name).write_text("x = 1\n", encoding="utf-8")
+
+        all_scripts = list(scripts_dir.glob("*.py"))
+        assert len(all_scripts) == 42
+
+        old_mention_rule = re.compile(r"marked as archived|script is archived")
+        old_excluded = [
+            p for p in all_scripts
+            if old_mention_rule.search(validator_harness._scan_head(p))
+        ]
+        assert len(old_excluded) == 25
+
+        candidates = validator_harness._candidate_scripts(tmp_path)
+        assert len(candidates) == 42 - 13
+
+        candidate_names = {p.name for p in candidates}
+        for i in range(11):
+            assert f"check_archived_{i:02d}.py" not in candidate_names
+        for i in range(2):
+            assert f"verify_removal_{i:02d}.py" not in candidate_names
+        for i in range(14):
+            assert f"validate_decay_helper_{i:02d}.py" in candidate_names
+        for i in range(15):
+            assert f"analyze_plain_{i:02d}.py" in candidate_names
+
+
 # ─── execution ───────────────────────────────────────────────────────────
 
 
@@ -242,7 +398,15 @@ class TestExecution:
         assert rows[0]["exit_code"] is None
         assert "timeout" in rows[0]["stderr_tail"]
         items = demand._validator_defect_items(state_dir)
-        assert items == []  # a None exit code is not a "fails when run" defect (no crash claim fabricated)
+        # #934: a timed-out run now DOES produce demand — but it must never
+        # fabricate a crash claim. The original #925 guarantee is that the
+        # item does not say "fails when run"; what changed is that the run
+        # stopped being invisible (it used to yield nothing at all while
+        # still burning a quarter of the invocation's budget every rotation).
+        assert len(items) == 1
+        assert items[0]["affected_path"] == "scripts/check_slow.py"
+        assert "fails when run" not in items[0]["summary"]
+        assert "time budget" in items[0]["summary"]
 
     def test_repo_mutation_is_not_policed_in_process(self, tmp_path):
         """The sandbox mounts the instance repo read-only, so the harness no
@@ -349,6 +513,136 @@ class TestTotalBudget:
         # one selected script must be left un-run.
         assert len(result["ran"]) < len(result["selected"])
         assert len(result["selected"]) == 3
+
+
+# ─── #934: a script that always times out is reclassified, not excluded ──
+
+
+def _seed_last_runs(state_dir: Path, rows: list[dict]) -> None:
+    """Append raw sidecar rows, bypassing the harness — how a validator
+    subprocess writes into the one carve-out it shares with the harness."""
+    path = state_dir / "validator_harness" / "last_runs.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", newline="") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+class TestTimeoutReclassified:
+    """#934: a run killed at ``_PER_SCRIPT_TIMEOUT`` has ``exit_code None``,
+    so it used to produce NOTHING anywhere — no demand, no operator signal —
+    while still burning a quarter of ``_TOTAL_BUDGET_SECONDS`` every
+    rotation (measured live: ``check_style.py`` AST-parses 456 files on
+    i386/2GB and times out on every single run).
+
+    It is reclassified into visible, fixable demand rather than excluded
+    from selection. The exclusion design is the dangerous one: its only
+    possible evidence is ``last_runs.jsonl``, which EVERY validator
+    subprocess can append to, so a handful of forged rows would drop an
+    arbitrary allowlisted validator from selection permanently — a script
+    that never runs never produces a real row to break its own streak.
+    ``test_forged_timeout_rows_cannot_exclude_a_script`` is the regression
+    test for exactly that."""
+
+    def test_timeout_is_reclassified(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_slow.py",
+            "import time\ntime.sleep(30)\n",
+            days_ago=2,
+        )
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_slow.py", repo, 1.0
+        )
+        assert record["exit_code"] is None
+        assert record["harness_contract"] == "exceeds_time_budget"
+
+    def test_ordinary_failure_is_not_marked_as_a_time_budget_problem(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_fails.py",
+            "import sys\nsys.stderr.write('real failure\\n')\nsys.exit(1)\n",
+            days_ago=2,
+        )
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_fails.py", repo, 30.0
+        )
+        assert record["exit_code"] == 1
+        assert "harness_contract" not in record
+
+    def test_timeout_becomes_visible_demand(self, tmp_path):
+        """Before #934 a timed-out run yielded no demand at all, because the
+        presentation path only looked at integer exit codes."""
+        state_dir = _state_dir(tmp_path)
+        _seed_last_runs(
+            state_dir,
+            [
+                {
+                    "path": "scripts/check_slow.py",
+                    "exit_code": None,
+                    "stderr_tail": "timeout after 60s",
+                    "harness_contract": "exceeds_time_budget",
+                    "finished_at": "2026-08-23T01:24:10Z",
+                }
+            ],
+        )
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == 1
+        assert items[0]["affected_path"] == "scripts/check_slow.py"
+        assert "cannot finish within the harness's per-script time budget" in (
+            items[0]["summary"]
+        )
+        assert "timeout after 60s" in items[0]["evidence"]
+
+    def test_a_plain_timeout_row_without_the_marker_still_yields_nothing(self, tmp_path):
+        """The marker, not the absent exit code, is what makes a timeout
+        visible — an unmarked row keeps the pre-#934 behaviour."""
+        state_dir = _state_dir(tmp_path)
+        _seed_last_runs(
+            state_dir,
+            [
+                {
+                    "path": "scripts/check_slow.py",
+                    "exit_code": None,
+                    "stderr_tail": "timeout after 60s",
+                    "finished_at": "2026-08-23T01:24:10Z",
+                }
+            ],
+        )
+        assert demand._validator_defect_items(state_dir) == []
+
+    def test_forged_timeout_rows_cannot_exclude_a_script(self, tmp_path):
+        """#934, the reason exclusion was rejected: every validator
+        subprocess can append to ``last_runs.jsonl``. If a streak of timeout
+        rows dropped a script from selection, these three forged lines —
+        naming a validator that is perfectly healthy — would silence it
+        permanently. The script must still be selected and still run."""
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        script = _add_script(repo, "check_healthy.py", "print('fine')\n", days_ago=2)
+        _seed_last_runs(
+            state_dir,
+            [
+                {
+                    "path": "scripts/check_healthy.py",
+                    "exit_code": None,
+                    "stderr_tail": "timeout after 60s",
+                    "harness_contract": "exceeds_time_budget",
+                    "source_mtime": script.stat().st_mtime,
+                    "finished_at": f"2026-08-2{n}T01:00:00Z",
+                }
+                for n in (1, 2, 3)
+            ],
+        )
+
+        result = validator_harness.run_validator_harness(state_dir, repo)
+
+        assert result["ran"] == ["scripts/check_healthy.py"]
+        rows = [r for r in _last_runs(state_dir) if r["path"] == "scripts/check_healthy.py"]
+        assert rows[-1]["exit_code"] == 0
+        assert "harness_contract" not in rows[-1]
 
 
 # ─── output cap enforced during capture, not after (#928) ────────────────
@@ -719,6 +1013,200 @@ class TestSandboxDenialMarker:
         record = validator_harness._run_one(repo / "scripts" / "check_fine.py", repo, 30.0)
         assert record["exit_code"] == 0
         assert "harness_env_error" not in record
+
+
+# ─── #934: EROFS coverage, keyed on the TERMINAL stderr line only ────────
+
+
+class TestSandboxDenialCoversErofsOnTerminalLine:
+    """#934 Class A: the sandbox makes ``state/reports`` read-only, so a
+    validator that writes its own report there crashes with ``OSError:
+    [Errno 30] Read-only file system: ...`` -- same class as the EACCES
+    case #928 fixed, but the old ``_SANDBOX_DENIAL_RE`` had no EROFS
+    alternative at all.
+
+    Narrowing to the TERMINAL non-empty stderr line (rather than searching
+    the whole stream) is the other half: a validator can log a mid-run,
+    non-fatal warning that happens to mention a read-only path and then go
+    on to report a genuine failure on its last line (the
+    ``analyze_repeat_failures.py`` shape below) -- whole-stderr matching
+    would suppress that genuine finding, and it is not hypothetical."""
+
+    def test_erofs_as_the_terminal_line_is_marked(self, tmp_path):
+        """verify_and_proof.py-style: the validator's own report write
+        fails with EROFS and that IS the last thing on stderr."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "verify_and_proof.py",
+            "import sys\n"
+            "sys.stderr.write('Traceback (most recent call last):\\n')\n"
+            "sys.stderr.write(\"OSError: [Errno 30] Read-only file "
+            "system: '/var/lib/eeepc-agent/self-evolving-agent/state/"
+            "reports/proof-20260823T012648Z.json'\\n\")\n"
+            "sys.exit(1)\n",
+            days_ago=2,
+        )
+        record = validator_harness._run_one(
+            repo / "scripts" / "verify_and_proof.py", repo, 30.0
+        )
+        assert record["exit_code"] == 1
+        assert record["harness_env_error"] == "permission_denied"
+
+    def test_erofs_midstream_with_genuine_terminal_failure_is_not_marked(
+        self, tmp_path
+    ):
+        """analyze_repeat_failures.py-style: EROFS shows up mid-stream as
+        non-fatal noise from a failed export, but the LAST line is a
+        genuine, unrelated failure. That genuine failure must still reach
+        the loop as demand -- it must NOT be suppressed just because an
+        earlier line happened to mention a read-only path."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "analyze_repeat_failures.py",
+            "import sys\n"
+            "sys.stderr.write('Warning: Failed to export repeat failures "
+            "to .../memory/repeat_failures.json: [Errno 30] Read-only "
+            "file system: ...\\n')\n"
+            "sys.stderr.write('Warning: Failed to export prevent repeats "
+            "to .../memory/prevent_repeats.json: [Errno 30] Read-only "
+            "file system: ...\\n')\n"
+            "sys.stderr.write('ERROR: 1 unresolved failure signature(s) "
+            "exceeded the retry budget of 2!\\n')\n"
+            "sys.exit(1)\n",
+            days_ago=2,
+        )
+        record = validator_harness._run_one(
+            repo / "scripts" / "analyze_repeat_failures.py", repo, 30.0
+        )
+        assert record["exit_code"] == 1
+        assert "harness_env_error" not in record
+
+    def test_eacces_still_marked_when_it_is_the_terminal_line(self, tmp_path):
+        """Regression pin: narrowing to the terminal line must not lose the
+        #928 EACCES coverage that already existed."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_denies2.py",
+            "import sys\n"
+            "sys.stderr.write('some preamble\\n')\n"
+            "sys.stderr.write('PermissionError: [Errno 13] Permission "
+            "denied: x\\n')\n"
+            "sys.exit(1)\n",
+            days_ago=2,
+        )
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_denies2.py", repo, 30.0
+        )
+        assert record["exit_code"] == 1
+        assert record["harness_env_error"] == "permission_denied"
+
+    def test_eacces_midstream_with_genuine_terminal_failure_is_not_marked(
+        self, tmp_path
+    ):
+        """Same silencing shape as the EROFS case above, for the EACCES
+        alternatives that already existed pre-#934."""
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_partial_denial.py",
+            "import sys\n"
+            "sys.stderr.write('PermissionError: [Errno 13] Permission "
+            "denied: /some/inaccessible/path\\n')\n"
+            "sys.stderr.write('ERROR: genuine validator failure\\n')\n"
+            "sys.exit(1)\n",
+            days_ago=2,
+        )
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_partial_denial.py", repo, 30.0
+        )
+        assert record["exit_code"] == 1
+        assert "harness_env_error" not in record
+
+
+# ─── #934 Class B: argparse usage errors are reclassified, not suppressed ─
+
+
+class TestArgparseUsageContract:
+    """#934: the harness invokes every selected script with NO arguments.
+    A validator whose argparse requires a flag exits 2 on EVERY run,
+    forever, and the false summary "validator X fails when run" sends the
+    loop chasing a script that is not broken. This must be recorded
+    distinguishably (``harness_contract``), never suppressed -- unlike
+    ``harness_env_error``, the condition is genuinely fixable by the loop."""
+
+    def test_argument_required_script_is_reclassified(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import argparse, sys\n"
+            "p = argparse.ArgumentParser(prog='validate_cycle_handoff.py')\n"
+            "p.add_argument('--manifest')\n"
+            "p.add_argument('--repo-root')\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "p.add_argument('--test', action='store_true')\n"
+            "args = p.parse_args()\n"
+            "if not args.manifest and not args.test:\n"
+            "    p.error('--manifest is required unless --test is used')\n"
+        )
+        _add_script(repo, "validate_cycle_handoff.py", script, days_ago=2)
+        record = validator_harness._run_one(
+            repo / "scripts" / "validate_cycle_handoff.py", repo, 30.0
+        )
+        assert record["exit_code"] == 2
+        assert record["harness_contract"] == "requires_arguments"
+        assert "harness_env_error" not in record
+
+    def test_legitimate_exit_2_with_findings_is_not_reclassified(self, tmp_path):
+        """A validator legitimately exiting 2 while printing findings text
+        (not an argparse usage error) must not be caught."""
+        repo = _init_repo(tmp_path)
+        script = (
+            "import sys\n"
+            "print('2 findings detected in scripts/')\n"
+            "sys.exit(2)\n"
+        )
+        _add_script(repo, "check_two.py", script, days_ago=2)
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_two.py", repo, 30.0
+        )
+        assert record["exit_code"] == 2
+        assert "harness_contract" not in record
+
+    def test_usage_line_alone_without_error_line_is_not_reclassified(self, tmp_path):
+        """A script that merely PRINTS something starting with 'usage:'
+        (e.g. as part of its own help text) without argparse's paired
+        '<prog>: error:' line must not be misclassified."""
+        repo = _init_repo(tmp_path)
+        script = (
+            "import sys\n"
+            "sys.stderr.write('usage: this is not an argparse error\\n')\n"
+            "sys.exit(2)\n"
+        )
+        _add_script(repo, "check_usage_text.py", script, days_ago=2)
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_usage_text.py", repo, 30.0
+        )
+        assert record["exit_code"] == 2
+        assert "harness_contract" not in record
+
+    def test_argparse_shape_at_a_different_exit_code_is_not_reclassified(self, tmp_path):
+        """The detection is scoped to exit_code == 2 -- argparse's own exit
+        code for a usage error -- not to the text shape alone."""
+        repo = _init_repo(tmp_path)
+        script = (
+            "import sys\n"
+            "sys.stderr.write('usage: check_weird.py [-h]\\n')\n"
+            "sys.stderr.write('check_weird.py: error: something\\n')\n"
+            "sys.exit(1)\n"
+        )
+        _add_script(repo, "check_weird.py", script, days_ago=2)
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_weird.py", repo, 30.0
+        )
+        assert record["exit_code"] == 1
+        assert "harness_contract" not in record
 
 
 # ─── #928 round 2: _run_one must always return ──────────────────────────

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -1937,7 +1937,11 @@ class TestFutureStampsBuyDelayNotSilence:
     the reverse channel — forging future stamps for MANY candidates to starve
     them out of the K-sized selection. The clamp's claimed property is that
     priority buys at most delay, never exclusion, so pin it: every candidate
-    must still run within ceil(N/K) invocations."""
+    must still run within ceil(N/K) invocations.
+
+    This fails on 8d738b6, before the clamp existed, so it guards the
+    original regression as well as pinning the property between the later
+    commits."""
 
     def test_every_candidate_still_runs_within_a_full_sweep(self, tmp_path, monkeypatch):
         monkeypatch.setattr(validator_harness, "_DEFAULT_MAX_K", 2)
@@ -1995,6 +1999,12 @@ class TestJsonFlagDeclarationForms:
             '"""Usage: python scripts/x.py --json"""\n',
             'p.add_argument("--json-output")\n',
             'p.add_argument("--no-json")\n',
+            # #934 review round 3: the widened alternatives need word
+            # boundaries, or any identifier ENDING in `option` and any name
+            # STARTING with `argv` matches. A script handed a flag it cannot
+            # parse becomes a "fails when run" false defect every rotation.
+            '# needle: foption("--json"\n',
+            'if "--json" in argv_names_this_auditor_checks:\n',
         ],
     )
     def test_mentions_and_near_misses_are_not_matched(self, source):

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -1520,3 +1520,312 @@ class TestPrunePreservesNewestPerPath:
 
         assert list(d.glob("*.tmp")) == []
         assert target.read_text(encoding="utf-8") == "original\n"
+
+
+# ─── #934 review round 1 fixes ───────────────────────────────────────────
+
+
+class TestSqueezedRunIsNeverBlamedOnTheScript:
+    """#934 review RED: `_run_one` used to be handed
+    ``min(_PER_SCRIPT_TIMEOUT, remaining)``, so the last script of a rotation
+    got whatever the total budget had left. Once a timeout became demand,
+    that turned a conformant validator into permanent false demand — and it
+    was guaranteed on the live host, where one script eats 60s of the 240s
+    every rotation."""
+
+    def test_a_script_is_never_started_without_the_full_contract(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(validator_harness, "_PER_SCRIPT_TIMEOUT", 5.0)
+        monkeypatch.setattr(validator_harness, "_TOTAL_BUDGET_SECONDS", 7.0)
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        # Sleeps past its own cap, consuming ~5s of the 7s budget.
+        _add_script(repo, "check_a_slow.py", "import time\ntime.sleep(30)\n", days_ago=2)
+        # Needs 2s, well inside the 5s contract — but only ~2s of budget is
+        # left when its turn comes, so it must not be started at all.
+        _add_script(repo, "check_b_healthy.py", "import time\ntime.sleep(2)\n", days_ago=2)
+
+        result = validator_harness.run_validator_harness(state_dir, repo)
+
+        assert result["ran"] == ["scripts/check_a_slow.py"]
+        rows = _last_runs(state_dir)
+        assert [r["path"] for r in rows] == ["scripts/check_a_slow.py"]
+        # And the healthy script keeps its never-run rotation position, so it
+        # is first in line next invocation rather than being penalised.
+        assert "scripts/check_b_healthy.py" not in _rotation(state_dir)["served"]
+
+    def test_only_the_genuinely_over_budget_script_becomes_demand(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(validator_harness, "_PER_SCRIPT_TIMEOUT", 5.0)
+        monkeypatch.setattr(validator_harness, "_TOTAL_BUDGET_SECONDS", 7.0)
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        _add_script(repo, "check_a_slow.py", "import time\ntime.sleep(30)\n", days_ago=2)
+        _add_script(repo, "check_b_healthy.py", "import time\ntime.sleep(2)\n", days_ago=2)
+
+        validator_harness.run_validator_harness(state_dir, repo)
+        items = demand._validator_defect_items(state_dir)
+
+        assert [i["affected_path"] for i in items] == ["scripts/check_a_slow.py"]
+
+
+class TestTruncatedStderrIsNotClassified:
+    """#934 review YELLOW: ``_drain_capped`` keeps the HEAD of the stream, so
+    for any stderr past ``_MAX_OUTPUT_BYTES`` the last captured line is not
+    the last line the script wrote — it is whatever sat at the cap boundary,
+    at an offset the script itself chooses. A hostile validator could pad so
+    that a read-only-path line lands there, collect ``harness_env_error``,
+    and have demand skip the genuine failure it reported afterwards. Refusing
+    to classify a truncated stream fails open toward a visible defect."""
+
+    def test_denial_at_the_truncation_boundary_is_not_marked(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(validator_harness, "_MAX_OUTPUT_BYTES", 4096)
+        repo = _init_repo(tmp_path)
+        # Alignment is the whole attack: the denial line is exactly 64 chars
+        # including its newline, and the cap is 4096, so the kept HEAD ends
+        # flush at the end of the 64th denial line. That makes the last
+        # CAPTURED line a denial even though the last WRITTEN line is the
+        # genuine failure below — which is the shape the padding buys.
+        script = (
+            "import sys\n"
+            "body = '[Errno 30] Read-only file system: '\n"
+            "line = body + 'x' * (63 - len(body))\n"
+            "assert len(line) + 1 == 64\n"
+            "for _ in range(100):\n"
+            "    sys.stderr.write(line + chr(10))\n"
+            "sys.stderr.write('ERROR: 3 unresolved failure signatures!' + chr(10))\n"
+            "sys.stderr.flush()\n"
+            "sys.exit(1)\n"
+        )
+        _add_script(repo, "check_padded.py", script, days_ago=2)
+
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_padded.py", repo, 30.0
+        )
+
+        assert record["exit_code"] == 1
+        # The genuine terminal line was discarded by the cap, so the harness
+        # must not pretend to know what the run's last word was.
+        assert "harness_env_error" not in record
+
+    def test_an_untruncated_denial_is_still_marked(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import sys\n"
+            "sys.stderr.write('OSError: [Errno 30] Read-only file system: /x' + chr(10))\n"
+            "sys.exit(1)\n"
+        )
+        _add_script(repo, "check_erofs.py", script, days_ago=2)
+        record = validator_harness._run_one(
+            repo / "scripts" / "check_erofs.py", repo, 30.0
+        )
+        assert record["harness_env_error"] == "permission_denied"
+
+
+class TestForgedRotationStampCannotExcludeAScript:
+    """#934 review YELLOW: ``rotation.json`` sits in the same writable
+    carve-out as the sidecar, and ``served[rel]`` is only overwritten for
+    scripts that actually RAN. A forged far-future stamp therefore used to
+    sort its target last forever — never selected, never run, never
+    overwriting the forgery. That is durable, self-maintaining exclusion of
+    any allowlisted validator from a single JSON write: precisely the
+    capability #934 refused to add via a timeout streak, already reachable
+    by another route. ``_rotation_key`` now treats a future stamp as
+    never-run, so the forgery buys priority instead of silence."""
+
+    def test_future_stamp_does_not_exclude(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validator_harness, "_DEFAULT_MAX_K", 1)
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        _add_script(repo, "validate_no_eval_exec.py", "print('safety')\n", days_ago=2)
+        _add_script(repo, "validate_zz_other.py", "print('other')\n", days_ago=2)
+        rotation_path = state_dir / "validator_harness" / "rotation.json"
+        rotation_path.parent.mkdir(parents=True, exist_ok=True)
+        rotation_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": validator_harness._ROTATION_SCHEMA,
+                    "served": {
+                        "scripts/validate_no_eval_exec.py": "3000-01-01T00:00:00+00:00"
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = validator_harness.run_validator_harness(state_dir, repo)
+
+        # The forged target is treated as never-run, so it sorts FIRST.
+        assert result["ran"] == ["scripts/validate_no_eval_exec.py"]
+        served = _rotation(state_dir)["served"]
+        assert served["scripts/validate_no_eval_exec.py"] != "3000-01-01T00:00:00+00:00"
+
+    def test_an_ordinary_past_stamp_still_orders_the_rotation(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(validator_harness, "_DEFAULT_MAX_K", 1)
+        state_dir = _state_dir(tmp_path)
+        repo = _init_repo(tmp_path)
+        _add_script(repo, "validate_aa_recent.py", "print('a')\n", days_ago=2)
+        _add_script(repo, "validate_zz_old.py", "print('z')\n", days_ago=2)
+        rotation_path = state_dir / "validator_harness" / "rotation.json"
+        rotation_path.parent.mkdir(parents=True, exist_ok=True)
+        rotation_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": validator_harness._ROTATION_SCHEMA,
+                    "served": {
+                        "scripts/validate_aa_recent.py": _iso(
+                            datetime.now(timezone.utc) - timedelta(hours=1)
+                        ),
+                        "scripts/validate_zz_old.py": _iso(
+                            datetime.now(timezone.utc) - timedelta(days=9)
+                        ),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = validator_harness.run_validator_harness(state_dir, repo)
+
+        assert result["ran"] == ["scripts/validate_zz_old.py"]
+
+
+class TestJsonFlagMustBeDeclaredNotMentioned:
+    """#934 review YELLOW: ``_accepts_json_flag`` was a bare mention test —
+    the same defect shape as the old ``_ARCHIVED_RE``, one function away. A
+    decay/pattern auditor that merely NAMES ``--json`` got the flag appended,
+    argparse rejected it with ``unrecognized arguments``, and the run failed
+    for a reason the script had no part in — then got a demand summary
+    asserting it "requires command-line arguments", the exact opposite of the
+    truth. The 14 validators #934 returns to service are that class."""
+
+    def test_a_mention_does_not_get_the_flag(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import argparse\n"
+            "PATTERNS = ['--json', '--verbose']  # strings this auditor looks FOR\n"
+            "p = argparse.ArgumentParser(prog='validate_flag_coverage.py')\n"
+            "args = p.parse_args()\n"
+            "print('scanned', len(PATTERNS))\n"
+        )
+        path = _add_script(repo, "validate_flag_coverage.py", script, days_ago=2)
+        assert validator_harness._accepts_json_flag(path) is False
+        record = validator_harness._run_one(path, repo, 30.0)
+        assert record["exit_code"] == 0
+        assert "harness_contract" not in record
+
+    def test_a_declaration_still_gets_the_flag(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import argparse, json\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "a = p.parse_args()\n"
+            "print(json.dumps({'findings': [1, 2]}) if a.json else 'plain')\n"
+        )
+        path = _add_script(repo, "validate_declares_json.py", script, days_ago=2)
+        assert validator_harness._accepts_json_flag(path) is True
+        record = validator_harness._run_one(path, repo, 30.0)
+        assert record["findings_count"] == 2
+
+    def test_short_alias_before_the_long_option_still_counts(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import argparse\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('-j', '--json', action='store_true')\n"
+            "p.parse_args()\n"
+            "print('{}')\n"
+        )
+        path = _add_script(repo, "validate_alias_json.py", script, days_ago=2)
+        assert validator_harness._accepts_json_flag(path) is True
+
+    def test_sys_argv_idiom_counts(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = "import sys\nprint('{}' if '--json' in sys.argv else 'plain')\n"
+        path = _add_script(repo, "validate_argv_json.py", script, days_ago=2)
+        assert validator_harness._accepts_json_flag(path) is True
+
+    def test_over_supply_is_not_labelled_as_requiring_arguments(self, tmp_path):
+        """argparse's ``unrecognized arguments`` is the OVER-supply shape.
+        Labelling it "requires command-line arguments" would be false."""
+        stderr = (
+            "usage: validate_x.py [-h]\n"
+            "validate_x.py: error: unrecognized arguments: --json\n"
+        )
+        assert validator_harness._is_argparse_usage_error(stderr) is False
+
+    def test_under_supply_is_still_labelled(self, tmp_path):
+        stderr = (
+            "usage: validate_x.py [-h] [--manifest MANIFEST]\n"
+            "validate_x.py: error: --manifest is required unless --test is used\n"
+        )
+        assert validator_harness._is_argparse_usage_error(stderr) is True
+
+
+class TestDecayDeclarationMustBeOnOneLine:
+    """#934 review YELLOW: co-occurrence anywhere in the 200KB head is too
+    loose now that docs/INITIAL_VALIDATOR_ROADMAP.md publishes the canonical
+    phrase verbatim — the next decay auditor will hold it as a constant AND
+    name its own path in its usage text, and would silence itself. Both real
+    declarations on the host are single-line ``WARNING:`` strings."""
+
+    def test_phrase_and_own_path_on_separate_lines_stays_a_candidate(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            '"""Audit decay declarations.\n'
+            "\n"
+            "Usage: python scripts/validate_decay_audit.py\n"
+            '"""\n'
+            'MARKER = "is deprecated and marked as archived"\n'
+            "print(MARKER)\n"
+        )
+        _add_script(repo, "validate_decay_audit.py", script, days_ago=2)
+        names = {p.name for p in validator_harness._candidate_scripts(repo)}
+        assert "validate_decay_audit.py" in names
+
+    def test_a_real_single_line_declaration_is_still_excluded(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import warnings\n"
+            'msg = "WARNING: scripts/analyze_repo_size.py is deprecated and '
+            'marked as archived (decay-36bd86468443) as unused."\n'
+            "warnings.warn(msg, DeprecationWarning, stacklevel=1)\n"
+            "raise SystemExit(1)\n"
+        )
+        _add_script(repo, "analyze_repo_size.py", script, days_ago=2)
+        names = {p.name for p in validator_harness._candidate_scripts(repo)}
+        assert "analyze_repo_size.py" not in names
+
+
+class TestUsageErrorIsNeverSuppressedByTheEnvMarker:
+    """#934 review GREEN-6: ``harness_env_error`` makes demand skip a row
+    entirely, and it was reachable together with the argparse contract —
+    ``argparse.FileType`` on a required flag reports EACCES as its terminal
+    line. The claim that a contract mismatch is "never suppressed" has to be
+    enforced, not asserted."""
+
+    def test_argparse_error_mentioning_a_denial_still_becomes_demand(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        script = (
+            "import sys\n"
+            "sys.stderr.write('usage: validate_ft.py [-h] --manifest MANIFEST' + chr(10))\n"
+            "sys.stderr.write(\"validate_ft.py: error: argument --manifest: \"\n"
+            "                 \"can't open '/x': [Errno 13] Permission denied\" + chr(10))\n"
+            "sys.exit(2)\n"
+        )
+        _add_script(repo, "validate_ft.py", script, days_ago=2)
+        record = validator_harness._run_one(repo / "scripts" / "validate_ft.py", repo, 30.0)
+
+        assert record["harness_contract"] == "requires_arguments"
+        assert "harness_env_error" not in record
+
+        state_dir = _state_dir(tmp_path)
+        _seed_last_runs(state_dir, [record])
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == 1
+        assert "requires command-line arguments" in items[0]["summary"]


### PR DESCRIPTION
Closes #934.

Four ways the harness reported its own execution environment as the validator's behaviour. One of them I introduced in #928, and it was silently disabling a third of the validator fleet.

## 1. Over-exclusion — 14 live validators had been silenced

`_ARCHIVED_RE = re.compile(r"marked as archived|script is archived")` was searched against the script's source head, so it matched any *mention* of archival. 14 of the 42 allowlisted validators on the live host share one copy-pasted helper docstring:

```
    """Check if a script is archived/deprecated by reading its content."""
```

which matched the `script is archived` alternative. All 14 were excluded from `_candidate_scripts` and never ran at all. Nothing reported it, because an unselected script produces no row.

Measured on the host, not inferred: the mention rule excluded **25 of 42**, only **13** genuinely self-declare, and the sidecar contained exactly the remaining **17** paths. The silenced set is the scripts that implement decay-detection themselves — `validate_deprecation_status.py`, `validate_no_eval_exec.py`, `validate_no_shell_true.py`, `validate_test_existence.py` and 10 more. Two of those are safety validators that had never run once.

The gradient was perverse: the more decay-awareness the instance builds — behaviour we want — the more of its fleet the regex killed.

Selection now requires a self-declaration: the phrase `is deprecated and (marked as archived|scheduled for removal)` **and** the script's own `scripts/<name>` path. That returns the 14 to service and, in the same change, excludes the two "scheduled for removal" scripts the old pattern missed entirely (Class C of the issue). Measured: 13 excluded either with or without the own-path requirement — it is kept anyway, because the case it defends against is exactly the one that caused this bug, and it fails open in the direction the module already prefers.

## 2. Sandbox denials — EROFS, and only on the terminal line

`verify_and_proof.py` writes its report into `state/reports`, which the unit makes read-only, and crashed with `OSError: [Errno 30] Read-only file system`. Same class as the EACCES case #928 fixed, so EROFS is now covered.

The more important half: the match is now against the **terminal non-empty stderr line**, not the whole stream. `analyze_repeat_failures.py` logs two non-fatal read-only export warnings and then reports a genuine finding on its last line — whole-stream matching would have suppressed a real defect. That is a silencing channel, and not a hypothetical one; it is in the live sidecar today. The narrowing applies to the pre-existing EACCES alternatives too, which strictly reduces suppression.

## 3. Validators that require arguments — relabelled, not hidden

`validate_cycle_handoff.py` exits 2 on every run with `--manifest is required unless --test is used`, because the harness invokes with no arguments. Summarised as "fails when run", it sent the loop chasing a crash that does not exist.

Detected via argparse's own two-line shape (`usage:` plus `<prog>: error:`) and relabelled to name the contract. **Deliberately not suppressed**, and deliberately not reusing `harness_env_error` — that field means "suppress, not the script's fault", and this is the opposite: under the harness's contract the script genuinely does not conform, and the loop can fix it. The observed script already offers a `--test` mode, so it anticipates a no-argument caller.

This reverses one of my own acceptance criteria on the issue, which I wrote before knowing the no-argument invocation is by design. Suppressing would have left the script permanently dead weight holding a rotation slot.

## 4. Timeouts — made visible, deliberately not auto-excluded

A run killed at `_PER_SCRIPT_TIMEOUT` has no exit code, so it produced no demand and no operator signal of any kind, while still burning a quarter of `_TOTAL_BUDGET_SECONDS` every rotation. `check_style.py` AST-parses 456 files on i386/2GB hardware and times out on every single run — a genuine resource limit, not a script bug. It is now reclassified into visible demand naming the time budget.

**This is where the first implementation had a real defect, and it is worth recording why the obvious design is the wrong one.** Auto-excluding a repeatedly-timing-out script requires deciding "has this timed out N times running?" from the only history that exists, `last_runs.jsonl` — and every validator subprocess can append to that file, since it is the harness's one writable carve-out shared by every child. A row's path, exit code, stderr tail and any mtime stamp are all forgeable, and the instance tree is readable, so three appended lines naming **any** allowlisted validator would drop it from selection **permanently**: a script that never runs never produces a real row to break its own streak.

That is a capability the sidecar does not otherwise grant. Forging a clean newest row already suppresses a script's demand — but the script still runs, and its next real verdict supersedes the forgery. Durable, self-maintaining silencing of an arbitrary validator would have been new, and it is precisely the bug class this whole issue is about.

So the budget is **not** reclaimed automatically, which fails the issue's sixth acceptance criterion as written. The waste becomes truthful, fixable demand instead: make the script incremental, or decay-declare it — which excludes it through the one mechanism that reads the script's own source rather than attacker-writable state. `test_forged_timeout_rows_cannot_exclude_a_script` is the regression test.

## 5. The invocation contract is now written down

It existed nowhere before, which is why scripts kept violating it. Added to the module docstring and to `docs/INITIAL_VALIDATOR_ROADMAP.md`: no arguments, the per-script timeout and total budget, what a non-zero exit means, and that decay self-declaration excludes a script permanently.

## Verification

Every behavioural change is covered by a test **verified to fail on `e10558c`** — run against the pre-fix modules in a detached worktree, not assumed:

```
FAILED TestDecayDeclarationExclusion::test_mention_only_stays_a_candidate
FAILED TestDecayDeclarationExclusion::test_scheduled_for_removal_rung_is_excluded
FAILED TestDecayDeclarationExclusion::test_old_rule_over_excludes_new_rule_does_not_synthetic_42
FAILED TestSandboxDenialCoversErofsOnTerminalLine::test_erofs_as_the_terminal_line_is_marked
FAILED TestSandboxDenialCoversErofsOnTerminalLine::test_eacces_midstream_with_genuine_terminal_failure_is_not_marked
FAILED TestArgparseUsageContract::test_argument_required_script_is_reclassified
6 failed, 70 deselected
```

The EACCES-mid-stream one is the significant entry: it failing on `main` is the proof that whole-stderr matching was suppressing genuine failures.

One pre-existing #925 test changed meaning rather than being deleted: `test_timeout_script_is_killed_and_recorded` asserted a timeout yields no demand. It now asserts the item exists, does **not** say "fails when run", and names the time budget — the original guarantee (never fabricate a crash claim) is kept explicitly.

## Rollout expectation

After deploy, `_candidate_scripts` should return **30 of 43** (the count was 42 when this work started; the loop authored another validator mid-review), and 14 validators that have never run will start producing verdicts. Some will surface genuine findings for the first time.

This also increases pressure on #933: the presented cap is 5 in plain alphabetical order, and 13 of the 14 restored scripts are named `validate_*` (the fourteenth is `check_confirmation_ratio.py`), inserted directly ahead of every `verify_*`.

## Review rounds

Three adversarial rounds, each of which found at least one real defect. Rounds 1 and 2 returned BLOCKED; round 3 returned MERGEABLE with two non-blocking items, both closed rather than shipped as documented cost.

- **Round 1 RED:** `_run_one` was handed `min(_PER_SCRIPT_TIMEOUT, remaining)`, so once a timeout became demand, a script squeezed by the *total* budget was reported as violating the *per-script* contract — guaranteed on the live host.
- **Round 2 RED:** one forged line in `rotation.json` (`0001-01-01T00:00:00+14:00`) made `_iso` raise `OverflowError` inside `eligible.sort`, aborting every invocation before either `_write_rotation` call. The poison was never overwritten, no script ever ran again, and `main()` still exited 0 — systemd reported a dead fleet as successful. Pre-existing on `main`, but in the lines this branch rewrote, and it falsified the new clamp comment's own self-healing claim.
- Also found and fixed: whole-stderr matching defeated by output volume (pad so a read-only-path line lands on the 64 KB cap boundary and a genuine failure gets skipped); `rotation.json` as a durable silencing channel; `_accepts_json_flag` as a bare mention test that made the harness pass a flag the script rejects and then blame the script for "requiring arguments"; the same pattern unanchored, matching `foption(` and `argv_names_*`.
- One review recommendation I implemented and then **reverted after measuring**: a same-line decay rule excludes 11 of 43 where co-occurrence excludes 13, and the two it loses are exactly the "scheduled for removal" pair this issue set out to start excluding. It would have undone Class C.

Filed rather than folded in: **#936** (decide decay from run output instead of source text — the reviewer's design, which converts a durable silent exclusion into a one-run suppression; sequenced separately because the source rule measures exactly correct on the live repo today and blocking would keep two never-run safety validators dead) and **#937** (`harness_failed` exits 0, so a totally dead harness reports success to systemd — #928 scoped that return deliberately, so changing it needs its own reasoning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
