### PR TITLE
fix(scorecard): exclude operator suppression from failure rate

### DIFF
--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -614,6 +614,7 @@ def _loop_section(
     proposer_rejects = 0
     self_dedup_rejects = 0
     duplicate_failure_skips = 0
+    excluded_failure_rows = 0
     skips_by_class: dict[str, int] = {}
     # #800 churn split: cycles whose proposed row served a decay demand
     # (demand_id "decay-…", the #760 traceability field). A success outcome
@@ -675,6 +676,8 @@ def _loop_section(
             elif outcome.startswith("skipped"):
                 skips_by_class[outcome] = skips_by_class.get(outcome, 0) + 1
                 if str(row.get("reason") or "").strip() == "recent_duplicate_failure":
+                    excluded_failure_rows += 1
+                else:
                     duplicate_failure_skips += 1
     cycleish = idle_rows + outcome_rows
     repeat_failures = duplicate_failure_skips + self_dedup_rejects
@@ -716,6 +719,7 @@ def _loop_section(
         "idle_share": _ratio(idle_rows, cycleish),
         "repeat_failures": repeat_failures,
         "repeat_failure_rate": _ratio(repeat_failures, proposals),
+        "excluded_failure_rows": excluded_failure_rows,
     }
 
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -90,9 +90,24 @@ class TestLoopSection:
         assert loop["cycleish_rows"] == 5  # 2 idle + 3 in-window outcomes
         assert loop["idle_share"] == round(2 / 5, 4)
         assert loop["proposals"] == 2
-        # repeat failures = 1 recent_duplicate_failure skip + 1 self_dedup.
-        assert loop["repeat_failures"] == 2
-        assert loop["repeat_failure_rate"] == 1.0
+        # Operator suppression is excluded; genuine self-dedup remains counted.
+        assert loop["repeat_failures"] == 1
+        assert loop["repeat_failure_rate"] == 0.5
+        assert loop["excluded_failure_rows"] == 1
+
+    def test_recent_duplicate_failure_is_excluded_but_genuine_failure_counts(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_ledger(state_dir, [
+            {"phase": "proposed", "cycle_id": "c1", "ts": _iso(3)},
+            {"phase": "proposed", "cycle_id": "c2", "ts": _iso(2)},
+            {"phase": "outcome", "cycle_id": "c1", "outcome": "skipped-duplicate", "reason": "recent_duplicate_failure", "ts": _iso(1)},
+            {"phase": "outcome", "cycle_id": "c2", "outcome": "skipped-duplicate", "reason": "smoke_gate_failed", "ts": _iso(1)}
+        ])
+        loop = scorecard.compute_scorecard(state_dir, None, force=True)["loop"]
+        assert loop["repeat_failures"] == 1
+        assert loop["repeat_failure_rate"] == 0.5
+        assert loop["excluded_failure_rows"] == 1
+        assert loop["skips_by_class"] == {"skipped-duplicate": 2}
 
     def test_decay_successes_split_from_integrations(self, tmp_path):
         """#800 churn split: a success whose proposed row served a decay
@@ -650,8 +665,8 @@ class TestWatermarkAndPersistence:
 
 
 def _minimal_repeat_failure_ledger(state_dir: Path) -> None:
-    """2 proposals, 1 recent_duplicate_failure skip + 1 self_dedup reject
-    → repeat_failure_rate = 1.0 > 0.3."""
+    """2 proposals, 1 excluded suppression + 1 self_dedup reject
+    → repeat_failure_rate = 0.5 > 0.3."""
     _write_ledger(
         state_dir,
         [
@@ -672,7 +687,7 @@ class TestGoalGaps:
         assert "repeat_failure_rate" in gaps
         gap = gaps["repeat_failure_rate"]
         assert gap["vector"] == "V1"
-        assert gap["current"] == 1.0
+        assert gap["current"] == 0.5
         assert gap["target"] == 0.3
         assert "repeat_failure_rate" in gap["evidence"]
 


### PR DESCRIPTION
Implements #977 with a narrow scorecard fold classification: exact recent_duplicate_failure suppression outcomes remain visible in skips_by_class and are audited via excluded_failure_rows, but do not count as agent repeat failures. Genuine gate failures continue to count. No bridge ledger/matcher changes.\n\nTest mapping:\n- Suppression excluded + genuine gate failure retained -> tests/test_scorecard.py::TestLoopSection::test_recent_duplicate_failure_is_excluded_but_genuine_failure_counts\n- Rotation expectation/regression -> tests/test_scorecard.py::TestLoopSection::test_counts_across_rotation\n- Goal-gap recomputation -> tests/test_scorecard.py::TestGoalGaps::test_repeat_failure_rate_breach_gaps_with_vector_v1\n\nNo immutable files, secrets, env vars, config, or usage_evidence changes.