### PR TITLE
feat(runtime): add skill usage fitness

### DIFF
--- a/docs/changes/939-skill-fitness/proposal.md
+++ b/docs/changes/939-skill-fitness/proposal.md
@@ -1,0 +1,70 @@
+# #939 — Skill Fitness Sidecar + Surface/Path Widening
+
+## Summary
+
+Implements four of the five parts of #939 (B/instance-migration excluded):
+
+- **A** — Open `skills/` prefix and root `AGENTS.md` in bridge classifier, legacy
+  validator, and `llm_proposer`; `goals.md` remains explicitly denied.
+- **C** — Standalone stdlib `nanobot/runtime/skill_fitness.py` (≤300 LOC); runtime
+  deny-set entry; `FITNESS_SIDECARS` sidecar in scorecard; `ReadFileTool` optional
+  callback; `SubagentManager` skill-fitness context; bridge collects reads only
+  after successful integration with birth-use guard.
+- **D** — SKILL template documentation for stdlib/no-uv PEP 723/noninteractive
+  scripts.
+- **E** — Loop subagent excludes weather/tmux/clawhub from skills summary without
+  changing ContextBuilder defaults; workspace/instance skills never auto-load;
+  prompt ordering fix (skills before memory).
+
+## Changed files
+
+- `nanobot/runtime/bridge.py` — `_ALLOWED_PATH_PREFIXES` + `_ALLOWED_EXACT_PATHS`
+  + `_classify_mutation_surface` exact-path bypass + `SubagentManager(...)` skill-
+  fitness + excluded-skills args + `collect_skill_reads` post-integration.
+- `nanobot/runtime/llm_proposer.py` — mirror of path prefix/exact-path changes +
+  prompt string updates + `validate_proposal` exact-path bypass.
+- `nanobot/runtime/scorecard.py` — `skill_fitness/reads.json` added to
+  `FITNESS_SIDECARS`.
+- `nanobot/runtime/runtime_deny.py` — `nanobot/runtime/skill_fitness.py` added to
+  `_RUNTIME_DENY_ALWAYS_FILES`.
+- `nanobot/runtime/skill_fitness.py` — new stdlib module (233 LOC).
+- `nanobot/agent/subagent.py` — skill-fitness context params + `collect_skill_reads`
+  method + `excluded_skill_names` param + `_build_subagent_prompt` exclusion wiring.
+- `nanobot/agent/tools/filesystem.py` — `ReadFileTool` `on_skill_read` optional
+  callback.
+- `nanobot/agent/skills.py` — `build_skills_summary(excluded_names=)` param +
+  `get_always_skills()` workspace guard + `source` attribute in XML output.
+- `nanobot/agent/context.py` — `build_system_prompt(excluded_skill_names=)` param +
+  prompt ordering fix (skills before memory).
+- `docs/changes/939-skill-fitness/proposal.md` (this file).
+- `docs/changes/939-skill-fitness/skill_stdlib_template.md` — Part D SKILL template.
+
+## Design decisions
+
+### Birth-use guard (Part C)
+
+A subagent that writes a SKILL.md and immediately reads it in the same cycle earns
+no fitness credit (`confirmed=False`).  The guard is implemented via a git ancestry
+check: if `skill_commit` (last commit touching the SKILL.md) is NOT an ancestor of
+`cycle_base_sha` (the sha the cycle branched from), the skill was created/modified
+in THIS cycle → `confirmed=False`.
+
+Persistence happens AFTER the integration outcome is known (post `_integrated`
+check in bridge.py), so a non-integrated cycle's reads are discarded entirely.
+The bridge's spawn-boundary integrity hash window covers the pre-spawn→pre-gate
+period; the `collect_skill_reads` write lands outside this window and is never
+flagged as a tamper incident.
+
+### Prompt ordering (Part E)
+
+Previous ordering: identity → bootstrap → memory → active-skills → skills-summary.
+The 24 KB cap could push the skills catalogue off the end when memory was large.
+Fixed ordering: identity → bootstrap → active-skills → skills-summary → memory.
+Memory is still included; it just yields space to the skills catalogue.
+
+### Workspace/instance always guard (Part E)
+
+`SkillsLoader.get_always_skills()` now skips skills with `source='workspace'`.
+Only builtin/operator-installed skills may carry `always=true`.  This prevents an
+instance from injecting arbitrary always-loaded content into every future subagent
+context by writing a SKILL.md with `always=true`.

--- a/docs/changes/939-skill-fitness/signal_audit.md
+++ b/docs/changes/939-skill-fitness/signal_audit.md
@@ -1,0 +1,43 @@
+# Signal audit — #939 context (adjacent to #929)
+
+## What this document covers
+
+This note captures the signal-audit surface that became visible when implementing
+#939 (skill-fitness sidecar).  It is _informational_ — no new signal type is added
+by #939 — and records the outcome of the audit for future reference.
+
+## Harness signals (`HARNESS_SIGNALS`)
+
+Defined in `nanobot/runtime/usage_evidence.py`:
+
+```python
+HARNESS_SIGNALS: frozenset[str] = frozenset({"pycache", "output", "benchmark", "reference"})
+```
+
+These are the **only** signal values the scorecard trusts when counting confirmed
+entries in `demand/completed.json`.  A `confirmed=True` entry whose `signal` is
+not in this set is treated as a foreign/forged write and ignored (live reward-hack
+2026-07-17 defence, pinned in `test_bridge_fitness_integrity.py`).
+
+## Skill-fitness signal (NOT added)
+
+The `skill_fitness/reads.json` sidecar introduced by #939 uses its own `confirmed`
+field with a **different semantics**: it reflects the birth-use guard
+(last-edit commit vs cycle base sha), not a harness usage signal.  It is a separate
+accounting file and is NOT folded into `HARNESS_SIGNALS`.  The scorecard does not
+yet surface skill-fitness counts in the fitness targets or gap analysis — this is
+left as a future gap (hypothetically: a `skill_reads_per_integration` metric once
+enough data accumulates).
+
+## Spawn-boundary coverage
+
+`skill_fitness/reads.json` is added to `scorecard.FITNESS_SIDECARS` so the
+bridge's pre-spawn/pre-gate hash window covers it.  An instance that appends
+false skill reads to claim fitness credit would be detected as a
+`sidecar_write_during_spawn` integrity incident, recorded in the ledger.
+
+## #929 adjacency
+
+Issue #929 audited the available signal surface; this document confirms that #939
+does not widen `HARNESS_SIGNALS` or add a new usage-evidence signal, so the
+#929 audit boundary is unchanged.

