### PR TITLE
feat(runtime): semantic proposer outcome digest (#997)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -782,14 +782,32 @@ def should_propose(state_dir: Path, selfevo_repo: Path | None) -> bool:
 
 
 def _digest_ledger(rows: list[dict[str, Any]], n: int = _LEDGER_DIGEST_ROWS) -> list[str]:
+    """Render recent outcomes with their proposed task meaning when available.
+
+    The outcome row is joined to its same-cycle ``proposed`` row. Legacy or
+    planner-authored outcomes without a proposal retain the branch fallback.
+    """
     tail = _terminal_rows(rows)[-n:]
+    title_by_cycle: dict[str, tuple[str, str]] = {}
+    for row in _proposed_rows(rows):
+        cycle_id = str(row.get("cycle_id") or "").strip()
+        title = str(row.get("task_title") or "").strip()
+        target = str(row.get("target_path") or "").strip()
+        if cycle_id and title:
+            title_by_cycle[cycle_id] = (title, target)
+
     lines: list[str] = []
     for row in tail:
         outcome = str(row.get("outcome") or "unknown")
-        reason = str(row.get("reason") or "").strip()
-        branch = str(row.get("branch") or row.get("cycle_id") or "").strip()
-        one_liner = f"{outcome}: {reason or branch or '(no detail)'}"
-        lines.append(one_liner[:160])
+        cycle_id = str(row.get("cycle_id") or "").strip()
+        proposal = title_by_cycle.get(cycle_id)
+        if proposal:
+            title, target = proposal
+            detail = f"{title[:120]} [{target}]" if target else title[:140]
+        else:
+            reason = str(row.get("reason") or "").strip()
+            detail = reason or str(row.get("branch") or cycle_id or "").strip() or "(no detail)"
+        lines.append(f"{outcome}: {detail}"[:160])
     return lines
 
 

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -62,9 +62,9 @@ def _append_proposed(state_dir: Path, cycle_id: str, task_title: str) -> None:
     )
 
 
-def _append_outcome(state_dir: Path, cycle_id: str, outcome: str) -> None:
+def _append_outcome(state_dir: Path, cycle_id: str, outcome: str, **extra) -> None:
     cycle_ledger.append_event(
-        state_dir, {"phase": "outcome", "cycle_id": cycle_id, "outcome": outcome}
+        state_dir, {"phase": "outcome", "cycle_id": cycle_id, "outcome": outcome, **extra}
     )
 
 
@@ -384,6 +384,29 @@ class TestHandledMarker:
 
 
 # ─── build_context ──────────────────────────────────────────────────────────
+
+
+def test_digest_ledger_joins_proposed_title_and_target():
+    rows = [
+        {"phase": "proposed", "cycle_id": "c1", "task_title": "Improve proposer context", "target_path": "nanobot/runtime/llm_proposer.py"},
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "branch": "selfevo/cycle-c1"},
+    ]
+    assert llm_proposer._digest_ledger(rows) == [
+        "success: Improve proposer context [nanobot/runtime/llm_proposer.py]"
+    ]
+
+
+def test_digest_ledger_falls_back_to_branch_without_proposal():
+    rows = [{"phase": "outcome", "cycle_id": "legacy", "outcome": "failed", "branch": "selfevo/cycle-legacy"}]
+    assert llm_proposer._digest_ledger(rows) == ["failed: selfevo/cycle-legacy"]
+
+
+def test_digest_ledger_bounds_joined_title_line():
+    rows = [
+        {"phase": "proposed", "cycle_id": "c1", "task_title": "x" * 300, "target_path": "scripts/x.py"},
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "partial"},
+    ]
+    assert len(llm_proposer._digest_ledger(rows)[0]) <= 160
 
 
 class TestBuildContext:


### PR DESCRIPTION
## Summary
- join each recent outcome with its matching `proposed` ledger row by `cycle_id`
- render semantic digest lines as `<outcome>: <task_title> [<target_path>]`
- retain the branch-name/reason fallback for legacy or planner-written outcomes without a matching proposal
- keep the existing 15-row digest and bounded context behavior

## Tests
- `python -m pytest --import-mode=importlib tests/test_llm_proposer.py -q` — 177 passed
- `python -m pytest --import-mode=importlib tests/test_llm_proposer_rotation.py -q` — 28 passed
- `git diff origin/main...HEAD --check` — clean

## Authorized golden updates
The issue explicitly authorizes golden-prompt updates. No standalone byte-exact golden prompt files existed in this checkout; the existing prompt assertions are semantic. The following test file was updated with the new digest-format expectations:
- `tests/test_llm_proposer.py` — added semantic join, legacy branch fallback, and 160-character bound fixtures.

No other conflicting test expectations were changed.

## Required mechanism grep
`git diff origin/main...HEAD | rg -n '_digest_ledger|title_by_cycle|task_title|target_path|branch fallback'`

Result: matches `_digest_ledger`, the `cycle_id` title/target join, semantic rendering, fallback documentation, and the three focused tests.

## Rollout
After merge:
`bash host/eeepc/scripts/deploy_release.sh --host eeepc-lan`

Then capture a proposer prompt from `state/llm_calls/prompts/` and quote the titled outcome lines on issue #997.
