### PR TITLE
fix(proposer): ignore bookkeeping in captured hints

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1288,14 +1288,17 @@ def _captured_pattern_hint(ledger_rows: list[dict[str, Any]]) -> str:
         if str(row.get("outcome") or "") != "success":
             continue
         paths = row.get("files_changed", []) if isinstance(row.get("files_changed"), list) else []
-        for path in set(paths):
+        row_paths = set()
+        for path in paths:
             rel = str(path).replace("\\", "/").strip()
-            if rel:
-                counts[rel] = counts.get(rel, 0) + 1
+            if rel.startswith(("scripts/", "skills/", "surfaces/")):
+                row_paths.add(rel)
+        for rel in row_paths:
+            counts[rel] = counts.get(rel, 0) + 1
     repeated = sorted(path for path, count in counts.items() if count >= 2)
     if not repeated:
         return ""
-    return "Repeated successful work touched " + ", ".join(repeated[:3]) + "; consider bundling the repeated pattern as a skill (bundle this repeated pattern as a skill)."
+    return "Repeated successful work touched " + ", ".join(repeated[:3]) + "; bundle this repeated pattern as a skill."
 
 
 def build_context(

--- a/tests/test_captured_hint.py
+++ b/tests/test_captured_hint.py
@@ -23,6 +23,14 @@ def test_captured_hint_requires_repeated_successful_path():
         {"phase": "outcome", "outcome": "success", "files_changed": ["memory/HISTORY.md", "memory/MEMORY.md"]},
         {"phase": "outcome", "outcome": "success", "files_changed": ["memory/HISTORY.md", "memory/MEMORY.md"]},
     ]) == ""
+    assert "bundle" in _captured_pattern_hint([
+        {"phase": "outcome", "outcome": "success", "files_changed": ["skills/a/SKILL.md", "surfaces/policy.json"]},
+        {"phase": "outcome", "outcome": "success", "files_changed": ["skills/a/SKILL.md", "surfaces/policy.json"]},
+    ])
+    assert _captured_pattern_hint([
+        {"phase": "outcome", "outcome": "success", "files_changed": ["lessons/a.md", "docs/a.md", "tests/a.py"]},
+        {"phase": "outcome", "outcome": "success", "files_changed": ["lessons/a.md", "docs/a.md", "tests/a.py"]},
+    ]) == ""
 
 
 def test_build_context_places_hint_in_protected_tail(tmp_path: Path, monkeypatch):
@@ -37,4 +45,5 @@ def test_build_context_places_hint_in_protected_tail(tmp_path: Path, monkeypatch
     context = build_context(tmp_path, None)
     assert "CAPTURED pattern hint" in context
     assert "bundle" in context
+    assert context.count("bundle this repeated pattern as a skill") == 1
     assert "(bundle this repeated pattern as a skill)" not in context

--- a/tests/test_captured_hint.py
+++ b/tests/test_captured_hint.py
@@ -19,6 +19,10 @@ def test_captured_hint_requires_repeated_successful_path():
     assert _captured_pattern_hint([
         {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/a.py", "scripts/a.py"]},
     ]) == ""
+    assert _captured_pattern_hint([
+        {"phase": "outcome", "outcome": "success", "files_changed": ["memory/HISTORY.md", "memory/MEMORY.md"]},
+        {"phase": "outcome", "outcome": "success", "files_changed": ["memory/HISTORY.md", "memory/MEMORY.md"]},
+    ]) == ""
 
 
 def test_build_context_places_hint_in_protected_tail(tmp_path: Path, monkeypatch):
@@ -33,3 +37,4 @@ def test_build_context_places_hint_in_protected_tail(tmp_path: Path, monkeypatch
     context = build_context(tmp_path, None)
     assert "CAPTURED pattern hint" in context
     assert "bundle" in context
+    assert "(bundle this repeated pattern as a skill)" not in context


### PR DESCRIPTION
## Summary
- restrict CAPTURED repeats to substantive scripts/, skills/, and surfaces/ paths
- exclude memory/, lessons/, docs/, and tests/ bookkeeping
- keep explicit successful terminal outcomes and per-row deduplication
- emit the bundle hint once with no duplicated suffix
- add positive skills/surfaces and negative bookkeeping tests

## Verification
- focused proposer suite: 174 passed
- full pytest and CI follow
- deploy/live verification follows protocol

Issue #940 remains status:test after rollout because natural CAPTURED production evidence is still pending.