### PR TITLE
feat(runtime): add loop agent identity

### DIFF
--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -1,0 +1,13 @@
+# eeebot self-evolving agent identity
+
+You are the autonomous improvement agent for the eeepc self-evolving runtime.
+You are a developer agent whose purpose is to improve the system and its
+engineering loop through bounded, evidence-based changes.
+
+Act autonomously: there is no user in the loop during a cycle. Inspect the
+workspace and task, then act; do not ask for clarification. Work only on the
+harness-created cycle branch, use the available tools deliberately, and keep
+changes small, testable, observable, and reversible.
+
+This file defines who you are. The immutable `goals.md` charter defines why the
+system exists and its ordered goals; do not duplicate or edit that charter.

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1302,8 +1302,6 @@ def build_task(req: dict, goal_text: str, report_source: str,
         ]
 
     lines = [
-        'You are an autonomous improvement subagent for the eeepc self-evolving runtime.',
-        '',
         f'Task: {task_title}',
         f'Request ID: {request_id}',
         f'Cycle ID: {cycle_id}',
@@ -2154,6 +2152,8 @@ async def _main_impl_body():
     # on the checked-out cycle branch. restrict_to_workspace=False already
     # leaves no fencing behavior to change.
     charter_text = read_charter_text(TARGET_WORKSPACE)
+    identity_path = TARGET_WORKSPACE / 'IDENTITY.md'
+    identity_text = identity_path.read_text(encoding='utf-8').strip() if identity_path.is_file() else ''
     # #939 Part E: builtins irrelevant to the self-evolving loop are excluded
     # from the subagent skills summary to reduce context noise.  The list is
     # closed here (bridge-side, not instance-controlled) — instance code cannot
@@ -2177,8 +2177,9 @@ async def _main_impl_body():
         max_iterations=resolve_max_tool_iterations(config.agents.defaults.max_tool_iterations),
         system_context=(
             "# Immutable operator charter\n\n" + charter_text
+            + ("\n\n# Loop agent identity\n\n" + identity_text if identity_text else "")
             if charter_text
-            else ""
+            else ("# Loop agent identity\n\n" + identity_text if identity_text else "")
         ),
         # #939 Part C: skill-fitness instrumentation context.  The bridge
         # supplies repo + cycle context so skill_fitness.py can resolve the
@@ -2999,7 +3000,7 @@ _ALLOWED_SENSITIVE_BASENAMES = frozenset({
 # instance regardless of path-prefix rules. goals.md is the immutable
 # operator charter — it ships read-only in the release tree and must not
 # appear on ANY mutation surface.
-_BLOCKED_EXACT_PATHS = frozenset({'goals.md'})
+_BLOCKED_EXACT_PATHS = frozenset({'goals.md', 'IDENTITY.md'})
 
 
 def _is_blocked_filename(f: str) -> bool:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -69,8 +69,7 @@ _ALLOWED_EXACT_PATHS = frozenset({'AGENTS.md'})
 # #944: explicitly blocked paths (immutable files that proposals may never
 # target), mirroring bridge._BLOCKED_EXACT_PATHS. goals.md is the immutable
 # operator charter shipped in the release tree.
-_BLOCKED_EXACT_PATHS = frozenset({'goals.md'})
-
+_BLOCKED_EXACT_PATHS = frozenset({'goals.md', 'IDENTITY.md'})
 # #947 (fix-pass): mirror of bridge structural filename policy. Keep this
 # module-level copy behaviorally identical because bridge imports proposer.
 # Backward-compat tuple used by test extraction:


### PR DESCRIPTION
## Summary
- add operator-owned release-root IDENTITY.md for loop executor identity
- inject identity only into loop SubagentManager system context
- block IDENTITY.md in bridge/proposer mutation paths
- remove duplicate task-prompt autonomous identity line
- preserve interactive ContextBuilder defaults

## Verification
- focused identity/mutation/context suite: 196 passed
- full pytest and CI follow
- deployment/live prompt evidence uses #955 dump path

Issue #953; #955 dump is deployed but a natural dispatched content dump remains pending.