### PR TITLE
fix(lessons): preserve file mode through rotation (#988)

### DIFF
--- a/nanobot/runtime/lessons_rotation.py
+++ b/nanobot/runtime/lessons_rotation.py
@@ -102,12 +102,28 @@ def _archive_path(lessons_dir: Path, stem: str) -> Path:
     return lessons_dir / "archive" / f"{stem}-{today}.yaml.gz"
 
 
+def _target_mode(path: Path) -> int:
+    """Permission bits to give a rewritten *path*.
+
+    mkstemp creates 0600 temp files and os.replace preserves that mode, which
+    silently locks out non-agent readers (e.g. the ops-dashboard collector
+    reading over ssh, #988). Preserve the existing file's bits; default new
+    files to 0644.
+    """
+    try:
+        return path.stat().st_mode & 0o777
+    except OSError:
+        return 0o644
+
+
 def _write_atomic(path: Path, payload: bytes, suffix: str) -> None:
     """Write bytes beside *path* and replace it atomically."""
+    mode = _target_mode(path)
     tmp_fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=suffix)
     try:
         os.close(tmp_fd)
         Path(tmp_path).write_bytes(payload)
+        os.chmod(tmp_path, mode)
         os.replace(tmp_path, str(path))
     except Exception:
         try:
@@ -126,6 +142,7 @@ def _write_archive_once(archive_path: Path, payload: bytes) -> None:
         os.close(tmp_fd)
         with gzip.open(tmp_path, "wb") as fh:
             fh.write(payload)
+        os.chmod(tmp_path, _target_mode(archive_path))
         os.replace(tmp_path, str(archive_path))
     except Exception:
         try:

--- a/tests/test_lessons_rotation.py
+++ b/tests/test_lessons_rotation.py
@@ -73,3 +73,36 @@ def test_rotation_path_has_no_llm_imports():
     text = Path(lessons_rotation.__file__).read_text(encoding="utf-8")
     assert "openai" not in text.lower()
     assert "litellm" not in text.lower()
+
+
+def test_rotation_preserves_world_readable_mode(tmp_path, monkeypatch):
+    """#988: mkstemp temp files are 0600 and os.replace preserves that mode,
+    which locked out non-agent readers (ops-dashboard collector over ssh).
+    Rotation must preserve the source file's permission bits and create
+    archives world-readable."""
+    if os.name == "nt":
+        import pytest
+        pytest.skip("POSIX permission bits")
+    path = tmp_path / "lessons.yaml"
+    _write(path, "lessons", 205)
+    os.chmod(path, 0o644)
+    _stale(path)
+    monkeypatch.setattr(lessons_rotation, "_archive_path", lambda d, s: d / "archive" / f"{s}-mode.yaml.gz")
+    lessons_rotation.rotate_lessons_file(path)
+    assert path.stat().st_mode & 0o777 == 0o644
+    archive = tmp_path / "archive" / "lessons-mode.yaml.gz"
+    assert archive.stat().st_mode & 0o044 == 0o044
+
+
+def test_rotation_preserves_custom_mode(tmp_path, monkeypatch):
+    """A deliberately non-default mode on the live file survives rotation."""
+    if os.name == "nt":
+        import pytest
+        pytest.skip("POSIX permission bits")
+    path = tmp_path / "lessons.yaml"
+    _write(path, "lessons", 205)
+    os.chmod(path, 0o640)
+    _stale(path)
+    monkeypatch.setattr(lessons_rotation, "_archive_path", lambda d, s: d / "archive" / f"{s}-custom.yaml.gz")
+    lessons_rotation.rotate_lessons_file(path)
+    assert path.stat().st_mode & 0o777 == 0o640


### PR DESCRIPTION
Fixes #988. `_write_atomic` and `_write_archive_once` now chmod the temp file to the target's existing permission bits (0644 default for new files) before `os.replace` — mkstemp's 0600 no longer survives into the rotated live file or archive.

Found live: the first natural rotation (2026-08-25 16:31 MSK) flipped `lessons/lessons.yaml` and the day archive to 0600, which would have broken the ops-dashboard collector (reads over ssh as a non-agent user) and the upcoming lessons page (ozand/eeebot-ops-dashboard#73).

Test mapping:
- world-readable preserved → `test_rotation_preserves_world_readable_mode`
- custom mode preserved → `test_rotation_preserves_custom_mode`
(both POSIX-only, skipped on Windows; CI runs them on Linux)

One-time host repair of the two already-flipped files happens at deploy (chmod 0644, will be verified on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)