### PR TITLE
fix(runtime): complete executor context tails

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1375,7 +1375,10 @@ def build_task(req: dict, goal_text: str, report_source: str,
             for i, _p in enumerate(_prev, 1):
                 _ts = str(_p.get('created_at', ''))[:16].replace('T', ' ')
                 _c = _p.get('commits_pushed', 0) or 0
-                _kl = (_p.get('key_learnings') or ['(no detail)'])[0][:120]
+                _raw_kl = str((_p.get('key_learnings') or ['(no detail)'])[0])
+                _kl = _raw_kl[:120]
+                if len(_raw_kl) > 120:
+                    _kl = _kl.rsplit(' ', 1)[0].rstrip() + '…'
                 _status = _p.get('result_status', 'completed')
                 if _c > 0:
                     _outcome_str = f'{_c} commit(s) pushed ✓'

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -8,8 +8,11 @@ always: true
 
 ## Structure
 
-- `memory/MEMORY.md` — Long-term facts (preferences, project context, relationships). Always loaded into your context.
-- `memory/HISTORY.md` — Append-only event log. NOT loaded into context. Search it with grep-style tools or in-memory filters. Each entry starts with [YYYY-MM-DD HH:MM].
+Interactive workspaces use `memory/MEMORY.md` for long-term facts; it is loaded into context, while `memory/HISTORY.md` remains an append-only event log searched on demand.
+
+Self-evolving workspaces use `memory/index.md` as the catalog. Read individual `memory/facts/*.md` files on demand, and curate the index manually; do not assume a full MEMORY.md is loaded.
+
+Both layouts keep `memory/HISTORY.md` append-only. Search it with grep-style tools or in-memory filters. Each entry starts with [YYYY-MM-DD HH:MM].
 
 ## Search Past Events
 
@@ -25,13 +28,11 @@ Examples:
 
 Prefer targeted command-line search for large history files.
 
-## When to Update MEMORY.md
+## When to Update Memory
 
-Write important facts immediately using `edit_file` or `write_file`:
-- User preferences ("I prefer dark mode")
-- Project context ("The API uses OAuth2")
-- Relationships ("Alice is the project lead")
+For interactive workspaces, write important facts to `memory/MEMORY.md` using `edit_file` or `write_file`.
+For self-evolving workspaces, create or update a fact under `memory/facts/` and add its entry to `memory/index.md`.
 
-## Auto-consolidation
+## Consolidation
 
-Old conversations are automatically summarized and appended to HISTORY.md when the session grows large. Long-term facts are extracted to MEMORY.md. You don't need to manage this.
+Interactive sessions may automatically summarize old conversations into HISTORY.md and extract facts into MEMORY.md. The self-evolving instance does not rely on that automation: the executor curates its index and facts explicitly.

--- a/tests/test_issue_971_context_tails.py
+++ b/tests/test_issue_971_context_tails.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime.bridge import build_task
+
+
+def test_memory_skill_documents_index_layout():
+    path = Path(__file__).parents[1] / "nanobot" / "skills" / "memory" / "SKILL.md"
+    text = path.read_text(encoding="utf-8")
+
+    assert "memory/index.md" in text
+    assert "memory/facts/*.md" in text
+    assert "on demand" in text
+    assert "curate" in text.lower()
+    assert "Always loaded into your context" not in text
+    assert "You don't need to manage this" not in text
+
+
+def test_previous_attempt_learning_truncates_at_word_boundary(tmp_path: Path):
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text(
+        json.dumps({"next_bounded_candidate": {"title": "context-tail-task"}}),
+        encoding="utf-8",
+    )
+    results = tmp_path / "subagents" / "results"
+    results.mkdir(parents=True)
+    learning = "This learning ends with a complete boundary before the final oversizedwordfragment and then includes enough additional context to exceed the rendering budget"
+    (results / "result.json").write_text(
+        json.dumps({
+            "materialized_from": "bridge_llm_execution",
+            "created_at": "2026-08-25T10:00:00Z",
+            "commits_pushed": 1,
+            "result_status": "completed",
+            "key_learnings": [learning],
+            "source_artifact": str(artifact),
+        }),
+        encoding="utf-8",
+    )
+
+    request = {
+        "task_title": "context-tail-task",
+        "request_id": "request-971",
+        "cycle_id": "cycle-971",
+        "goal_id": "goal-1",
+        "source_artifact": str(artifact),
+    }
+    prompt = build_task(request, "goal", "", state_dir=tmp_path)
+
+    assert "## Previous attempts for this task" in prompt
+    assert "additional…" in prompt
+    assert "additional c" not in prompt


### PR DESCRIPTION
Implements #971 M1 and M3. M1 updates builtin memory guidance for interactive MEMORY.md and self-evolving index/facts layouts. M3 truncates previous-attempt learnings at a word boundary with a Unicode ellipsis. M4 is delivered separately in ozand/eeebot-self-evolving#182. M2 is observation-only; M5 remains tracked by #959.\n\nTest mapping:\n- M1 acceptance test -> tests/test_issue_971_context_tails.py::test_memory_skill_documents_index_layout\n- M3 acceptance test -> tests/test_issue_971_context_tails.py::test_previous_attempt_learning_truncates_at_word_boundary\n\nNo immutable operator files or secrets changed.