### PR TITLE
fix(bridge): make pytest verification guidance truthful

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -19,6 +19,7 @@ entrypoint.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import os
 import sys
@@ -1425,6 +1426,18 @@ def build_task(req: dict, goal_text: str, report_source: str,
         'Work you do not commit is discarded when this turn ends; commit completed',
         'implementation work on this cycle branch before the session ends.',
         '',
+    ]
+
+    _pytest_available = importlib.util.find_spec('pytest') is not None
+    _verification_line = (
+        '   - Verify: exec(\"python3 -m pytest <affected test file>\") — pytest is installed; run the tests you touch.'
+        if _pytest_available
+        else '   - Verify: exec(\"python3 -c \'import <module>; print(ok)\'\") or exec(\"python3 <script>\")'
+    )
+    _verification_note = (
+        '' if _pytest_available else '     (pytest is not installed — use python3 -c imports as smoke tests)'
+    )
+    lines += [
         '## Your instructions',
         'You MUST take a concrete action in this session. Do not return a review only.',
         '',
@@ -1434,8 +1447,8 @@ def build_task(req: dict, goal_text: str, report_source: str,
         '2. Read the source artifact and the concrete task above.',
         f'3. Implement the task within the resolved limit of {max_iterations} tool iterations:',
         '   - Write or edit the file using write_file or edit_file.',
-        "   - Verify: exec(\"python3 -c 'import <module>; print(ok)'\") or exec(\"python3 <script>\")",
-        '     (pytest is not installed — use python3 -c imports as smoke tests)',
+        _verification_line,
+        _verification_note,
         "   - Commit implementation changes: exec(\"git add <file> && git commit -m '<type>: <what>'\") ",
         '   - Do not create bookkeeping-only commits.',
         '4. If the task is already done or not applicable: report outcome: "skipped" without a bookkeeping commit.',

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -59,7 +59,7 @@ def _extract_fn(name: str, extra_setup: str = '') -> object:
     ns: dict = {}
     ordered_src = '\n'.join(srcs[n] for n in names_needed)
     exec(
-        f'import subprocess, json, os, re, sys, time\nfrom pathlib import Path\n'
+        f'import importlib.util, subprocess, json, os, re, sys, time\nfrom pathlib import Path\n'
         f'from unittest.mock import MagicMock\n'
         f'_ALLOWED_PATH_PREFIXES=("surfaces/", "scripts/", "memory/", "lessons/", "docs/", "tests/", "skills/")\n'
         f'_ALLOWED_EXACT_PATHS={"AGENTS.md"!r}\n'

--- a/tests/test_task_prompt_hygiene.py
+++ b/tests/test_task_prompt_hygiene.py
@@ -8,6 +8,20 @@ def test_iteration_and_skip_contract_are_explicit():
     assert 'outcome: "skipped"' in prompt
     assert "pick next priority from memory/MEMORY.md" not in prompt
     assert "bookkeeping-only commits" in prompt
+    assert "python3 -m pytest <affected test file>" in prompt
+    assert "pytest is installed; run the tests you touch" in prompt
+    assert "pytest is not installed" not in prompt
+
+
+def test_task_prompt_uses_import_fallback_when_pytest_is_absent(monkeypatch):
+    monkeypatch.setattr(
+        "nanobot.runtime.bridge.importlib.util.find_spec",
+        lambda name: None if name == "pytest" else object(),
+    )
+    req = {"task_title": "x", "request_id": "r", "cycle_id": "c", "goal_id": "g"}
+    prompt = build_task(req, "derived", "")
+    assert "pytest is not installed — use python3 -c imports as smoke tests" in prompt
+    assert "python3 -m pytest <affected test file>" not in prompt
 
 
 def test_system_mission_pointer_does_not_duplicate_charter():


### PR DESCRIPTION
Implements #974 with one harness-side importlib.util.find_spec('pytest') detection and one wording branch; no env vars, config, or subprocesses added.\n\nTest mapping:\n- AC available pytest -> tests/test_task_prompt_hygiene.py::test_iteration_and_skip_contract_are_explicit\n- AC absent pytest fallback -> tests/test_task_prompt_hygiene.py::test_task_prompt_uses_import_fallback_when_pytest_is_absent\n\nThe extracted build_task fixture imports importlib.util so the existing repair-loop tests cover the same prompt path. No immutable operator files or root junk committed.