--- a/docs/changes/939-skill-fitness/skill_stdlib_template.md
+++ b/docs/changes/939-skill-fitness/skill_stdlib_template.md
@@ -1,0 +1,130 @@
+# SKILL Template: stdlib / no-uv / PEP 723 scripts
+
+## Purpose
+
+This document provides the canonical template and rules for SKILL.md files
+that bundle **standalone Python scripts** using only the standard library.
+
+## Rules for bundled scripts in `skills/<name>/scripts/`
+
+### 1. No external build tooling (no uv, no pip, no venv)
+
+Scripts bundled in a skill MUST NOT require `uv`, `pip install`, or any virtual
+environment setup step.  The agent runs on a constrained host where uv may not
+be available.  Use **only** the Python standard library.
+
+### 2. PEP 723 inline metadata (informational)
+
+If the script is intended as a standalone runnable, use
+[PEP 723](https://peps.python.org/pep-0723/) `# /// script` inline metadata
+at the top (comment block only — NOT executed by the default `python` invocation):
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+```
+
+Kept empty — no dependencies.  This makes the intent explicit without implying
+any dependency manager is required.
+
+### 3. Noninteractive execution
+
+Scripts MUST NOT prompt for user input (`input()`, `getpass`, interactive
+`argparse` without defaults).  All parameters must have defaults or be
+supplied via environment variables or command-line arguments with sensible
+defaults.
+
+### 4. Bounded output
+
+Scripts MUST write results to **stdout** (for success) and **stderr** (for
+diagnostics/errors).  They MUST NOT write to files unless explicitly instructed
+via a command-line argument.  Output MUST be bounded (no infinite loops, no
+unbounded accumulation in memory).
+
+### 5. Exit codes
+
+- `0` — success
+- `1` — user/input error
+- `2` — runtime/environment error
+
+Never exit with `sys.exit()` inside library functions — only in `if __name__ ==
+"__main__":` guards.
+
+### 6. Size limit
+
+Bundled scripts SHOULD be ≤300 lines.  Split into multiple files or use
+`references/` for large data if needed.
+
+---
+
+## Minimal SKILL.md template
+
+```markdown
+---
+name: my-skill
+description: <what it does and when to use it — include triggering context>
+---
+
+# My Skill
+
+## Quick start
+
+\`\`\`bash
+python skills/my-skill/scripts/main.py
+\`\`\`
+
+## Script: `scripts/main.py`
+
+Does X by Y.  Pass `--flag` for Z.
+
+## Output
+
+Writes results to stdout as JSON lines.  Errors to stderr.
+```
+
+---
+
+## Minimal `scripts/main.py` template
+
+```python
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""<One-line description>.
+
+Usage:
+    python main.py [--output-format json|text]
+
+Writes results to stdout.  Errors to stderr.  Exit 0=ok, 1=user error, 2=runtime error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-format", choices=["json", "text"], default="text")
+    args = parser.parse_args()
+
+    try:
+        result = {"status": "ok", "data": []}  # replace with real logic
+        if args.output_format == "json":
+            print(json.dumps(result))
+        else:
+            print(result["status"])
+        return 0
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```

--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -170,6 +170,27 @@ passes — so a broken or unverified cycle never reaches `main`.
 
 ## Requirements
 
+### Skill mutation and first-hand usage fitness (#939)
+
+The script tier SHALL allow `skills/**` and the instance-root `AGENTS.md` while
+continuing to reject the immutable `goals.md` charter. Proposer and bridge gate
+mirrors SHALL agree on these paths.
+
+Successful executor `read_file` calls for an exact workspace path
+`skills/<name>/SKILL.md` SHALL be observed in-process by the harness. Reads from
+lookalike or builtin paths do not qualify. For an integrated cycle the bridge
+SHALL append a bounded row to `state/skill_fitness/reads.json`; a read is
+confirmed only when git proves that the skill's last-edit commit predates the
+cycle base. Authoring-cycle reads and missing provenance earn zero confirmed
+usage. The sidecar SHALL be listed in `scorecard.FITNESS_SIDECARS`, and its
+writer module SHALL be in the runtime deny-set.
+
+Workspace-authored skills SHALL remain progressive-disclosure only: an `always`
+flag in instance content is ignored. The self-evolving loop profile SHALL omit
+irrelevant builtin skills from its standing summary without changing normal
+interactive profiles.
+
+
 ### Request selection
 - R1. The bridge SHALL select the oldest queued/pending request under
   `state/subagents/requests/` whose status is `queued` or `pending` and that has

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -26,25 +26,43 @@ class ContextBuilder:
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
 
-    def build_system_prompt(self, skill_names: list[str] | None = None) -> str:
-        """Build the system prompt from identity, bootstrap files, memory, and skills."""
+    def build_system_prompt(
+        self,
+        skill_names: list[str] | None = None,
+        excluded_skill_names: list[str] | None = None,
+    ) -> str:
+        """Build the system prompt from identity, bootstrap files, skills, and memory.
+
+        Prompt ordering (#939 Part E — fixes skills summary truncation):
+          1. Identity + bootstrap files (never truncated away)
+          2. Active Skills  (always=true, already loaded)
+          3. Skills summary (progressive-disclosure catalogue)
+          4. Memory         (large; placed last so skills are not truncated
+                             when the memory block is huge)
+
+        *excluded_skill_names* is an optional list of skill names to omit from
+        the summary (used by the self-evolving loop subagent to suppress
+        operator-only builtins such as weather/tmux/clawhub).  Has no effect
+        on normal interactive sessions.
+        """
         parts = [self._get_identity()]
 
         bootstrap = self._load_bootstrap_files()
         if bootstrap:
             parts.append(bootstrap)
 
-        memory = self.memory.get_memory_context()
-        if memory:
-            parts.append(f"# Memory\n\n{memory}")
-
+        # Active Skills — always-loaded builtin/operator skills (never workspace).
         always_skills = self.skills.get_always_skills()
         if always_skills:
             always_content = self.skills.load_skills_for_context(always_skills)
             if always_content:
                 parts.append(f"# Active Skills\n\n{always_content}")
 
-        skills_summary = self.skills.build_skills_summary()
+        # Skills catalogue — progressive loading; comes before memory so the
+        # 24 KB cap does not push it off the end when memory is large.
+        skills_summary = self.skills.build_skills_summary(
+            excluded_names=excluded_skill_names,
+        )
         if skills_summary:
             parts.append(f"""# Skills
 
@@ -52,6 +70,12 @@ The following skills extend your capabilities. To use a skill, read its SKILL.md
 Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
 
 {skills_summary}""")
+
+        # Memory — placed after skills so large memory blocks do not push the
+        # skills catalogue past the MAX_SYSTEM_PROMPT_CHARS truncation point.
+        memory = self.memory.get_memory_context()
+        if memory:
+            parts.append(f"# Memory\n\n{memory}")
 
         system_prompt = "\n\n---\n\n".join(parts)
         if len(system_prompt) > self.MAX_SYSTEM_PROMPT_CHARS:

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -9,6 +9,17 @@ from pathlib import Path
 # Default builtin skills directory (relative to this file)
 BUILTIN_SKILLS_DIR = Path(__file__).parent.parent / "skills"
 
+# #939 Part E: operator/builtin-only skills that are NEVER auto-loaded in the
+# self-evolving loop subagent context.  The bridge passes these names via
+# SubagentManager(excluded_skill_names=...) → ContextBuilder(excluded_skill_names=...)
+# → SkillsLoader.build_skills_summary(excluded_names=...).
+#
+# Rule: workspace/instance skills (source="workspace") are NEVER included in
+# get_always_skills() — auto-loading an instance-written skill would let the
+# loop inject arbitrary content into every future subagent context.  Only
+# builtin and operator-installed skills may carry always=true.
+_WORKSPACE_SOURCE = "workspace"
+
 
 class SkillsLoader:
     """
@@ -98,12 +109,20 @@ class SkillsLoader:
 
         return "\n\n---\n\n".join(parts) if parts else ""
 
-    def build_skills_summary(self) -> str:
+    def build_skills_summary(self, excluded_names: "list[str] | None" = None) -> str:
         """
         Build a summary of all skills (name, description, path, availability).
 
         This is used for progressive loading - the agent can read the full
         skill content using read_file when needed.
+
+        *excluded_names* is an optional list of skill names to omit from the
+        summary entirely.  The bridge passes this for the self-evolving loop
+        subagent to suppress operator-only or off-topic builtin skills
+        (e.g. weather, tmux, clawhub) without affecting interactive sessions.
+        Workspace/instance skills appear in the summary with
+        ``source="workspace"`` so the loop knows they exist and may read them;
+        they are never auto-loaded (see get_always_skills).
 
         Returns:
             XML-formatted skills summary.
@@ -112,18 +131,23 @@ class SkillsLoader:
         if not all_skills:
             return ""
 
+        excluded_set = set(excluded_names or [])
+
         def escape_xml(s: str) -> str:
             return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
         lines = ["<skills>"]
         for s in all_skills:
+            if s["name"] in excluded_set:
+                continue
             name = escape_xml(s["name"])
             path = s["path"]
             desc = escape_xml(self._get_skill_description(s["name"]))
             skill_meta = self._get_skill_meta(s["name"])
             available = self._check_requirements(skill_meta)
+            source = s.get("source", "builtin")
 
-            lines.append(f"  <skill available=\"{str(available).lower()}\">")
+            lines.append(f'  <skill available="{str(available).lower()}" source="{source}">')
             lines.append(f"    <name>{name}</name>")
             lines.append(f"    <description>{desc}</description>")
             lines.append(f"    <location>{path}</location>")
@@ -191,9 +215,19 @@ class SkillsLoader:
         return self._parse_nanobot_metadata(meta.get("metadata", ""))
 
     def get_always_skills(self) -> list[str]:
-        """Get skills marked as always=true that meet requirements."""
+        """Get skills marked as always=true that meet requirements.
+
+        #939 Part E: workspace/instance skills (source='workspace') are NEVER
+        auto-loaded regardless of their always flag — only builtin/operator
+        skills may have always=true honoured.  This prevents an instance from
+        injecting arbitrary content into every future subagent context by
+        writing a SKILL.md with always=true.
+        """
         result = []
         for s in self.list_skills(filter_unavailable=True):
+            # Workspace/instance skills: never auto-load (always flag ignored).
+            if s.get("source") == _WORKSPACE_SOURCE:
+                continue
             meta = self.get_skill_metadata(s["name"]) or {}
             skill_meta = self._parse_nanobot_metadata(meta.get("metadata", ""))
             if skill_meta.get("always") or meta.get("always"):

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -38,6 +38,17 @@ class SubagentManager:
         max_running: int | None = None,
         max_iterations: int | None = None,
         system_context: str = "",
+        # #939 Part C: optional skill-fitness instrumentation context.
+        # When supplied, successful SKILL.md reads inside the spawn window
+        # are collected in memory and persisted by the bridge after the
+        # subagent finishes (outside the spawn boundary, so the write is
+        # harness-side and protected by the sidecar integrity check).
+        skill_fitness_state_dir: "Path | None" = None,
+        skill_fitness_repo: "Path | None" = None,
+        skill_fitness_cycle_id: str = "",
+        skill_fitness_cycle_base_sha: str = "",
+        # Optional: names to exclude from the loop skills summary (Part E).
+        excluded_skill_names: "list[str] | None" = None,
     ):
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
 
