### PR TITLE
feat(demand): evolve idle skills and capture patterns

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -176,6 +176,7 @@ _MAX_DECAY_ITEMS = 5
 
 _MAX_REPAIR_UNUSED_ITEMS = 3  # #845: bounded repair-unused (fix_skill) demand
 _REPAIR_UNUSED_MIN_DAYS = 3  # idle >= this but < _DECAY_DAYS => re-wire band
+_SKILL_NEVER_READ_GRACE_DAYS = 3
 # (younger than the decay/archival band; disjoint by construction — the
 # invariant _REPAIR_UNUSED_MIN_DAYS < _DECAY_DAYS holds for these literals)
 
@@ -1275,7 +1276,32 @@ def _repair_unused_items(
             )
             if len(items) >= _MAX_REPAIR_UNUSED_ITEMS:
                 break
-        return items
+        # #940: workspace skills use the same bounded repair-unused demand.
+        if selfevo_repo is None:
+            return items[:_MAX_REPAIR_UNUSED_ITEMS]
+        from nanobot.runtime import skill_fitness
+        last_reads = skill_fitness.last_confirmed_skill_reads(state_dir)
+        skills_root = Path(selfevo_repo) / "skills"
+        if skills_root.is_dir():
+            for skill_file in sorted(skills_root.glob("*/SKILL.md")):
+                rel = skill_file.relative_to(selfevo_repo).as_posix()
+                skill_name = skill_file.parent.name
+                last_read = last_reads.get(skill_name)
+                created_raw = usage_evidence._git_creation_iso(selfevo_repo, rel)
+                created = usage_evidence._parse_ts(created_raw) if created_raw else None
+                last = usage_evidence._parse_ts(last_read) if last_read else None
+                if last is None:
+                    if created is None or (now - created).days < _SKILL_NEVER_READ_GRACE_DAYS:
+                        continue
+                    summary = f"repair: exercise never-read skill {rel} — wire or improve it, do not build a new one-shot"
+                elif _REPAIR_UNUSED_MIN_DAYS <= (now - last).days < _DECAY_DAYS:
+                    summary = f"repair: re-wire idle skill {rel} — extend or consume it, do not build a new one-shot"
+                else:
+                    continue
+                items.append(_make_item("defect", summary, f"harness-confirmed skill path={rel}; repair-unused demand" , affected_path=rel))
+                if len(items) >= _MAX_REPAIR_UNUSED_ITEMS:
+                    break
+        return items[:_MAX_REPAIR_UNUSED_ITEMS]
     except Exception:
         return []
 

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1279,6 +1279,24 @@ def _stepping_stones_section(state_dir: Path) -> str:
         return ""
 
 
