### PR TITLE
fix(curator): unit credentials, preset model, distinct no-credentials error (#986)

### DIFF
--- a/host/eeepc/etc/presets/local_qwen.env
+++ b/host/eeepc/etc/presets/local_qwen.env
@@ -42,3 +42,7 @@ SELFEVO_CYCLE_PAUSE=3m
 # static config default (40) because local tokens are free and cycles were
 # observed truncating at the cap.
 SELFEVO_MAX_TOOL_ITERATIONS=80
+# Knowledge curator (#986): daily lessons distillation. Same LiteLLM group as
+# the proposer — cheap, known-live on this instance. Without this the
+# registry falls back to a default group that does not exist here.
+SELFEVO_CURATOR_MODEL=openai/an/gemini-3.7-flash-high

--- a/host/eeepc/systemd/eeebot-knowledge-curator.service
+++ b/host/eeepc/systemd/eeebot-knowledge-curator.service
@@ -9,6 +9,10 @@ Group=eeepc-agent
 WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 EnvironmentFile=-/etc/eeepc-agent/preset.env
 EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
+# LiteLLM credentials live only here (same accretion as the bridge drop-in,
+# #601) — without it _default_llm has no base_url/api_key and every run dies
+# with a misleading "malformed curator output" (#986 first-run incident).
+EnvironmentFile=/etc/eeepc-agent/litellm.env
 Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 Environment=PYTHONDONTWRITEBYTECODE=1
 ExecStartPre=+/bin/mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/curator

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -208,7 +208,13 @@ def _default_llm(messages: list[dict[str, str]], model: str) -> Any:
     base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
     api_key = os.environ.get("LITELLM_API_KEY", "").strip()
     if not base_url or not api_key:
-        return None
+        # Distinct, actionable error: without this the missing-credentials
+        # case surfaced as "malformed curator output" (#986 first run) and
+        # was indistinguishable from a bad model response.
+        raise RuntimeError(
+            "litellm credentials not configured (LITELLM_BASE_URL/LITELLM_API_KEY) — "
+            "check the unit's EnvironmentFile chain"
+        )
     client = OpenAI(base_url=base_url, api_key=api_key, timeout=120)
     started = __import__("time").monotonic()
     response = client.chat.completions.create(model=model, messages=messages, max_tokens=1200, temperature=0.2)

--- a/tests/test_knowledge_curator.py
+++ b/tests/test_knowledge_curator.py
@@ -89,3 +89,23 @@ def test_sanitary_migration_archives_loose_notes(tmp_path):
     assert not (tmp_path / "lessons/a.md").exists()
     assert (tmp_path / "lessons/archive/loose/a.md").exists()
     assert (tmp_path / "memory/facts/a.md").exists()
+
+
+def test_missing_litellm_credentials_yields_distinct_error(tmp_path, monkeypatch):
+    """#986 first-run incident: with no LITELLM_BASE_URL/LITELLM_API_KEY the
+    default LLM path must fail with an actionable credentials error, not the
+    misleading 'malformed curator output'."""
+    from nanobot.runtime import knowledge_curator as kc
+    monkeypatch.delenv("LITELLM_BASE_URL", raising=False)
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+    workspace = tmp_path / "ws"
+    (workspace / "lessons").mkdir(parents=True)
+    (workspace / "lessons" / "lessons.yaml").write_text(
+        "lessons:\n- id: LESS-1\n  date: '2026-08-25'\n  reusable_insight: x\n",
+        encoding="utf-8",
+    )
+    state = tmp_path / "state"
+    result = kc.run_curation(workspace, state)
+    assert result["ok"] is False
+    assert "credentials not configured" in result["error"]
+    assert "malformed" not in result["error"]


### PR DESCRIPTION
Part of #986 live bring-up. First-run failure 'malformed curator output' was two stacked config gaps, not a model-output problem: (1) the unit never loaded `/etc/eeepc-agent/litellm.env` — `_default_llm` returned None before any request; (2) no `SELFEVO_CURATOR_MODEL` in the preset — registry fell to a group that does not exist on this LiteLLM. Diagnosed by manual runs on the host (still failed with a live model until the env chain was sourced).

Changes: unit gains `EnvironmentFile=/etc/eeepc-agent/litellm.env`; `local_qwen` preset pins `SELFEVO_CURATOR_MODEL=openai/an/gemini-3.7-flash-high`; missing credentials now raise `litellm credentials not configured (...)` instead of masquerading as malformed output.

Test mapping: `test_missing_litellm_credentials_yields_distinct_error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)