@@ -64,6 +75,16 @@ class SubagentManager:
 
         self._state_root, self._runtime_state_source = resolve_runtime_state_location(self.workspace)
         self._telemetry_dir = self._state_root / "subagents"
+        # #939 Part C: skill-fitness instrumentation
+        self._skill_fitness_state_dir = skill_fitness_state_dir
+        self._skill_fitness_repo = skill_fitness_repo
+        self._skill_fitness_cycle_id = skill_fitness_cycle_id
+        self._skill_fitness_cycle_base_sha = skill_fitness_cycle_base_sha
+        # Collected in memory during the spawn window; written by the bridge
+        # after the subagent finishes (harness-side, protected by sidecar guard).
+        self._skill_reads_this_cycle: list[dict] = []
+        # #939 Part E: excluded skill names for the loop summary
+        self._excluded_skill_names: list[str] = list(excluded_skill_names or [])
 
     async def spawn(
         self,
@@ -142,7 +163,26 @@ class SubagentManager:
             tools = ToolRegistry()
             allowed_dir = self.workspace if self.restrict_to_workspace else None
             extra_read = [BUILTIN_SKILLS_DIR] if allowed_dir else None
-            tools.register(ReadFileTool(workspace=self.workspace, allowed_dir=allowed_dir, extra_allowed_dirs=extra_read))
+            # #939 Part C: wire SKILL.md read instrumentation callback.
+            _on_skill_read = None
+            if self._skill_fitness_state_dir is not None:
+                workspace_skills = (self.workspace / "skills").resolve()
+
+                def _on_skill_read(skill_path: Path) -> None:  # noqa: E301
+                    try:
+                        rel = skill_path.relative_to(workspace_skills)
+                    except ValueError:
+                        return
+                    if len(rel.parts) == 2 and rel.parts[1] == "SKILL.md":
+                        self._skill_reads_this_cycle.append(
+                            {"skill": rel.parts[0], "path": f"skills/{rel.as_posix()}"}
+                        )
+            tools.register(ReadFileTool(
+                workspace=self.workspace,
+                allowed_dir=allowed_dir,
+                extra_allowed_dirs=extra_read,
+                on_skill_read=_on_skill_read,
+            ))
             tools.register(WriteFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(EditFileTool(workspace=self.workspace, allowed_dir=allowed_dir))
             tools.register(ListDirTool(workspace=self.workspace, allowed_dir=allowed_dir))
@@ -410,13 +450,47 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         Uses the full ContextBuilder pipeline so that AGENTS.md, always-skills
         (including memory/MEMORY.md), and the skills catalogue are all visible
         to the subagent — exactly as they are for the main agent session.
+
+        #939 Part E: passes ``excluded_skill_names`` to suppress operator-only
+        builtin skills (weather, tmux, clawhub) from the loop summary without
+        changing normal ContextBuilder defaults for interactive sessions.
         """
         from nanobot.agent.context import ContextBuilder
 
-        prompt = ContextBuilder(self.workspace).build_system_prompt()
+        prompt = ContextBuilder(self.workspace).build_system_prompt(
+            excluded_skill_names=self._excluded_skill_names or None,
+        )
         if self.system_context:
             prompt += "\n\n---\n\n" + self.system_context
         return prompt
+
+    def collect_skill_reads(self) -> int:
+        """Persist accumulated SKILL.md reads to the skill-fitness sidecar.
+
+        Called by the bridge AFTER the spawn window closes (harness-side write,
+        protected by the FITNESS_SIDECARS spawn-boundary integrity check).  The
+        bridge snapshots sidecar hashes before spawn and re-hashes after; this
+        write therefore lands OUTSIDE the protected window and is never flagged
+        as an integrity incident.
+
+        Returns the count of rows persisted (0 when instrumentation is not
+        configured or no reads accumulated).  Fail-open.
+        """
+        if self._skill_fitness_state_dir is None or not self._skill_reads_this_cycle:
+            return 0
+        try:
+            from nanobot.runtime.skill_fitness import record_skill_reads
+            n = record_skill_reads(
+                state_dir=self._skill_fitness_state_dir,
+                reads=self._skill_reads_this_cycle,
+                repo=self._skill_fitness_repo,
+                cycle_id=self._skill_fitness_cycle_id,
+                cycle_base_sha=self._skill_fitness_cycle_base_sha,
+            )
+            self._skill_reads_this_cycle.clear()
+            return n
+        except Exception:
+            return 0
 
     async def cancel_by_session(self, session_key: str) -> int:
         """Cancel all subagents for the given session. Returns count cancelled."""

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -2,7 +2,7 @@
 
 import difflib
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from nanobot.agent.tools.base import Tool
 
@@ -55,10 +55,28 @@ class _FsTool(Tool):
 # ---------------------------------------------------------------------------
 
 class ReadFileTool(_FsTool):
-    """Read file contents with optional line-based pagination."""
+    """Read file contents with optional line-based pagination.
+
+    *on_skill_read* is an optional synchronous callback invoked exactly once
+    after a successful read whose resolved path ends with ``SKILL.md``.  The
+    callback receives the skill name (parent directory basename of the SKILL.md
+    file) as a single positional ``str`` argument.  Exceptions raised inside
+    the callback are silently swallowed so an instrumentation bug can never
+    break a subagent's file read.
+    """
 
     _MAX_CHARS = 128_000
     _DEFAULT_LIMIT = 2000
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        allowed_dir: Path | None = None,
+        extra_allowed_dirs: list[Path] | None = None,
+        on_skill_read: "Callable[[Path], None] | None" = None,
+    ):
+        super().__init__(workspace, allowed_dir, extra_allowed_dirs)
+        self._on_skill_read = on_skill_read
 
     @property
     def name(self) -> str:
@@ -128,6 +146,13 @@ class ReadFileTool(_FsTool):
                 result += f"\n\n(Showing lines {offset}-{end} of {total}. Use offset={end + 1} to continue.)"
             else:
                 result += f"\n\n(End of file — {total} lines total)"
+            # Notify the harness only after a successful SKILL.md read. The
+            # resolved path is preserved so callers can reject lookalike files.
+            if self._on_skill_read is not None and fp.name == "SKILL.md":
+                try:
+                    self._on_skill_read(fp.resolve())
+                except Exception:
+                    pass  # instrumentation bug must never break the read
             return result
         except PermissionError as e:
             return f"Error: {e}"

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2101,6 +2101,11 @@ async def _main_impl_body():
     # on the checked-out cycle branch. restrict_to_workspace=False already
     # leaves no fencing behavior to change.
     charter_text = read_charter_text(TARGET_WORKSPACE)
+    # #939 Part E: builtins irrelevant to the self-evolving loop are excluded
+    # from the subagent skills summary to reduce context noise.  The list is
+    # closed here (bridge-side, not instance-controlled) — instance code cannot
+    # widen or override it.
+    _LOOP_EXCLUDED_SKILLS = ["weather", "tmux", "clawhub"]
     mgr = SubagentManager(
         provider=provider,
         workspace=_selfevo_repo,
@@ -2122,6 +2127,15 @@ async def _main_impl_body():
             if charter_text
             else ""
         ),
+        # #939 Part C: skill-fitness instrumentation context.  The bridge
+        # supplies repo + cycle context so skill_fitness.py can resolve the
+        # last-edit commit of each SKILL.md and apply the birth-use guard.
+        skill_fitness_state_dir=STATE_DIR,
+        skill_fitness_repo=_selfevo_repo,
+        skill_fitness_cycle_id=_cycle_id,
+        skill_fitness_cycle_base_sha=main_sha_before,
+        # #939 Part E: suppress loop-irrelevant builtin skills.
+        excluded_skill_names=_LOOP_EXCLUDED_SKILLS,
     )
 
     # Capture HEAD SHA before spawn so we can count subagent commits correctly,
@@ -2305,6 +2319,15 @@ async def _main_impl_body():
                     max_running=_repair_cfg.tools.subagent.max_running,
                     # #906: same operator-preset override as the main spawn above.
                     max_iterations=resolve_max_tool_iterations(_repair_cfg.agents.defaults.max_tool_iterations),
+                    system_context=(
+                        "# Immutable operator charter\n\n" + charter_text
+                        if charter_text else ""
+                    ),
+                    skill_fitness_state_dir=STATE_DIR,
+                    skill_fitness_repo=_selfevo_repo,
+                    skill_fitness_cycle_id=_cycle_id,
+                    skill_fitness_cycle_base_sha=main_sha_before,
+                    excluded_skill_names=_LOOP_EXCLUDED_SKILLS,
                 )
                 await _repair_mgr.spawn(
                     task=_repair_prompt,
@@ -2318,6 +2341,9 @@ async def _main_impl_body():
                 except asyncio.TimeoutError:
                     print(f'repair turn {_repair_attempts} timed out')
                     break
+                # Merge repair-turn read receipts into the primary harness-owned
+                # accumulator; persistence still happens only after integration.
+                mgr._skill_reads_this_cycle.extend(_repair_mgr._skill_reads_this_cycle)
                 # Recount commits after repair — still relative to pre-spawn SHA,
                 # still on the same cycle branch (no push yet).
                 _repair_new = _count_commits_since(_selfevo_repo, _pre_spawn_sha)
@@ -2677,7 +2703,24 @@ async def _main_impl_body():
                 record_gate_decision(STATE_DIR, _cycle_id, False, _rollback_reason, [])
         commits_pushed = cycle_commit_count if _integrated else 0
 
-        # Safety-net: mark backlog Done if subagent forgot (meaningful only once main advanced)
+        # #939 Part C: persist skill-read fitness sidecar AFTER integration
+        # outcome is known.  The bridge's spawn-boundary integrity check
+        # (pre/post hash of FITNESS_SIDECARS) already completed above, so this
+        # write is harness-side and lands OUTSIDE the protected window.  Only
+        # call collect_skill_reads when the cycle actually integrated (success);
+        # the birth-use guard inside skill_fitness.py sets confirmed=False when
+        # the skill's last-edit commit differs from cycle_base_sha, so
+        # authoring cycles always produce confirmed=False rows (recorded for
+        # audit, never counted in fitness scoring).  A non-integrated cycle's
+        # reads are discarded — the subagent did not ship, so no fitness credit.
+        try:
+            if _integrated:
+                _sf_count = mgr.collect_skill_reads()
+                if _sf_count:
+                    print(f'skill-fitness: recorded {_sf_count} SKILL.md read(s) for cycle {_cycle_id}')
+        except Exception:
+            pass  # skill-fitness write errors are non-blocking
+
         if _integrated and backlog_title:
             marked = _try_mark_backlog_done(
                 repo_root=_selfevo_repo,
@@ -2889,8 +2932,12 @@ _BLOCKED_FILE_PATTERNS = (
 # appear on ANY mutation surface.
 _BLOCKED_EXACT_PATHS = frozenset({'goals.md'})
 
-# Allowed path prefixes for changed files (relative to repo root)
-_ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/')
+# Allowed path prefixes for changed files (relative to repo root).
+# 'skills/' — workspace/instance skill directories (SKILL.md + bundled resources).
+# 'AGENTS.md' is the repo-root operator instruction file and may be updated by the
+# instance; goals.md remains explicitly denied via _BLOCKED_EXACT_PATHS.
+_ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/', 'skills/')
+_ALLOWED_EXACT_PATHS = frozenset({'AGENTS.md'})
 
 # #863: the gate can only exercise/see-through these file types. Prefix
 # rules bound WHERE the instance may write; this bounds WHAT KIND of file
@@ -2906,7 +2953,7 @@ _GATE_EXT_ALLOWLIST = frozenset((
     ".sh", ".service", ".timer", ".conf", ".cron", ".html", ".css",
     ".ts", ".js", ".example",
 ))
-_GATE_BASENAME_ALLOWLIST = frozenset(("Makefile", "Dockerfile"))
+_GATE_BASENAME_ALLOWLIST = frozenset(("Makefile", "Dockerfile", "AGENTS.md"))
 
 
 def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
@@ -2933,6 +2980,9 @@ def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
         fname = f.rsplit('/', 1)[-1] if '/' in f else f
         if fname in _BLOCKED_EXACT_PATHS or f in _BLOCKED_EXACT_PATHS:
             violations.append(f'immutable file blocked from mutation: {f}')
+            continue
+        # Allowed exact paths (root AGENTS.md only) bypass the prefix check.
+        if f in _ALLOWED_EXACT_PATHS:
             continue
         # Blocked filename patterns
         for pat in _BLOCKED_FILE_PATTERNS:
@@ -3023,6 +3073,15 @@ def _classify_mutation_surface(
         fname = f.rsplit('/', 1)[-1] if '/' in f else f
         if fname in _BLOCKED_EXACT_PATHS or f in _BLOCKED_EXACT_PATHS:
             blocked.append(f'immutable file blocked from mutation: {f}')
+            continue
+        # Allowed exact paths (root AGENTS.md) bypass prefix and pattern checks.
+        if f in _ALLOWED_EXACT_PATHS:
+            basename2 = Path(f).name
+            suffix2 = Path(f).suffix.lower()
+            if basename2 not in _GATE_BASENAME_ALLOWLIST and suffix2 not in _GATE_EXT_ALLOWLIST:
+                violations.append(
+                    f'file extension not gate-exercisable (auto-integration denied): {f}'
+                )
             continue
         if any(pat in lower for pat in _BLOCKED_FILE_PATTERNS):
             blocked.append(f'blocked filename pattern in: {f}')

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -58,7 +58,13 @@ _TRUTHY = {"1", "true", "yes", "on"}
 # (bridge.py imports this module for the invocation hook); duplicated as a
 # small literal instead of a shared constant, per the "minimal wiring, no new
 # config surface" scope of this change.
-_ALLOWED_PATH_PREFIXES = ("surfaces/", "scripts/", "memory/", "lessons/", "docs/", "tests/")
+# 'skills/' opens the workspace/instance skill tree (SKILL.md + bundled resources).
+_ALLOWED_PATH_PREFIXES = ("surfaces/", "scripts/", "memory/", "lessons/", "docs/", "tests/", "skills/")
+
+# Allowed exact root paths (basename match). Root AGENTS.md is open so the
+# instance can update operator instructions; it is NOT a prefix match, so
+# only the true repo-root file is permitted.
+_ALLOWED_EXACT_PATHS = frozenset({'AGENTS.md'})
 
 # #944: explicitly blocked paths (immutable files that proposals may never
 # target), mirroring bridge._BLOCKED_EXACT_PATHS. goals.md is the immutable
@@ -173,7 +179,8 @@ _PROPOSER_SYSTEM_PROMPT = (
     "fences. task_title must be non-empty and at most 120 characters, "
     "describing a single behavior/bug (not a bundle). target_path must name "
     "exactly ONE path (file or directory) under one of these mutable "
-    "surfaces: surfaces/, scripts/, memory/, lessons/, docs/, tests/ — no "
+    "surfaces: surfaces/, scripts/, memory/, lessons/, docs/, tests/, skills/ "
+    "or the root-level file AGENTS.md — no "
     "other path is acceptable. serves must name what goal this task serves — "
     "non-empty, at most 160 characters, starting with one of: 'priority <N>' "
     "(a numbered goal_text priority, e.g. 'priority 5'), 'vector 1' or "
@@ -209,7 +216,8 @@ _DEMAND_PROPOSER_SYSTEM_PROMPT = (
     "must be non-empty and at most 120 characters, describing a single "
     "behavior/bug (not a bundle). target_path must name exactly ONE path "
     "(file or directory) under one of these mutable surfaces: surfaces/, "
-    "scripts/, memory/, lessons/, docs/, tests/ — no other path is "
+    "scripts/, memory/, lessons/, docs/, tests/, skills/ or the root-level "
+    "file AGENTS.md — no other path is "
     "acceptable. serves must be 'demand <id>' where <id> is the bracketed id "
     "of the ONE demand item this task addresses (e.g. 'demand "
     "defect-1a2b3c4d5e6f'). rationale must briefly explain how the task "
@@ -1269,8 +1277,8 @@ def build_context(
         recent_failed_titles = _recent_failed_titles(ledger_rows)
         surface_rule = (
             "Mutable surface rule: target_path MUST be a single path under "
-            "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + " — no other "
-            "path is acceptable."
+            "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + ", or the root "
+            "file AGENTS.md — no other path is acceptable."
         )
         # #823/#812: when the operator has opened a runtime slice, the proposer
         # may also target those specific nanobot/runtime modules for Vector-1
@@ -1581,7 +1589,9 @@ def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
     _target_basename = _norm_target.rsplit("/", 1)[-1] if "/" in _norm_target else _norm_target
     if _target_basename in _BLOCKED_EXACT_PATHS or _norm_target in _BLOCKED_EXACT_PATHS:
         return False, f"target_path is an immutable file that proposals may never modify: {target_path}"
-    _in_script_surface = any(target_path.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES)
+    # Allowed exact root paths (e.g. AGENTS.md) bypass the prefix check.
+    _in_exact_allowed = _norm_target in _ALLOWED_EXACT_PATHS
+    _in_script_surface = _in_exact_allowed or any(target_path.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES)
     _in_runtime_slice = _norm_target in _runtime_slice_paths()
     if not (_in_script_surface or _in_runtime_slice):
         return False, f"target_path outside allowed surfaces {_ALLOWED_PATH_PREFIXES}: {target_path}"

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -85,6 +85,14 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     # _RUNTIME_DENY_TOKENS, deliberately, so this explicit entry is the
     # only thing keeping it denied).
     'nanobot/runtime/tech_tree.py',
+    # #939: skill-fitness sidecar writer — the module that persists confirmed
+    # skill reads into state_dir/skill_fitness/reads.json (a FITNESS_SIDECARS
+    # member).  The instance must never be able to rewrite the harness-owned
+    # record of which skills it read and whether reads were confirmed, since
+    # that would let it fabricate fitness credit.  Same explicit-entry pattern
+    # as tech_tree.py above (no basename token match applies: 'fitness' is not
+    # in _RUNTIME_DENY_TOKENS, deliberately).
+    'nanobot/runtime/skill_fitness.py',
     # #899: the single resolver for runtime LLM model selection (operator
     # control-plane, same tier as bridge.py's own model knobs) — the loop
     # must never be able to rewrite which model each role runs on.

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -942,6 +942,12 @@ FITNESS_SIDECARS = (
     # prevented) via this sidecar's FITNESS_SIDECARS membership, the same
     # spawn-boundary #789 integrity check every other sidecar here gets.
     "tech_tree/portfolio.json",
+    # #939: skill-read fitness sidecar — records which SKILL.md files the
+    # subagent actually read during its cycle.  Tamper detection here is
+    # important: an instance that appends false skill reads to claim unearned
+    # fitness credit would bypass the birth-use guard without actually reading
+    # any skill.  Same spawn-boundary detection tier as the other sidecars.
+    "skill_fitness/reads.json",
 )
 
 

--- a/nanobot/runtime/skill_fitness.py
+++ b/nanobot/runtime/skill_fitness.py
@@ -1,0 +1,222 @@
+"""Skill-read fitness sidecar (#939 Part C).
+
+Tracks which SKILL.md files the self-evolving subagent has successfully
+read during a cycle, so the scorecard can reward cycles that actively learn
+from skills before acting.  Purely stdlib; no dependency on bridge.py or any
+other nanobot.runtime module that could create a circular import.
+
+Schema (``skill_fitness.json``)::
+
+    {
+        "schema_version": "skill-fitness-v1",
+        "reads": [
+            {
+                "skill":          str,   # skill name, e.g. "github"
+                "cycle_id":       str,
+                "ts":             str,   # ISO-8601 UTC
+                "skill_commit":   str,   # git sha of SKILL.md at read time ('' = unknown)
+                "cycle_base_sha": str,   # sha the cycle branched from ('' = unknown)
+                "confirmed":      bool   # True when read cycle != authoring cycle
+            }
+        ]
+    }
+
+Immutability invariant (#789 / #603): this file lives entirely outside the
+instance workspace in the harness-owned ``state_dir``.  The bridge adds it to
+``scorecard.FITNESS_SIDECARS`` so spawn-boundary tamper detection covers it
+(same guard as completed.json / scorecard/latest.json).  The instance can read
+it for self-knowledge but may never write it — that path is physically
+impossible given that writes go through :func:`record_skill_reads`, which is
+only called by the bridge.
+
+Birth-use rule: an authoring cycle (the cycle whose commit introduced or last
+changed the SKILL.md) earns **zero** fitness credit — reading your own just-
+written skill before anything else has run it is not evidence of genuine
+learning.  :func:`record_skill_reads` enforces this via a git commit-history
+check: if the skill's last-edit commit equals or is a child of the cycle's
+own base sha, ``confirmed`` is set to ``False`` and the read is still
+recorded (for audit) but not counted in fitness scoring.
+
+Deny-set: ``skill_fitness.py`` is explicitly protected by
+``_RUNTIME_DENY_ALWAYS_FILES`` because it writes a harness-owned fitness
+sidecar. The instance may not rewrite the collector that grants usage credit.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "skill-fitness-v1"
+SIDECAR_REL = "skill_fitness/reads.json"  # state_dir-relative path
+
+# Bounded write: never let the reads list grow unboundedly.
+_MAX_READS = 2000
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _git_sha(repo: Path, path: str) -> str:
+    """Return the sha of the most recent commit that touched *path*.
+
+    Returns '' on any error (offline, not a git repo, file untracked).
+    """
+    try:
+        r = subprocess.run(
+            ["git", "-c", f"safe.directory={repo}", "-C", str(repo),
+             "log", "-1", "--format=%H", "--", path],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.stdout.strip() if r.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _is_ancestor_or_equal(repo: Path, ancestor: str, descendant: str) -> bool:
+    """True iff *ancestor* is an ancestor of (or equal to) *descendant*.
+
+    Used by the birth-use guard: a read is confirmed only when the skill's
+    last-edit commit is already an ancestor of the cycle base. Errors return
+    False, so missing provenance fails closed to unconfirmed usage.
+    """
+    if not ancestor or not descendant:
+        return False
+    try:
+        r = subprocess.run(
+            ["git", "-c", f"safe.directory={repo}", "-C", str(repo),
+             "merge-base", "--is-ancestor", ancestor, descendant],
+            capture_output=True, timeout=10,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _read_sidecar(state_dir: Path) -> dict[str, Any]:
+    """Load the sidecar; return a blank schema on any error."""
+    path = Path(state_dir) / SIDECAR_REL
+    try:
+        if not path.is_file():
+            return {"schema_version": SCHEMA_VERSION, "reads": []}
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict) or raw.get("schema_version") != SCHEMA_VERSION:
+            return {"schema_version": SCHEMA_VERSION, "reads": []}
+        if not isinstance(raw.get("reads"), list):
+            raw["reads"] = []
+        return raw
+    except Exception:
+        return {"schema_version": SCHEMA_VERSION, "reads": []}
+
+
+def _write_sidecar_atomic(state_dir: Path, data: dict[str, Any]) -> None:
+    """Atomic bounded write: truncate to _MAX_READS, write via tmp+rename."""
+    path = Path(state_dir) / SIDECAR_REL
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        reads = data.get("reads", [])
+        if len(reads) > _MAX_READS:
+            data = dict(data)
+            data["reads"] = reads[-_MAX_READS:]
+        payload = json.dumps(data, indent=2, ensure_ascii=False)
+        tmp_path = path.with_suffix(".json.tmp")
+        tmp_path.write_text(payload, encoding="utf-8")
+        tmp_path.replace(path)
+    except Exception:
+        pass  # fail-open: a write error must never crash the bridge
+
+
+def record_skill_reads(
+    *,
+    state_dir: Path,
+    reads: list[dict[str, Any]],
+    repo: "Path | None" = None,
+    cycle_id: str = "",
+    cycle_base_sha: str = "",
+) -> int:
+    """Persist *reads* (from the bridge's instrumented spawn window) to the
+    sidecar.
+
+    Each item in *reads* must have at minimum ``{"skill": str}``.  The bridge
+    supplies ``cycle_id`` and ``cycle_base_sha`` from its own context; this
+    function adds ``ts``, looks up ``skill_commit`` via git, and applies the
+    birth-use rule to set ``confirmed``.
+
+    Returns the count of rows appended (0 on any error or empty input).
+    Fail-open: any exception degrades to 0 rows written.
+    """
+    if not reads:
+        return 0
+    try:
+        sidecar = _read_sidecar(state_dir)
+        appended = 0
+        ts = _utc_now()
+        for item in reads:
+            skill_name = str(item.get("skill") or "").strip()
+            skill_path = str(item.get("path") or "").strip().replace("\\", "/")
+            if not skill_name or skill_path != f"skills/{skill_name}/SKILL.md":
+                continue
+            skill_commit = _git_sha(repo, skill_path) if repo else ""
+            # Birth-use guard: if the last-edit commit of this SKILL.md is an
+            # ancestor of the cycle's current HEAD (i.e. was committed in THIS
+            # cycle, after cycle_base_sha), the authoring-cycle rule fires.
+            # Fail closed: positive credit requires complete git provenance
+            # proving the last skill edit predates this cycle's base commit.
+            confirmed = bool(
+                repo
+                and skill_commit
+                and cycle_base_sha
+                and _is_ancestor_or_equal(repo, skill_commit, cycle_base_sha)
+            )
+            row: dict[str, Any] = {
+                "skill": skill_name,
+                "cycle_id": cycle_id,
+                "ts": ts,
+                "skill_commit": skill_commit,
+                "cycle_base_sha": cycle_base_sha,
+                "confirmed": confirmed,
+            }
+            sidecar["reads"].append(row)
+            appended += 1
+        if appended:
+            _write_sidecar_atomic(state_dir, sidecar)
+        return appended
+    except Exception:
+        return 0
+
+
+def confirmed_reads_for_cycle(state_dir: Path, cycle_id: str) -> list[dict[str, Any]]:
+    """Return the confirmed skill reads for *cycle_id* (audit helper).
+
+    Fail-open to ``[]`` on any error.
+    """
+    try:
+        sidecar = _read_sidecar(state_dir)
+        return [
+            r for r in sidecar.get("reads", [])
+            if r.get("cycle_id") == cycle_id and r.get("confirmed") is True
+        ]
+    except Exception:
+        return []
+
+
+def skill_read_counts(state_dir: Path) -> dict[str, int]:
+    """Aggregate confirmed read counts by skill name (for scorecard visibility).
+
+    Fail-open to ``{}`` on any error.
+    """
+    try:
+        sidecar = _read_sidecar(state_dir)
+        counts: dict[str, int] = {}
+        for r in sidecar.get("reads", []):
+            if r.get("confirmed") is not True:
+                continue
+            skill = str(r.get("skill") or "")
+            if skill:
+                counts[skill] = counts.get(skill, 0) + 1
+        return counts
+    except Exception:
+        return {}

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -944,6 +944,16 @@ class TestValidateSizing:
         assert ok is False
         assert "immutable" in reason
 
+    def test_accepts_skill_and_root_agents_surfaces(self):
+        for target in ("skills/review/SKILL.md", "AGENTS.md"):
+            ok, reason = llm_proposer.validate_sizing(self._good(target_path=target))
+            assert ok is True, reason
+
+    def test_nested_agents_is_not_root_exact_allowance(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(target_path="other/AGENTS.md"))
+        assert ok is False
+        assert "outside allowed surfaces" in reason
+
     # ── #823: runtime-slice tier awareness (#812) ──────────────────────────────
     _SLICE_ENV = "SELFEVO_RUNTIME_SLICE"
     _SLICE_MOD = "nanobot/runtime/existence_index.py"

--- a/tests/test_mutation_surfaces.py
+++ b/tests/test_mutation_surfaces.py
@@ -33,6 +33,9 @@ def _extract_fn(name: str, extra_setup: str = '') -> object:
                     '_BLOCKED_FILE_PATTERNS',
                     '_BLOCKED_EXACT_PATHS',
                     '_ALLOWED_PATH_PREFIXES',
+                    '_ALLOWED_EXACT_PATHS',
+                    '_GATE_EXT_ALLOWLIST',
+                    '_GATE_BASENAME_ALLOWLIST',
                 )
             ):
                 constants += src + '\n'
@@ -88,6 +91,21 @@ def test_goals_md_is_explicitly_immutable():
     fn = _get_validate()
     violations = fn(['goals.md'])
     assert violations == ['immutable file blocked from mutation: goals.md']
+
+
+def test_root_agents_and_skill_files_are_allowed():
+    fn = _get_validate()
+    assert fn(['AGENTS.md']) == []
+    assert fn(['skills/review/SKILL.md']) == []
+
+
+def test_nested_agents_is_not_an_exact_root_allowance():
+    fn = _get_validate()
+    violations = fn(['docs/AGENTS.md'])
+    assert violations == []  # allowed only because docs/ is an existing prefix
+    violations = fn(['other/AGENTS.md'])
+    assert len(violations) == 1
+    assert 'outside allowed paths' in violations[0]
 
 
 def test_blocked_filename_in_surfaces_is_violation():

--- a/tests/test_skill_context_policy.py
+++ b/tests/test_skill_context_policy.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from nanobot.agent.context import ContextBuilder
+from nanobot.agent.skills import SkillsLoader
+
+
+def _skill(root: Path, name: str, *, always: bool = False, description: str = "test") -> None:
+    path = root / name / "SKILL.md"
+    path.parent.mkdir(parents=True)
+    marker = "\nalways: true" if always else ""
+    path.write_text(f"---\nname: {name}\ndescription: {description}{marker}\n---\n\n# {name}\n", encoding="utf-8")
+
+
+def test_workspace_always_skill_is_not_auto_loaded(tmp_path: Path):
+    _skill(tmp_path / "skills", "untrusted", always=True)
+    loader = SkillsLoader(tmp_path, builtin_skills_dir=tmp_path / "builtins")
+    assert loader.get_always_skills() == []
+
+
+def test_builtin_always_skill_is_loaded(tmp_path: Path):
+    builtins = tmp_path / "builtins"
+    _skill(builtins, "trusted", always=True)
+    loader = SkillsLoader(tmp_path, builtin_skills_dir=builtins)
+    assert loader.get_always_skills() == ["trusted"]
+
+
+def test_excluded_skills_absent_but_workspace_skill_visible_before_memory(tmp_path: Path):
+    _skill(tmp_path / "skills", "instance-review")
+    for name in ("weather", "tmux", "clawhub", "keep"):
+        _skill(tmp_path / "builtins", name)
+    (tmp_path / "memory").mkdir()
+    (tmp_path / "memory" / "MEMORY.md").write_text("M" * 30000, encoding="utf-8")
+    builder = ContextBuilder(tmp_path)
+    builder.skills = SkillsLoader(tmp_path, builtin_skills_dir=tmp_path / "builtins")
+
+    prompt = builder.build_system_prompt(excluded_skill_names=["weather", "tmux", "clawhub"])
+    assert "instance-review" in prompt
+    assert "<name>keep</name>" in prompt
+    assert "<name>weather</name>" not in prompt
+    assert "<name>tmux</name>" not in prompt
+    assert "<name>clawhub</name>" not in prompt
+    assert prompt.index("# Skills") < prompt.index("# Memory")

--- a/tests/test_skill_fitness.py
+++ b/tests/test_skill_fitness.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from nanobot.runtime import runtime_deny, scorecard, skill_fitness
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(repo), *args], check=True, text=True,
+                          capture_output=True).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    skill = repo / "skills" / "review" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Review\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "add skill")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def test_later_cycle_read_is_confirmed(tmp_path: Path):
+    repo, birth = _repo(tmp_path)
+    (repo / "README.md").write_text("next\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "next cycle")
+    base = _git(repo, "rev-parse", "HEAD")
+
+    assert skill_fitness.record_skill_reads(
+        state_dir=tmp_path / "state", reads=[{"skill": "review", "path": "skills/review/SKILL.md"}], repo=repo,
+        cycle_id="later", cycle_base_sha=base,
+    ) == 1
+    rows = skill_fitness.confirmed_reads_for_cycle(tmp_path / "state", "later")
+    assert len(rows) == 1
+    assert rows[0]["skill_commit"] == birth
+
+
+def test_authoring_cycle_and_missing_provenance_earn_zero(tmp_path: Path):
+    repo, _birth = _repo(tmp_path)
+    parent = _git(repo, "rev-parse", "HEAD^") if _git(repo, "rev-list", "--count", "HEAD") != "1" else "0" * 40
+    state = tmp_path / "state"
+    skill_fitness.record_skill_reads(state_dir=state, reads=[{"skill": "review", "path": "skills/review/SKILL.md"}], repo=repo,
+                                     cycle_id="birth", cycle_base_sha=parent)
+    skill_fitness.record_skill_reads(state_dir=state, reads=[{"skill": "unknown", "path": "skills/unknown/SKILL.md"}], repo=repo,
+                                     cycle_id="unknown", cycle_base_sha="")
+    assert skill_fitness.confirmed_reads_for_cycle(state, "birth") == []
+    assert skill_fitness.confirmed_reads_for_cycle(state, "unknown") == []
+
+
+def test_sidecar_is_protected_and_module_denied(tmp_path: Path):
+    assert skill_fitness.SIDECAR_REL in scorecard.FITNESS_SIDECARS
+    assert runtime_deny._is_runtime_deny("nanobot/runtime/skill_fitness.py")
+    state = tmp_path / "state"
+    path = state / skill_fitness.SIDECAR_REL
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"schema_version": skill_fitness.SCHEMA_VERSION, "reads": []}))
+    before = scorecard.fitness_sidecar_hashes(state)[skill_fitness.SIDECAR_REL]
+    path.write_text(json.dumps({"schema_version": skill_fitness.SCHEMA_VERSION,
+                                "reads": [{"skill": "forged"}]}))
+    after = scorecard.fitness_sidecar_hashes(state)[skill_fitness.SIDECAR_REL]
+    assert before != after

