### PR TITLE
fix(proposer): mark pycache inventory evidence unverified

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -807,7 +807,7 @@ def _digest_ledger(rows: list[dict[str, Any]], n: int = _LEDGER_DIGEST_ROWS) -> 
 # misleading hint only steers the prompt; every proposal still passes the
 # full gate unchanged. Steering only, no gate/fitness/scorecard changes.
 _INVENTORY_STEERING_LINE = (
-    "Prefer EXTENDING a [used:*] tool over creating a new file when the task allows."
+    "Prefer EXTENDING a verified-used tool ([used:output], [used:reference], or another behavioral signal) over creating a new file when the task allows."
 )
 
 
@@ -872,6 +872,8 @@ def _annotate_inventory_line(
         last_used = _parse_inventory_ts(entry.get("last_used"))
         if last_used is not None:
             signal = str(entry.get("signal") or "").strip() or "unknown"
+            if signal.lower() == "pycache":
+                return f"{line} [unverified {_inventory_days_ago(last_used, now)}d ago]"
             return f"{line} [used:{signal} {_inventory_days_ago(last_used, now)}d ago]"
         last_touched = _parse_inventory_ts(entry.get("last_touched"))
         if last_touched is not None:

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -710,7 +710,8 @@ class TestInventoryUtilityAnnotations:
         section = llm_proposer._system_map_inventory_section(repo, state_dir=state_dir)
 
         line = next(ln for ln in section.splitlines() if "scripts/helper.py" in ln)
-        assert line.endswith("[used:pycache 2d ago]")
+        assert line.endswith("[unverified 2d ago]")
+        assert "[used:pycache" not in section
 
     def test_last_touched_only_entry_shows_edited_never_used(self, tmp_path):
         state_dir = _state_dir(tmp_path)
@@ -772,6 +773,7 @@ class TestInventoryUtilityAnnotations:
         )
         with_sidecar = llm_proposer._system_map_inventory_section(repo, state_dir=state_dir)
         assert llm_proposer._INVENTORY_STEERING_LINE in with_sidecar
+        assert "Prefer EXTENDING a verified-used tool" in with_sidecar
 
     def test_malformed_timestamp_treated_as_absent_no_crash(self, tmp_path):
         state_dir = _state_dir(tmp_path)


### PR DESCRIPTION
Implements #978 in the proposer inventory section only. Pycache evidence renders as [unverified Nd ago], output/reference and other behavioral signals retain used tags, and the steering line now names verified-used tools. usage_evidence/#929 is untouched.\n\nTest mapping:\n- Pycache no used tag -> tests/test_llm_proposer.py::TestInventoryUtilityAnnotations::test_last_used_entry_shows_signal_and_days_ago\n- Output/reference used tags remain covered by the existing inventory annotation tests in TestInventoryUtilityAnnotations\n- Verified-use preference -> tests/test_llm_proposer.py::TestInventoryUtilityAnnotations::test_steering_line_present_only_when_sidecar_has_data\n- Existing inventory golden/cap tests remain unchanged and run in CI.