### PR TITLE
feat(runtime): add decoupled per-cycle reflector (#1007)

### DIFF
--- a/host/eeepc/etc/presets/local_qwen.env
+++ b/host/eeepc/etc/presets/local_qwen.env
@@ -46,3 +46,6 @@ SELFEVO_MAX_TOOL_ITERATIONS=80
 # the proposer — cheap, known-live on this instance. Without this the
 # registry falls back to a default group that does not exist here.
 SELFEVO_CURATOR_MODEL=openai/an/gemini-3.7-flash-high
+# Reflector (#1007): per-cycle transcript analysis. Explicitly pinned because
+# the registry default may not exist on the eeepc LiteLLM.
+SELFEVO_REFLECTOR_MODEL=openai/an/gemini-3.7-flash-high

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -170,6 +170,8 @@ sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/curator 2>/dev/null
 sudo chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/curator 2>/dev/null || true
 sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/action_index 2>/dev/null || true
 sudo chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/action_index 2>/dev/null || true
+sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/reflector 2>/dev/null || true
+sudo chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/reflector 2>/dev/null || true
 
 echo "[remote] syncing libexec scripts from release"
 # Bridge is NOT copied since #601 — its unit runs `-m nanobot.runtime.bridge`
@@ -188,6 +190,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now eeepc-promotion-verifier.timer 2>/dev/null || true
 sudo systemctl enable --now eeebot-knowledge-curator.timer 2>/dev/null || true
 sudo systemctl enable --now eeebot-action-index.timer 2>/dev/null || true
+sudo systemctl enable --now eeebot-reflector.timer 2>/dev/null || true
 
 echo "[remote] current release: $(readlink /opt/eeepc-agent/runtimes/self-evolving-agent/current)"
 echo "[remote] done — commit $COMMIT"

--- a/host/eeepc/scripts/install.sh
+++ b/host/eeepc/scripts/install.sh
@@ -247,7 +247,7 @@ init_state() {
   # or inaccessible to it, state/usage included. Pre-creating it here means
   # the bind target exists on a fresh install (deploy_release.sh does the
   # same for deploy-only hosts).
-  for subdir in reports subagents/requests subagents/results improvements approvals goals outbox subagent_bridge workspace/subagents validator_harness usage curator action_index; do
+  for subdir in reports subagents/requests subagents/results improvements approvals goals outbox subagent_bridge workspace/subagents validator_harness usage curator action_index reflector; do
     run mkdir -p "$state/$subdir"
   done
   run chown -R eeepc-agent:eeepc-agent /var/lib/eeepc-agent
@@ -265,6 +265,7 @@ enable_timers() {
     eeebot-validator-harness.timer
     eeebot-knowledge-curator.timer
     eeebot-action-index.timer
+    eeebot-reflector.timer
   )
   for t in "${timers[@]}"; do
     run systemctl enable "$t"

--- a/host/eeepc/systemd/eeebot-reflector.service
+++ b/host/eeepc/systemd/eeebot-reflector.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Reflect on completed eeebot cycles (#1007)
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=eeepc-agent
+Group=eeepc-agent
+WorkingDirectory=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+EnvironmentFile=-/etc/eeepc-agent/preset.env
+EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env
+EnvironmentFile=/etc/eeepc-agent/litellm.env
+EnvironmentFile=-/etc/eeepc-agent/instances/self-evolving-subagent-bridge-workspace.env
+Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
+Environment=PYTHONDONTWRITEBYTECODE=1
+ExecStartPre=+/bin/mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/reflector
+ExecStartPre=+/bin/chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/reflector
+ExecStart=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.reflector --state-root /var/lib/eeepc-agent/self-evolving-agent/state
+TimeoutStartSec=900
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=false
+ProtectSystem=strict
+ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/reflector

--- a/host/eeepc/systemd/eeebot-reflector.timer
+++ b/host/eeepc/systemd/eeebot-reflector.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Reflect on completed eeebot cycles every 30 minutes (#1007)
+
+[Timer]
+OnBootSec=25m
+OnUnitActiveSec=30m
+Persistent=true
+Unit=eeebot-reflector.service
+
+[Install]
+WantedBy=timers.target

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -595,7 +595,7 @@ def _compile_defects(state_dir: Path, selfevo_repo: Path | None, head: str | Non
                         compile(source, str(py_path), "exec")
                     except SyntaxError as exc:
                         try:
-                            rel = str(py_path.relative_to(repo))
+                            rel = str(py_path.relative_to(repo)).replace("\\", "/")
                         except Exception:
                             rel = py_path.name
                         failures.append({"path": rel, "error": f"{type(exc).__name__}: {exc.msg} (line {exc.lineno})"})
@@ -1845,6 +1845,29 @@ def _emit_vector_split_event(state_dir: Path, items: list[dict[str, str]]) -> No
         pass
 
 
+def _reflection_items(state_dir: Path) -> list[dict[str, str]]:
+    """Turn reflector recommendations into normal, evidence-linked demand."""
+    items: list[dict[str, str]] = []
+    try:
+        path = Path(state_dir) / "reflector" / "reflections.jsonl"
+        if not path.is_file():
+            return items
+        for line in path.read_text(encoding="utf-8").splitlines():
+            row = json.loads(line)
+            if not isinstance(row, dict) or row.get("status") or not row.get("cycle_id"):
+                continue
+            for recommendation in row.get("recommendations") or []:
+                if not isinstance(recommendation, dict):
+                    continue
+                detail = str(recommendation.get("detail") or "").strip()
+                if detail:
+                    evidence = str(recommendation.get("evidence") or "").strip()
+                    items.append(_make_item("reflection", detail, f"cycle {row['cycle_id']}: {evidence}"))
+        return items
+    except Exception:
+        return items
+
+
 # ─── public entrypoint ──────────────────────────────────────────────────────
 
 
@@ -1894,6 +1917,7 @@ def collect_demand(
             _goal_gap_items(state_dir, selfevo_repo),
             _hypothesis_items(state_dir, selfevo_repo),
             _decay_items(state_dir, selfevo_repo, now),
+            _reflection_items(state_dir),
         ):
             for item in batch:
                 if item["id"] in seen_ids:

--- a/nanobot/runtime/model_registry.py
+++ b/nanobot/runtime/model_registry.py
@@ -31,7 +31,7 @@ import os
 
 # Role names, in a stable order — scorecard iterates this to report each
 # role's resolved model for control-plane visibility.
-ROLES: tuple[str, ...] = ("proposer", "executor", "harness", "summary", "coordinator", "curator")
+ROLES: tuple[str, ...] = ("proposer", "executor", "harness", "summary", "coordinator", "curator", "reflector")
 
 # Per-role env-var precedence (checked in list order, first non-empty wins)
 # and built-in default (used when explicit/env/config_fallback are all
@@ -43,6 +43,7 @@ _ROLE_ENV_VARS: dict[str, tuple[str, ...]] = {
     "summary": ("SELFEVO_SUMMARY_MODEL",),
     "coordinator": ("LITELLM_MODEL",),
     "curator": ("SELFEVO_CURATOR_MODEL", "SELFEVO_SUMMARY_MODEL"),
+    "reflector": ("SELFEVO_REFLECTOR_MODEL", "SELFEVO_SUMMARY_MODEL"),
 }
 
 _ROLE_DEFAULTS: dict[str, str] = {
@@ -52,6 +53,7 @@ _ROLE_DEFAULTS: dict[str, str] = {
     "summary": "cl/gemini-3.5-flash-low",
     "coordinator": "cl/gemini-3.5-flash-low",
     "curator": "cl/gemini-3.5-flash-low",
+    "reflector": "cl/gemini-3.5-flash-low",
 }
 
 

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -1,0 +1,241 @@
+"""Decoupled per-cycle transcript reflector (#1007)."""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
+from nanobot.runtime.model_registry import resolve_model
+
+_MAX_CYCLES = 10
+_MAX_RECOMMENDATIONS = 3
+_JOURNAL_TAIL = 10
+_MAX_TRANSCRIPT_CHARS = 48_000
+_MAX_LEDGER_CHARS = 12_000
+_MAX_JOURNAL_CHARS = 12_000
+_VALID_FINDINGS = {"wasted_steps", "error_pattern", "tool_misuse", "good_practice"}
+_VALID_RECOMMENDATIONS = {"skill_candidate", "instruction_change", "approach_hint"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _iter_jsonl(path: Path):
+    opener = gzip.open if path.name.endswith(".gz") else open
+    try:
+        with opener(path, "rt", encoding="utf-8") as fh:  # type: ignore[call-arg]
+            for line in fh:
+                try:
+                    value = json.loads(line)
+                    if isinstance(value, dict):
+                        yield value
+                except Exception:
+                    continue
+    except Exception:
+        return
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return list(_iter_jsonl(path))
+
+
+def _files(directory: Path, pattern: str) -> list[Path]:
+    return sorted([*directory.glob(pattern), *directory.glob(pattern + ".gz")])
+
+
+def _ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
+    directory = state_dir / "ledger"
+    rows: list[dict[str, Any]] = []
+    for path in [directory / "cycles.jsonl", *_files(directory, "cycles-*.jsonl")]:
+        if path.is_file():
+            rows.extend(_read_jsonl(path))
+    return rows
+
+
+def _prompt_records(state_dir: Path) -> dict[str, dict[str, Any]]:
+    directory = state_dir / "llm_calls" / "prompts"
+    latest: dict[str, dict[str, Any]] = {}
+    for path in _files(directory, "*.jsonl"):
+        for record in _iter_jsonl(path):
+            cycle_id = str(record.get("cycle_id") or "").strip()
+            if not cycle_id:
+                continue
+            sequence = record.get("seq") if isinstance(record.get("seq"), int) else -1
+            previous = latest.get(cycle_id)
+            if previous is None or sequence >= int(previous.get("seq") or -1):
+                latest[cycle_id] = record
+    return latest
+
+
+def _watermark_path(state_dir: Path) -> Path:
+    return state_dir / "reflector" / "watermark.json"
+
+
+def _load_watermark(state_dir: Path) -> str:
+    try:
+        value = json.loads(_watermark_path(state_dir).read_text(encoding="utf-8"))
+        return str(value.get("last_processed") or "") if isinstance(value, dict) else ""
+    except Exception:
+        return ""
+
+
+def _save_watermark(state_dir: Path, cycle_id: str) -> None:
+    path = _watermark_path(state_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".watermark.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"last_processed": cycle_id, "timestamp": _now()}, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def _append_journal(state_dir: Path, row: dict[str, Any]) -> None:
+    path = state_dir / "reflector" / "reflections.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
+def _journal_tail(state_dir: Path) -> list[dict[str, Any]]:
+    return _read_jsonl(state_dir / "reflector" / "reflections.jsonl")[-_JOURNAL_TAIL:]
+
+
+def _completed_cycles(rows: list[dict[str, Any]], watermark: str) -> list[dict[str, Any]]:
+    outcomes = [row for row in rows if row.get("phase") == "outcome" and row.get("cycle_id")]
+    outcomes.sort(key=lambda row: str(row.get("ts") or ""))
+    if not watermark:
+        return outcomes
+    for index, row in enumerate(outcomes):
+        if str(row.get("cycle_id")) == watermark:
+            return outcomes[index + 1 :]
+    return outcomes
+
+
+def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, Any]], journal: list[dict[str, Any]]) -> list[dict[str, str]]:
+    system = (
+        "Analyze every message, skill, command, tool call/result, error, retry, and detour in this completed cycle. "
+        "Return ONLY strict JSON with keys cycle_id, summary, findings, recommendations, followed_previous, and optional mermaid. "
+        "finding kind must be wasted_steps, error_pattern, tool_misuse, or good_practice. "
+        "recommendation kind must be skill_candidate, instruction_change, or approach_hint. "
+        "Each finding has kind/detail; each recommendation has kind/detail/evidence; return at most three recommendations. "
+        "Recommendations are steering only: do not edit files, invent evidence, or claim scorecard value."
+    )
+    user = (
+        f"CYCLE_ID: {cycle_id}\nTRANSCRIPT:\n{json.dumps(transcript, ensure_ascii=False)[:_MAX_TRANSCRIPT_CHARS]}\n"
+        f"LEDGER:\n{json.dumps(ledger, ensure_ascii=False)[:_MAX_LEDGER_CHARS]}\n"
+        f"PRIOR REFLECTIONS:\n{json.dumps(journal, ensure_ascii=False)[:_MAX_JOURNAL_CHARS]}"
+    )
+    return [{"role": "system", "content": system}, {"role": "user", "content": user}]
+
+
+def _parse_output(value: Any, cycle_id: str) -> dict[str, Any] | None:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except Exception:
+            return None
+    if not isinstance(value, dict) or str(value.get("cycle_id") or "") != cycle_id:
+        return None
+    if not isinstance(value.get("summary"), str) or not isinstance(value.get("findings"), list) or not isinstance(value.get("recommendations"), list):
+        return None
+    findings = []
+    for item in value["findings"]:
+        if not isinstance(item, dict) or item.get("kind") not in _VALID_FINDINGS or not str(item.get("detail") or "").strip():
+            return None
+        findings.append({"kind": item["kind"], "detail": str(item["detail"])[:1000]})
+    recommendations = []
+    for item in value["recommendations"][:_MAX_RECOMMENDATIONS]:
+        if not isinstance(item, dict) or item.get("kind") not in _VALID_RECOMMENDATIONS or not str(item.get("detail") or "").strip():
+            return None
+        recommendations.append({"kind": item["kind"], "detail": str(item["detail"])[:1000], "evidence": str(item.get("evidence") or "")[:1000]})
+    result = {
+        "cycle_id": cycle_id,
+        "summary": value["summary"][:2000],
+        "findings": findings,
+        "recommendations": recommendations,
+        "followed_previous": value.get("followed_previous") if isinstance(value.get("followed_previous"), list) else [],
+    }
+    if isinstance(value.get("mermaid"), str):
+        result["mermaid"] = value["mermaid"][:4000]
+    return result
+
+
+def _default_llm(messages: list[dict[str, str]], model: str, cycle_id: str) -> str:
+    from openai import OpenAI
+    base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
+    api_key = os.environ.get("LITELLM_API_KEY", "").strip()
+    if not base_url or not api_key:
+        raise RuntimeError("litellm credentials not configured")
+    started = time.monotonic()
+    response = OpenAI(base_url=base_url, api_key=api_key, timeout=120).chat.completions.create(model=model, messages=messages, max_tokens=1600, temperature=0.2)
+    choice = response.choices[0]
+    content = getattr(getattr(choice, "message", None), "content", "") or ""
+    usage_obj = getattr(response, "usage", None)
+    usage = {key: int(getattr(usage_obj, key, 0) or 0) for key in ("prompt_tokens", "completion_tokens", "total_tokens")}
+    with call_context(cycle_id, "reflector"):
+        record_llm_call(model=model, duration_ms=(time.monotonic() - started) * 1000, usage=usage, finish_reason=getattr(choice, "finish_reason", ""), retries=0)
+        record_llm_prompt(messages=messages, content=content, reasoning_content=None, finish_reason=getattr(choice, "finish_reason", ""), model=model, prompt_tokens=usage["prompt_tokens"], completion_tokens=usage["completion_tokens"])
+    return content
+
+
+def run_reflector(state_dir: Path, *, llm: Callable[[list[dict[str, str]], str], Any] | None = None, max_cycles: int = _MAX_CYCLES) -> dict[str, int]:
+    state_dir = Path(state_dir)
+    rows = _ledger_rows(state_dir)
+    candidates = _completed_cycles(rows, _load_watermark(state_dir))[:max(1, int(max_cycles))]
+    prompts = _prompt_records(state_dir)
+    result = {"candidates": len(candidates), "processed": 0, "skipped_pruned": 0, "errors": 0}
+    proposed = {str(row.get("cycle_id")): row for row in rows if row.get("phase") == "proposed"}
+    for outcome in candidates:
+        cycle_id = str(outcome["cycle_id"])
+        transcript = prompts.get(cycle_id)
+        if not transcript:
+            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Transcript already pruned; cycle skipped.", "findings": [], "recommendations": [], "followed_previous": [], "status": "skipped_pruned"})
+            _save_watermark(state_dir, cycle_id)
+            result["skipped_pruned"] += 1
+            continue
+        context_rows = [row for row in rows if str(row.get("cycle_id") or "") == cycle_id]
+        if cycle_id in proposed:
+            context_rows.insert(0, proposed[cycle_id])
+        try:
+            messages = _messages(cycle_id, transcript, context_rows, _journal_tail(state_dir))
+            model = resolve_model("reflector", strip_openai=True)
+            response = llm(messages, model) if llm else _default_llm(messages, model, cycle_id)
+            parsed = _parse_output(response, cycle_id)
+            if parsed is None:
+                raise ValueError("malformed reflector output")
+            _append_journal(state_dir, {**parsed, "timestamp": _now()})
+            _save_watermark(state_dir, cycle_id)
+            result["processed"] += 1
+        except Exception as exc:
+            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500]})
+            result["errors"] += 1
+            break
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Reflect on completed self-evolving cycles")
+    parser.add_argument("--state-root", type=Path, default=None)
+    args = parser.parse_args()
+    state = args.state_root or Path(os.environ.get("STATE_DIR", "/var/lib/eeepc-agent/self-evolving-agent/state"))
+    print("reflector: " + json.dumps(run_reflector(state), ensure_ascii=False, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -55,6 +55,10 @@ def test_golden_default_curator():
     assert resolve_model("curator") == "cl/gemini-3.5-flash-low"
 
 
+def test_golden_default_reflector():
+    assert resolve_model("reflector") == "cl/gemini-3.5-flash-low"
+
+
 def test_curator_env_override(monkeypatch):
     monkeypatch.setenv("SELFEVO_CURATOR_MODEL", "an/curator-model")
     assert resolve_model("curator") == "an/curator-model"
@@ -68,6 +72,7 @@ def test_roles_constant_covers_every_documented_role():
         "summary",
         "coordinator",
         "curator",
+        "reflector",
     }
 
 

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime import demand, model_registry, reflector
+
+
+def _write(path: Path, rows: list[dict] | list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(x if isinstance(x, str) else json.dumps(x) for x in rows) + "\n", encoding="utf-8")
+
+
+def _seed(state: Path, cycle: str = "c1") -> None:
+    _write(state / "ledger/cycles.jsonl", [
+        {"phase": "proposed", "cycle_id": cycle, "task_title": "Do work", "target_path": "scripts/a.py"},
+        {"phase": "gate", "cycle_id": cycle, "allowed": True},
+        {"phase": "outcome", "cycle_id": cycle, "outcome": "success", "ts": "2026-08-26T00:00:00Z"},
+    ])
+    _write(state / "llm_calls/prompts/2026-08-26.jsonl", [
+        {"cycle_id": cycle, "seq": 1, "messages": [{"role": "assistant", "tool_calls": [{"function": {"name": "read_file", "arguments": {"path": "scripts/a.py"}}}]}]},
+    ])
+
+
+def _answer(cycle: str = "c1") -> str:
+    return json.dumps({"cycle_id": cycle, "summary": "good", "findings": [{"kind": "good_practice", "detail": "bounded"}], "recommendations": [{"kind": "approach_hint", "detail": "reuse helper", "evidence": cycle}], "followed_previous": []})
+
+
+def test_reflector_journal_watermark_and_prior_tail(tmp_path: Path):
+    _seed(tmp_path)
+    seen = []
+    def llm(messages, model):
+        seen.append(messages[1]["content"])
+        return _answer()
+    assert reflector.run_reflector(tmp_path, llm=llm)["processed"] == 1
+    assert "PRIOR REFLECTIONS" in seen[0]
+    assert reflector.run_reflector(tmp_path, llm=llm)["processed"] == 0
+    assert (tmp_path / "reflector/reflections.jsonl").exists()
+
+
+def test_malformed_output_watermark_unmoved(tmp_path: Path):
+    _seed(tmp_path)
+    assert reflector.run_reflector(tmp_path, llm=lambda *_: "bad")["errors"] == 1
+    assert not (tmp_path / "reflector/watermark.json").exists()
+    assert json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])["status"] == "error"
+
+
+def test_pruned_transcript_is_journaled_and_watermarked(tmp_path: Path):
+    _write(tmp_path / "ledger/cycles.jsonl", [{"phase": "outcome", "cycle_id": "gone", "outcome": "failed"}])
+    result = reflector.run_reflector(tmp_path, llm=lambda *_: "bad")
+    assert result["skipped_pruned"] == 1
+    assert json.loads((tmp_path / "reflector/watermark.json").read_text())["last_processed"] == "gone"
+
+
+def test_recommendations_are_demand_items(tmp_path: Path):
+    _seed(tmp_path)
+    reflector.run_reflector(tmp_path, llm=lambda *_: _answer())
+    items = demand._reflection_items(tmp_path)
+    assert items and items[0]["kind"] == "reflection" and "cycle c1" in items[0]["evidence"]
+
+
+def test_reflector_model_override(monkeypatch):
+    monkeypatch.setenv("SELFEVO_REFLECTOR_MODEL", "an/reflection-model")
+    assert model_registry.resolve_model("reflector") == "an/reflection-model"


### PR DESCRIPTION
## Summary
- add a decoupled timer-paced reflector watcher; no bridge hook or execution wait
- process every completed outcome cycle from the watermark, including success/partial/failed
- analyze bounded final prompt record, cycle ledger rows, and reflector journal tail
- validate strict JSON findings/recommendations, write only `state/reflector/`, and retry malformed cycles without advancing watermark
- surface recommendations as normal `reflection` demand items with cycle evidence
- add `reflector` model-registry role and explicit local_qwen preset pin

## Binding safety
- Curator-style environment chain: `litellm.env` plus workspace override.
- No repo checkout writes.
- No scorecard/fitness consumer reads `state/reflector/`; grep below confirms no such path.
- Telemetry uses `component: reflector`.

## Tests
- `python -m pytest --import-mode=importlib tests/test_reflector.py tests/test_model_registry.py tests/test_demand.py tests/test_llm_prompt_recording.py -q` — 198 passed
- Existing model-registry exact-set golden was updated additively and narrowly as authorized in issue comment `issuecomment-5420825586`; all six existing roles/defaults remain unchanged.
- No other conflicting tests were found or changed.

## Required mechanism grep
`git diff origin/main...HEAD | rg -n 'component.*reflector|reflector|reflections.jsonl|watermark|_reflection_items|scorecard|fitness'`

Result: matches the reflector telemetry component, state journal, watermark, demand integration, model role, timer/service wiring, and the explicit no-fitness claim. No scorecard/fitness source reads reflector state.

## Rollout
After merge:
`bash host/eeepc/scripts/deploy_release.sh --host eeepc-lan`
Then enable/start `eeebot-reflector.timer` and quote natural journal evidence. If the first natural reflections need more time, leave issue at `status:test` with deployed+armed evidence.
