### PR TITLE
feat(observability): record proposer LLM calls

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -35,6 +35,7 @@ import contextlib
 import json
 import os
 import re
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -49,6 +50,7 @@ from nanobot.runtime.goal_text_utils import (
 )
 from nanobot.runtime.lessons_context import build_lessons_context
 from nanobot.runtime.model_registry import resolve_model
+from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
 
 ENABLED_ENV = "SELFEVO_LLM_PROPOSER_ENABLED"
 _RELEASE_ROOT_DEFAULT = "/opt/eeepc-agent/runtimes/self-evolving-agent/current"
@@ -1621,8 +1623,34 @@ def propose(
         effort = bridge_reasoning_effort()  # #832: opt-in high-reasoning proposals
         if effort:
             create_kwargs["reasoning_effort"] = effort
+        call_start = time.monotonic()
         response = client.chat.completions.create(**create_kwargs)
-        reply = response.choices[0].message.content or ""
+        duration_ms = (time.monotonic() - call_start) * 1000
+        usage_obj = getattr(response, "usage", None)
+        usage = {
+            "prompt_tokens": getattr(usage_obj, "prompt_tokens", 0) or 0,
+            "completion_tokens": getattr(usage_obj, "completion_tokens", 0) or 0,
+            "total_tokens": getattr(usage_obj, "total_tokens", 0) or 0,
+        }
+        choice = response.choices[0]
+        finish_reason = getattr(choice, "finish_reason", "") or ""
+        model = str(getattr(response, "model", "") or create_kwargs["model"])
+        content = getattr(getattr(choice, "message", None), "content", "") or ""
+        try:
+            with call_context(None, "proposer"):
+                record_llm_call(
+                    model=model, duration_ms=duration_ms, usage=usage,
+                    finish_reason=finish_reason, retries=0,
+                )
+                record_llm_prompt(
+                    messages=create_kwargs["messages"], content=content,
+                    reasoning_content=None, finish_reason=finish_reason, model=model,
+                    prompt_tokens=usage["prompt_tokens"],
+                    completion_tokens=usage["completion_tokens"],
+                )
+        except Exception:
+            pass
+        reply = content
     except Exception:
         return None
     return _extract_json_object(reply)

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1420,11 +1420,16 @@ class _FakeMessage:
 class _FakeChoice:
     def __init__(self, content):
         self.message = _FakeMessage(content)
+        self.finish_reason = "stop"
 
 
 class _FakeResponse:
     def __init__(self, content):
         self.choices = [_FakeChoice(content)]
+        self.model = "an/test-proposer"
+        self.usage = type("Usage", (), {
+            "prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18,
+        })()
 
 
 class _FakeCompletions:
@@ -1471,6 +1476,24 @@ class TestProposeMockedClient:
             "rationale": "closes a gap",
             "target_path": "tests/test_x.py",
         }
+
+    def test_proposer_records_call_and_prompt_telemetry(self, monkeypatch, tmp_path):
+        self._patch_client(monkeypatch, json.dumps({"task_title": "x"}))
+        monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+        assert llm_proposer.propose("some context") == {"task_title": "x"}
+        main_rows = [json.loads(line) for line in (tmp_path / f"{datetime.now(timezone.utc):%Y-%m-%d}.jsonl").read_text().splitlines()]
+        assert main_rows[-1]["component"] == "proposer"
+        assert main_rows[-1]["model"] == "an/test-proposer"
+        assert main_rows[-1]["prompt_tokens"] == 11
+        prompt_path = tmp_path / "prompts" / f"{datetime.now(timezone.utc):%Y-%m-%d}.jsonl"
+        prompt = json.loads(prompt_path.read_text().splitlines()[-1])
+        assert prompt["component"] == "proposer"
+        assert prompt["messages"][1]["content"] == "some context"
+
+    def test_proposer_logging_failure_does_not_break_result(self, monkeypatch):
+        self._patch_client(monkeypatch, json.dumps({"task_title": "x"}))
+        monkeypatch.setattr(llm_proposer, "record_llm_call", lambda **_: (_ for _ in ()).throw(RuntimeError("telemetry")))
+        assert llm_proposer.propose("some context") == {"task_title": "x"}
 
     def test_fenced_json(self, monkeypatch):
         payload = {


### PR DESCRIPTION
Implements #976 by reusing nanobot.observability.llm_telemetry record_llm_call and record_llm_prompt around the direct proposer completion. Logging remains fail-open and records component=proposer, model, usage, duration, finish reason, and sent messages.\n\nTest mapping:\n- Successful main + prompt telemetry -> tests/test_llm_proposer.py::TestProposeMockedClient::test_proposer_records_call_and_prompt_telemetry\n- Recorder failure remains non-blocking -> tests/test_llm_proposer.py::TestProposeMockedClient::test_proposer_logging_failure_does_not_break_result\n\nNo new format, env var, config, subprocess, immutable file, or secret touched.