### PR TITLE
fix(demand): prioritize served validator defects

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -769,7 +769,40 @@ def _validator_defect_items(state_dir: Path) -> list[dict[str, str]]:
                 # (or a traversal attempt) must not become demand.
                 continue
             latest[rel] = row  # later lines overwrite -> most recent run wins
-        for rel in sorted(latest):
+        # #933: sort by served-map membership rather than alphabetical path
+        # string to prevent attacker-controlled sidecar forging from choosing
+        # which items reach the cap.  Paths the harness's rotation.json
+        # records as actually having been run (``served`` map) sort BEFORE
+        # paths unknown to that map.  Because the harness rewrites rotation.json
+        # atomically at the end of every run — using only scripts it actually
+        # executed — a validator subprocess cannot forge a durable served entry
+        # for a script that never ran; such entries are erased on every harness
+        # completion.  Unknown paths (forged names or brand-new scripts whose
+        # very first run is in progress) sort last, after every known path.
+        # Fail-open: if rotation.json is missing or malformed we fall back to
+        # the previous alphabetical order rather than raising.
+        _rotation_path = (
+            Path(state_dir) / "validator_harness" / "rotation.json"
+        )
+        try:
+            if _rotation_path.is_file():
+                _rot_data = json.loads(
+                    _rotation_path.read_text(encoding="utf-8")
+                )
+                _served: dict[str, Any] = (
+                    _rot_data.get("served", {})
+                    if isinstance(_rot_data, dict)
+                    else {}
+                )
+            else:
+                _served = {}
+        except Exception:
+            _served = {}
+        _ordered = sorted(
+            latest,
+            key=lambda r: (0 if r in _served else 1, r),
+        )
+        for rel in _ordered:
             row = latest[rel]
             if row.get("harness_env_error"):
                 # #928: the harness classified this run as blocked by its OWN

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1797,6 +1797,124 @@ class TestValidatorHarnessContractReclassified:
         assert len(demand._validator_defect_items(state_dir)) == 1
 
 
