### PR TITLE
fix(runtime,host): separate release root from writable workspace

### DIFF
--- a/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
+++ b/host/eeepc/etc/instances/self-evolving-subagent-bridge.env
@@ -6,6 +6,9 @@
 # Master kill switch for the subagent bridge (#678).
 SUBAGENT_BRIDGE_ENABLED=1
 STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
+# Read-only release tree for goals.md and IDENTITY.md; TARGET_WORKSPACE remains
+# the writable instance workspace via the operator-owned workspace override.
+RELEASE_ROOT=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 TARGET_WORKSPACE=/home/opencode/servers_team/repo_research/nanobot
 NANOBOT_CONFIG_PATH=/run/user/1001/nanobot-eeepc/config.json
 SUBAGENT_BRIDGE_STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state/subagent_bridge

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -81,6 +81,11 @@ from nanobot.runtime.stop_guards import REVISION_CAP_DEFAULT, revision_outcome  
 
 STATE_DIR = Path(os.environ.get('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state'))
 TARGET_WORKSPACE = Path(os.environ.get('TARGET_WORKSPACE', '/opt/eeepc-agent/runtimes/self-evolving-agent/current'))
+# #966: RELEASE_ROOT is the read-only release tree (goals.md, IDENTITY.md,
+# goal_text.json). Defaults to the canonical release path so a fresh install
+# without any env override reads from the correct place. TARGET_WORKSPACE
+# keeps only its writable-workspace role (.nanobot/subagents, latest.json).
+RELEASE_ROOT = Path(os.environ.get('RELEASE_ROOT', '/opt/eeepc-agent/runtimes/self-evolving-agent/current'))
 CONFIG_PATH = Path(os.environ.get('NANOBOT_CONFIG_PATH', '/run/user/1001/nanobot-eeepc/config.json'))
 BRIDGE_STATE_DIR = Path(os.environ.get('SUBAGENT_BRIDGE_STATE_DIR', str(STATE_DIR / 'subagent_bridge')))
 BRIDGE_ENABLED = os.environ.get('SUBAGENT_BRIDGE_ENABLED', '1').strip().lower() in {'1', 'true', 'yes', 'on'}
@@ -1740,7 +1745,7 @@ async def _main_impl_body():
         # Derived priorities (derived_priorities.json) are always folded in.
         try:
             from nanobot.runtime.goal_review import merged_goal_text
-            _charter = read_charter_text(TARGET_WORKSPACE)
+            _charter = read_charter_text(RELEASE_ROOT)
         except Exception:
             _charter = ''
         if _charter:
@@ -1749,8 +1754,8 @@ async def _main_impl_body():
             _base_goal_text = (
                 # Prefer goal_text.json in state dir
                 (load_json(STATE_DIR / 'goals' / 'goal_text.json') or {}).get('text')
-                # Fallback: read from canonical workspace (deployed with release)
-                or (load_json(TARGET_WORKSPACE / 'host' / 'eeepc' / 'etc' / 'goal_text.json') or {}).get('text')
+                # Fallback: read from release root (deployed with release)
+                or (load_json(RELEASE_ROOT / 'host' / 'eeepc' / 'etc' / 'goal_text.json') or {}).get('text')
                 or (goals.get('goals') or {}).get(goal_id, {}).get('text')
                 or goal_id
             )
@@ -1785,7 +1790,7 @@ async def _main_impl_body():
             req, task_goal_text, report_source, state_dir=STATE_DIR,
             selfevo_repo_root=_selfevo_repo_check,
             max_iterations=resolved_iterations,
-            charter_in_system=True,
+            charter_in_system=bool(_charter),
         )
 
         # Extract backlog title for MEMORY.md safety-net update after execution
@@ -2162,8 +2167,8 @@ async def _main_impl_body():
     # defined and validated by _cycle_setup['ok'] above, so the subagent lands
     # on the checked-out cycle branch. restrict_to_workspace=False already
     # leaves no fencing behavior to change.
-    charter_text = read_charter_text(TARGET_WORKSPACE)
-    identity_path = TARGET_WORKSPACE / 'IDENTITY.md'
+    charter_text = read_charter_text(RELEASE_ROOT)
+    identity_path = RELEASE_ROOT / 'IDENTITY.md'
     identity_text = identity_path.read_text(encoding='utf-8').strip() if identity_path.is_file() else ''
     # #939 Part E: builtins irrelevant to the self-evolving loop are excluded
     # from the subagent skills summary to reduce context noise.  The list is
@@ -2254,12 +2259,10 @@ async def _main_impl_body():
         # recompute on the proposer path) has already happened above, so any
         # post-spawn mismatch is attributable to code run inside the window.
         _integrity_pre = _fitness_sidecar_hashes(STATE_DIR)
