### PR TITLE
docs(identity): frame evolution as a production chain (operator edit)

### DIFF
--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -7,7 +7,23 @@ engineering loop through bounded, evidence-based changes.
 Act autonomously: there is no user in the loop during a cycle. Inspect the
 workspace and task, then act; do not ask for clarification. Work only on the
 harness-created cycle branch, use the available tools deliberately, and keep
-changes small, testable, observable, and reversible.
+changes scoped, testable, observable, and reversible.
+
+## How to think about evolution
+
+Self-improvement is not one distant, unreachable feat; it is a production
+chain, like a factory game: raw resources are refined into intermediate
+parts, parts into complex components, components into end products. Each
+cycle is one pass of Plan -> Build -> Automate -> Expand: build or improve
+one concrete tool — a script, a skill, a memory fact, a doc — verify it, and
+let it become the input the next cycle stands on. The scripts and skills you
+built earlier are your unlocked technology: prefer composing and extending
+them over restarting from raw materials, and automate what you find yourself
+repeating. A task too large for one cycle is a chain of small cycles —
+deliver its first link well. Scoped does not mean trivial: when the task
+deserves it, spend the full tool-iteration budget you are given on one
+ambitious, well-tested change rather than settling for the smallest safe
+edit.
 
 This file defines who you are. The immutable `goals.md` charter defines why the
 system exists and its ordered goals; do not duplicate or edit that charter.

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1375,7 +1375,10 @@ def build_task(req: dict, goal_text: str, report_source: str,
             for i, _p in enumerate(_prev, 1):
                 _ts = str(_p.get('created_at', ''))[:16].replace('T', ' ')
                 _c = _p.get('commits_pushed', 0) or 0
-                _kl = (_p.get('key_learnings') or ['(no detail)'])[0][:120]
+                _raw_kl = str((_p.get('key_learnings') or ['(no detail)'])[0])
+                _kl = _raw_kl[:120]
+                if len(_raw_kl) > 120:
+                    _kl = _kl.rsplit(' ', 1)[0].rstrip() + '…'
                 _status = _p.get('result_status', 'completed')
                 if _c > 0:
                     _outcome_str = f'{_c} commit(s) pushed ✓'

--- a/nanobot/skills/memory/SKILL.md
+++ b/nanobot/skills/memory/SKILL.md
@@ -8,8 +8,11 @@ always: true
 
 ## Structure
 
-- `memory/MEMORY.md` — Long-term facts (preferences, project context, relationships). Always loaded into your context.
-- `memory/HISTORY.md` — Append-only event log. NOT loaded into context. Search it with grep-style tools or in-memory filters. Each entry starts with [YYYY-MM-DD HH:MM].
+Interactive workspaces use `memory/MEMORY.md` for long-term facts; it is loaded into context, while `memory/HISTORY.md` remains an append-only event log searched on demand.
+
+Self-evolving workspaces use `memory/index.md` as the catalog. Read individual `memory/facts/*.md` files on demand, and curate the index manually; do not assume a full MEMORY.md is loaded.
+
+Both layouts keep `memory/HISTORY.md` append-only. Search it with grep-style tools or in-memory filters. Each entry starts with [YYYY-MM-DD HH:MM].
 
 ## Search Past Events
 
@@ -25,13 +28,11 @@ Examples:
 
 Prefer targeted command-line search for large history files.
 
-## When to Update MEMORY.md
+## When to Update Memory
 
-Write important facts immediately using `edit_file` or `write_file`:
-- User preferences ("I prefer dark mode")
-- Project context ("The API uses OAuth2")
-- Relationships ("Alice is the project lead")
+For interactive workspaces, write important facts to `memory/MEMORY.md` using `edit_file` or `write_file`.
+For self-evolving workspaces, create or update a fact under `memory/facts/` and add its entry to `memory/index.md`.
 
-## Auto-consolidation
+## Consolidation
 
-Old conversations are automatically summarized and appended to HISTORY.md when the session grows large. Long-term facts are extracted to MEMORY.md. You don't need to manage this.
+Interactive sessions may automatically summarize old conversations into HISTORY.md and extract facts into MEMORY.md. The self-evolving instance does not rely on that automation: the executor curates its index and facts explicitly.

--- a/tests/test_issue_971_context_tails.py
+++ b/tests/test_issue_971_context_tails.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime.bridge import build_task
+
+
+def test_memory_skill_documents_index_layout():
+    path = Path(__file__).parents[1] / "nanobot" / "skills" / "memory" / "SKILL.md"
+    text = path.read_text(encoding="utf-8")
+
+    assert "memory/index.md" in text
+    assert "memory/facts/*.md" in text
+    assert "on demand" in text
+    assert "curate" in text.lower()
+    assert "Always loaded into your context" not in text
+    assert "You don't need to manage this" not in text
+
+
+def test_previous_attempt_learning_truncates_at_word_boundary(tmp_path: Path):
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text(
+        json.dumps({"next_bounded_candidate": {"title": "context-tail-task"}}),
+        encoding="utf-8",
+    )
+    results = tmp_path / "subagents" / "results"
+    results.mkdir(parents=True)
+    learning = "This learning ends with a complete boundary before the final oversizedwordfragment and then includes enough additional context to exceed the rendering budget"
+    (results / "result.json").write_text(
+        json.dumps({
+            "materialized_from": "bridge_llm_execution",
+            "created_at": "2026-08-25T10:00:00Z",
+            "commits_pushed": 1,
+            "result_status": "completed",
+            "key_learnings": [learning],
+            "source_artifact": str(artifact),
+        }),
+        encoding="utf-8",
+    )
+
+    request = {
+        "task_title": "context-tail-task",
+        "request_id": "request-971",
+        "cycle_id": "cycle-971",
+        "goal_id": "goal-1",
+        "source_artifact": str(artifact),
+    }
+    prompt = build_task(request, "goal", "", state_dir=tmp_path)
+
+    assert "## Previous attempts for this task" in prompt
+    assert "additional…" in prompt
+    assert "additional c" not in prompt


### PR DESCRIPTION
Operator-owned IDENTITY.md update per operator direction.

Adds a 'How to think about evolution' section: self-improvement as an incremental production chain (raw resources -> intermediate parts -> complex components -> end products), each cycle one pass of Plan -> Build -> Automate -> Expand. Earlier scripts/skills are unlocked technology to compose and extend; oversized tasks become chains of small cycles. 'Scoped does not mean trivial' — the agent is told to spend its full tool-iteration budget on one ambitious, well-tested change when warranted (live telemetry: cycles use 6-19 of 80 allowed iterations).

Also softens 'small' -> 'scoped' in the existing autonomy paragraph to remove the contradiction with the budget guidance.

Context: iteration budget itself is already config-driven in the task prompt (#906/#954/#962) — no code change needed there. IDENTITY.md is delivered post-cap via system_context (#961/#966), so the +0.9 KB is incompressible by design; contract tests read the file dynamically and pass (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)