+def _captured_pattern_hint(ledger_rows: list[dict[str, Any]]) -> str:
+    """Return a deterministic hint when the same target path repeats."""
+    counts: dict[str, int] = {}
+    for row in ledger_rows[-20:]:
+        if str(row.get("phase") or row.get("event") or "") not in {"proposed", "outcome"}:
+            continue
+        if str(row.get("outcome") or "success") not in {"success", ""}:
+            continue
+        for path in row.get("files_changed", []) if isinstance(row.get("files_changed"), list) else []:
+            rel = str(path).replace("\\", "/").strip()
+            if rel:
+                counts[rel] = counts.get(rel, 0) + 1
+    repeated = sorted(path for path, count in counts.items() if count >= 2)
+    if not repeated:
+        return ""
+    return "Repeated successful work touched " + ", ".join(repeated[:3]) + "; consider bundling the repeated pattern as a skill (bundle this repeated pattern as a skill)."
+
+
 def build_context(
     state_dir: Path,
     selfevo_repo: Path | None,
@@ -1372,11 +1390,14 @@ def build_context(
             "## Recent cycle outcomes (most recent last — do not repeat done/failed work)",
             "\n".join(f"- {line}" for line in digest_lines) or "(no ledger history yet)",
         ]
+        captured_hint = _captured_pattern_hint(ledger_rows)
         guardrail_parts = [
             "",
             "## Recently proposed (rejected as duplicates — do NOT propose these themes again)",
             "\n".join(f"- {title}" for title in recent_proposed_titles) or "(none yet)",
         ]
+        if captured_hint:
+            guardrail_parts += ["", "## CAPTURED pattern hint (steering only)", captured_hint]
         # #716: only appended when non-empty — with no recent failures this section
         # is absent (keeps output byte-identical to pre-#716 on that axis).
         if recent_failed_titles:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1283,11 +1283,12 @@ def _captured_pattern_hint(ledger_rows: list[dict[str, Any]]) -> str:
     """Return a deterministic hint when the same target path repeats."""
     counts: dict[str, int] = {}
     for row in ledger_rows[-20:]:
-        if str(row.get("phase") or row.get("event") or "") not in {"proposed", "outcome"}:
+        if str(row.get("phase") or row.get("event") or "") != "outcome":
             continue
-        if str(row.get("outcome") or "success") not in {"success", ""}:
+        if str(row.get("outcome") or "") != "success":
             continue
-        for path in row.get("files_changed", []) if isinstance(row.get("files_changed"), list) else []:
+        paths = row.get("files_changed", []) if isinstance(row.get("files_changed"), list) else []
+        for path in set(paths):
             rel = str(path).replace("\\", "/").strip()
             if rel:
                 counts[rel] = counts.get(rel, 0) + 1

--- a/nanobot/runtime/skill_fitness.py
+++ b/nanobot/runtime/skill_fitness.py
@@ -203,6 +203,23 @@ def confirmed_reads_for_cycle(state_dir: Path, cycle_id: str) -> list[dict[str, 
         return []
 
 
+def last_confirmed_skill_reads(state_dir: Path) -> dict[str, str]:
+    """Return newest confirmed read timestamp per skill name."""
+    try:
+        data = _read_sidecar(Path(state_dir))
+        latest: dict[str, str] = {}
+        for row in data.get("reads", []):
+            if not isinstance(row, dict) or row.get("confirmed") is not True:
+                continue
+            skill = str(row.get("skill") or "").strip()
+            ts = str(row.get("ts") or "").strip()
+            if skill and ts and ts > latest.get(skill, ""):
+                latest[skill] = ts
+        return latest
+    except Exception:
+        return {}
+
+
 def skill_read_counts(state_dir: Path) -> dict[str, int]:
     """Aggregate confirmed read counts by skill name (for scorecard visibility).
 

--- a/tests/test_captured_hint.py
+++ b/tests/test_captured_hint.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from nanobot.runtime.llm_proposer import build_context, _captured_pattern_hint
+
+
+def test_captured_hint_requires_repeated_successful_path():
+    rows = [
+        {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/a.py"]},
+        {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/a.py"]},
+    ]
+    assert "bundle" in _captured_pattern_hint(rows)
+    assert _captured_pattern_hint([rows[0]]) == ""
+
+
+def test_build_context_places_hint_in_protected_tail(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "nanobot.runtime.llm_proposer._load_ledger_rows",
+        lambda _state: [
+            {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/repeat.py"]},
+            {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/repeat.py"]},
+        ],
+    )
+    monkeypatch.setattr("nanobot.runtime.llm_proposer._load_goal_text", lambda _state: "goal")
+    context = build_context(tmp_path, None)
+    assert "CAPTURED pattern hint" in context
+    assert "bundle" in context

--- a/tests/test_captured_hint.py
+++ b/tests/test_captured_hint.py
@@ -12,6 +12,13 @@ def test_captured_hint_requires_repeated_successful_path():
     ]
     assert "bundle" in _captured_pattern_hint(rows)
     assert _captured_pattern_hint([rows[0]]) == ""
+    assert _captured_pattern_hint([
+        {"phase": "proposed", "files_changed": ["scripts/a.py"]},
+        {"phase": "outcome", "outcome": "failed", "files_changed": ["scripts/a.py"]},
+    ]) == ""
+    assert _captured_pattern_hint([
+        {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/a.py", "scripts/a.py"]},
+    ]) == ""
 
 
 def test_build_context_places_hint_in_protected_tail(tmp_path: Path, monkeypatch):

--- a/tests/test_skill_demand.py
+++ b/tests/test_skill_demand.py
@@ -52,6 +52,24 @@ def test_never_read_young_skill_and_current_read_are_not_demands(tmp_path):
                    for i in demand._repair_unused_items(state, repo, now))
 
 
+def test_never_read_old_skill_becomes_demand(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "state"
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso", lambda *_: (now - timedelta(days=5)).isoformat())
+    items = demand._repair_unused_items(state, repo, now)
+    assert any(i.get("affected_path") == "skills/review/SKILL.md" for i in items)
+
+
+def test_unconfirmed_read_is_not_usage(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "state"
+    _sidecar(state, "review", (now - timedelta(days=5)).isoformat().replace("+00:00", "Z"), confirmed=False)
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso", lambda *_: (now - timedelta(days=1)).isoformat())
+    assert not any(i.get("affected_path") == "skills/review/SKILL.md" for i in demand._repair_unused_items(state, repo, now))
+
+
 def test_forged_or_missing_skill_rows_do_not_create_arbitrary_demand(tmp_path):
     repo = _repo(tmp_path)
     now = datetime.now(timezone.utc)

--- a/tests/test_skill_demand.py
+++ b/tests/test_skill_demand.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+
+from nanobot.runtime import demand
+
+
+def _repo(tmp_path: Path, skill: str = "review") -> Path:
+    repo = tmp_path / "repo"
+    (repo / "skills" / skill).mkdir(parents=True)
+    (repo / "skills" / skill / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    import subprocess
+    subprocess.run(["git", "-C", str(repo), "init", "-b", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "add skill"], check=True, capture_output=True)
+    return repo
+
+
+def _sidecar(state: Path, skill: str, ts: str, confirmed: bool = True) -> None:
+    path = state / "skill_fitness" / "reads.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"schema_version": "skill-fitness-v1", "reads": [
+        {"skill": skill, "ts": ts, "confirmed": confirmed}
+    ]}), encoding="utf-8")
+
+
+def test_idle_confirmed_skill_becomes_bounded_repair_item(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "state"
+    _sidecar(state, "review", (now - timedelta(days=5)).isoformat().replace("+00:00", "Z"))
+
+    items = demand._repair_unused_items(state, repo, now)
+
+    skills = [i for i in items if i.get("affected_path") == "skills/review/SKILL.md"]
+    assert len(skills) == 1
+    assert skills[0]["kind"] == "defect"
+    assert "re-wire idle skill" in skills[0]["summary"]
+
+
+def test_never_read_young_skill_and_current_read_are_not_demands(tmp_path):
+    repo = _repo(tmp_path)
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "state"
+    _sidecar(state, "review", now.isoformat().replace("+00:00", "Z"))
+
+    assert not any(i.get("affected_path", "").startswith("skills/")
+                   for i in demand._repair_unused_items(state, repo, now))
+
+
+def test_forged_or_missing_skill_rows_do_not_create_arbitrary_demand(tmp_path):
+    repo = _repo(tmp_path)
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "state"
+    _sidecar(state, "does-not-exist", (now - timedelta(days=10)).isoformat().replace("+00:00", "Z"))
+
+    assert not any("does-not-exist" in i.get("summary", "")
+                   for i in demand._repair_unused_items(state, repo, now))


### PR DESCRIPTION
## Summary
- extend existing repair-unused lane to workspace skills using confirmed skill_fitness reads
- ignore forged/unconfirmed/nonexistent sidecar names; preserve cap 3 and grace behavior
- add deterministic CAPTURED hint only from repeated explicit successful outcome rows, protected from truncation and with zero new LLM calls
- add focused demand and hint tests

## Verification
- focused demand/proposer/hint suite: 179 passed
- full pytest follows CI and delivery pipeline
- no sidecar or secret changes

Issue #940; dependency #939 operationally satisfied by merged/live #946.