### PR TITLE
fix(scorecard): restore repeat-failure reason filter (#977)

### DIFF
--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -674,7 +674,12 @@ def _loop_section(
                             confirmed_confirmable_integrations += 1
             elif outcome.startswith("skipped"):
                 skips_by_class[outcome] = skips_by_class.get(outcome, 0) + 1
-                duplicate_failure_skips += 1
+                # Only recent_duplicate_failure suppressions are repeat-failure
+                # signals (module docstring). Healthy dedup skips
+                # (already_done, already_done_tag, existence_index_duplicate)
+                # are not failures and must not feed repeat_failure_rate.
+                if str(row.get("reason") or "").strip() == "recent_duplicate_failure":
+                    duplicate_failure_skips += 1
     cycleish = idle_rows + outcome_rows
     repeat_failures = duplicate_failure_skips + self_dedup_rejects
     return {

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -94,18 +94,23 @@ class TestLoopSection:
         assert loop["repeat_failures"] == 2
         assert loop["repeat_failure_rate"] == 1.0
 
-    def test_recent_duplicate_failure_counts_and_genuine_failure_remains_visible(self, tmp_path):
+    def test_only_recent_duplicate_failure_skips_count_as_repeat_failures(self, tmp_path):
+        """Healthy dedup skips (already_done, existence_index_duplicate) are
+        not failures and must not feed repeat_failure_rate — only the
+        recent_duplicate_failure suppression signal counts (#977)."""
         state_dir = tmp_path / "state"
         _write_ledger(state_dir, [
-            {"phase": "proposed", "cycle_id": "c1", "ts": _iso(3)},
-            {"phase": "proposed", "cycle_id": "c2", "ts": _iso(2)},
+            {"phase": "proposed", "cycle_id": "c1", "ts": _iso(4)},
+            {"phase": "proposed", "cycle_id": "c2", "ts": _iso(3)},
+            {"phase": "proposed", "cycle_id": "c3", "ts": _iso(2)},
             {"phase": "outcome", "cycle_id": "c1", "outcome": "skipped-duplicate", "reason": "recent_duplicate_failure", "ts": _iso(1)},
-            {"phase": "outcome", "cycle_id": "c2", "outcome": "skipped-duplicate", "reason": "smoke_gate_failed", "ts": _iso(1)}
+            {"phase": "outcome", "cycle_id": "c2", "outcome": "skipped-duplicate", "reason": "already_done", "ts": _iso(1)},
+            {"phase": "outcome", "cycle_id": "c3", "outcome": "skipped-duplicate", "reason": "existence_index_duplicate", "ts": _iso(1)}
         ])
         loop = scorecard.compute_scorecard(state_dir, None, force=True)["loop"]
-        assert loop["repeat_failures"] == 2
-        assert loop["repeat_failure_rate"] == 1.0
-        assert loop["skips_by_class"] == {"skipped-duplicate": 2}
+        assert loop["repeat_failures"] == 1
+        assert loop["repeat_failure_rate"] == round(1 / 3, 4)
+        assert loop["skips_by_class"] == {"skipped-duplicate": 3}
 
     def test_decay_successes_split_from_integrations(self, tmp_path):
         """#800 churn split: a success whose proposed row served a decay


### PR DESCRIPTION
Fix-pass 2 on #977. PR #982 correctly excluded `out_of_band_main_detected` from the failure-history scan (`_SKIP_ROLLBACK_REASONS`), but its scorecard hunk dropped the reason filter entirely: every `skipped-*` ledger row — including healthy dedup skips with reasons `already_done`, `already_done_tag`, `existence_index_duplicate` — counted toward `repeat_failures`. That inflates `repeat_failure_rate` beyond even the pre-#980 value and contradicts the module docstring (scorecard.py:15).

This restores the original semantics: `repeat_failures = recent_duplicate_failure skips + self_dedup rejects`.

Test mapping:
- healthy dedup skips excluded / suppression still counts → `tests/test_scorecard.py::TestLoopSection::test_only_recent_duplicate_failure_skips_count_as_repeat_failures` (replaces the #982 test that asserted the unfiltered count)

No bridge changes — the #982 `_recent_failure_match` fix and its test stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)