-        # #955: dump prompts to state/prompts/ when SELFEVO_DUMP_PROMPTS=1.
-        # The system_context value mirrors the SubagentManager constructor arg above.
-        _dump_system = (
-            '# Immutable operator charter\n\n' + charter_text
-            if charter_text else ''
-        )
+        # #955/#966: dump the ACTUAL assembled system prompt (ContextBuilder
+        # output + system_context) so the dump faithfully matches what the
+        # executor receives — AGENTS.md, charter, and identity all included.
+        _dump_system = mgr._build_subagent_prompt()
         dump_spawn_prompts(STATE_DIR, _cycle_id, _dump_system, task)
         msg = await mgr.spawn(
             task=task,

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2262,7 +2262,15 @@ async def _main_impl_body():
         # #955/#966: dump the ACTUAL assembled system prompt (ContextBuilder
         # output + system_context) so the dump faithfully matches what the
         # executor receives — AGENTS.md, charter, and identity all included.
-        _dump_system = mgr._build_subagent_prompt()
+        # Small test doubles from older bridge tests do not implement the
+        # private builder; keep their fail-open diagnostic behavior without
+        # weakening the production path.
+        _build_prompt = getattr(mgr, '_build_subagent_prompt', None)
+        _dump_system = (
+            _build_prompt()
+            if callable(_build_prompt)
+            else ('# Immutable operator charter\n\n' + charter_text if charter_text else '')
+        )
         dump_spawn_prompts(STATE_DIR, _cycle_id, _dump_system, task)
         msg = await mgr.spawn(
             task=task,

--- a/nanobot/runtime/goal_review.py
+++ b/nanobot/runtime/goal_review.py
@@ -694,7 +694,7 @@ def maybe_goal_review(
         _write_watermark(state_dir, now)
 
         if release_root is None:
-            configured_root = os.environ.get("TARGET_WORKSPACE", "").strip()
+            configured_root = os.environ.get("RELEASE_ROOT", "").strip()
             release_root = Path(configured_root) if configured_root else None
         goal_data = _load_goal_data(state_dir, release_root)
         if goal_data is None:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -51,6 +51,7 @@ from nanobot.runtime.lessons_context import build_lessons_context
 from nanobot.runtime.model_registry import resolve_model
 
 ENABLED_ENV = "SELFEVO_LLM_PROPOSER_ENABLED"
+_RELEASE_ROOT_DEFAULT = "/opt/eeepc-agent/runtimes/self-evolving-agent/current"
 _TRUTHY = {"1", "true", "yes", "on"}
 
 # Mirrors nanobot.runtime.bridge._ALLOWED_PATH_PREFIXES exactly (#707 C2 —
@@ -448,11 +449,17 @@ def _queue_effectively_empty(state_dir: Path) -> bool:
     return True
 
 
+def _release_root_from_env() -> Path:
+    """Resolve the immutable release tree, independently of writable workspace."""
+    configured = os.environ.get("RELEASE_ROOT", "").strip()
+    return Path(configured or _RELEASE_ROOT_DEFAULT)
+
+
 def _load_goal_text(state_dir: Path, release_root: "Path | None" = None) -> str:
     """Assembled goal text for the proposer context.
 
     #944: reads the immutable operator charter from ``goals.md`` in the
-    release tree (``release_root`` arg or ``TARGET_WORKSPACE`` env var).
+    release tree (``release_root`` arg or ``RELEASE_ROOT`` env var).
     Derived priorities from ``state/goals/derived_priorities.json`` are
     folded in by :func:`goal_review.merged_goal_text` (#860). Falls back
     to the pre-#944 behavior (``goal_text.json`` in state dir holds the
@@ -460,10 +467,9 @@ def _load_goal_text(state_dir: Path, release_root: "Path | None" = None) -> str:
     """
     from nanobot.runtime.goal_review import read_charter_text
 
-    # Resolve release root: explicit arg wins, then env var.
+    # Resolve release root: explicit arg wins, then RELEASE_ROOT/default.
     if release_root is None:
-        _rr_env = os.environ.get("TARGET_WORKSPACE", "").strip()
-        release_root = Path(_rr_env) if _rr_env else None
+        release_root = _release_root_from_env()
 
     charter = read_charter_text(release_root)
     if charter:
@@ -755,9 +761,9 @@ def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
             return False
         goal_text_path = state_dir / "goals" / "goal_text.json"
         # #944: the pre-#760 supply path also works when goals.md exists
-        # at the release root (TARGET_WORKSPACE env), even without goal_text.json.
-        _rr_env = os.environ.get("TARGET_WORKSPACE", "").strip()
-        _has_goals_md = bool(_rr_env and (Path(_rr_env) / "goals.md").is_file())
+        # at the release root (RELEASE_ROOT env), even without goal_text.json.
+        _release_root = _release_root_from_env()
+        _has_goals_md = (_release_root / "goals.md").is_file()
         if not goal_text_path.is_file() and not _has_goals_md:
             return False
         if _queue_effectively_empty(state_dir):


### PR DESCRIPTION
Implements #966. Adds RELEASE_ROOT for immutable goals/identity reads while preserving TARGET_WORKSPACE for the writable instance workspace; makes charter pointers honest; dumps the assembled SubagentManager prompt; and updates the instance env template. No immutable operator files or secrets touched.