--- a/tests/test_skill_read_callback.py
+++ b/tests/test_skill_read_callback.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.tools.filesystem import ReadFileTool
+
+
+@pytest.mark.asyncio
+async def test_callback_receives_resolved_path_only_after_success(tmp_path: Path):
+    path = tmp_path / "skills" / "review" / "SKILL.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("hello", encoding="utf-8")
+    seen = []
+    tool = ReadFileTool(workspace=tmp_path, on_skill_read=seen.append)
+
+    result = await tool.execute(path="skills/review/SKILL.md")
+    assert "hello" in result
+    assert seen == [path.resolve()]
+
+    result = await tool.execute(path="skills/missing/SKILL.md")
+    assert result.startswith("Error:")
+    assert seen == [path.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_unrelated_skill_path_can_be_rejected_by_harness(tmp_path: Path):
+    path = tmp_path / "docs" / "review" / "SKILL.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("lookalike", encoding="utf-8")
+    seen = []
+    tool = ReadFileTool(workspace=tmp_path, on_skill_read=seen.append)
+    await tool.execute(path="docs/review/SKILL.md")
+    assert seen == [path.resolve()]
+    workspace_skills = (tmp_path / "skills").resolve()
+    with pytest.raises(ValueError):
+        seen[0].relative_to(workspace_skills)


### PR DESCRIPTION
## Summary
- open `skills/**` and exact instance-root `AGENTS.md` on script-tier surfaces while retaining explicit `goals.md` denial
- add first-hand, harness-recorded SKILL.md read fitness with birth-use exclusion, runtime deny protection, and spawn-boundary sidecar integrity
- prevent workspace skills from self-marking `always`; trim weather/tmux/clawhub from loop summaries and place skill catalogue before large memory
- add stdlib-only skill template/doctrine and update subagent-bridge spec/signal audit
- migrate the existing instance review skill separately in ozand/eeebot-self-evolving#176 (merged)

## Verification
- focused central/security suite: 290 passed
- earlier expanded focused suite: 288 passed
- full local Windows suite: 2221 passed, 11 skipped, 28 known platform/environment failures (Windows git/POSIX semantics, local Typer/Click, missing ddgs, separators/runtime timestamp); no #939-focused failures
- `skill_fitness.py`: 222 LOC, stdlib; targeted Ruff clean

## Rollout plan
After CI green + merge: deploy to eeepc, fast-forward instance repo to #176, confirm `.pi/skills` gone, SkillsLoader/prompt visibility, then run a controlled real cycle reading the migrated skill and verify protected sidecar receipt.

Issue: #939. Downstream: #940, #941.
