### PR TITLE
feat(memory): load loop index on demand

### DIFF
--- a/docs/memory-v2.md
+++ b/docs/memory-v2.md
@@ -1,0 +1,16 @@
+# Loop memory v2
+
+The loop reads `memory/index.md` first. Use `read_file` with the linked path to
+read one fact from `memory/facts/`. Fact files use minimal OKF frontmatter:
+
+```yaml
+---
+type: fact
+---
+```
+
+Keep `memory/index.md` compact. Add a new fact as a new file and add one index
+bullet. Read the last N lines of `memory/HISTORY.md` with `read_file` offset and
+limit. Do not load or rewrite the legacy memory wholesale. Periodic deduplication
+and pruning is operator/assistant curation, not a loop duty. Examples are POSIX
+path examples; no extra memory tool is required.

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -30,6 +30,7 @@ class ContextBuilder:
         self,
         skill_names: list[str] | None = None,
         excluded_skill_names: list[str] | None = None,
+        loop_profile: bool = False,
     ) -> str:
         """Build the system prompt from identity, bootstrap files, skills, and memory.
 
@@ -73,7 +74,7 @@ Skills with available="false" need dependencies installed first - you can try in
 
         # Memory — placed after skills so large memory blocks do not push the
         # skills catalogue past the MAX_SYSTEM_PROMPT_CHARS truncation point.
-        memory = self.memory.get_memory_context()
+        memory = self.memory.get_memory_context(loop=loop_profile)
         if memory:
             parts.append(f"# Memory\n\n{memory}")
 

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -95,7 +95,11 @@ class MemoryStore:
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
 
-    def get_memory_context(self) -> str:
+    def get_memory_context(self, *, loop: bool = False, max_chars: int = 4000) -> str:
+        if loop:
+            index = self.memory_dir / "index.md"
+            text = index.read_text(encoding="utf-8") if index.is_file() else ""
+            return f"## Long-term Memory\n{text[:max_chars]}" if text else ""
         long_term = self.read_long_term()
         return f"## Long-term Memory\n{long_term}" if long_term else ""
 

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -459,6 +459,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
 
         prompt = ContextBuilder(self.workspace).build_system_prompt(
             excluded_skill_names=self._excluded_skill_names or None,
+            loop_profile=True,
         )
         if self.system_context:
             prompt += "\n\n---\n\n" + self.system_context

--- a/tests/test_memory_v2.py
+++ b/tests/test_memory_v2.py
@@ -1,0 +1,19 @@
+from nanobot.agent.context import ContextBuilder
+from pathlib import Path
+
+
+def test_loop_context_uses_index_only(tmp_path: Path):
+    (tmp_path / "memory").mkdir()
+    (tmp_path / "memory" / "index.md").write_text("* [Fact](facts/fact.md) - desc\n", encoding="utf-8")
+    (tmp_path / "memory" / "MEMORY.md").write_text("FULL LEGACY BODY", encoding="utf-8")
+    prompt = ContextBuilder(tmp_path).build_system_prompt(loop_profile=True)
+    assert "facts/fact.md" in prompt
+    assert "FULL LEGACY BODY" not in prompt
+
+
+def test_interactive_context_keeps_legacy_memory(tmp_path: Path):
+    (tmp_path / "memory").mkdir()
+    (tmp_path / "memory" / "index.md").write_text("INDEX ONLY", encoding="utf-8")
+    (tmp_path / "memory" / "MEMORY.md").write_text("FULL LEGACY BODY", encoding="utf-8")
+    prompt = ContextBuilder(tmp_path).build_system_prompt()
+    assert "FULL LEGACY BODY" in prompt


### PR DESCRIPTION
## Summary
- loop-profile memory loads only compact memory/index.md (bounded), interactive ContextBuilder remains legacy MEMORY.md
- add OKF memory v2 usage documentation
- remove no memory bloat behavior from loop context path
- instance migration is delivered separately in ozand/eeebot-self-evolving#177 with full legacy preservation

## Verification
- focused memory/context suite: 12 passed
- full pytest and CI follow
- deploy/live verification after merge; prompt dump enabled on host

Issue #956; instance migration PR #177.