### PR TITLE
fix(runtime): exclude out-of-band rows from failure history

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3892,6 +3892,7 @@ def _task_already_done_for_path(
 _SKIP_ROLLBACK_REASONS = frozenset({
     'recent_duplicate_failure',
     'existence_index_duplicate',
+    'out_of_band_main_detected',
 })
 
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -614,7 +614,6 @@ def _loop_section(
     proposer_rejects = 0
     self_dedup_rejects = 0
     duplicate_failure_skips = 0
-    excluded_failure_rows = 0
     skips_by_class: dict[str, int] = {}
     # #800 churn split: cycles whose proposed row served a decay demand
     # (demand_id "decay-…", the #760 traceability field). A success outcome
@@ -675,10 +674,7 @@ def _loop_section(
                             confirmed_confirmable_integrations += 1
             elif outcome.startswith("skipped"):
                 skips_by_class[outcome] = skips_by_class.get(outcome, 0) + 1
-                if str(row.get("reason") or "").strip() == "recent_duplicate_failure":
-                    excluded_failure_rows += 1
-                else:
-                    duplicate_failure_skips += 1
+                duplicate_failure_skips += 1
     cycleish = idle_rows + outcome_rows
     repeat_failures = duplicate_failure_skips + self_dedup_rejects
     return {
@@ -719,7 +715,6 @@ def _loop_section(
         "idle_share": _ratio(idle_rows, cycleish),
         "repeat_failures": repeat_failures,
         "repeat_failure_rate": _ratio(repeat_failures, proposals),
-        "excluded_failure_rows": excluded_failure_rows,
     }
 
 

--- a/tests/test_bridge_recent_failure_suppress.py
+++ b/tests/test_bridge_recent_failure_suppress.py
@@ -49,6 +49,21 @@ def test_matches_recent_blocked_result_by_keyword_overlap(tmp_path: Path):
     ) == "Wire host_metrics dashboard integration panel"
 
 
+def test_out_of_band_result_does_not_suppress(tmp_path: Path):
+    state_dir = tmp_path / "state"
+    results_dir = state_dir / "subagents" / "results"
+    _write_result(
+        results_dir,
+        "r1.json",
+        backlog_title="Refactor coordinator materializer split logic",
+        result_status="blocked",
+        rollback={"reason": "out_of_band_main_detected"},
+    )
+    assert _recent_failure_match(
+        "Refactor coordinator materializer split logic", state_dir,
+    ) is None
+
+
 def test_matches_recent_result_via_rollback_reason(tmp_path: Path):
     state_dir = tmp_path / "state"
     results_dir = state_dir / "subagents" / "results"

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -90,12 +90,11 @@ class TestLoopSection:
         assert loop["cycleish_rows"] == 5  # 2 idle + 3 in-window outcomes
         assert loop["idle_share"] == round(2 / 5, 4)
         assert loop["proposals"] == 2
-        # Operator suppression is excluded; genuine self-dedup remains counted.
-        assert loop["repeat_failures"] == 1
-        assert loop["repeat_failure_rate"] == 0.5
-        assert loop["excluded_failure_rows"] == 1
+        # Recent duplicate suppression and self-dedup are the repeat-failure signals.
+        assert loop["repeat_failures"] == 2
+        assert loop["repeat_failure_rate"] == 1.0
 
-    def test_recent_duplicate_failure_is_excluded_but_genuine_failure_counts(self, tmp_path):
+    def test_recent_duplicate_failure_counts_and_genuine_failure_remains_visible(self, tmp_path):
         state_dir = tmp_path / "state"
         _write_ledger(state_dir, [
             {"phase": "proposed", "cycle_id": "c1", "ts": _iso(3)},
@@ -104,9 +103,8 @@ class TestLoopSection:
             {"phase": "outcome", "cycle_id": "c2", "outcome": "skipped-duplicate", "reason": "smoke_gate_failed", "ts": _iso(1)}
         ])
         loop = scorecard.compute_scorecard(state_dir, None, force=True)["loop"]
-        assert loop["repeat_failures"] == 1
-        assert loop["repeat_failure_rate"] == 0.5
-        assert loop["excluded_failure_rows"] == 1
+        assert loop["repeat_failures"] == 2
+        assert loop["repeat_failure_rate"] == 1.0
         assert loop["skips_by_class"] == {"skipped-duplicate": 2}
 
     def test_decay_successes_split_from_integrations(self, tmp_path):
@@ -665,8 +663,8 @@ class TestWatermarkAndPersistence:
 
 
 def _minimal_repeat_failure_ledger(state_dir: Path) -> None:
-    """2 proposals, 1 excluded suppression + 1 self_dedup reject
-    → repeat_failure_rate = 0.5 > 0.3."""
+    """2 proposals, 1 recent_duplicate_failure skip + 1 self_dedup reject
+    → repeat_failure_rate = 1.0 > 0.3."""
     _write_ledger(
         state_dir,
         [
@@ -687,7 +685,7 @@ class TestGoalGaps:
         assert "repeat_failure_rate" in gaps
         gap = gaps["repeat_failure_rate"]
         assert gap["vector"] == "V1"
-        assert gap["current"] == 0.5
+        assert gap["current"] == 1.0
         assert gap["target"] == 0.3
         assert "repeat_failure_rate" in gap["evidence"]
 


### PR DESCRIPTION
Fix-pass for #977 per review comment #5404581627. Restores the original scorecard semantics (recent_duplicate_failure skips + self_dedup rejects) and fixes the actual pollution layer by adding out_of_band_main_detected to the narrow _SKIP_ROLLBACK_REASONS set used by _recent_failure_match. Genuine rollback failures remain matches.\n\nTest mapping:\n- OOB result is not failure history -> tests/test_bridge_recent_failure_suppress.py::test_out_of_band_result_does_not_suppress\n- Genuine rollback failure still matches -> tests/test_bridge_recent_failure_suppress.py::test_matches_recent_result_via_rollback_reason\n- Scorecard semantics restored -> tests/test_scorecard.py::TestLoopSection::test_counts_across_rotation and ::TestGoalGaps::test_repeat_failure_rate_breach_gaps_with_vector_v1\n\nNo goals.md/IDENTITY.md, secrets, env/config, or unrelated golden tests touched.