### PR TITLE
feat(runtime): suppress futile goal gaps

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1103,6 +1103,7 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
             current_direction = None
 
         items: list[dict[str, str]] = []
+        gap_rows: list[dict[str, Any]] = []
         for gap in scorecard.goal_gaps(state_dir, selfevo_repo)[:_MAX_GOAL_GAP_ITEMS]:
             metric = str(gap.get("metric") or "").strip()
             vector = str(gap.get("vector") or "").strip()
@@ -1123,15 +1124,22 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
                     direction = tech_tree.direction_for_metric(state_dir, metric) or ""
                 except Exception:
                     direction = ""
-            items.append(
-                _make_item(
+            item = _make_item(
                     "goal-gap",
                     f"goal gap: {metric} ({vector})",
                     rationale,
                     vector=vector,
                     direction=direction,
                 )
-            )
+            items.append(item)
+            gap_rows.append({**gap, "id": item["id"]})
+        try:
+            from nanobot.runtime import goal_gap_futility
+            futile_ids = goal_gap_futility.futile_gap_ids(state_dir, gap_rows)
+            if futile_ids:
+                items = [item for item in items if item.get("id") not in futile_ids]
+        except Exception:
+            pass
         if current_direction:
             items.sort(
                 key=lambda it: (

--- a/nanobot/runtime/goal_gap_futility.py
+++ b/nanobot/runtime/goal_gap_futility.py
@@ -1,0 +1,218 @@
+"""Deterministic goal-gap futility tracking (#996).
+
+Stdlib-only and fail-open.  The demand layer supplies current scorecard gaps;
+this module records bounded observations and suppresses a gap only after a
+bounded number of successful integrated proposals without metric movement.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_THRESHOLD = 10
+_DEFAULT_TTL_DAYS = 14
+_EPSILON = 1e-6
+_MAX_LEDGER_BYTES = 2 * 1024 * 1024
+
+
+def _threshold() -> int:
+    try:
+        return max(1, int(os.environ.get("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "10")))
+    except (TypeError, ValueError):
+        return _DEFAULT_THRESHOLD
+
+
+def _ttl_days() -> int:
+    try:
+        return max(1, int(os.environ.get("SELFEVO_GOAL_GAP_FUTILITY_TTL_DAYS", "14")))
+    except (TypeError, ValueError):
+        return _DEFAULT_TTL_DAYS
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sidecar(state_dir: Path) -> Path:
+    return Path(state_dir) / "demand" / "futility.json"
+
+
+def _load(state_dir: Path) -> dict[str, dict[str, Any]]:
+    try:
+        data = json.loads(_sidecar(state_dir).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save(state_dir: Path, records: dict[str, dict[str, Any]]) -> None:
+    try:
+        target = _sidecar(state_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temp = target.with_name(f".{target.name}.tmp")
+        temp.write_text(json.dumps(records, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        temp.replace(target)
+    except Exception:
+        pass
+
+
+def _rows(state_dir: Path) -> list[dict[str, Any]]:
+    try:
+        path = Path(state_dir) / "ledger" / "cycles.jsonl"
+        if not path.is_file() or path.stat().st_size > _MAX_LEDGER_BYTES:
+            return []
+        result = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(row, dict):
+                result.append(row)
+        return result
+    except Exception:
+        return []
+
+
+def _integrated_count(state_dir: Path, gap_id: str, after: datetime) -> int:
+    proposed: set[str] = set()
+    successful: set[str] = set()
+    for row in _rows(state_dir):
+        cycle = str(row.get("cycle_id") or "").strip()
+        if not cycle:
+            continue
+        ts = _parse_ts(row.get("ts") or row.get("timestamp"))
+        if ts is None or ts <= after:
+            continue
+        if row.get("phase") == "proposed" and str(row.get("demand_id") or "") == gap_id:
+            proposed.add(cycle)
+        elif row.get("phase") == "outcome" and row.get("outcome") == "success":
+            # Current bridge success is an integrated cycle.  Legacy explicit
+            # integrated=False remains excluded if present.
+            if row.get("integrated", True) is not False:
+                successful.add(cycle)
+    return len(proposed & successful)
+
+
+def _delta(first: Any, current: Any) -> float | None:
+    try:
+        return round(float(current) - float(first), 12)
+    except (TypeError, ValueError):
+        return None
+
+
+def _improved(direction: str, first: Any, current: Any) -> bool:
+    try:
+        delta = float(current) - float(first)
+    except (TypeError, ValueError):
+        return False
+    if direction == "max":
+        return delta < -_EPSILON
+    if direction == "min":
+        return delta > _EPSILON
+    return False
+
+
+def _emit(state_dir: Path, record: dict[str, Any], futile: bool) -> None:
+    try:
+        from nanobot.runtime.cycle_ledger import append_event
+        append_event(state_dir, {
+            "phase": "goal_gap_futile",
+            "gap_id": record.get("gap_id", ""),
+            "metric": record.get("metric", ""),
+            "attempt_count": record.get("attempt_count", 0),
+            "metric_delta": record.get("metric_delta"),
+            "futile": futile,
+        })
+    except Exception:
+        pass
+
+
+def _update(state_dir: Path, gap: dict[str, Any], records: dict[str, dict[str, Any]], now: datetime) -> bool:
+    gap_id = str(gap.get("id") or "").strip()
+    if not gap_id:
+        return False
+    record = records.get(gap_id)
+    if not isinstance(record, dict):
+        record = {
+            "gap_id": gap_id,
+            "metric": str(gap.get("metric") or ""),
+            "first_seen_ts": _iso(now),
+            "first_metric": gap.get("current"),
+            "current_metric": gap.get("current"),
+            "metric_delta": 0.0,
+            "attempt_count": 0,
+            "futile": False,
+        }
+    until = _parse_ts(record.get("futile_until"))
+    if until is not None and now < until:
+        record["current_metric"] = gap.get("current")
+        record["metric_delta"] = _delta(record.get("first_metric"), gap.get("current"))
+        records[gap_id] = record
+        return True
+    if until is not None and now >= until:
+        record = {
+            "gap_id": gap_id,
+            "metric": str(gap.get("metric") or ""),
+            "first_seen_ts": _iso(now),
+            "first_metric": gap.get("current"),
+            "current_metric": gap.get("current"),
+            "metric_delta": 0.0,
+            "attempt_count": 0,
+            "futile": False,
+        }
+    first_seen = _parse_ts(record.get("first_seen_ts")) or now
+    record["metric"] = str(gap.get("metric") or record.get("metric") or "")
+    record["current_metric"] = gap.get("current")
+    record["metric_delta"] = _delta(record.get("first_metric"), gap.get("current"))
+    record["attempt_count"] = _integrated_count(state_dir, gap_id, first_seen)
+    now_futile = (
+        record["attempt_count"] >= _threshold()
+        and not _improved(str(gap.get("direction") or ""), record.get("first_metric"), gap.get("current"))
+    )
+    was_futile = bool(record.get("futile")) and until is not None and now < until
+    record["futile"] = now_futile
+    if now_futile:
+        record["futile_until"] = _iso(now + timedelta(days=_ttl_days()))
+    else:
+        record.pop("futile_until", None)
+    records[gap_id] = record
+    if now_futile != was_futile:
+        _emit(state_dir, record, now_futile)
+    return now_futile
+
+
+def futile_gap_ids(state_dir: Path, gaps: list[dict[str, Any]]) -> set[str]:
+    """Update current gaps and return the IDs currently suppressed."""
+    try:
+        records = _load(state_dir)
+        now = datetime.now(timezone.utc)
+        result = {str(gap.get("id")) for gap in gaps if _update(state_dir, gap, records, now)}
+        _save(state_dir, records)
+        return {item for item in result if item}
+    except Exception:
+        return set()
+
+
+def futility_snapshot(state_dir: Path) -> dict[str, Any]:
+    try:
+        records = _load(state_dir)
+        return {
+            "futile_gap_ids": sorted(key for key, value in records.items() if value.get("futile")),
+            "total_tracked": len(records),
+        }
+    except Exception:
+        return {"futile_gap_ids": [], "total_tracked": 0}

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -113,6 +113,8 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     # unrelated '*_compact*.py' module is not silently swept in by name
     # alone); this explicit entry is the only protection.
     'nanobot/runtime/context_compaction.py',
+    # #996: deterministic goal-gap futility tracking and suppression.
+    'nanobot/runtime/goal_gap_futility.py',
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -288,6 +288,12 @@ def _control_plane_snapshot(state_dir: 'Path | None' = None) -> dict[str, Any]:
     snapshot["hypothesis_loop"] = _hypothesis_loop_snapshot(state_dir)
     snapshot["tech_tree"] = _tech_tree_snapshot(state_dir)
     snapshot["models"] = _models_snapshot()
+    # #996: visibility-only futility state; never feeds metric computation.
+    try:
+        from nanobot.runtime import goal_gap_futility
+        snapshot["goal_gap_futility"] = goal_gap_futility.futility_snapshot(state_dir)
+    except Exception:
+        snapshot["goal_gap_futility"] = {}
     for key in _CONTROL_PLANE_KEYS:
         try:
             snapshot[key] = os.environ.get(key)

--- a/tests/test_goal_gap_futility.py
+++ b/tests/test_goal_gap_futility.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime import goal_gap_futility as futility
+
+
+def _gap(gap_id="goal-gap-x", current=0.5, direction="max"):
+    return {"id": gap_id, "metric": "repeat_failure_rate", "current": current, "target": 0.3, "direction": direction}
+
+
+def _row(state, gap_id, cycle, ts):
+    path = Path(state) / "ledger" / "cycles.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"phase": "proposed", "cycle_id": cycle, "demand_id": gap_id, "ts": ts}) + "\n")
+        fh.write(json.dumps({"phase": "outcome", "cycle_id": cycle, "outcome": "success", "integrated": True, "ts": ts}) + "\n")
+
+
+def test_futile_gap_suppresses_flat_metric_and_records_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "3")
+    state = tmp_path / "state"
+    assert futility.futile_gap_ids(state, [_gap()]) == set()
+    first = datetime.now(timezone.utc).isoformat()
+    for i in range(3):
+        _row(state, "goal-gap-x", f"c{i}", first)
+    assert "goal-gap-x" in futility.futile_gap_ids(state, [_gap()])
+    rec = json.loads((state / "demand" / "futility.json").read_text())["goal-gap-x"]
+    assert {"gap_id", "metric", "attempt_count", "metric_delta"} <= rec.keys()
+    rows = [json.loads(x) for x in (state / "ledger" / "cycles.jsonl").read_text().splitlines() if "goal_gap_futile" in x]
+    assert rows and rows[-1]["metric"] == "repeat_failure_rate"
+
+
+def test_improved_metric_not_suppressed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "2")
+    state = tmp_path / "state"
+    assert futility.futile_gap_ids(state, [_gap()]) == set()
+    ts = datetime.now(timezone.utc).isoformat()
+    for i in range(2):
+        _row(state, "goal-gap-x", f"c{i}", ts)
+    assert futility.futile_gap_ids(state, [_gap(current=0.1)]) == set()
+
+
+def test_suppression_expires_after_ttl(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "1")
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_TTL_DAYS", "1")
+    state = tmp_path / "state"
+    assert futility.futile_gap_ids(state, [_gap()]) == set()
+    ts = datetime.now(timezone.utc).isoformat()
+    _row(state, "goal-gap-x", "c0", ts)
+    assert "goal-gap-x" in futility.futile_gap_ids(state, [_gap()])
+    path = state / "demand" / "futility.json"
+    data = json.loads(path.read_text())
+    data["goal-gap-x"]["futile_until"] = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    path.write_text(json.dumps(data))
+    assert futility.futile_gap_ids(state, [_gap()]) == set()
+
+
+def test_deny_set_contains_module():
+    from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES
+    assert "nanobot/runtime/goal_gap_futility.py" in _RUNTIME_DENY_ALWAYS_FILES
+
+
+def test_no_llm_and_snapshot(tmp_path):
+    source = Path("nanobot/runtime/goal_gap_futility.py").read_text()
+    assert not any(token in source for token in ("openai", "litellm", "LLMProvider"))
+    assert futility.futility_snapshot(tmp_path / "state") == {"futile_gap_ids": [], "total_tracked": 0}

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -994,12 +994,11 @@ class TestControlPlaneSnapshot:
         state_dir = tmp_path / "state"
         snap = scorecard.compute_scorecard(state_dir, None, force=True)
         control_plane = snap["control_plane"]
-        # #875/#876/#899: runtime_promotions + runtime_trust_ladder + models
-        # are fixed extra keys (not env-driven), so they are asserted
-        # separately rather than folded into the allowlist.
+        # #875/#876/#899/#996: fixed visibility keys (not env-driven) are
+        # asserted separately rather than folded into the allowlist.
         assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {
             "runtime_promotions", "runtime_trust_ladder", "evolution_tree", "hypothesis_loop",
-            "tech_tree", "models",
+            "tech_tree", "models", "goal_gap_futility",
         }
         assert all(control_plane[key] is None for key in scorecard._CONTROL_PLANE_KEYS)
         assert control_plane["runtime_promotions"] == {"active": 0, "soaking": 0, "rejected": 0}
@@ -1078,7 +1077,7 @@ class TestControlPlaneSnapshot:
         control_plane = snap["control_plane"]
         assert set(control_plane.keys()) == set(scorecard._CONTROL_PLANE_KEYS) | {
             "runtime_promotions", "runtime_trust_ladder", "evolution_tree", "hypothesis_loop",
-            "tech_tree", "models",
+            "tech_tree", "models", "goal_gap_futility",
         }
 
     def test_no_secret_ever_appears_in_serialized_scorecard(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Implements #996 deterministic goal-gap futility suppression.

`nanobot/runtime/goal_gap_futility.py` is a 218-line stdlib-only, deny-set-protected module with no LLM/provider imports. It tracks per-gap first/current metric values, metric delta, and integrated proposal counts from bounded cycle-ledger reads. After the configurable threshold (default 10) without directional improvement beyond epsilon, it writes one `goal_gap_futile` ledger event, records `state/demand/futility.json`, and suppresses the gap until the configurable TTL (default 14 days). Improved metrics are never suppressed; expired records reset. Failures fail open.

`demand.py` contains only a read hook into the module. Scorecard control-plane visibility is extended additively with the authorized `goal_gap_futility` key; the two exact-set goldens were extended without changing any existing key or assertion style, per https://github.com/ozand/eeebot/issues/996#issuecomment-5421424640.

## Key-term diff check
Before opening this PR:
`git diff origin/main...HEAD | grep -ni -E 'goal_gap_futile|goal_gap_futility'`
matched the module, demand hook, deny-set registration, scorecard visibility, and tests.

## Acceptance criteria -> named tests
- Flat metric suppression + sidecar/event -> `test_futile_gap_suppresses_flat_metric_and_records_fields`
- Improved metric not suppressed -> `test_improved_metric_not_suppressed`
- TTL expiry -> `test_suppression_expires_after_ttl`
- Record fields -> same flat suppression test
- Deny-set and no LLM -> `test_deny_set_contains_module`, `test_no_llm_and_snapshot`
- Demand read hook -> `nanobot/runtime/demand.py::_goal_gap_items` imports and calls the module only; existing demand suite remains green
- Scorecard visibility/additive exact sets -> `TestControlPlaneSnapshot::test_section_present_with_all_allowlisted_keys` and `::test_no_key_outside_the_allowlist_ever_appears`

Focused validation: 187 passed across goal-gap futility, demand, and scorecard suites; ruff passed. Full pytest and CI are required before merge.