### PR TITLE
fix(lessons): rotation entry boundary is '- id:', never a bare list item (#991)

### DIFF
--- a/nanobot/runtime/lessons_rotation.py
+++ b/nanobot/runtime/lessons_rotation.py
@@ -63,17 +63,18 @@ def _parse_entries(raw_bytes: bytes) -> tuple[bool, list[bytes]]:
             content_start = i + 1
         break
 
-    # Split into entry chunks: each top-level list item starts with "- "
-    # (possibly indented by 0 or 2 spaces when dict-wrapped).
+    # Split into entry chunks. An entry ALWAYS begins with its "- id:" field
+    # (bridge._write_structured_lesson writes id first for both lessons.yaml
+    # and errors.yaml), at 0 or 2 spaces of indent. A bare "- " line is a
+    # nested list item (e.g. a files_changed entry) and must NEVER be treated
+    # as a boundary — the first live rotation (#991) used bare "- " at an
+    # assumed 2-indent and tore entries apart on their files_changed lists.
     entry_chunks: list[list[str]] = []
     current: list[str] = []
     for line in lines[content_start:]:
-        # A line that starts a new top-level list entry.
         stripped_line = line.lstrip()
         leading_spaces = len(line) - len(stripped_line)
-        # Dict-wrapped entries are indented 2 spaces; bare list entries have 0.
-        expected_indent = 2 if is_dict_wrapped else 0
-        if leading_spaces == expected_indent and stripped_line.startswith("- "):
+        if leading_spaces in (0, 2) and stripped_line.startswith("- id:"):
             if current:
                 entry_chunks.append(current)
             current = [line]
@@ -81,6 +82,20 @@ def _parse_entries(raw_bytes: bytes) -> tuple[bool, list[bytes]]:
             current.append(line)
     if current:
         entry_chunks.append(current)
+
+    # Leading lines before the first "- id:" boundary: pure whitespace is
+    # harmless — fold it into the first real entry. Anything else means we
+    # failed to identify the format; degrade to a single chunk (no-op
+    # rotation) rather than archiving an orphan fragment (#991).
+    if entry_chunks and not entry_chunks[0][0].lstrip().startswith("- id:"):
+        head = entry_chunks.pop(0)
+        if any(ln.strip() for ln in head):
+            body = "".join(lines[content_start:])
+            return is_dict_wrapped, [body.encode("utf-8")]
+        if entry_chunks:
+            entry_chunks[0] = head + entry_chunks[0]
+        else:
+            entry_chunks = [head]
 
     # Convert to byte strings.
     chunks = ["".join(c).encode("utf-8") for c in entry_chunks]

--- a/tests/test_lessons_rotation.py
+++ b/tests/test_lessons_rotation.py
@@ -106,3 +106,62 @@ def test_rotation_preserves_custom_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(lessons_rotation, "_archive_path", lambda d, s: d / "archive" / f"{s}-custom.yaml.gz")
     lessons_rotation.rotate_lessons_file(path)
     assert path.stat().st_mode & 0o777 == 0o640
+
+
+def _write_live_format(path: Path, count: int) -> None:
+    """Mirror the REAL bridge._write_structured_lesson output: 'lessons:'
+    header, entries at 0-indent, nested 2-indent files_changed lists (#991)."""
+    lines = ["lessons:\n"]
+    for i in range(count):
+        lines.extend([
+            f"- id: LESS-2026-{i:04d}\n",
+            f"  date: '2026-08-{(i % 28) + 1:02d}'\n",
+            f"  cycle_id: cycle-{i:012d}\n",
+            "  approach: keep me\n",
+            "  reusable_insight: keep me\n",
+            "  files_changed:\n",
+            f"  - scripts/tool_{i}.py\n",
+            f"  - tests/test_tool_{i}.py\n",
+        ])
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def test_live_format_rotation_does_not_tear_entries(tmp_path, monkeypatch):
+    """#991: a 2-indent '- <file>' line inside files_changed must never be an
+    entry boundary. The first live rotation split on those lines and produced
+    an archive starting with an orphaned files_changed fragment."""
+    path = tmp_path / "lessons.yaml"
+    _write_live_format(path, 205)
+    _stale(path)
+    monkeypatch.setattr(lessons_rotation, "_archive_path", lambda d, s: d / "archive" / f"{s}-live.yaml.gz")
+    result = lessons_rotation.rotate_lessons_file(path)
+    assert result == "archive/lessons-live.yaml.gz"
+    live_text = path.read_text(encoding="utf-8")
+    assert live_text.count("- id:") == 200
+    # Every live entry keeps BOTH of its files_changed items — nothing torn.
+    assert live_text.count("- scripts/tool_") == 200
+    assert live_text.count("- tests/test_tool_") == 200
+    with gzip.open(tmp_path / "archive" / "lessons-live.yaml.gz", "rt", encoding="utf-8") as fh:
+        archived = fh.read()
+    # Archived content starts at an entry boundary, not an orphan fragment.
+    body = archived.split("lessons:\n", 1)[-1].lstrip("\n")
+    assert body.startswith("- id:")
+    assert archived.count("- id:") == 5
+    assert archived.count("- scripts/tool_") == 5
+
+
+def test_unrecognized_leading_content_degrades_to_noop(tmp_path, monkeypatch):
+    """#991 ambiguity guard: content before the first '- id:' that is not
+    whitespace means the format was not identified — rotation must not
+    archive an orphan fragment."""
+    path = tmp_path / "lessons.yaml"
+    lines = ["lessons:\n", "  - stray/fragment.py\n"]
+    for i in range(205):
+        lines.extend([f"- id: LESS-x-{i:04d}\n", "  approach: keep me\n"])
+    path.write_text("".join(lines), encoding="utf-8")
+    _stale(path)
+    monkeypatch.setattr(lessons_rotation, "_archive_path", lambda d, s: d / "archive" / f"{s}-guard.yaml.gz")
+    before = path.read_text(encoding="utf-8")
+    lessons_rotation.rotate_lessons_file(path)
+    assert path.read_text(encoding="utf-8") == before
+    assert not (tmp_path / "archive" / "lessons-guard.yaml.gz").exists()


### PR DESCRIPTION
Fixes #991. Root cause and live damage evidence in the issue. Boundary detection now keys on `- id:` at 0–2 indent (the field that leads every entry in both journals); bare `- ` lines are continuations (files_changed items). Whitespace-only lead-in folds into the first entry; any other unrecognized lead-in degrades to a single-chunk no-op instead of archiving an orphan fragment.

Test mapping:
- live-format fixture (0-indent entries + nested files_changed) rotates without tearing → `test_live_format_rotation_does_not_tear_entries` — **verified to FAIL against the pre-fix splitter**
- ambiguity guard no-op → `test_unrecognized_leading_content_degrades_to_noop`
- legacy 2-indent shape → existing rotation tests unchanged

The 2026-08-25 archive already written by the buggy splitter stays as-is (entry bytes preserved; one torn files_changed fragment at its head) — noted on the issue for the dashboard parser to tolerate; tomorrow's rotation starts a clean dated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)