### PR TITLE
feat(runtime): complete skills flywheel retirement

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2169,7 +2169,8 @@ async def _main_impl_body():
     # from the subagent skills summary to reduce context noise.  The list is
     # closed here (bridge-side, not instance-controlled) — instance code cannot
     # widen or override it.
-    _LOOP_EXCLUDED_SKILLS = ["weather", "tmux", "clawhub"]
+    # #958 Part B: add cron, summarize, github (never used by the loop).
+    _LOOP_EXCLUDED_SKILLS = ["weather", "tmux", "clawhub", "cron", "summarize", "github"]
     mgr = SubagentManager(
         provider=provider,
         workspace=_selfevo_repo,

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -174,9 +174,17 @@ _MAX_EVIDENCE_CHARS = 420
 _DECAY_DAYS = 14
 _MAX_DECAY_ITEMS = 5
 
-_MAX_REPAIR_UNUSED_ITEMS = 3  # #845: bounded repair-unused (fix_skill) demand
+_MAX_REPAIR_UNUSED_ITEMS = 3  # #845/#958: shared cap for repair-unused AND retirement demand
 _REPAIR_UNUSED_MIN_DAYS = 3  # idle >= this but < _DECAY_DAYS => re-wire band
 _SKILL_NEVER_READ_GRACE_DAYS = 3
+# #958: retirement path — a never-read skill that has already been the subject
+# of this many integrated repair-unused cycles (without gaining a confirmed read)
+# graduates to a retirement demand item instead of another repair item.
+_SKILL_RETIRE_AFTER_REPAIR_CYCLES = 2
+# #958: anti-flap cooldown in days — a path retired within this window triggers
+# a re-creation warning in the proposer context instead of a new retirement item.
+_SKILL_RETIRE_COOLDOWN_DAYS = 30
+_SKILL_RETIREMENT_COOLDOWN_SCHEMA = "skill-retirement-cooldown-v1"
 # (younger than the decay/archival band; disjoint by construction — the
 # invariant _REPAIR_UNUSED_MIN_DAYS < _DECAY_DAYS holds for these literals)
 
@@ -1233,6 +1241,110 @@ def _decay_items(
 # ─── kind: defect — repair-unused / fix_skill (#845) ───────────────────────
 
 
+# ─── skill retirement cooldown sidecar (#958) ────────────────────────────────
+
+
+def _retirement_cooldown_path(state_dir: Path) -> Path:
+    return Path(state_dir) / "demand" / "skill_retirement_cooldown.json"
+
+
+def _load_retirement_cooldown(state_dir: Path) -> dict[str, Any]:
+    data = _read_json(_retirement_cooldown_path(state_dir), None)
+    if not isinstance(data, dict) or not isinstance(data.get("paths"), dict):
+        return {"schema_version": _SKILL_RETIREMENT_COOLDOWN_SCHEMA, "paths": {}}
+    return data
+
+
+def mark_skill_retired(state_dir: Path, rel: str, now: datetime) -> None:
+    """Record a skill path in the retirement cooldown sidecar (#958).
+
+    Called by the demand collector when it emits a retirement item, so
+    subsequent passes know this path was retired and can warn on re-creation.
+    Fail-open: any write error is silently swallowed.
+    """
+    try:
+        data = _load_retirement_cooldown(state_dir)
+        data["paths"][rel] = now.isoformat().replace("+00:00", "Z")
+        _write_json(_retirement_cooldown_path(state_dir), data)
+    except Exception:
+        pass
+
+
+def retired_skill_paths_in_cooldown(state_dir: Path, now: datetime) -> dict[str, str]:
+    """Return skill paths retired within _SKILL_RETIRE_COOLDOWN_DAYS (path -> retired_at).
+
+    Used by the proposer context to warn about re-creation of recently-retired paths.
+    Fail-open to empty dict.
+    """
+    try:
+        data = _load_retirement_cooldown(state_dir)
+        cutoff = now - timedelta(days=_SKILL_RETIRE_COOLDOWN_DAYS)
+        active: dict[str, str] = {}
+        for path, ts_raw in data.get("paths", {}).items():
+            ts = _parse_ts(ts_raw)
+            if ts is not None and ts >= cutoff:
+                active[path] = ts_raw
+        return active
+    except Exception:
+        return {}
+
+
+def _completed_repair_count_for_skill(state_dir: Path, rel: str) -> int:
+    """Count integrated repair-unused cycles for the exact skill path.
+
+    The completed sidecar is the durable summary for ordinary demand reads, but
+    a stable demand id can recur after a reset.  Count successful proposed →
+    outcome pairs in the bounded cycle ledger as well, de-duplicating by cycle
+    id.  A sidecar entry without a cycle id remains useful for small migrations
+    and tests.  Never trust a path from a sidecar as a workspace skill: callers
+    enumerate real ``skills/*/SKILL.md`` files.
+    """
+    try:
+        repair_ids = {
+            item_id("defect", summary[:_MAX_SUMMARY_CHARS])
+            for summary in (
+                f"repair: exercise never-read skill {rel} — wire or improve it, do not build a new one-shot",
+                f"repair: re-wire idle skill {rel} — extend or consume it, do not build a new one-shot",
+                f"repair: exercise never-read skill {rel}",
+                f"repair: re-wire idle skill {rel}",
+            )
+        }
+        completed = _load_completed(state_dir).get("entries", {})
+        completed_ids = {
+            str(demand_id)
+            for demand_id in completed
+            if str(demand_id) in repair_ids
+        }
+        cycle_ids: set[str] = set()
+        proposed: dict[str, str] = {}
+        ledger = Path(state_dir) / "ledger" / "cycles.jsonl"
+        if ledger.is_file():
+            for line in ledger.read_text(encoding="utf-8").splitlines():
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                cycle_id = str(row.get("cycle_id") or "").strip()
+                if not cycle_id:
+                    continue
+                if row.get("phase") == "proposed" and str(row.get("demand_id") or "") in repair_ids:
+                    proposed[cycle_id] = str(row.get("demand_id"))
+                elif (
+                    row.get("phase") == "outcome"
+                    and str(row.get("outcome") or "").strip().lower() == "success"
+                    and cycle_id in proposed
+                ):
+                    cycle_ids.add(cycle_id)
+        return len(completed_ids) + len(cycle_ids)
+    except Exception:
+        return 0
+
+
+# ─── kind: defect — repair-unused / fix_skill (#845) ───────────────────────
+
+
 def _repair_unused_items(
     state_dir: Path, selfevo_repo: Path | None, now: datetime
 ) -> list[dict[str, str]]:
@@ -1245,7 +1357,16 @@ def _repair_unused_items(
     decay/archival band (>= _DECAY_DAYS) by construction, so a script is
     never simultaneously a repair and an archival candidate. Bounded to
     :data:`_MAX_REPAIR_UNUSED_ITEMS`; ties #840 (reuse) / #838 (usage).
-    Fail-open: any error yields no repair demand."""
+    Fail-open: any error yields no repair demand.
+
+    #958: skills/*/SKILL.md paths that have zero confirmed reads AND are
+    past the never-read grace period AND have already been the subject of
+    _SKILL_RETIRE_AFTER_REPAIR_CYCLES integrated repair-unused cycles yield
+    a *retirement* item instead of another repair item. Both kinds share the
+    _MAX_REPAIR_UNUSED_ITEMS cap. Retired paths are recorded in the cooldown
+    sidecar; re-creation within _SKILL_RETIRE_COOLDOWN_DAYS surfaces a
+    warning in the proposer context (see retired_skill_paths_in_cooldown).
+    """
     try:
         from nanobot.runtime import usage_evidence
 
@@ -1286,6 +1407,8 @@ def _repair_unused_items(
             for skill_file in sorted(skills_root.glob("*/SKILL.md")):
                 rel = skill_file.relative_to(selfevo_repo).as_posix()
                 skill_name = skill_file.parent.name
+                if not skill_file.is_file() or not rel.startswith("skills/"):
+                    continue
                 last_read = last_reads.get(skill_name)
                 created_raw = usage_evidence._git_creation_iso(selfevo_repo, rel)
                 created = usage_evidence._parse_ts(created_raw) if created_raw else None
@@ -1293,12 +1416,32 @@ def _repair_unused_items(
                 if last is None:
                     if created is None or (now - created).days < _SKILL_NEVER_READ_GRACE_DAYS:
                         continue
-                    summary = f"repair: exercise never-read skill {rel} — wire or improve it, do not build a new one-shot"
+                    # #958: never-read past grace — check retirement condition
+                    repair_count = _completed_repair_count_for_skill(state_dir, rel)
+                    if repair_count >= _SKILL_RETIRE_AFTER_REPAIR_CYCLES:
+                        summary = (
+                            f"retire skill {rel}: fold anything reusable into docs/ or "
+                            "another skill, then delete the directory"
+                        )
+                        items.append(
+                            _make_item(
+                                "defect",
+                                summary,
+                                f"zero confirmed reads after grace period and "
+                                f"{repair_count} integrated repair-unused cycles; "
+                                "delete via normal gated cycle (git history preserves content)",
+                                affected_path=rel,
+                            )
+                        )
+                        mark_skill_retired(state_dir, rel, now)
+                    else:
+                        summary = f"repair: exercise never-read skill {rel} — wire or improve it, do not build a new one-shot"
+                        items.append(_make_item("defect", summary, f"harness-confirmed skill path={rel}; repair-unused demand" , affected_path=rel))
                 elif _REPAIR_UNUSED_MIN_DAYS <= (now - last).days < _DECAY_DAYS:
                     summary = f"repair: re-wire idle skill {rel} — extend or consume it, do not build a new one-shot"
+                    items.append(_make_item("defect", summary, f"harness-confirmed skill path={rel}; repair-unused demand" , affected_path=rel))
                 else:
                     continue
-                items.append(_make_item("defect", summary, f"harness-confirmed skill path={rel}; repair-unused demand" , affected_path=rel))
                 if len(items) >= _MAX_REPAIR_UNUSED_ITEMS:
                     break
         return items[:_MAX_REPAIR_UNUSED_ITEMS]

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1351,6 +1351,7 @@ def build_context(
     """
     try:
         state_dir = Path(state_dir)
+        now = datetime.now(timezone.utc)
         raw_goal_text = _load_goal_text(state_dir)
         filtered_goal = filter_completed_priorities_from_goal_text(
             raw_goal_text, selfevo_repo, state_dir=state_dir
@@ -1401,6 +1402,20 @@ def build_context(
         ]
         if captured_hint:
             guardrail_parts += ["", "## CAPTURED pattern hint (steering only)", captured_hint]
+        # #958: warn about re-creation of recently-retired skill paths.
+        try:
+            _cooldown_paths = demand.retired_skill_paths_in_cooldown(state_dir, now)
+            if _cooldown_paths:
+                _warn_lines = [
+                    f"- {p} (retired {ts[:10]})" for p, ts in sorted(_cooldown_paths.items())
+                ]
+                guardrail_parts += [
+                    "",
+                    "## WARNING: recently-retired skill paths (re-creation not recommended)",
+                    "\n".join(_warn_lines),
+                ]
+        except Exception:
+            pass
         # #716: only appended when non-empty — with no recent failures this section
         # is absent (keeps output byte-identical to pre-#716 on that axis).
         if recent_failed_titles:

--- a/tests/test_loop_excluded_skills.py
+++ b/tests/test_loop_excluded_skills.py
@@ -1,0 +1,123 @@
+"""Tests for _LOOP_EXCLUDED_SKILLS in bridge.py (#958 Part B).
+
+Verifies:
+- cron, summarize, github are in the exclusion list alongside existing entries
+- The list is wired into both primary and repair SubagentManager calls
+- Interactive (non-loop) sessions are unaffected (excluded_skill_names is bridge-local)
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+BRIDGE_PATH = Path(__file__).parent.parent / "nanobot" / "runtime" / "bridge.py"
+
+
+def _bridge_src() -> str:
+    return BRIDGE_PATH.read_text(encoding="utf-8")
+
+
+def _find_loop_excluded_skills_literal() -> list[str]:
+    """Extract the _LOOP_EXCLUDED_SKILLS list literal from bridge.py."""
+    tree = ast.parse(_bridge_src(), filename=str(BRIDGE_PATH))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "_LOOP_EXCLUDED_SKILLS"
+            and isinstance(node.value, ast.List)
+        ):
+            return [elt.value for elt in node.value.elts if isinstance(elt, ast.Constant)]
+    raise AssertionError("_LOOP_EXCLUDED_SKILLS not found in bridge.py")
+
+
+def _find_excluded_skill_names_call_sites() -> list[str]:
+    """Find all keyword values for 'excluded_skill_names' in bridge.py AST."""
+    tree = ast.parse(_bridge_src(), filename=str(BRIDGE_PATH))
+    sites: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "excluded_skill_names":
+                    if isinstance(kw.value, ast.Name):
+                        sites.append(kw.value.id)
+    return sites
+
+
+# ─── Part B: catalogue cleanup ───────────────────────────────────────────────
+
+
+def test_cron_in_excluded_skills():
+    excluded = _find_loop_excluded_skills_literal()
+    assert "cron" in excluded, f"'cron' must be in _LOOP_EXCLUDED_SKILLS; got {excluded}"
+
+
+def test_summarize_in_excluded_skills():
+    excluded = _find_loop_excluded_skills_literal()
+    assert "summarize" in excluded, f"'summarize' must be in _LOOP_EXCLUDED_SKILLS; got {excluded}"
+
+
+def test_github_in_excluded_skills():
+    excluded = _find_loop_excluded_skills_literal()
+    assert "github" in excluded, f"'github' must be in _LOOP_EXCLUDED_SKILLS; got {excluded}"
+
+
+def test_existing_excluded_skills_preserved():
+    """Ensure existing entries (weather, tmux, clawhub) are still present."""
+    excluded = _find_loop_excluded_skills_literal()
+    for name in ("weather", "tmux", "clawhub"):
+        assert name in excluded, f"'{name}' should still be in _LOOP_EXCLUDED_SKILLS"
+
+
+def test_excluded_skill_names_wired_to_loop_excluded_variable():
+    """Both SubagentManager call sites pass excluded_skill_names=_LOOP_EXCLUDED_SKILLS."""
+    sites = _find_excluded_skill_names_call_sites()
+    assert sites.count("_LOOP_EXCLUDED_SKILLS") >= 2, (
+        f"Expected >= 2 call sites passing _LOOP_EXCLUDED_SKILLS, "
+        f"found: {sites}"
+    )
+
+
+# ─── Interactive sessions unaffected ─────────────────────────────────────────
+
+
+def test_interactive_session_build_system_prompt_accepts_no_exclusions(tmp_path: Path):
+    """ContextBuilder.build_system_prompt works with no excluded_skill_names (interactive path)."""
+    from nanobot.agent.context import ContextBuilder
+    from nanobot.agent.skills import SkillsLoader
+
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "cron").mkdir(parents=True)
+    (skills_dir / "cron" / "SKILL.md").write_text(
+        "---\nname: cron\ndescription: cron skill\n---\n# cron\n", encoding="utf-8"
+    )
+
+    builder = ContextBuilder(tmp_path)
+    builder.skills = SkillsLoader(tmp_path, builtin_skills_dir=skills_dir)
+
+    # No excluded_skill_names = interactive mode; cron should appear
+    prompt = builder.build_system_prompt()
+    assert "<name>cron</name>" in prompt, (
+        "Interactive build_system_prompt with no exclusions should include cron"
+    )
+
+
+def test_excluded_skill_names_removes_cron_in_loop_context(tmp_path: Path):
+    """When bridge passes excluded_skill_names=['cron', ...], cron is absent."""
+    from nanobot.agent.context import ContextBuilder
+    from nanobot.agent.skills import SkillsLoader
+
+    skills_dir = tmp_path / "skills"
+    for name in ("cron", "keep-me"):
+        (skills_dir / name).mkdir(parents=True)
+        (skills_dir / name / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: test\n---\n# {name}\n", encoding="utf-8"
+        )
+
+    builder = ContextBuilder(tmp_path)
+    builder.skills = SkillsLoader(tmp_path, builtin_skills_dir=skills_dir)
+
+    prompt = builder.build_system_prompt(excluded_skill_names=["cron", "summarize", "github"])
+    assert "<name>cron</name>" not in prompt
+    assert "<name>keep-me</name>" in prompt

--- a/tests/test_skill_retirement.py
+++ b/tests/test_skill_retirement.py
@@ -1,0 +1,241 @@
+"""Tests for skill retirement demand path (#958 Part A).
+
+Covers:
+- Retirement item appears only when all three conditions hold
+- Cap shared with repair items (max 3)
+- Confirmed read prevents retirement
+- Anti-forgery: forged sidecar rows cannot force retirement of a healthy skill
+- Cooldown sidecar is written on retirement
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime import demand
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+def _repo(tmp_path: Path, skill: str = "idle-skill") -> Path:
+    repo = tmp_path / "repo"
+    (repo / "skills" / skill).mkdir(parents=True)
+    (repo / "skills" / skill / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "init", "-b", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "add skill"], check=True, capture_output=True)
+    return repo
+
+
+def _sidecar(state: Path, skill: str, ts: str, confirmed: bool = True) -> None:
+    path = state / "skill_fitness" / "reads.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "schema_version": "skill-fitness-v1",
+        "reads": [{"skill": skill, "ts": ts, "confirmed": confirmed}],
+    }), encoding="utf-8")
+
+
+def _seed_completed(state: Path, demand_id: str) -> None:
+    """Seed the completed demand sidecar with a demand_id as if it was integrated."""
+    path = demand._completed_path(state)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = demand._load_completed(state)
+    data["entries"][demand_id] = {
+        "cycle_id": "test-cycle",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "files_changed": [],
+        "serves": "",
+    }
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ─── condition (a): zero confirmed reads ────────────────────────────────────
+
+
+def test_confirmed_read_prevents_retirement(tmp_path: Path, monkeypatch):
+    """Condition (a): a skill with a confirmed read is NOT retired."""
+    repo = _repo(tmp_path)
+    now = _now()
+    state = tmp_path / "state"
+    # Recent confirmed read
+    _sidecar(state, "idle-skill", now.isoformat().replace("+00:00", "Z"))
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=10)).isoformat())
+
+    items = demand._repair_unused_items(state, repo, now)
+    retire = [i for i in items if "retire skill" in i.get("summary", "")]
+    assert retire == [], "A skill with a confirmed read must not be retired"
+
+
+# ─── condition (b): past never-read grace period ────────────────────────────
+
+
+def test_skill_within_grace_period_not_retired(tmp_path: Path, monkeypatch):
+    """Condition (b): a never-read skill younger than grace period produces no demand."""
+    repo = _repo(tmp_path)
+    now = _now()
+    state = tmp_path / "state"
+    # Created 1 day ago — within _SKILL_NEVER_READ_GRACE_DAYS (3)
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=1)).isoformat())
+
+    items = demand._repair_unused_items(state, repo, now)
+    skill_items = [i for i in items if "skills/idle-skill/SKILL.md" in i.get("affected_path", "")]
+    assert skill_items == [], "Skill within grace period must not become demand"
+
+
+# ─── condition (c): N integrated repair cycles ──────────────────────────────
+
+
+def test_retirement_requires_n_repair_cycles(tmp_path: Path, monkeypatch):
+    """Condition (c): a skill needs >= N=2 integrated repair cycles before retirement."""
+    repo = _repo(tmp_path)
+    now = _now()
+    state = tmp_path / "state"
+    rel = "skills/idle-skill/SKILL.md"
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=10)).isoformat())
+
+    # Seed 1 completed repair cycle (below threshold)
+    repair_summary = f"repair: exercise never-read skill {rel}"[:demand._MAX_SUMMARY_CHARS]
+    repair_id = demand.item_id("defect", repair_summary)
+    _seed_completed(state, repair_id)
+
+    items = demand._repair_unused_items(state, repo, now)
+    retire = [i for i in items if "retire skill" in i.get("summary", "")]
+    assert retire == [], "One repair cycle is not enough to trigger retirement"
+
+    # Seed a second completed repair cycle (meets threshold)
+    repair_summary2 = f"repair: re-wire idle skill {rel}"[:demand._MAX_SUMMARY_CHARS]
+    repair_id2 = demand.item_id("defect", repair_summary2)
+    _seed_completed(state, repair_id2)
+
+    items2 = demand._repair_unused_items(state, repo, now)
+    retire2 = [i for i in items2 if "retire skill" in i.get("summary", "")]
+    assert len(retire2) == 1, "Two repair cycles must trigger retirement"
+    assert retire2[0]["affected_path"] == rel
+
+
+# ─── cap shared with repair items ───────────────────────────────────────────
+
+
+def test_retirement_and_repair_share_cap(tmp_path: Path, monkeypatch):
+    """The combined repair+retire count is bounded to _MAX_REPAIR_UNUSED_ITEMS (3)."""
+    repo = tmp_path / "repo"
+    now = _now()
+    state = tmp_path / "state"
+
+    # Create 4 skills
+    for i in range(4):
+        name = f"skill-{i}"
+        (repo / "skills" / name).mkdir(parents=True)
+        (repo / "skills" / name / "SKILL.md").write_text(f"# skill {i}\n", encoding="utf-8")
+
+    subprocess.run(["git", "-C", str(repo), "init", "-b", "main"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "add skills"], check=True, capture_output=True)
+
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=10)).isoformat())
+
+    items = demand._repair_unused_items(state, repo, now)
+    assert len(items) <= demand._MAX_REPAIR_UNUSED_ITEMS
+
+
+# ─── all three conditions boundary ──────────────────────────────────────────
+
+
+def test_all_three_conditions_required(tmp_path: Path, monkeypatch):
+    """Retirement item appears only when all three conditions hold simultaneously."""
+    repo = _repo(tmp_path)
+    now = _now()
+    state = tmp_path / "state"
+    rel = "skills/idle-skill/SKILL.md"
+
+    # Conditions (b) and (c) met, but condition (a) violated (has confirmed read)
+    _sidecar(state, "idle-skill", (now - timedelta(days=5)).isoformat().replace("+00:00", "Z"))
+    for summary_base in (
+        f"repair: exercise never-read skill {rel}",
+        f"repair: re-wire idle skill {rel}",
+    ):
+        _seed_completed(state, demand.item_id("defect", summary_base[:demand._MAX_SUMMARY_CHARS]))
+
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=10)).isoformat())
+
+    items = demand._repair_unused_items(state, repo, now)
+    retire = [i for i in items if "retire skill" in i.get("summary", "")]
+    assert retire == [], "Confirmed read (condition a violated) must block retirement"
+
+
+# ─── cooldown sidecar ────────────────────────────────────────────────────────
+
+
+def test_retirement_writes_cooldown_sidecar(tmp_path: Path, monkeypatch):
+    """A retired skill path appears in the cooldown sidecar."""
+    repo = _repo(tmp_path)
+    now = _now()
+    state = tmp_path / "state"
+    rel = "skills/idle-skill/SKILL.md"
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=10)).isoformat())
+
+    for summary_base in (
+        f"repair: exercise never-read skill {rel}",
+        f"repair: re-wire idle skill {rel}",
+    ):
+        _seed_completed(state, demand.item_id("defect", summary_base[:demand._MAX_SUMMARY_CHARS]))
+
+    demand._repair_unused_items(state, repo, now)
+
+    cooldown = demand.retired_skill_paths_in_cooldown(state, now)
+    assert rel in cooldown, "Retired skill path must appear in cooldown sidecar"
+
+
+def test_cooldown_expires_after_m_days(tmp_path: Path):
+    """Paths retired longer than _SKILL_RETIRE_COOLDOWN_DAYS ago are not in cooldown."""
+    state = tmp_path / "state"
+    now = _now()
+    old_ts = now - timedelta(days=demand._SKILL_RETIRE_COOLDOWN_DAYS + 1)
+    demand.mark_skill_retired(state, "skills/old-skill/SKILL.md", old_ts)
+
+    cooldown = demand.retired_skill_paths_in_cooldown(state, now)
+    assert "skills/old-skill/SKILL.md" not in cooldown
+
+
+# ─── anti-forgery ────────────────────────────────────────────────────────────
+
+
+def test_forged_skill_path_not_in_repo_cannot_retire(tmp_path: Path, monkeypatch):
+    """A forged completed-sidecar entry for a non-existent skill path must not produce demand."""
+    repo = _repo(tmp_path, "real-skill")
+    now = _now()
+    state = tmp_path / "state"
+
+    # Forge repair-completed entries for a skill that doesn't exist in the repo
+    fake_rel = "skills/forged-skill/SKILL.md"
+    for summary_base in (
+        f"repair: exercise never-read skill {fake_rel}",
+        f"repair: re-wire idle skill {fake_rel}",
+    ):
+        _seed_completed(state, demand.item_id("defect", summary_base[:demand._MAX_SUMMARY_CHARS]))
+
+    monkeypatch.setattr("nanobot.runtime.usage_evidence._git_creation_iso",
+                        lambda *_: (now - timedelta(days=10)).isoformat())
+
+    items = demand._repair_unused_items(state, repo, now)
+    assert not any(
+        "forged-skill" in i.get("summary", "") for i in items
+    ), "Forged sidecar entries for non-existent skill must not create demand"


### PR DESCRIPTION
Implements ozand/eeebot#958 Parts A and B. Extends repair-unused demand with bounded skill retirement after two integrated repair cycles, confirmed-read and anti-forgery guards, cooldown warnings, and adds cron/summarize/github to the loop-only excluded skills list. Interactive sessions remain unchanged. Targeted tests pass; full suite follows CI.