### PR TITLE
fix(runtime): bound action index memory (#1005)

### DIFF
--- a/nanobot/runtime/action_index.py
+++ b/nanobot/runtime/action_index.py
@@ -207,7 +207,7 @@ def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dic
                 if row.get("cycle_id"):
                     existing.add(str(row["cycle_id"]))
         ledger = _ledger_by_cycle(state_root)
-        grouped: dict[str, tuple[str, dict[str, Any]]] = {}
+        grouped: dict[str, tuple[str, str, list[str]]] = {}
         for path in _prompt_files(prompts_dir):
             day = _day_from_name(path.name)
             if not day:
@@ -220,11 +220,11 @@ def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dic
                     continue
                 current = grouped.get(cycle_id)
                 seq = record.get("seq") if isinstance(record.get("seq"), int) else -1
-                old_seq = current[1].get("seq", -1) if current else -1
+                old_seq = current[1] if current else -1
                 if current is None or seq >= old_seq:
-                    grouped[cycle_id] = (day, record)
+                    grouped[cycle_id] = (day, seq, _tool_calls(record))
         summary["cycles"] = len(grouped)
-        for cycle_id, (day, record) in grouped.items():
+        for cycle_id, (day, _seq, actions) in grouped.items():
             # A cycle is complete only once the ledger has a terminal row.
             # This prevents the prompt-record hook from indexing the first
             # call of a still-running cycle before later calls are captured.
@@ -233,10 +233,10 @@ def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dic
             row = ledger[cycle_id]
             output = {
                 "cycle_id": cycle_id,
-                "ts": record.get("ts") or row.get("ts") or "",
+                "ts": row.get("ts") or "",
                 "task_title": row.get("task_title"),
                 "outcome": row.get("outcome"),
-                "actions": _tool_calls(record),
+                "actions": actions,
             }
             output_path = index_dir / f"{day}.jsonl"
             with output_path.open("a", encoding="utf-8") as fh:

--- a/nanobot/runtime/action_index.py
+++ b/nanobot/runtime/action_index.py
@@ -29,10 +29,8 @@ def _day_from_name(name: str) -> str | None:
     return stem
 
 
-def _read_jsonl(path: Path) -> tuple[list[dict[str, Any]], int]:
-    """Read one capture/index file, returning records and malformed count."""
-    records: list[dict[str, Any]] = []
-    malformed = 0
+def _iter_jsonl(path: Path, stats: dict[str, int] | None = None) -> Iterable[dict[str, Any]]:
+    """Stream JSONL records without retaining large prompt files in memory."""
     opener = gzip.open if path.name.endswith(".gz") else open
     try:
         with opener(path, "rt", encoding="utf-8") as fh:  # type: ignore[call-arg]
@@ -42,20 +40,16 @@ def _read_jsonl(path: Path) -> tuple[list[dict[str, Any]], int]:
                 try:
                     value = json.loads(line)
                 except (json.JSONDecodeError, UnicodeDecodeError):
-                    malformed += 1
+                    if stats is not None:
+                        stats["skipped"] = stats.get("skipped", 0) + 1
                     continue
                 if isinstance(value, dict):
-                    records.append(value)
-                else:
-                    malformed += 1
+                    yield value
+                elif stats is not None:
+                    stats["skipped"] = stats.get("skipped", 0) + 1
     except (OSError, EOFError, gzip.BadGzipFile):
-        malformed += 1
-    return records, malformed
-
-
-def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
-    records, _ = _read_jsonl(path)
-    yield from records
+        if stats is not None:
+            stats["skipped"] = stats.get("skipped", 0) + 1
 
 
 def _prompt_files(prompts_dir: Path) -> list[Path]:
@@ -219,9 +213,7 @@ def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dic
             if not day:
                 continue
             summary["prompt_files"] += 1
-            records, malformed = _read_jsonl(path)
-            summary["skipped"] += malformed
-            for record in records:
+            for record in _iter_jsonl(path, summary):
                 cycle_id = str(record.get("cycle_id") or "").strip()
                 if not cycle_id or not isinstance(record.get("messages"), list):
                     summary["skipped"] += 1


### PR DESCRIPTION
Follow-up correction for merged #1009: stream prompt JSONL instead of materializing full daily prompt files, and retain only normalized actions for the latest record. Focused tests pass. Required because the first live verification exposed excessive memory use on the host.