### PR TITLE
feat(runtime): compact oversized subagent history

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -19,6 +19,7 @@ from nanobot.bus.queue import MessageBus
 from nanobot.config.schema import ExecToolConfig
 from nanobot.providers.base import LLMProvider
 from nanobot.utils.helpers import build_assistant_message
+from nanobot.runtime import context_compaction as _ctx_compact
 
 
 class SubagentManager:
@@ -241,6 +242,15 @@ class SubagentManager:
                             "name": tool_call.name,
                             "content": result,
                         })
+                        # #959 context compaction: trim old tool results when
+                        # approaching the context-window limit.  Fail-open.
+                        if self._state_root is not None:
+                            messages = _ctx_compact.compact_messages(
+                                messages,
+                                cycle_id=self._skill_fitness_cycle_id,
+                                iteration=iteration,
+                                state_root=self._state_root,
+                            )
                 else:
                     final_result = response.content
                     break

--- a/nanobot/runtime/context_compaction.py
+++ b/nanobot/runtime/context_compaction.py
@@ -1,0 +1,285 @@
+"""Context compaction for the subagent loop. #959
+
+Reduces the token size of ``messages`` when a running conversation exceeds a
+configurable fraction of the model's context window.  The module is stdlib-only
+(no provider calls, no third-party imports) and fail-open: every public entry
+point returns an unmodified history and/or writes no journal on any error.
+
+Char ÷ 4 heuristic
+------------------
+Token estimation uses ``ceil(len(text) / 4)``.  This is a deliberate
+approximation — tight enough for the compaction threshold decision and fast
+enough to call on every iteration.  For the default 98 000-token window the
+heuristic is conservative (actual token counts are often 20-30 % lower for
+English prose), which means compaction fires slightly early rather than late,
+keeping a safety margin.
+
+Environment knobs (all optional, applied once at import time)
+-------------------------------------------------------------
+``SELFEVO_COMPACT_THRESHOLD``   float 0–1  fraction of window that triggers
+                                compaction (default 0.8)
+``SELFEVO_COMPACT_KEEP_RESULTS`` int ≥ 1  number of most-recent tool-result
+                                messages that are always kept verbatim
+                                (default 3)
+``SELFEVO_COMPACT_WINDOW_TOKENS`` int > 0  total context-window size in tokens
+                                used for threshold calculation
+                                (default 98 000)
+``SELFEVO_COMPACT_EXCERPT_HEAD`` int ≥ 1  chars kept from the start of a
+                                compacted tool-result body (default 200)
+``SELFEVO_COMPACT_EXCERPT_TAIL`` int ≥ 1  chars kept from the end of a
+                                compacted tool-result body (default 200)
+
+Deny-set
+--------
+This module is listed in ``_RUNTIME_DENY_ALWAYS_FILES`` in
+``nanobot/runtime/runtime_deny.py``.  The instance must never be able to
+weaken the compaction logic or remove the deny-set entry itself.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Environment-driven configuration (evaluated once at import time)
+# ---------------------------------------------------------------------------
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ[name])
+    except (KeyError, ValueError):
+        return default
+
+
+#: Fraction of the context window at which compaction fires (0–1).
+THRESHOLD: float = _env_float("SELFEVO_COMPACT_THRESHOLD", 0.8)
+
+#: Number of most-recent tool-result messages always kept verbatim.
+KEEP_RESULTS: int = max(1, _env_int("SELFEVO_COMPACT_KEEP_RESULTS", 3))
+
+#: Assumed context-window size in tokens.
+WINDOW_TOKENS: int = max(1, _env_int("SELFEVO_COMPACT_WINDOW_TOKENS", 98_000))
+
+#: Characters kept from the head of a compacted tool-result body.
+EXCERPT_HEAD: int = max(1, _env_int("SELFEVO_COMPACT_EXCERPT_HEAD", 200))
+
+#: Characters kept from the tail of a compacted tool-result body.
+EXCERPT_TAIL: int = max(1, _env_int("SELFEVO_COMPACT_EXCERPT_TAIL", 200))
+
+# Byte marker inserted between head and tail excerpts.
+_OMIT_MARKER = "\n[…compacted…]\n"
+
+
+# ---------------------------------------------------------------------------
+# Token estimation
+# ---------------------------------------------------------------------------
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count using the chars÷4 heuristic (ceil)."""
+    return math.ceil(len(text) / 4)
+
+
+def _message_tokens(msg: dict[str, Any]) -> int:
+    """Estimate tokens for a single message dict."""
+    content = msg.get("content") or ""
+    if isinstance(content, list):
+        # Anthropic-style block list
+        total = 0
+        for block in content:
+            if isinstance(block, dict):
+                total += _estimate_tokens(str(block.get("text") or block.get("content") or ""))
+            else:
+                total += _estimate_tokens(str(block))
+        return total
+    return _estimate_tokens(str(content))
+
+
+def _total_tokens(messages: list[dict[str, Any]]) -> int:
+    return sum(_message_tokens(m) for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Compaction helpers
+# ---------------------------------------------------------------------------
+
+def _is_system_or_user_task(msg: dict[str, Any]) -> bool:
+    """True for system prompts and the initial user task message."""
+    return msg.get("role") in ("system", "user")
+
+
+def _is_tool_result(msg: dict[str, Any]) -> bool:
+    return msg.get("role") == "tool"
+
+
+def _compact_content(content: str) -> str:
+    """Replace long content with a bounded head/tail excerpt."""
+    min_length = EXCERPT_HEAD + len(_OMIT_MARKER) + EXCERPT_TAIL
+    if len(content) <= min_length:
+        return content
+    return content[:EXCERPT_HEAD] + _OMIT_MARKER + content[-EXCERPT_TAIL:]
+
+
+def _compact_message(msg: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Return (compacted_msg, was_changed) for a tool-result message."""
+    content = msg.get("content") or ""
+    if isinstance(content, list):
+        # Anthropic block list — compact text blocks
+        changed = False
+        new_blocks: list[Any] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                new_block = dict(block)
+                inner = block.get("content") or ""
+                if isinstance(inner, str):
+                    compacted = _compact_content(inner)
+                    if compacted != inner:
+                        new_block["content"] = compacted
+                        changed = True
+                new_blocks.append(new_block)
+            else:
+                new_blocks.append(block)
+        new_msg = dict(msg, content=new_blocks)
+        return new_msg, changed
+    else:
+        text = str(content)
+        compacted = _compact_content(text)
+        if compacted == text:
+            return msg, False
+        return dict(msg, content=compacted), True
+
+
+# ---------------------------------------------------------------------------
+# Journal helper
+# ---------------------------------------------------------------------------
+
+def _write_journal(
+    state_root: Path | str,
+    cycle_id: str,
+    iteration: int,
+    before_tokens: int,
+    after_tokens: int,
+    results_compacted: int,
+) -> None:
+    """Append one JSONL event to state_root/compaction/journal.jsonl.
+
+    Fail-open: any I/O error is silently swallowed.
+    """
+    try:
+        journal_dir = Path(state_root) / "compaction"
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        journal_path = journal_dir / "journal.jsonl"
+        event = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "cycle_id": cycle_id,
+            "iteration": iteration,
+            "before_tokens": before_tokens,
+            "after_tokens": after_tokens,
+            "results_compacted": results_compacted,
+        }
+        with journal_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def compact_messages(
+    messages: list[dict[str, Any]],
+    cycle_id: str,
+    iteration: int,
+    state_root: Path | str,
+    *,
+    threshold: float | None = None,
+    keep_results: int | None = None,
+    window_tokens: int | None = None,
+) -> list[dict[str, Any]]:
+    """Compact ``messages`` if their estimated token count exceeds the threshold.
+
+    Protected messages (never compacted):
+    - All ``system`` and ``user`` messages (system prompt + initial task).
+    - The ``keep_results`` most-recent tool-result messages.
+
+    Older tool-result messages have their ``content`` replaced with a bounded
+    head/tail excerpt separated by ``_OMIT_MARKER``.  Assistant messages are
+    never compacted.
+
+    Parameters
+    ----------
+    messages:
+        The current conversation history (mutated copy is returned).
+    cycle_id:
+        Bridge cycle identifier — written to the journal event.
+    iteration:
+        Current subagent loop iteration — written to the journal event.
+    state_root:
+        Runtime state directory; journal written under
+        ``{state_root}/compaction/journal.jsonl``.
+    threshold:
+        Override ``THRESHOLD`` for this call (used in tests).
+    keep_results:
+        Override ``KEEP_RESULTS`` for this call (used in tests).
+    window_tokens:
+        Override ``WINDOW_TOKENS`` for this call (used in tests).
+
+    Returns
+    -------
+    list[dict]
+        The (possibly compacted) message list.  Always returns a valid list;
+        returns the original ``messages`` unchanged on any error.
+    """
+    try:
+        _threshold = threshold if threshold is not None else THRESHOLD
+        _keep = keep_results if keep_results is not None else KEEP_RESULTS
+        _window = window_tokens if window_tokens is not None else WINDOW_TOKENS
+
+        before_tokens = _total_tokens(messages)
+        trigger_tokens = math.ceil(_threshold * _window)
+
+        if before_tokens < trigger_tokens:
+            # Below threshold — nothing to do.
+            return messages
+
+        # Identify compactable tool-result indices (excluding last _keep).
+        tool_result_indices = [
+            i for i, m in enumerate(messages) if _is_tool_result(m)
+        ]
+        # Keep the last _keep verbatim.
+        compactable_indices = set(tool_result_indices[: max(0, len(tool_result_indices) - _keep)])
+
+        if not compactable_indices:
+            # No old tool results to compact — return original.
+            return messages
+
+        # Build compacted copy.
+        new_messages: list[dict[str, Any]] = []
+        results_compacted = 0
+        for i, msg in enumerate(messages):
+            if i in compactable_indices:
+                compacted, changed = _compact_message(msg)
+                new_messages.append(compacted)
+                if changed:
+                    results_compacted += 1
+            else:
+                new_messages.append(msg)
+
+        after_tokens = _total_tokens(new_messages)
+        _write_journal(state_root, cycle_id, iteration, before_tokens, after_tokens, results_compacted)
+        return new_messages
+
+    except Exception:  # noqa: BLE001
+        # Fail-open: return original history untouched.
+        return messages

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -97,6 +97,14 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     # control-plane, same tier as bridge.py's own model knobs) — the loop
     # must never be able to rewrite which model each role runs on.
     'nanobot/runtime/model_registry.py',
+    # #959: context-compaction module — controls which messages survive each
+    # loop iteration and writes the compaction journal; the instance must
+    # never be able to weaken compaction logic (e.g. raise the threshold or
+    # remove the deny entry itself).  No basename token match applies here
+    # ('compact' is not in _RUNTIME_DENY_TOKENS, deliberately, so a future
+    # unrelated '*_compact*.py' module is not silently swept in by name
+    # alone); this explicit entry is the only protection.
+    'nanobot/runtime/context_compaction.py',
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without

--- a/tests/test_context_compaction.py
+++ b/tests/test_context_compaction.py
@@ -1,0 +1,384 @@
+"""Tests for nanobot.runtime.context_compaction (#959).
+
+Covers:
+- below-threshold: messages returned unchanged
+- above-threshold: old tool results compacted, system/user protected
+- last-K tool results protected verbatim
+- excerpt bounded with head/tail + marker
+- fail-open: any exception still returns a useful list
+- no provider/LLM calls involved
+- deny-set entry is present and immutable (module listed in runtime_deny)
+"""
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+# The module under test (stdlib-only, safe to import without network/secrets).
+from nanobot.runtime import context_compaction as cc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_messages(tool_contents: list[str]) -> list[dict]:
+    """Build a realistic message list: system, user/task, then alternating
+    assistant-with-tool-call + tool-result for each entry in tool_contents."""
+    msgs: list[dict] = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Do a thing."},
+    ]
+    for i, content in enumerate(tool_contents):
+        msgs.append({
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": f"tc{i}", "type": "function",
+                             "function": {"name": "bash", "arguments": "{}"}}],
+        })
+        msgs.append({
+            "role": "tool",
+            "tool_call_id": f"tc{i}",
+            "name": "bash",
+            "content": content,
+        })
+    return msgs
+
+
+def _short_content(n: int = 50) -> str:
+    return "x" * n
+
+
+def _long_content(n: int = 5000) -> str:
+    return "a" * n
+
+
+# ---------------------------------------------------------------------------
+# Below-threshold: no compaction
+# ---------------------------------------------------------------------------
+
+def test_below_threshold_returns_unchanged():
+    """When total tokens < threshold*window, messages are returned as-is."""
+    messages = _make_messages([_short_content(10)])
+    original_ids = [id(m) for m in messages]
+    result = cc.compact_messages(
+        messages,
+        cycle_id="c1",
+        iteration=1,
+        state_root="/tmp/cc_test_below",
+        threshold=0.8,
+        keep_results=3,
+        window_tokens=98_000,
+    )
+    # Returned list is the same object (no copy needed) or equal contents
+    assert result == messages
+    # No messages were mutated
+    for orig, res in zip(messages, result):
+        assert orig == res
+
+
+# ---------------------------------------------------------------------------
+# Above-threshold: old results compacted
+# ---------------------------------------------------------------------------
+
+def test_above_threshold_compacts_old_tool_results(tmp_path):
+    """When above threshold, old tool result contents are excerpted."""
+    big = _long_content(40_000)  # 40000 chars ≈ 10000 tokens per result
+    messages = _make_messages([big, big, big, big])  # 4 tool results
+
+    result = cc.compact_messages(
+        messages,
+        cycle_id="c2",
+        iteration=2,
+        state_root=tmp_path,
+        threshold=0.01,   # force trigger with very low threshold
+        keep_results=1,   # protect only the last 1
+        window_tokens=98_000,
+    )
+
+    # System and user messages must be untouched
+    assert result[0] == messages[0]
+    assert result[1] == messages[1]
+
+    # Collect tool results from result
+    tool_results = [m for m in result if m.get("role") == "tool"]
+    assert len(tool_results) == 4
+
+    # Last 1 must be verbatim
+    assert tool_results[-1]["content"] == big
+
+    # Earlier results should be compacted (contain the omit marker)
+    for tr in tool_results[:-1]:
+        assert cc._OMIT_MARKER in tr["content"], (
+            f"Expected omit marker in compacted content, got: {tr['content'][:100]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Last-K tool results protected
+# ---------------------------------------------------------------------------
+
+def test_last_k_tool_results_protected(tmp_path):
+    """The ``keep_results`` most-recent tool results are never compacted."""
+    big = _long_content(20_000)
+    messages = _make_messages([big] * 6)  # 6 tool results
+
+    result = cc.compact_messages(
+        messages,
+        cycle_id="c3",
+        iteration=3,
+        state_root=tmp_path,
+        threshold=0.01,  # force trigger
+        keep_results=3,
+        window_tokens=98_000,
+    )
+
+    tool_results = [m for m in result if m.get("role") == "tool"]
+    assert len(tool_results) == 6
+
+    # Last 3 must be verbatim
+    for tr in tool_results[-3:]:
+        assert tr["content"] == big, "Last-K results should be untouched"
+
+    # First 3 should be compacted
+    for tr in tool_results[:3]:
+        assert cc._OMIT_MARKER in tr["content"], "Older results should be compacted"
+
+
+# ---------------------------------------------------------------------------
+# System and user task always protected
+# ---------------------------------------------------------------------------
+
+def test_system_and_user_always_protected(tmp_path):
+    """System and user messages are never touched by compaction."""
+    big = _long_content(30_000)
+    system_content = "SYSTEM PROMPT MUST SURVIVE"
+    user_content = "USER TASK MUST SURVIVE"
+
+    msgs: list[dict] = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+    for i in range(5):
+        msgs.append({
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": f"tc{i}", "type": "function",
+                             "function": {"name": "bash", "arguments": "{}"}}],
+        })
+        msgs.append({"role": "tool", "tool_call_id": f"tc{i}",
+                     "name": "bash", "content": big})
+
+    result = cc.compact_messages(
+        msgs,
+        cycle_id="c4",
+        iteration=4,
+        state_root=tmp_path,
+        threshold=0.01,
+        keep_results=1,
+        window_tokens=98_000,
+    )
+
+    assert result[0]["content"] == system_content
+    assert result[1]["content"] == user_content
+
+
+# ---------------------------------------------------------------------------
+# Excerpt is bounded by head/tail
+# ---------------------------------------------------------------------------
+
+def test_excerpt_bounded_head_tail():
+    """Compacted content has at most EXCERPT_HEAD + marker + EXCERPT_TAIL chars."""
+    big = "A" * 500 + "B" * 500  # 1000 chars, bigger than default 200+200
+    original_content = big
+    result_content, changed = cc._compact_content(big), True
+
+    head = cc.EXCERPT_HEAD
+    tail = cc.EXCERPT_TAIL
+    marker = cc._OMIT_MARKER
+
+    assert result_content.startswith(big[:head])
+    assert result_content.endswith(big[-tail:])
+    assert marker in result_content
+    assert len(result_content) == head + len(marker) + tail
+
+
+def test_excerpt_not_compacted_when_small():
+    """Content smaller than head+marker+tail is returned as-is."""
+    small = "x" * 50
+    result = cc._compact_content(small)
+    assert result == small
+
+
+# ---------------------------------------------------------------------------
+# Fail-open on exception
+# ---------------------------------------------------------------------------
+
+def test_fail_open_on_invalid_state_root():
+    """If state_root is unwriteable/bad, compact_messages still returns a list."""
+    big = _long_content(30_000)
+    messages = _make_messages([big] * 4)
+
+    # Pass a nonsensical path that will fail to mkdir
+    result = cc.compact_messages(
+        messages,
+        cycle_id="fail_test",
+        iteration=1,
+        state_root="/dev/null/cannot/exist",
+        threshold=0.01,
+        keep_results=1,
+        window_tokens=98_000,
+    )
+    # Must return a list (either compacted or original)
+    assert isinstance(result, list)
+    assert len(result) == len(messages)
+
+
+def test_fail_open_on_bad_message_structure():
+    """Malformed messages never cause compact_messages to raise."""
+    messages = [None, 42, {"role": "tool", "content": {}}, "not-a-dict"]  # type: ignore[list-item]
+    try:
+        result = cc.compact_messages(
+            messages,  # type: ignore[arg-type]
+            cycle_id="bad",
+            iteration=1,
+            state_root="/tmp/cc_failopen",
+        )
+        # Either returned the original or a list; must not raise
+        assert isinstance(result, list)
+    except Exception as exc:  # noqa: BLE001
+        pytest.fail(f"compact_messages raised unexpectedly: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Journal is written on compaction
+# ---------------------------------------------------------------------------
+
+def test_journal_written_on_compaction(tmp_path):
+    """A JSONL event is written to state_root/compaction/journal.jsonl."""
+    big = _long_content(20_000)
+    messages = _make_messages([big] * 4)
+
+    cc.compact_messages(
+        messages,
+        cycle_id="journal_test",
+        iteration=7,
+        state_root=tmp_path,
+        threshold=0.01,
+        keep_results=1,
+        window_tokens=98_000,
+    )
+
+    journal_path = tmp_path / "compaction" / "journal.jsonl"
+    assert journal_path.exists(), "Journal file should exist after compaction"
+
+    events = [json.loads(line) for line in journal_path.read_text().splitlines() if line.strip()]
+    assert len(events) >= 1
+
+    ev = events[-1]
+    assert ev["cycle_id"] == "journal_test"
+    assert ev["iteration"] == 7
+    assert "before_tokens" in ev
+    assert "after_tokens" in ev
+    assert "results_compacted" in ev
+    assert ev["after_tokens"] <= ev["before_tokens"]
+
+
+def test_journal_not_written_below_threshold(tmp_path):
+    """No journal entry when compaction does not fire."""
+    messages = _make_messages([_short_content(10)])
+    cc.compact_messages(
+        messages,
+        cycle_id="noevent",
+        iteration=1,
+        state_root=tmp_path,
+        threshold=0.9999,
+        keep_results=3,
+        window_tokens=98_000,
+    )
+    journal_path = tmp_path / "compaction" / "journal.jsonl"
+    assert not journal_path.exists(), "Journal should not be written below threshold"
+
+
+# ---------------------------------------------------------------------------
+# No provider/LLM calls (import-time check)
+# ---------------------------------------------------------------------------
+
+def test_no_provider_imports():
+    """context_compaction must not import any LLM provider module."""
+    import importlib
+    import sys
+
+    # Reload the module to inspect its dependencies
+    mod = importlib.import_module("nanobot.runtime.context_compaction")
+    # The module's own __file__ imports should not include provider packages
+    provider_names = {"openai", "anthropic", "litellm", "httpx", "aiohttp", "requests"}
+    imported = set(sys.modules.keys())
+    # Only flag if they were imported *by* context_compaction (approximate check:
+    # if they weren't in sys.modules before, they shouldn't be there after a bare import).
+    # This is a smoke-level check: the module itself uses only stdlib.
+    module_source = Path(mod.__file__).read_text()
+    for name in provider_names:
+        assert f"import {name}" not in module_source, (
+            f"context_compaction.py must not import {name}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deny-set: module is listed in runtime_deny (immutability check)
+# ---------------------------------------------------------------------------
+
+def test_deny_set_has_context_compaction_entry():
+    """context_compaction.py must be in _RUNTIME_DENY_ALWAYS_FILES."""
+    from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES  # type: ignore[attr-defined]
+
+    assert "nanobot/runtime/context_compaction.py" in _RUNTIME_DENY_ALWAYS_FILES, (
+        "context_compaction.py must be in the explicit deny-set so the runtime "
+        "loop cannot modify its own compaction logic."
+    )
+
+
+def test_deny_set_is_frozenset():
+    """_RUNTIME_DENY_ALWAYS_FILES must be a frozenset (immutable)."""
+    from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES  # type: ignore[attr-defined]
+
+    assert isinstance(_RUNTIME_DENY_ALWAYS_FILES, frozenset), (
+        "_RUNTIME_DENY_ALWAYS_FILES must be frozenset so the deny set is immutable."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token estimation sanity check
+# ---------------------------------------------------------------------------
+
+def test_estimate_tokens_heuristic():
+    """_estimate_tokens uses ceil(len/4)."""
+    text = "x" * 100
+    assert cc._estimate_tokens(text) == math.ceil(100 / 4)
+    assert cc._estimate_tokens("") == 0
+    assert cc._estimate_tokens("a") == 1
+    assert cc._estimate_tokens("ab") == 1
+
+
+# ---------------------------------------------------------------------------
+# Edge: all messages are system/user only (no tool results to compact)
+# ---------------------------------------------------------------------------
+
+def test_no_tool_results_returns_unchanged(tmp_path):
+    """If there are no tool results, compaction is a no-op."""
+    messages = [
+        {"role": "system", "content": "x" * 400_000},  # huge system prompt
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "done"},
+    ]
+    result = cc.compact_messages(
+        messages,
+        cycle_id="notool",
+        iteration=1,
+        state_root=tmp_path,
+        threshold=0.0,  # always trigger
+        keep_results=3,
+        window_tokens=1,
+    )
+    # Returns original list unchanged because there are no tool results to compact
+    assert result == messages


### PR DESCRIPTION
Implements #959 step 2 after the measurement gate passed in issue comment #5409250897. Adds a stdlib-only <=300 LOC deny-set compaction module, a minimal post-tool-result SubagentManager hook, deterministic chars/4 estimation, threshold/keep/window/excerpt settings, protected system/task/last-K results, bounded excerpts, and fail-open JSONL journaling. No extra LLM calls or measurement sidecar.\n\nTest mapping:\n- Above/below threshold and compaction -> tests/test_context_compaction.py::test_above_threshold_compacts_old_tool_results and ::test_below_threshold_returns_unchanged\n- System/user and last-K protected -> ::test_system_and_user_always_protected and ::test_last_k_tool_results_protected\n- Bounded excerpts -> ::test_excerpt_bounded_head_tail\n- Fail-open -> ::test_fail_open_on_invalid_state_root and ::test_fail_open_on_bad_message_structure\n- No provider/LLM calls -> ::test_no_provider_imports\n- Deny-set immutability -> ::test_deny_set_has_context_compaction_entry and ::test_deny_set_is_frozenset\n\nRelevant existing loop tests also pass. No goals.md/IDENTITY.md, secrets, or root junk touched.