+# ─── #933: served-map ordering prevents forged early-sorting rows from
+# displacing genuine failing validators ─────────────────────────────────────
+
+
+class TestValidatorDemandServedMapOrdering:
+    """#933: demand._validator_defect_items must use the harness rotation.json
+    ``served`` map to sort candidate rows rather than alphabetical path order.
+    Validator subprocesses share the harness's writable carve-out and can
+    forge rows in last_runs.jsonl with early-alphabet valid paths; the served
+    map, rewritten atomically by the harness after every run, is the trusted
+    ordering handle."""
+
+    def _vh_dir(self, state_dir: Path) -> Path:
+        d = state_dir / "validator_harness"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _write_rows(self, state_dir: Path, *rows: dict) -> None:
+        vh = self._vh_dir(state_dir)
+        with (vh / "last_runs.jsonl").open("a", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row) + "\n")
+
+    def _write_rotation(self, state_dir: Path, served: dict[str, str]) -> None:
+        vh = self._vh_dir(state_dir)
+        (vh / "rotation.json").write_text(
+            json.dumps({"schema_version": "validator-harness-rotation-v1",
+                        "served": served}),
+            encoding="utf-8",
+        )
+
+    def _now_iso(self) -> str:
+        from datetime import datetime, timezone
+        return datetime.now(timezone.utc).isoformat()
+
+    def test_genuine_defect_survives_five_forged_early_sorting_rows(self, tmp_path):
+        """Regression: five forged rows with early-alphabet valid paths + one
+        genuine failing validator.  With alphabetical sorting the genuine
+        script (check_zzz_genuine.py) falls off the front.  With served-map
+        ordering the genuine script (listed in served) is selected first,
+        leaving forged paths (not in served) deprioritized."""
+        state_dir = _state_dir(tmp_path)
+        # Five forged early-alphabet valid-format rows (NOT in served).
+        forged = [
+            {"path": f"scripts/analyze_aaa_{i}.py", "exit_code": 1,
+             "findings_count": None, "finished_at": self._now_iso()}
+            for i in range(5)
+        ]
+        # One genuine failing validator (IS in served map).
+        genuine = {"path": "scripts/check_zzz_genuine.py", "exit_code": 1,
+                   "findings_count": None, "finished_at": self._now_iso()}
+        self._write_rows(state_dir, *forged, genuine)
+        # rotation.json only records the genuine script (attackers cannot
+        # persist entries for scripts that never ran through the harness).
+        self._write_rotation(
+            state_dir,
+            {"scripts/check_zzz_genuine.py": self._now_iso()},
+        )
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == demand._MAX_VALIDATOR_DEFECTS  # still bounded
+        paths = [i["affected_path"] for i in items]
+        # The genuine script must appear in the output.
+        assert "scripts/check_zzz_genuine.py" in paths, (
+            f"genuine script missing from {paths}"
+        )
+
+    def test_alphabetical_fallback_still_bounded_when_no_rotation_json(self, tmp_path):
+        """Fail-open: if rotation.json is absent, ordering falls back to
+        alphabetical (previous behaviour) and the cap is still respected."""
+        state_dir = _state_dir(tmp_path)
+        rows = [
+            {"path": f"scripts/check_{i:03d}.py", "exit_code": 1,
+             "findings_count": None, "finished_at": self._now_iso()}
+            for i in range(8)
+        ]
+        self._write_rows(state_dir, *rows)
+        # No rotation.json written — must not raise.
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == demand._MAX_VALIDATOR_DEFECTS
+
+    def test_malformed_rotation_json_falls_back_gracefully(self, tmp_path):
+        """Malformed rotation.json must not raise; ordering falls back to
+        alphabetical and the cap is still respected."""
+        state_dir = _state_dir(tmp_path)
+        vh = self._vh_dir(state_dir)
+        (vh / "rotation.json").write_text("not json", encoding="utf-8")
+        rows = [
+            {"path": f"scripts/check_{i:03d}.py", "exit_code": 1,
+             "findings_count": None, "finished_at": self._now_iso()}
+            for i in range(8)
+        ]
+        self._write_rows(state_dir, *rows)
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == demand._MAX_VALIDATOR_DEFECTS
+
+    def test_served_scripts_ordered_before_unserved_deterministically(self, tmp_path):
+        """All known (served) scripts sort before all unknown (unserved)
+        scripts; within each group the tie-break is alphabetical."""
+        state_dir = _state_dir(tmp_path)
+        rows = [
+            {"path": "scripts/check_zzz.py", "exit_code": 1,
+             "findings_count": None, "finished_at": self._now_iso()},
+            {"path": "scripts/analyze_aaa.py", "exit_code": 1,
+             "findings_count": None, "finished_at": self._now_iso()},
+        ]
+        self._write_rows(state_dir, *rows)
+        # Only check_zzz.py is in the served map.
+        self._write_rotation(
+            state_dir,
+            {"scripts/check_zzz.py": self._now_iso()},
+        )
+        items = demand._validator_defect_items(state_dir)
+        assert len(items) == 2
+        # check_zzz (served) must come before analyze_aaa (not served).
+        assert items[0]["affected_path"] == "scripts/check_zzz.py"
+        assert items[1]["affected_path"] == "scripts/analyze_aaa.py"
+
+
 # ─── #789: tamper defect demand ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Implements #933 by replacing alphabetical validator-defect presentation with deterministic rotation-state membership ordering. Latest rows for scripts recorded in the existing harness `rotation.json` served map are presented before unknown rows; ties remain lexical and the hard cap remains 5. Missing/malformed rotation state fails open to the prior bounded alphabetical ordering. No new state file and no demand-side trust input is created.

## Key-term diff check
Before opening this PR:
`git diff main...HEAD | grep -ni -E '#933|served|rotation'`
returned matches in `nanobot/runtime/demand.py` and `tests/test_demand.py`.

## Acceptance criteria -> named tests
- Forged early-sorting rows cannot displace genuine defect -> `TestValidatorDemandServedMapOrdering::test_genuine_defect_survives_five_forged_early_sorting_rows`
- Deterministic bounded selection -> `::test_served_scripts_ordered_before_unserved_deterministically`
- Missing rotation fail-open and cap -> `::test_alphabetical_fallback_still_bounded_when_no_rotation_json`
- Malformed rotation fail-open -> `::test_malformed_rotation_json_falls_back_gracefully`

The implementation reuses the harness's existing rotation state and leaves existing validator-demand expectations unchanged.

Focused checks: regression class 4 passed; full demand + validator harness tests were 233 passed, 5 skipped, with two known Windows path-separator baseline failures. Full pytest and CI are required before merge.