### PR TITLE
feat(runtime): durable per-cycle action index (#1005)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -168,6 +168,8 @@ sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/validator_harness 2
 sudo chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/validator_harness 2>/dev/null || true
 sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/curator 2>/dev/null || true
 sudo chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/curator 2>/dev/null || true
+sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/action_index 2>/dev/null || true
+sudo chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/action_index 2>/dev/null || true
 
 echo "[remote] syncing libexec scripts from release"
 # Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`
@@ -185,6 +187,7 @@ sudo cp "$RELEASE_DIR/host/eeepc/systemd/"*.service "$RELEASE_DIR/host/eeepc/sys
 sudo systemctl daemon-reload
 sudo systemctl enable --now eeepc-promotion-verifier.timer 2>/dev/null || true
 sudo systemctl enable --now eeebot-knowledge-curator.timer 2>/dev/null || true
+sudo systemctl enable --now eeebot-action-index.timer 2>/dev/null || true
 
 echo "[remote] current release: $(readlink /opt/eeepc-agent/runtimes/self-evolving-agent/current)"
 echo "[remote] done — commit $COMMIT"

--- a/host/eeepc/scripts/install.sh
+++ b/host/eeepc/scripts/install.sh
@@ -247,7 +247,7 @@ init_state() {
   # or inaccessible to it, state/usage included. Pre-creating it here means
   # the bind target exists on a fresh install (deploy_release.sh does the
   # same for deploy-only hosts).
-  for subdir in reports subagents/requests subagents/results improvements approvals goals outbox subagent_bridge workspace/subagents validator_harness usage curator; do
+  for subdir in reports subagents/requests subagents/results improvements approvals goals outbox subagent_bridge workspace/subagents validator_harness usage curator action_index; do
     run mkdir -p "$state/$subdir"
   done
   run chown -R eeepc-agent:eeepc-agent /var/lib/eeepc-agent
@@ -264,6 +264,7 @@ enable_timers() {
     eeebot-archive-subagent-requests.timer
     eeebot-validator-harness.timer
     eeebot-knowledge-curator.timer
+    eeebot-action-index.timer
   )
   for t in "${timers[@]}"; do
     run systemctl enable "$t"

--- a/host/eeepc/systemd/eeebot-action-index.service
+++ b/host/eeepc/systemd/eeebot-action-index.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Extract durable per-cycle action index before prompt rotation (#1005)
+After=local-fs.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=PYTHONDONTWRITEBYTECODE=1
+ExecStart=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.action_index --state-root /var/lib/eeepc-agent/self-evolving-agent/state
+ProtectHome=false
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/action_index
+NoNewPrivileges=true
+PrivateTmp=true

--- a/host/eeepc/systemd/eeebot-action-index.timer
+++ b/host/eeepc/systemd/eeebot-action-index.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Build durable per-cycle action index before prompt rotation (#1005)
+
+[Timer]
+OnCalendar=*-*-* 00:05:00
+Persistent=true
+Unit=eeebot-action-index.service
+
+[Install]
+WantedBy=timers.target

--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -254,6 +254,16 @@ def record_llm_prompt(
         prompts_dir.mkdir(parents=True, exist_ok=True)
 
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        # #1005: distill the previous day's complete cycle records before
+        # rotation gzips them.  The extractor is its own stdlib-only module;
+        # this small hook makes the timer a safety net rather than the only
+        # chance to observe a file before it disappears.
+        try:
+            from nanobot.runtime.action_index import build_action_index
+
+            build_action_index(prompts_dir.parent.parent, prompts_dir)
+        except Exception:
+            pass
         _rotate_and_prune(prompts_dir, today, _prompts_retention_days())
 
         out_path = prompts_dir / f"{today}.jsonl"

--- a/nanobot/runtime/action_index.py
+++ b/nanobot/runtime/action_index.py
@@ -1,0 +1,272 @@
+"""Durable, deterministic per-cycle action index.
+
+The prompt capture is large and short-lived.  This module reads the final
+prompt record for each cycle, extracts tool calls, and writes a compact JSONL
+summary before prompt rotation can remove the source.  It deliberately uses
+only the standard library and is fail-open for host-timer use.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import shlex
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+_DEFAULT_RETENTION_DAYS = 90
+_ARCHIVE_AFTER_DAYS = 7
+
+
+def _day_from_name(name: str) -> str | None:
+    stem = name[:-9] if name.endswith(".jsonl.gz") else name[:-6] if name.endswith(".jsonl") else ""
+    try:
+        datetime.strptime(stem, "%Y-%m-%d")
+    except ValueError:
+        return None
+    return stem
+
+
+def _read_jsonl(path: Path) -> tuple[list[dict[str, Any]], int]:
+    """Read one capture/index file, returning records and malformed count."""
+    records: list[dict[str, Any]] = []
+    malformed = 0
+    opener = gzip.open if path.name.endswith(".gz") else open
+    try:
+        with opener(path, "rt", encoding="utf-8") as fh:  # type: ignore[call-arg]
+            for line in fh:
+                if not line.strip():
+                    continue
+                try:
+                    value = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    malformed += 1
+                    continue
+                if isinstance(value, dict):
+                    records.append(value)
+                else:
+                    malformed += 1
+    except (OSError, EOFError, gzip.BadGzipFile):
+        malformed += 1
+    return records, malformed
+
+
+def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    records, _ = _read_jsonl(path)
+    yield from records
+
+
+def _prompt_files(prompts_dir: Path) -> list[Path]:
+    return sorted([*prompts_dir.glob("*.jsonl"), *prompts_dir.glob("*.jsonl.gz")])
+
+
+def _ledger_rows(state_root: Path) -> list[dict[str, Any]]:
+    ledger_dir = state_root / "ledger"
+    paths = [ledger_dir / "cycles.jsonl", *sorted(ledger_dir.glob("cycles-*.jsonl.gz"))]
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        if path.is_file():
+            rows.extend(_iter_jsonl(path))
+    return rows
+
+
+def _ledger_by_cycle(state_root: Path) -> dict[str, dict[str, Any]]:
+    titles: dict[str, str] = {}
+    outcomes: dict[str, dict[str, Any]] = {}
+    for row in _ledger_rows(state_root):
+        cycle_id = str(row.get("cycle_id") or "").strip()
+        if not cycle_id:
+            continue
+        if row.get("phase") == "proposed" and row.get("task_title"):
+            titles[cycle_id] = str(row["task_title"])
+        if row.get("phase") == "outcome":
+            outcomes[cycle_id] = row
+    return {
+        cycle_id: {
+            "task_title": titles.get(cycle_id),
+            "outcome": row.get("outcome"),
+            "ts": row.get("ts"),
+        }
+        for cycle_id, row in outcomes.items()
+    }
+
+
+def _path_template(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    value = value.replace("\\", "/").strip()
+    parts = [part for part in value.split("/") if part not in ("", ".", "..")]
+    if not parts:
+        return None
+    name = parts[-1]
+    suffix = Path(name).suffix
+    if not suffix:
+        return "/".join(parts[:-1] + ["*"]) if len(parts) > 1 else "*"
+    return f"{parts[0]}/*{suffix}" if len(parts) > 1 else f"*{suffix}"
+
+
+def _command_template(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        tokens = shlex.split(value)
+    except ValueError:
+        tokens = value.split()
+    if not tokens:
+        return None
+    head = Path(tokens[0]).name
+    # Keep the useful action for the common git command while still dropping
+    # all arguments (the general contract is the executable head).
+    if head == "git" and len(tokens) > 1 and not tokens[1].startswith("-"):
+        head = f"git-{tokens[1]}"
+    return head
+
+
+def normalize_action(tool_name: Any, arguments: Any) -> str | None:
+    """Return a compact ``tool:argument-shape`` template."""
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        return None
+    name = tool_name.strip().lower()
+    args = arguments if isinstance(arguments, dict) else {}
+    if name in {"exec", "shell", "run_command", "execute"}:
+        command = args.get("command", args.get("cmd"))
+        template = _command_template(command)
+        return f"exec:{template}" if template else "exec:*"
+    prefix = {
+        "read_file": "read", "read": "read", "write_file": "write", "write": "write",
+        "edit_file": "edit", "edit": "edit", "list_dir": "list", "list": "list",
+    }.get(name, name)
+    value = next((args[key] for key in ("path", "file_path", "filename", "target_path") if key in args), None)
+    template = _path_template(value)
+    return f"{prefix}:{template}" if template else f"{prefix}:*"
+
+
+def _tool_calls(record: dict[str, Any]) -> list[str]:
+    actions: list[str] = []
+    for message in record.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        calls = message.get("tool_calls") or []
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            function = call.get("function") if isinstance(call.get("function"), dict) else call
+            name = function.get("name")
+            arguments = function.get("arguments", {})
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except (json.JSONDecodeError, TypeError):
+                    arguments = {}
+            action = normalize_action(name, arguments)
+            if action:
+                actions.append(action)
+    return actions
+
+
+def _retention_days() -> int:
+    try:
+        return max(1, int(os.environ.get("ACTION_INDEX_RETENTION_DAYS", _DEFAULT_RETENTION_DAYS)))
+    except ValueError:
+        return _DEFAULT_RETENTION_DAYS
+
+
+def _rotate_and_prune(index_dir: Path, today: str) -> None:
+    cutoff = datetime.now(timezone.utc).date() - timedelta(days=_retention_days())
+    archive_cutoff = datetime.now(timezone.utc).date() - timedelta(days=_ARCHIVE_AFTER_DAYS)
+    for path in index_dir.glob("*.jsonl"):
+        day = _day_from_name(path.name)
+        if not day:
+            continue
+        date = datetime.strptime(day, "%Y-%m-%d").date()
+        if day != today and date <= archive_cutoff:
+            try:
+                with path.open("rb") as source, gzip.open(f"{path}.gz", "wb") as target:
+                    target.write(source.read())
+                path.unlink()
+            except OSError:
+                pass
+    for path in index_dir.glob("*.jsonl.gz"):
+        day = _day_from_name(path.name)
+        if day:
+            try:
+                if datetime.strptime(day, "%Y-%m-%d").date() < cutoff:
+                    path.unlink(missing_ok=True)
+            except (OSError, ValueError):
+                pass
+
+
+def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dict[str, int]:
+    """Extract present prompt files into the durable index; never raises."""
+    summary = {"prompt_files": 0, "cycles": 0, "written": 0, "skipped": 0}
+    try:
+        prompts_dir = prompts_dir or state_root / "llm_calls" / "prompts"
+        index_dir = state_root / "action_index"
+        index_dir.mkdir(parents=True, exist_ok=True)
+        existing: set[str] = set()
+        for path in _prompt_files(index_dir):
+            for row in _iter_jsonl(path):
+                if row.get("cycle_id"):
+                    existing.add(str(row["cycle_id"]))
+        ledger = _ledger_by_cycle(state_root)
+        grouped: dict[str, tuple[str, dict[str, Any]]] = {}
+        for path in _prompt_files(prompts_dir):
+            day = _day_from_name(path.name)
+            if not day:
+                continue
+            summary["prompt_files"] += 1
+            records, malformed = _read_jsonl(path)
+            summary["skipped"] += malformed
+            for record in records:
+                cycle_id = str(record.get("cycle_id") or "").strip()
+                if not cycle_id or not isinstance(record.get("messages"), list):
+                    summary["skipped"] += 1
+                    continue
+                current = grouped.get(cycle_id)
+                seq = record.get("seq") if isinstance(record.get("seq"), int) else -1
+                old_seq = current[1].get("seq", -1) if current else -1
+                if current is None or seq >= old_seq:
+                    grouped[cycle_id] = (day, record)
+        summary["cycles"] = len(grouped)
+        for cycle_id, (day, record) in grouped.items():
+            # A cycle is complete only once the ledger has a terminal row.
+            # This prevents the prompt-record hook from indexing the first
+            # call of a still-running cycle before later calls are captured.
+            if cycle_id in existing or cycle_id not in ledger:
+                continue
+            row = ledger[cycle_id]
+            output = {
+                "cycle_id": cycle_id,
+                "ts": record.get("ts") or row.get("ts") or "",
+                "task_title": row.get("task_title"),
+                "outcome": row.get("outcome"),
+                "actions": _tool_calls(record),
+            }
+            output_path = index_dir / f"{day}.jsonl"
+            with output_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(output, ensure_ascii=False, separators=(",", ":")) + "\n")
+            existing.add(cycle_id)
+            summary["written"] += 1
+        _rotate_and_prune(index_dir, datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    except Exception:
+        pass
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the durable per-cycle action index")
+    parser.add_argument("--state-root", type=Path, default=None)
+    parser.add_argument("--prompts-dir", type=Path, default=None)
+    args = parser.parse_args()
+    state_root = args.state_root or Path(os.environ.get("STATE_DIR", Path.home() / ".nanobot"))
+    summary = build_action_index(state_root, args.prompts_dir)
+    print("action-index: " + " ".join(f"{key}={value}" for key, value in summary.items()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_action_index.py
+++ b/tests/test_action_index.py
@@ -1,0 +1,78 @@
+"""Tests for the deterministic durable action index (#1005)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime.action_index import build_action_index, normalize_action
+
+
+def _write(path: Path, rows: list[dict] | list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(row if isinstance(row, str) else json.dumps(row))
+            fh.write("\n")
+
+
+def _seed_ledger(state: Path, cycle_id: str, title: str, outcome: str = "success") -> None:
+    _write(state / "ledger" / "cycles.jsonl", [
+        {"phase": "proposed", "cycle_id": cycle_id, "task_title": title},
+        {"phase": "outcome", "cycle_id": cycle_id, "outcome": outcome, "ts": "2026-08-25T01:00:00Z"},
+    ])
+
+
+def test_normalization_collapses_paths_and_commands():
+    assert normalize_action("read_file", {"path": "scripts/secret_name.py"}) == "read:scripts/*.py"
+    assert normalize_action("edit_file", {"path": "nanobot/runtime/action_index.py"}) == "edit:nanobot/*.py"
+    assert normalize_action("exec", {"command": "pytest tests/test_action_index.py -q"}) == "exec:pytest"
+    assert normalize_action("exec", {"command": "git commit -am done"}) == "exec:git-commit"
+
+
+def test_extracts_final_ordered_call_sequence_and_is_idempotent(tmp_path: Path):
+    cycle = "cycle-1"
+    _seed_ledger(tmp_path, cycle, "Build action index")
+    _write(tmp_path / "llm_calls" / "prompts" / "2026-08-25.jsonl", [
+        {"cycle_id": cycle, "seq": 1, "messages": [{"role": "assistant", "tool_calls": [
+            {"function": {"name": "read_file", "arguments": {"path": "lessons/old.md"}}},
+            {"function": {"name": "exec", "arguments": {"command": "pytest -q"}}},
+        ]}]},
+        {"cycle_id": cycle, "seq": 2, "messages": [{"role": "assistant", "tool_calls": [
+            {"function": {"name": "edit_file", "arguments": {"path": "scripts/final.py"}}},
+            {"function": {"name": "write_file", "arguments": {"path": "memory/facts/result.md"}}},
+        ]}]},
+    ])
+
+    first = build_action_index(tmp_path)
+    second = build_action_index(tmp_path)
+    rows = [json.loads(line) for line in (tmp_path / "action_index" / "2026-08-25.jsonl").read_text().splitlines()]
+    assert first["written"] == 1
+    assert second["written"] == 0
+    assert rows == [{
+        "cycle_id": cycle,
+        "ts": "2026-08-25T01:00:00Z",
+        "task_title": "Build action index",
+        "outcome": "success",
+        "actions": ["edit:scripts/*.py", "write:memory/*.md"],
+    }]
+
+
+def test_malformed_records_counted_and_backfill_processes_two_days(tmp_path: Path):
+    _seed_ledger(tmp_path, "cycle-a", "Day A")
+    with (tmp_path / "ledger" / "cycles.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"phase": "proposed", "cycle_id": "cycle-b", "task_title": "Day B"}) + "\n")
+        fh.write(json.dumps({"phase": "outcome", "cycle_id": "cycle-b", "outcome": "failed"}) + "\n")
+    _write(tmp_path / "llm_calls" / "prompts" / "2026-08-24.jsonl", [
+        '{bad json',
+        {"cycle_id": "cycle-a", "seq": 1, "messages": [{"role": "assistant", "tool_calls": []}]},
+    ])
+    _write(tmp_path / "llm_calls" / "prompts" / "2026-08-25.jsonl", [
+        {"cycle_id": "cycle-b", "seq": 1, "messages": [{"role": "assistant", "tool_calls": []}]},
+    ])
+
+    summary = build_action_index(tmp_path)
+    assert summary["skipped"] == 1
+    assert summary["written"] == 2
+    assert {p.name for p in (tmp_path / "action_index").glob("*.jsonl")} == {
+        "2026-08-24.jsonl", "2026-08-25.jsonl"
+    }


### PR DESCRIPTION
## Summary
- add a stdlib-only deterministic action extractor in `nanobot/runtime/action_index.py`
- extract the final prompt record per completed cycle and normalize tool-call templates
- persist compact daily JSONL with ledger title/outcome, idempotency, malformed-record counts, backfill, gzip/90-day retention
- run the extractor from the host timer before the daily prompt-rotation window and as a fail-open telemetry safety hook
- add focused unit coverage without changing existing golden/fixture expectations

## Verification
- Focused tests: `python -m pytest tests/test_action_index.py tests/test_llm_prompt_recording.py -q` — 17 passed
- Ledger regression tests: `python -m pytest tests/test_action_index.py tests/test_cycle_ledger.py -q` — 20 passed
- Full local pytest is blocked at collection by the known Windows `tests` package shadowing baseline (`ModuleNotFoundError: tests.test_cycle_ledger` / `tests.test_goal_backlog_routing`); no expectations were changed.
- `git diff origin/main...HEAD --check` — clean

### Required mechanism grep
`git diff origin/main...HEAD | rg -n 'action_index|build_action_index|normalize_action'` — matches the new state path/install/deploy/timer wiring, `build_action_index` integration, `normalize_action`, and focused tests; no missing `action_index` mechanism found.

## Rollout
After merge, run:
`bash host/eeepc/scripts/deploy_release.sh --host eeepc-lan`
Then verify the current release and `state/action_index/<today>.jsonl` on the host; quote a sample line in the issue completion comment.
