### PR TITLE
fix(harness): classify validator decay from output

### DIFF
--- a/docs/INITIAL_VALIDATOR_ROADMAP.md
+++ b/docs/INITIAL_VALIDATOR_ROADMAP.md
@@ -154,17 +154,17 @@ contract:
 - **What a non-zero exit means.** The harness treats a non-zero exit as a
   finding worth surfacing to the loop as demand — write real errors to
   stderr/stdout, since that text becomes the evidence attached to the item.
-- **Decay self-declaration excludes a script.** A script whose source
-  contains both `is deprecated and marked as archived` (or `is deprecated and
-  scheduled for removal`) and its own `scripts/<name>.py` path is treated as
-  having declared itself decayed, and is never selected again. The two do not
-  have to be on the same line, because real declarations are not written that
-  way. **So if you are writing a validator that audits decay declarations,
-  do not put your own path in the same file as the phrase** — refer to the
-  scripts you check by variable, not by quoting your own name next to the
-  marker you search for. A pattern cannot tell "quotes the phrase" from
-  "declares the phrase", and guessing wrong in the exclude direction is what
-  silenced 14 validators before #934.
+- **Decay self-declaration is detected from your printed output, not your source.** A
+  script whose stdout or stderr contains both `is deprecated and marked as archived`
+  (or `is deprecated and scheduled for removal`) and its own `scripts/<name>.py` path
+  is classified `decay_declared` at run time, and its non-zero exit creates no demand
+  item (#936). This is strictly more honest than source inspection: a script that
+  *implements* decay detection by reading other scripts will never accidentally silence
+  itself, because it does not print the phrase about itself. If you are authoring a
+  validator that audits decay declarations, your printed output will not contain your
+  own path next to the marker phrase — so you are never misclassified. A decay-declared
+  script will still run on every rotation; it produces no demand, and the loop
+  eventually proposes archival through the normal decay channel.
 - **Declare `--json`, don't just mention it.** The harness appends `--json`
   only when your source declares the option (an `add_argument("--json")`
   call, or a `"--json" in sys.argv` test). Naming the string in a docstring

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -803,7 +803,15 @@ def _validator_defect_items(state_dir: Path) -> list[dict[str, str]]:
             findings = row.get("findings_count")
             if isinstance(exit_code, int) and exit_code != 0:
                 stderr_tail = _sanitize_stderr_tail(str(row.get("stderr_tail") or ""))
-                if row.get("harness_contract") == "requires_arguments":
+                if row.get("harness_contract") == "decay_declared":
+                    # #936: the script printed its own decay declaration at run
+                    # time. Its non-zero exit is the CORRECT behaviour for a
+                    # decayed script, not a defect — same "no false demand"
+                    # guarantee that source-based exclusion provided, now
+                    # enforced from runtime output instead of source text.
+                    # Skip entirely (same as harness_env_error above).
+                    continue
+                elif row.get("harness_contract") == "requires_arguments":
                     # #934 Class B: the harness invokes every script with NO
                     # arguments, so a validator whose argparse requires a
                     # flag exits 2 on every run forever. "fails when run"

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -16,14 +16,11 @@ Design, one call to :func:`run_validator_harness` per invocation:
 1. Select up to :func:`_max_k` (env ``SELFEVO_VALIDATOR_HARNESS_MAX``,
    default 5) scripts matching the allowlist
    ``scripts/(check|validate|audit|analyze|verify)_*.py``, least-recently-run
-   first, excluding any script whose own source SELF-DECLARES decay (#934:
-   see :data:`_DECAY_DECL_RE` — there is no machine-readable decay registry,
-   so the declaration text is the only signal, and it must be a
-   self-declaration — the phrase and the script's OWN path together — not
-   merely a mention, or scripts that implement decay detection get silently
-   excluded from ever running; a decayed script's refusal to run is correct
-   behaviour, not a defect, and must never be selected in the first place).
-   Rotation state persists in
+   first. #936: source-based decay exclusion is removed — ALL allowlisted
+   scripts are candidates. A script that has declared itself decayed will
+   print the canonical phrase plus its own path at run time; :func:`_run_one`
+   then sets ``harness_contract: "decay_declared"`` and demand skips it
+   (see step 3 below and :data:`_DECAY_DECL_RE`). Rotation state persists in
    ``<state_dir>/validator_harness/rotation.json`` (same served-map schema
    style as ``llm_proposer``'s #902 demand rotation: ``{"served":
    {"<rel_path>": "<iso-ts>"}}``, pruned to the current candidate set on
@@ -139,9 +136,15 @@ defect when a script did not anticipate it:
 - Non-zero exit = a finding worth surfacing: it becomes ``defect`` demand
   with your stderr/stdout as evidence (see
   ``demand._validator_defect_items``).
-- Decay self-declaration excludes a script from ever running again: see
-  :data:`_DECAY_DECL_RE` for the exact phrasing and the own-path
-  requirement.
+- Decay self-declaration is detected from printed output (#936): when a
+   script's captured stdout+stderr contains :data:`_DECAY_DECL_RE` AND the
+   script's own repo-relative path (``scripts/<filename>``), the run is
+   classified ``harness_contract: "decay_declared"``; demand skips it. A
+   decayed script's refusal to run is correct behaviour, not a defect. This
+   replaces the pre-#936 source-scan exclusion from :func:`_candidate_scripts`
+   (which silently excluded 14 of 42 validators that merely IMPLEMENTED decay
+   detection). NOT applied when either captured stream was truncated (see the
+   comment in :func:`_run_one`).
 """
 from __future__ import annotations
 
@@ -322,53 +325,16 @@ def _scan_head(script: Path) -> str:
         return handle.read(_MAX_SCAN_BYTES)
 
 
-def _is_decay_declared(script: Path) -> bool:
-    """#934: does the script's own source SELF-DECLARE decay (see
-    :data:`_DECAY_DECL_RE`) — the phrase AND the script's own repo-relative
-    path (``scripts/<filename>``) both present in its source head? Bounded
-    read, same pattern as :func:`_accepts_json_flag` — this scans text, it
-    does not execute anything. Fail-open to ``False`` (not declared, i.e.
-    still a candidate) on any read error, AND when the phrase matches but
-    the script's own path is absent: an unreadable file or an unverifiable
-    claim must not silently stop a script from running — see the long
-    comment on :data:`_DECAY_DECL_RE` for why that direction is safe."""
-    try:
-        head = _scan_head(script)
-        own_path = f"scripts/{script.name}"
-        # Co-occurrence anywhere in the head, NOT on the same line.
-        #
-        # The #934 review argued for a same-line rule, on the grounds that
-        # co-occurrence is loose now that docs/INITIAL_VALIDATOR_ROADMAP.md
-        # publishes the canonical phrase verbatim, so a future decay-auditing
-        # validator could hold the phrase as a constant, name its own path in
-        # its usage text, and silence itself. The concern is right. The fix
-        # was wrong, and measuring it against the live instance repo is what
-        # showed that: same-line excludes 11 of 43 where co-occurrence
-        # excludes 13, and the two it loses are precisely the "scheduled for
-        # removal" pair this issue set out to start excluding (Class C).
-        # Their declarations are not single-line —
-        # verify_eeepc_self_evolving_service_guard.py carries the phrase in
-        # its module docstring and its own path four lines later, and its
-        # runtime WARNING string is split across two adjacent literals so the
-        # phrase spans a line break there too.
-        #
-        # So the residual is handled where it can be handled honestly: the
-        # roadmap doc tells authors not to put the phrase and their own path
-        # in the same file unless they mean it. A pattern cannot distinguish
-        # "quotes the phrase" from "declares the phrase" when both appear in
-        # one file, and guessing wrong in the exclude direction is what
-        # silenced 14 validators in the first place.
-        return bool(_DECAY_DECL_RE.search(head)) and own_path in head
-    except Exception:
-        return False
-
-
 def _candidate_scripts(selfevo_repo: Path) -> list[Path]:
     """Allowlisted validator-class scripts in the instance repo, sorted for
-    determinism, excluding any that SELF-DECLARE decay (#934: see
-    :data:`_DECAY_DECL_RE` — a decayed script's refusal to run is correct
-    behaviour, not a defect). Fail-open: no ``scripts/`` dir or any error
-    yields ``[]``."""
+    determinism. Fail-open: no ``scripts/`` dir or any error yields ``[]``.
+
+    #936: source-based decay exclusion is removed. Every allowlisted script
+    is a candidate regardless of what its source says. A script that has
+    declared itself decayed will print that declaration at run time; the
+    run record then carries ``harness_contract: "decay_declared"`` (set by
+    :func:`_run_one`) and demand skips it — same "do not create a false
+    defect" guarantee, now from output rather than source inspection."""
     try:
         scripts_dir = Path(selfevo_repo) / "scripts"
         if not scripts_dir.is_dir():
@@ -376,7 +342,7 @@ def _candidate_scripts(selfevo_repo: Path) -> list[Path]:
         return sorted(
             p
             for p in scripts_dir.glob("*.py")
-            if _ALLOWLIST_RE.match(p.name) and not _is_decay_declared(p)
+            if _ALLOWLIST_RE.match(p.name)
         )
     except Exception:
         return []
@@ -953,6 +919,42 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
         # attacker-writable state). Forging THIS marker only fabricates a
         # defect, which forging an exit_code already did — no new capability.
         record["harness_contract"] = "exceeds_time_budget"
+    elif (
+        isinstance(exit_code, int)
+        and exit_code != 0
+        and not usage_error
+    ):
+        # #936: source-based decay exclusion is retired. Instead, detect decay
+        # from the script's OWN captured runtime output. A script that has
+        # declared itself decayed will print the canonical phrase plus its own
+        # repo-relative path (``scripts/<name>.py``) — the same two conditions
+        # The same two conditions are now required from the captured
+        # stdout+stderr combined. This is strictly more honest:
+        # source inspection could trigger on a validator that IMPLEMENTS decay
+        # detection (the 14-validator false-exclusion measured pre-#934), while
+        # runtime output is the script's own verdict about itself at execution
+        # time — a decay-declared script refusing to run is the correct
+        # behaviour, not a defect.
+        #
+        # Bounded and non-truncated: combined output is checked only when the
+        # capture was NOT truncated (len < _MAX_OUTPUT_BYTES for each stream,
+        # enforced via the combined check below). A truncated stream means the
+        # last captured line is not the last line written, so a validator could
+        # pad stdout to place an unrelated error after the boundary, get the
+        # decay marker, and have demand skip a genuine defect. Refusing to
+        # classify truncated output fails open toward a VISIBLE defect.
+        #
+        # NOT applied on a sandbox-denial match: harness_env_error already
+        # handles that branch and is checked first (ordering preserved).
+        combined = stdout + stderr
+        own_path = rel
+        if (
+            len(stdout) < _MAX_OUTPUT_BYTES
+            and len(stderr) < _MAX_OUTPUT_BYTES
+            and _DECAY_DECL_RE.search(combined)
+            and own_path in combined
+        ):
+            record["harness_contract"] = "decay_declared"
     return record
 
 

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -96,19 +96,35 @@ class TestCandidateSelection:
         assert validator_harness._candidate_scripts(tmp_path / "nope") == []
 
     def test_archived_marker_excludes_script(self, tmp_path):
-        """#928: an archived script's declared contract is "do not run me";
-        it must never even be a candidate, regardless of exit code."""
+        """#936: a script that PRINTS its decay declaration is a candidate
+        (source exclusion retired), but its run is classified decay_declared
+        and produces no defect demand. #928's real requirement -- no false
+        defect from an archived script -- holds via output classification."""
         repo = _init_repo(tmp_path)
         _add_script(
             repo,
             "check_archived.py",
+            "import sys\n"
             "print('WARNING: scripts/check_archived.py is deprecated and "
-            "marked as archived (decay-36bd86468443) as unused.')\n",
+            "marked as archived (decay-36bd86468443) as unused.')\n"
+            "sys.exit(2)\n",
             days_ago=2,
         )
         _add_script(repo, "check_ok.py", "x = 1\n", days_ago=2)
+        # Both scripts ARE candidates now (source exclusion removed).
         names = sorted(p.name for p in validator_harness._candidate_scripts(repo))
-        assert names == ["check_ok.py"]
+        assert names == ["check_archived.py", "check_ok.py"]
+        # Running the archived script classifies it decay_declared.
+        state_dir = _state_dir(tmp_path)
+        result = validator_harness.run_validator_harness(state_dir, repo)
+        assert "scripts/check_archived.py" in result["ran"]
+        rows = _last_runs(state_dir)
+        archived_rows = [r for r in rows if r["path"] == "scripts/check_archived.py"]
+        assert archived_rows
+        assert archived_rows[-1]["harness_contract"] == "decay_declared"
+        # No defect demand is created for the decay_declared run.
+        items = demand._validator_defect_items(state_dir)
+        assert not any(i["affected_path"] == "scripts/check_archived.py" for i in items)
 
     def test_bare_mention_without_self_declaration_stays_a_candidate(self, tmp_path):
         """#934: the pre-#934 rule matched the bare phrase 'script is
@@ -245,34 +261,61 @@ class TestDecayDeclarationExclusion:
         assert "validate_decay_helper.py" in names
 
     def test_self_declaration_with_own_path_is_excluded(self, tmp_path):
+        """#936: source-based exclusion retired. A script whose PRINTED output
+        contains the decay phrase plus its own path is classified
+        decay_declared at run time; no defect is created. Same protected
+        semantic as before: no false demand from an archived script."""
         repo = _init_repo(tmp_path)
         _add_script(
             repo,
             "analyze_repo_size.py",
+            "import sys\n"
             "print('WARNING: scripts/analyze_repo_size.py is deprecated "
-            "and marked as archived (decay-36bd86468443) as unused.')\n",
+            "and marked as archived (decay-36bd86468443) as unused.')\n"
+            "sys.exit(2)\n",
             days_ago=2,
         )
+        # Script IS a candidate now.
         names = [p.name for p in validator_harness._candidate_scripts(repo)]
-        assert "analyze_repo_size.py" not in names
+        assert "analyze_repo_size.py" in names
+        # Run classifies it decay_declared, creates no defect.
+        state_dir = _state_dir(tmp_path)
+        validator_harness.run_validator_harness(state_dir, repo)
+        rows = [r for r in _last_runs(state_dir) if r["path"] == "scripts/analyze_repo_size.py"]
+        assert rows and rows[-1]["harness_contract"] == "decay_declared"
+        assert not any(
+            i["affected_path"] == "scripts/analyze_repo_size.py"
+            for i in demand._validator_defect_items(state_dir)
+        )
 
     def test_scheduled_for_removal_rung_is_excluded(self, tmp_path):
-        """Class C in #934: the rung BEFORE 'marked as archived' -- a
-        script declining to run for exactly the same reason, which the old
-        rule missed entirely (it does not contain either old alternative)."""
+        """#936: 'scheduled for removal' is also classified from output.
+        Class C in #934: the rung BEFORE 'marked as archived' — same
+        protected semantic via output classification."""
         repo = _init_repo(tmp_path)
+        name = "verify_eeepc_self_evolving_service_guard.py"
         _add_script(
             repo,
-            "verify_eeepc_self_evolving_service_guard.py",
+            name,
+            "import sys\n"
             "print('WARNING: scripts/verify_eeepc_self_evolving_service_"
             "guard.py is deprecated and scheduled for removal after 14+ "
-            "days of disuse.')\n",
+            "days of disuse.')\n"
+            "sys.exit(2)\n",
             days_ago=2,
         )
-        names = [
-            p.name for p in validator_harness._candidate_scripts(repo)
-        ]
-        assert "verify_eeepc_self_evolving_service_guard.py" not in names
+        # Script IS a candidate.
+        names = [p.name for p in validator_harness._candidate_scripts(repo)]
+        assert name in names
+        # Run classifies it decay_declared, creates no defect.
+        state_dir = _state_dir(tmp_path)
+        validator_harness.run_validator_harness(state_dir, repo)
+        rows = [r for r in _last_runs(state_dir) if r["path"] == f"scripts/{name}"]
+        assert rows and rows[-1]["harness_contract"] == "decay_declared"
+        assert not any(
+            i["affected_path"] == f"scripts/{name}"
+            for i in demand._validator_defect_items(state_dir)
+        )
 
     def test_self_declaration_missing_own_path_fails_open(self, tmp_path):
         """The own-path requirement fails open the same direction as an
@@ -292,13 +335,22 @@ class TestDecayDeclarationExclusion:
         assert "check_vague.py" in names
 
     def test_old_rule_over_excludes_new_rule_does_not_synthetic_42(self, tmp_path):
-        """Reproduces the measured live shape: 42 allowlisted scripts, 13 of
-        which genuinely self-declare (11 'marked as archived' + 2 'scheduled
-        for removal', each naming its own path) and 14 of which merely carry
-        the copy-pasted mention-only docstring. The OLD (mention) rule
-        excludes 25 (13 - 2 genuine 'scheduled for removal' misses it
-        entirely + 14 false positives = 11 + 14); the NEW (self-declaration)
-        rule excludes exactly the 13 genuine ones."""
+        """#936: output-classification successor to the synthetic-42 fixture.
+
+        Same shape as before: 42 allowlisted scripts (11 'marked as archived'
+        + 2 'scheduled for removal' + 14 mention-only + 15 plain). All 42 are
+        candidates now (source exclusion retired). At run time:
+        - The 13 genuine self-declaring scripts print the canonical phrase plus
+          their own path — classified decay_declared, NO defect demand.
+        - The 14 mention-only scripts (copy-pasted helper docstring) run
+          normally and exit 0 — NOT classified as decay, NO false defect.
+          This is the over-CLASSIFICATION protection: the old mention rule
+          would have silently excluded them; the output rule must not
+          misclassify them either.
+        - The 15 plain scripts run fine, exit 0.
+
+        Uses _run_one directly (no git repo, no birth-window) so all 42
+        scripts run without the rotation cap."""
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()
 
@@ -306,8 +358,10 @@ class TestDecayDeclarationExclusion:
         for i in range(11):
             name = f"check_archived_{i:02d}.py"
             (scripts_dir / name).write_text(
+                "import sys\n"
                 f"print('WARNING: scripts/{name} is deprecated and marked "
-                "as archived (decay-deadbeef) as unused.')\n",
+                "as archived (decay-deadbeef) as unused.')\n"
+                "sys.exit(2)\n",
                 encoding="utf-8",
             )
 
@@ -315,19 +369,22 @@ class TestDecayDeclarationExclusion:
         for i in range(2):
             name = f"verify_removal_{i:02d}.py"
             (scripts_dir / name).write_text(
+                "import sys\n"
                 f"print('WARNING: scripts/{name} is deprecated and "
-                "scheduled for removal after 14+ days of disuse.')\n",
+                "scheduled for removal after 14+ days of disuse.')\n"
+                "sys.exit(2)\n",
                 encoding="utf-8",
             )
 
-        # 14 mention-only scripts: the copy-pasted helper docstring, which
-        # implements decay DETECTION rather than declaring itself decayed.
+        # 14 mention-only scripts: the copy-pasted helper docstring that
+        # IMPLEMENTS decay detection. They must run normally and NOT be
+        # classified as decay (over-classification protection).
         for i in range(14):
             name = f"validate_decay_helper_{i:02d}.py"
             (scripts_dir / name).write_text(
-                '    """Check if a script is archived/deprecated by '
-                'reading its content."""\n'
-                "def helper():\n    pass\n",
+                """def helper():
+    \"\"\"Check if a script is archived/deprecated by reading its content.\"\"\"
+    pass\n""",
                 encoding="utf-8",
             )
 
@@ -339,25 +396,32 @@ class TestDecayDeclarationExclusion:
         all_scripts = list(scripts_dir.glob("*.py"))
         assert len(all_scripts) == 42
 
-        old_mention_rule = re.compile(r"marked as archived|script is archived")
-        old_excluded = [
-            p for p in all_scripts
-            if old_mention_rule.search(validator_harness._scan_head(p))
-        ]
-        assert len(old_excluded) == 25
-
+        # All 42 are candidates (source exclusion removed).
         candidates = validator_harness._candidate_scripts(tmp_path)
-        assert len(candidates) == 42 - 13
+        assert len(candidates) == 42
 
-        candidate_names = {p.name for p in candidates}
+        # Run each script directly and collect classifications.
+        decay_declared = []
+        not_decay = []
+        for script in sorted(scripts_dir.glob("*.py")):
+            record = validator_harness._run_one(script, tmp_path, 30.0)
+            if record.get("harness_contract") == "decay_declared":
+                decay_declared.append(script.name)
+            else:
+                not_decay.append(script.name)
+
+        # Exactly the 13 genuine self-declaring scripts classify as decay_declared.
+        assert len(decay_declared) == 13
         for i in range(11):
-            assert f"check_archived_{i:02d}.py" not in candidate_names
+            assert f"check_archived_{i:02d}.py" in decay_declared
         for i in range(2):
-            assert f"verify_removal_{i:02d}.py" not in candidate_names
+            assert f"verify_removal_{i:02d}.py" in decay_declared
+
+        # The 14 mention-only scripts and 15 plain scripts are NOT classified.
         for i in range(14):
-            assert f"validate_decay_helper_{i:02d}.py" in candidate_names
+            assert f"validate_decay_helper_{i:02d}.py" in not_decay
         for i in range(15):
-            assert f"analyze_plain_{i:02d}.py" in candidate_names
+            assert f"analyze_plain_{i:02d}.py" in not_decay
 
 
 # ─── execution ───────────────────────────────────────────────────────────
@@ -1812,22 +1876,21 @@ class TestJsonFlagMustBeDeclaredNotMentioned:
 
 
 class TestDecayDeclarationSpanningLines:
-    """#934 review round 2: the review asked for a same-line rule (phrase and
-    own path on one line), because co-occurrence anywhere in the head is loose
-    now that the roadmap doc publishes the phrase verbatim. Measured against
-    the live instance repo, that rule excludes 11 of 43 where co-occurrence
-    excludes 13 — and the two it loses are exactly the "scheduled for removal"
-    pair this issue set out to START excluding. Their declarations are not
-    single-line: the guard script carries the phrase in its module docstring
-    and its own path four lines later, and its runtime WARNING string is split
-    across two adjacent literals so the phrase itself spans a line break.
-
-    These two tests pin the real shapes, so a future tightening cannot quietly
-    regress Class C again."""
+    """#936: output-classification successors for the two spanning-lines shapes
+    from #934 review round 2. The live scripts print the phrase across
+    adjacent string literals or with the path several lines apart in their
+    source; this class pins that those PRINTED shapes are classified correctly
+    at run time — the phrase and own path in the combined captured output
+    (stdout+stderr) trigger decay_declared regardless of line boundaries,
+    matching the pre-#936 co-occurrence rule applied to source."""
 
     def test_docstring_phrase_with_the_path_lines_later_is_excluded(self, tmp_path):
+        """#936: the live verify_eeepc_self_evolving_service_guard.py shape.
+        Its WARNING spans two adjacent string literals so the phrase and the
+        path print on separate stdout lines. Both must appear in the combined
+        output to classify decay_declared — and they do, so no defect."""
         repo = _init_repo(tmp_path)
-        # The live verify_eeepc_self_evolving_service_guard.py shape.
+        # The script prints the phrase across two literals, plus its own path.
         script = (
             '"""Guard check.\n'
             "\n"
@@ -1837,34 +1900,53 @@ class TestDecayDeclarationSpanningLines:
             "Replacement:\n"
             "        scripts/verify_eeepc_self_evolving_service_guard.py\n"
             '"""\n'
-            "import warnings\n"
-            "warnings.warn(\n"
+            "import sys\n"
+            "sys.stdout.write(\n"
             '    "WARNING: scripts/verify_eeepc_self_evolving_service_guard.py '
             'is deprecated "\n'
-            '    "and scheduled for removal after 14+ days of disuse.",\n'
-            "    DeprecationWarning,\n"
-            "    stacklevel=1,\n"
+            '    "and scheduled for removal after 14+ days of disuse.\\n"\n'
             ")\n"
-            "raise SystemExit(2)\n"
+            "sys.exit(2)\n"
         )
         _add_script(
             repo, "verify_eeepc_self_evolving_service_guard.py", script, days_ago=2
         )
+        # Script IS a candidate.
         names = {p.name for p in validator_harness._candidate_scripts(repo)}
-        assert "verify_eeepc_self_evolving_service_guard.py" not in names
+        assert "verify_eeepc_self_evolving_service_guard.py" in names
+        # Run classifies decay_declared, no defect.
+        record = validator_harness._run_one(
+            repo / "scripts" / "verify_eeepc_self_evolving_service_guard.py",
+            repo, 30.0,
+        )
+        assert record["harness_contract"] == "decay_declared"
+        state_dir = _state_dir(tmp_path)
+        _seed_last_runs(state_dir, [record])
+        assert demand._validator_defect_items(state_dir) == []
 
     def test_a_real_single_line_declaration_is_still_excluded(self, tmp_path):
+        """#936: a script that prints the canonical single-line declaration
+        is classified decay_declared. Pins the simpler shape alongside the
+        spanning-lines case above."""
         repo = _init_repo(tmp_path)
         script = (
-            "import warnings\n"
-            'msg = "WARNING: scripts/analyze_repo_size.py is deprecated and '
-            'marked as archived (decay-36bd86468443) as unused."\n'
-            "warnings.warn(msg, DeprecationWarning, stacklevel=1)\n"
-            "raise SystemExit(1)\n"
+            "import sys\n"
+            'sys.stdout.write("WARNING: scripts/analyze_repo_size.py is deprecated and '
+            'marked as archived (decay-36bd86468443) as unused.\\n")\n'
+            "sys.exit(1)\n"
         )
         _add_script(repo, "analyze_repo_size.py", script, days_ago=2)
+        # Script IS a candidate.
         names = {p.name for p in validator_harness._candidate_scripts(repo)}
-        assert "analyze_repo_size.py" not in names
+        assert "analyze_repo_size.py" in names
+        # Run classifies decay_declared, no defect.
+        record = validator_harness._run_one(
+            repo / "scripts" / "analyze_repo_size.py", repo, 30.0
+        )
+        assert record["harness_contract"] == "decay_declared"
+        state_dir = _state_dir(tmp_path)
+        _seed_last_runs(state_dir, [record])
+        assert demand._validator_defect_items(state_dir) == []
 
 
 class TestUsageErrorIsNeverSuppressedByTheEnvMarker:


### PR DESCRIPTION
## Summary
Implements #936 by retiring source-based validator decay exclusion and classifying decay from the validator's captured runtime output. Every allowlisted validator remains a candidate and runs. A non-zero run is marked `harness_contract: decay_declared` only when its untruncated stdout/stderr contains the canonical decay marker and that script's own `scripts/<name>` path; demand suppresses only that correctly classified decay result. Auditor output naming other scripts is not classified. Truncated output fails open toward visible defect demand.

Updated `docs/INITIAL_VALIDATOR_ROADMAP.md` to document the output contract.

## Key-term diff check
Before opening this PR:
`git diff main...HEAD | grep -n decay_declared`
returned matches in `nanobot/runtime/validator_harness.py`, `nanobot/runtime/demand.py`, `tests/test_validator_harness.py`, and `docs/INITIAL_VALIDATOR_ROADMAP.md`.

## Scoped test decisions honored
Per [decision 5416194979](https://github.com/ozand/eeebot/issues/936#issuecomment-5416194979), replaced:
- `TestDecayDeclarationSpanningLines::test_docstring_phrase_with_the_path_lines_later_is_excluded`
- `TestDecayDeclarationSpanningLines::test_a_real_single_line_declaration_is_still_excluded`

Per [decision 5416502985](https://github.com/ozand/eeebot/issues/936#issuecomment-5416502985), replaced:
- `TestCandidateSelection::test_archived_marker_excludes_script`
- `TestDecayDeclarationExclusion::test_self_declaration_with_own_path_is_excluded`
- `TestDecayDeclarationExclusion::test_scheduled_for_removal_rung_is_excluded`
- `TestDecayDeclarationExclusion::test_old_rule_over_excludes_new_rule_does_not_synthetic_42`

Protected semantics are preserved through output classification: archived/scheduled scripts are candidates, execute, classify `decay_declared`, and produce no defect demand; synthetic-42 protects against over-classifying 14 mention-only auditors. `test_self_declaration_missing_own_path_fails_open` remains unchanged. No seventh conflicting test was edited.

## Tests
- `python -m pytest tests/test_validator_harness.py -q`: 104 passed, 5 skipped
- `ruff check nanobot/runtime/validator_harness.py nanobot/runtime/demand.py`: passed
- Full pytest required before merge; known Windows baseline failures will be reported exactly.