### PR TITLE
feat(runtime): improve proposer efficiency diagnostics (#998)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -37,7 +37,7 @@ import os
 import re
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -185,6 +185,16 @@ _RECENT_FAILED_WINDOW_CYCLES = 15
 _MAX_LLM_CALLS = 3
 _MAX_CONSECUTIVE_NOOP_SKIPS = 3
 _MAX_SERVES_CHARS = 160
+_DEDUP_EXHAUSTION_K_ENV = "SELFEVO_DEDUP_EXHAUSTION_K"
+_DEDUP_EXHAUSTION_DAYS_ENV = "SELFEVO_DEDUP_EXHAUSTION_DAYS"
+_DEFAULT_DEDUP_EXHAUSTION_K = 2
+_DEFAULT_DEDUP_EXHAUSTION_DAYS = 3
+
+# Set only for the duration of a propose() call.  maybe_propose uses this
+# small process-local signal to distinguish a failed gateway call from a
+# response that arrived but was not valid JSON, without changing propose()'s
+# existing dict-or-None public contract.
+_last_propose_failure: str | None = None
 
 _PRIORITY_PATTERN = re.compile(
     r"\([A-Za-z]\)\s*Priority\s+(\d+)\s*[—-]\s*(.+?):\s*(.+?)(?=\n\([A-Za-z]\)|\Z)",
@@ -1598,6 +1608,52 @@ def _extract_json_object(text: str) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
+def _dedup_exhaustion_k() -> int:
+    try:
+        return max(1, int(os.environ.get(_DEDUP_EXHAUSTION_K_ENV, _DEFAULT_DEDUP_EXHAUSTION_K)))
+    except ValueError:
+        return _DEFAULT_DEDUP_EXHAUSTION_K
+
+
+def _dedup_exhaustion_days() -> int:
+    try:
+        return max(1, int(os.environ.get(_DEDUP_EXHAUSTION_DAYS_ENV, _DEFAULT_DEDUP_EXHAUSTION_DAYS)))
+    except ValueError:
+        return _DEFAULT_DEDUP_EXHAUSTION_DAYS
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _dedup_exhausted(state_dir: Path, demand_id: str) -> bool:
+    """Return whether this assigned demand has recent self-dedup exhaustion."""
+    if not demand_id:
+        return False
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=_dedup_exhaustion_days())
+        count = 0
+        for row in reversed(_load_ledger_rows(state_dir)):
+            if row.get("phase") != "proposer_reject":
+                continue
+            if row.get("reason") != "self_dedup" or str(row.get("demand_id") or "").strip() != demand_id:
+                continue
+            ts = _parse_ts(row.get("ts"))
+            if ts is not None and ts < cutoff:
+                break
+            count += 1
+            if count >= _dedup_exhaustion_k():
+                return True
+        return False
+    except Exception:
+        return False
+
+
 def propose(
     context: str,
     *,
@@ -1614,13 +1670,17 @@ def propose(
     Fails open (returns ``None``) on any missing config, network error, or
     unparseable reply — never raises.
     """
+    global _last_propose_failure
+    _last_propose_failure = None
     try:
         from openai import OpenAI
-    except Exception:
+    except Exception as exc:
+        _last_propose_failure = type(exc).__name__
         return None
     base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
     api_key = os.environ.get("LITELLM_API_KEY", "").strip()
     if not base_url or not api_key:
+        _last_propose_failure = "MissingGatewayConfiguration"
         return None
     user_content = context
     if rejection_reason:
@@ -1671,7 +1731,8 @@ def propose(
         except Exception:
             pass
         reply = content
-    except Exception:
+    except Exception as exc:
+        _last_propose_failure = f"{type(exc).__name__}: {exc}"
         return None
     return _extract_json_object(reply)
 
@@ -2616,13 +2677,19 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             return reason
 
         def _call_propose(rejection_reason: str | None = None) -> dict[str, Any] | None:
-            if demand_mode:
-                return propose(
-                    context,
-                    rejection_reason=rejection_reason,
-                    system_prompt=_DEMAND_PROPOSER_SYSTEM_PROMPT,
-                )
-            return propose(context, rejection_reason=rejection_reason)
+            global _last_propose_failure
+            _last_propose_failure = None
+            try:
+                if demand_mode:
+                    return propose(
+                        context,
+                        rejection_reason=rejection_reason,
+                        system_prompt=_DEMAND_PROPOSER_SYSTEM_PROMPT,
+                    )
+                return propose(context, rejection_reason=rejection_reason)
+            except Exception as exc:
+                _last_propose_failure = f"{type(exc).__name__}: {exc}"
+                return None
 
         def _proposal_demand_id(p: Any) -> str:
             return _demand_id_from_serves(p.get("serves")) if isinstance(p, dict) else ""
@@ -2640,6 +2707,12 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             return isinstance(v, str) and v.strip().lower() in ("true", "yes", "1")
 
         calls_made = 0
+        assigned_id = ""
+        if assigned and demand_items and isinstance(demand_items[0], dict):
+            assigned_id = str(demand_items[0].get("id") or "").strip()
+        if assigned_id and _dedup_exhausted(state_dir, assigned_id):
+            _record_noop_skip(state_dir, f"dedup_exhausted: demand {assigned_id}")
+            return None
 
         proposal = _call_propose()
         calls_made += 1
@@ -2668,13 +2741,18 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             return f"{reason_text}; reply={snippet}"
 
         if not ok:
-            # #762: double sizing failure — record what was rejected and why.
+            reject_reason = "llm_unavailable" if _last_propose_failure else "sizing_rejected"
+            detail = (
+                f"{_last_propose_failure}"
+                if _last_propose_failure
+                else _sizing_detail(reason, proposal)
+            )
             _record_proposer_reject(
                 state_dir,
-                "sizing_rejected",
+                reject_reason,
                 task_title=str((proposal or {}).get("task_title") or "") if isinstance(proposal, dict) else "",
                 target_path=str((proposal or {}).get("target_path") or "") if isinstance(proposal, dict) else "",
-                detail=_sizing_detail(reason, proposal),
+                detail=detail,
                 demand_id=_proposal_demand_id(proposal),
             )
             return None

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1539,6 +1539,19 @@ class TestProposeMockedClient:
         monkeypatch.delenv("LITELLM_API_KEY", raising=False)
         assert llm_proposer.propose("some context") is None
 
+    def test_network_failure_sets_unavailable_status(self, monkeypatch):
+        self._patch_client(monkeypatch, "unused")
+        class _FailingCompletions:
+            def create(self, **kwargs):
+                raise TimeoutError("gateway timeout")
+        class _FailingClient:
+            def __init__(self, *args, **kwargs):
+                self.chat = type("Chat", (), {"completions": _FailingCompletions()})()
+        import openai
+        monkeypatch.setattr(openai, "OpenAI", _FailingClient)
+        assert llm_proposer.propose("some context") is None
+        assert llm_proposer._last_propose_failure.startswith("TimeoutError")
+
 
 # ─── write_request — C1 schema equality ────────────────────────────────────
 
@@ -2127,11 +2140,27 @@ def _reject_rows(state_dir: Path) -> list[dict]:
     return [r for r in _ledger_rows(state_dir) if r.get("phase") == "proposer_reject"]
 
 
-def _append_reject(state_dir: Path, reason: str = "self_dedup") -> None:
-    cycle_ledger.append_event(state_dir, {"phase": "proposer_reject", "reason": reason})
+def _append_reject(state_dir: Path, reason: str = "self_dedup", **extra) -> None:
+    cycle_ledger.append_event(state_dir, {"phase": "proposer_reject", "reason": reason, **extra})
 
 
 class TestProposerRejectLedger:
+    def test_dedup_exhaustion_skips_before_llm_call(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        demand_id = "defect-exhausted"
+        for _ in range(llm_proposer._DEFAULT_DEDUP_EXHAUSTION_K):
+            _append_reject(state_dir, "self_dedup", demand_id=demand_id)
+        item = {"id": demand_id, "kind": "defect", "summary": "same issue", "evidence": "e"}
+        monkeypatch.setenv(demand.ENABLED_ENV, "1")
+        monkeypatch.setattr(llm_proposer, "should_propose", lambda *_: True)
+        monkeypatch.setattr(demand, "collect_demand", lambda *a, **k: [item])
+        monkeypatch.setattr(llm_proposer, "_select_assigned_demand", lambda *a, **k: [item])
+        monkeypatch.setattr(llm_proposer, "propose", lambda *a, **k: (_ for _ in ()).throw(AssertionError("LLM called")))
+        assert llm_proposer.maybe_propose(state_dir, None) is None
+        skips = [r for r in _ledger_rows(state_dir) if r.get("phase") == "proposer_skip"]
+        assert skips[-1]["reason"] == f"dedup_exhausted: demand {demand_id}"
+
     @pytest.fixture(autouse=True)
     def _enable(self, monkeypatch):
         monkeypatch.setenv(ENV_VAR, "1")
@@ -2244,7 +2273,7 @@ class TestProposerRejectLedger:
 
         rows = _reject_rows(state_dir)
         assert len(rows) == 1
-        assert rows[0]["reason"] == "error"
+        assert rows[0]["reason"] == "llm_unavailable"
         assert "RuntimeError" in rows[0]["detail"]
         assert "proposer exploded" in rows[0]["detail"]
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -94,6 +94,16 @@ class TestLoopSection:
         assert loop["repeat_failures"] == 2
         assert loop["repeat_failure_rate"] == 1.0
 
+    def test_new_proposer_reasons_do_not_count_as_repeat_failures(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_ledger(state_dir, [
+            {"phase": "proposed", "cycle_id": "c1", "ts": _iso(4)},
+            {"phase": "proposer_skip", "reason": "dedup_exhausted", "ts": _iso(3)},
+            {"phase": "proposer_reject", "reason": "llm_unavailable", "detail": "TimeoutError", "ts": _iso(2)},
+        ])
+        loop = scorecard.compute_scorecard(state_dir, None, force=True)["loop"]
+        assert loop["repeat_failures"] == 0
+
     def test_only_recent_duplicate_failure_skips_count_as_repeat_failures(self, tmp_path):
         """Healthy dedup skips (already_done, existence_index_duplicate) are
         not failures and must not feed repeat_failure_rate — only the


### PR DESCRIPTION
## Summary
- add deterministic pre-call `dedup_exhausted` short-circuit for assigned demand items
- classify gateway/network/timeout failures as `llm_unavailable` with exception detail
- preserve `sizing_rejected` for replies that arrived but failed validation
- add scorecard regression coverage proving both new reasons are excluded from repeat failures

## Verification
- `python -m pytest --import-mode=importlib tests/test_llm_proposer.py tests/test_scorecard.py -q` — 230 passed
- No unrelated golden/fixture expectations changed.
- `git diff --check` — clean

## Required mechanism grep
`git diff origin/main...HEAD | rg -n 'dedup_exhausted|llm_unavailable|_dedup_exhausted|repeat_failure'`

Result: matches the pre-call `dedup_exhausted` path, `llm_unavailable` classification, helper, scorecard regression, and related tests.

## Rollout
After merge:
`bash host/eeepc/scripts/deploy_release.sh --host eeepc-lan`

Then verify a natural `dedup_exhausted` or `llm_unavailable` ledger row and quote it on issue #998.
