### PR TITLE
feat(demand): mine recurring action sequences for skills

### DIFF
--- a/host/eeepc/systemd/eeebot-action-index.service
+++ b/host/eeepc/systemd/eeebot-action-index.service
@@ -9,6 +9,7 @@ Group=eeepc-agent
 Environment=PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 Environment=PYTHONDONTWRITEBYTECODE=1
 ExecStart=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.action_index --state-root /var/lib/eeepc-agent/self-evolving-agent/state
+ExecStartPost=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.skill_candidate_mining --state-root /var/lib/eeepc-agent/self-evolving-agent/state --repo /var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving
 ProtectHome=false
 ProtectSystem=strict
 ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/action_index

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -52,7 +52,7 @@ Demand kinds, in trust order (see ``docs/changes/760-demand-driven-proposer/``):
   here, and the metric moves only if that work happens. Bounded to
   :data:`_MAX_VALIDATOR_DEFECTS`; fail-open: any error or a missing sidecar
   yields no validator demand.
-- ``goal-gap`` (#765, ordered between ``defect`` and ``hypothesis``) —
+- ``goal-gap`` (#765, ordered between ``defect`` and ``skill-candidate``) —
   scorecard metrics violating their goal-derived target
   (``nanobot.runtime.scorecard.goal_gaps``): the deterministic fitness
   snapshot's gap analysis, targets derived from the ORDERED goal vectors
@@ -66,6 +66,7 @@ Demand kinds, in trust order (see ``docs/changes/760-demand-driven-proposer/``):
   completed goal-gap id is re-presented after
   :data:`_GOAL_GAP_COMPLETED_TTL_DAYS` days — a metric can legitimately
   regress. All other kinds keep permanent completed-suppression.
+- ``skill-candidate`` (#1006, ordered after ``defect`` and before ``hypothesis``) — deterministic recurring action sequences that qualify for packaging as skills.
 - ``hypothesis`` — ONLY hypotheses carrying measurement evidence: a
   non-empty ``evidence`` or ``metric`` field, or an ``acceptance`` text that
   references a file path actually present in the instance repo. The chronic
@@ -1190,6 +1191,25 @@ def _hypothesis_has_evidence(entry: dict[str, Any], selfevo_repo: Path | None) -
     return False
 
 
+def _skill_candidate_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str, str]]:
+    """Read deterministic recurring-action skill candidates (#1006)."""
+    try:
+        from nanobot.runtime import skill_candidate_mining
+        items = []
+        for candidate in skill_candidate_mining.mine(state_dir, selfevo_repo):
+            sequence = candidate.get("sequence") or []
+            text = " -> ".join(str(x) for x in sequence)
+            evidence = (
+                f"recurs in {candidate.get('cycles', 0)} distinct cycles over "
+                f"{candidate.get('days', 0)} days; samples: "
+                + ", ".join(str(x) for x in (candidate.get("samples") or [])[:3])
+            )
+            items.append(_make_item("skill-candidate", f"package recurring procedure: {text}", evidence))
+        return items
+    except Exception:
+        return []
+
+
 def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str, str]]:
     items: list[dict[str, str]] = []
     seen: set[str] = set()
@@ -1923,6 +1943,7 @@ def collect_demand(
             _tamper_defect_items(state_dir, selfevo_repo),
             _repair_unused_items(state_dir, selfevo_repo, now),
             _goal_gap_items(state_dir, selfevo_repo),
+            _skill_candidate_items(state_dir, selfevo_repo),
             _hypothesis_items(state_dir, selfevo_repo),
             _decay_items(state_dir, selfevo_repo, now),
             _reflection_items(state_dir),

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -115,6 +115,8 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     'nanobot/runtime/context_compaction.py',
     # #996: deterministic goal-gap futility tracking and suppression.
     'nanobot/runtime/goal_gap_futility.py',
+    # #1006: deterministic action-index recurrence miner.
+    'nanobot/runtime/skill_candidate_mining.py',
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without

--- a/nanobot/runtime/skill_candidate_mining.py
+++ b/nanobot/runtime/skill_candidate_mining.py
@@ -1,0 +1,162 @@
+"""Deterministic recurring-action skill candidate miner (#1006)."""
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_WINDOW_DAYS = 30
+_DEFAULT_MIN_CYCLES = 8
+_DEFAULT_MIN_DAYS = 3
+_MAX_SAMPLES = 3
+_DEFAULT_NGRAMS = (2, 3, 4, 5)
+_TRIVIAL = frozenset({
+    ("exec:pytest", "exec:git-commit"),
+    ("exec:pytest", "exec:git-commit", "exec:git-push"),
+})
+
+
+def _trivial_patterns() -> frozenset[tuple[str, ...]]:
+    """Return built-in loop patterns plus operator comma-separated additions.
+
+    Format: ``exec:pytest>exec:git-commit``. This is an operator environment
+    knob, not instance state, so the instance cannot disable suppression.
+    """
+    extra = os.environ.get("SELFEVO_SKILL_CANDIDATE_DENY", "")
+    patterns = set(_TRIVIAL)
+    for raw in extra.split(","):
+        parts = tuple(part.strip() for part in raw.split(">") if part.strip())
+        if len(parts) >= 2:
+            patterns.add(parts)
+    return frozenset(patterns)
+
+
+def _int_env(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.environ.get(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _iter_rows(state_dir: Path, window_days: int) -> list[dict[str, Any]]:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
+    index_dir = Path(state_dir) / "action_index"
+    paths = sorted([*index_dir.glob("*.jsonl"), *index_dir.glob("*.jsonl.gz")])
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        try:
+            opener = gzip.open if path.name.endswith(".gz") else open
+            with opener(path, "rt", encoding="utf-8") as fh:  # type: ignore[call-arg]
+                for line in fh:
+                    try:
+                        row = json.loads(line)
+                    except Exception:
+                        continue
+                    if not isinstance(row, dict) or not isinstance(row.get("actions"), list):
+                        continue
+                    ts = _parse_ts(row.get("ts"))
+                    if ts is not None and ts >= cutoff:
+                        rows.append(row)
+        except (OSError, EOFError, gzip.BadGzipFile):
+            continue
+    return rows
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _grams(actions: list[str]) -> list[tuple[str, ...]]:
+    result = []
+    for n in _DEFAULT_NGRAMS:
+        result.extend(tuple(actions[i:i+n]) for i in range(len(actions) - n + 1))
+    return result
+
+
+def _is_subsequence(short: tuple[str, ...], long: tuple[str, ...]) -> bool:
+    return len(short) < len(long) and any(long[i:i+len(short)] == short for i in range(len(long) - len(short) + 1))
+
+
+def _existing_skill_match(sequence: tuple[str, ...], selfevo_repo: Path | None) -> bool:
+    if not selfevo_repo:
+        return False
+    try:
+        needle = " ".join(sequence).lower()
+        for path in (Path(selfevo_repo) / "skills").glob("*/SKILL.md"):
+            text = path.read_text(encoding="utf-8", errors="replace").lower()
+            if needle in text or all(token in text for token in sequence):
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, Any]]:
+    """Return longest qualifying recurring n-grams; fail-open to empty."""
+    try:
+        min_cycles = _int_env("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", _DEFAULT_MIN_CYCLES)
+        min_days = _int_env("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", _DEFAULT_MIN_DAYS)
+        stats: dict[tuple[str, ...], dict[str, Any]] = defaultdict(lambda: {"cycles": set(), "days": set(), "samples": []})
+        for row in _iter_rows(Path(state_dir), _int_env("SELFEVO_SKILL_CANDIDATE_WINDOW_DAYS", _DEFAULT_WINDOW_DAYS)):
+            cycle = str(row.get("cycle_id") or "")
+            day = str(row.get("ts") or "")[:10]
+            if not cycle or not day:
+                continue
+            seen = set(_grams([str(a) for a in row["actions"]]))
+            for gram in seen:
+                stats[gram]["cycles"].add(cycle)
+                stats[gram]["days"].add(day)
+                if len(stats[gram]["samples"]) < _MAX_SAMPLES:
+                    stats[gram]["samples"].append(cycle)
+        trivial = _trivial_patterns()
+        qualifying = {
+            gram: data for gram, data in stats.items()
+            if len(data["cycles"]) >= min_cycles
+            and len(data["days"]) >= min_days
+            and gram not in trivial
+        }
+        selected = {}
+        for gram, data in qualifying.items():
+            if any(_is_subsequence(gram, other) for other in qualifying):
+                continue
+            if _existing_skill_match(gram, selfevo_repo):
+                continue
+            selected[gram] = data
+        return [
+            {
+                "sequence": list(gram),
+                "cycles": len(data["cycles"]),
+                "days": len(data["days"]),
+                "samples": data["samples"],
+            }
+            for gram, data in sorted(selected.items(), key=lambda item: (-len(item[0]), item[0]))
+        ]
+    except Exception:
+        return []
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Mine recurring action sequences for skill candidates")
+    parser.add_argument("--state-root", type=Path, default=None)
+    parser.add_argument("--repo", type=Path, default=None)
+    args = parser.parse_args()
+    state = args.state_root or Path(os.environ.get("STATE_DIR", Path.home() / ".nanobot"))
+    candidates = mine(state, args.repo)
+    print(json.dumps({"candidates": candidates, "count": len(candidates)}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skill_candidate_mining.py
+++ b/tests/test_skill_candidate_mining.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.runtime import demand
+from nanobot.runtime.skill_candidate_mining import mine
+
+
+def _write_rows(state: Path, rows: list[dict]) -> None:
+    path = state / "action_index" / "2026-08-01.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _rows(count: int = 10) -> list[dict]:
+    return [
+        {
+            "cycle_id": f"cycle-{i}",
+            "ts": f"2026-08-{i + 1:02d}T12:00:00Z",
+            "actions": ["read:scripts/*.py", "exec:pytest", "edit:scripts/*.py"],
+        }
+        for i in range(1, count + 1)
+    ]
+
+
+def test_longest_recurrent_ngram_collapses_prefix(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    _write_rows(tmp_path, _rows())
+    candidates = mine(tmp_path, None)
+    assert len(candidates) == 1
+    assert candidates[0]["sequence"] == ["read:scripts/*.py", "exec:pytest", "edit:scripts/*.py"]
+    assert candidates[0]["cycles"] == 10
+    assert candidates[0]["days"] == 10
+    assert candidates[0]["samples"] == ["cycle-1", "cycle-2", "cycle-3"]
+
+
+def test_trivial_and_below_threshold_patterns_are_suppressed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    rows = _rows(7)
+    rows.extend({**row, "cycle_id": "trivial-" + row["cycle_id"], "actions": ["exec:pytest", "exec:git-commit"]} for row in _rows(10))
+    _write_rows(tmp_path, rows)
+    candidates = mine(tmp_path, None)
+    assert candidates == []
+
+
+def test_candidate_enters_demand_and_completed_candidate_is_suppressed(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    _write_rows(tmp_path, _rows())
+    items = demand._skill_candidate_items(tmp_path, None)
+    assert len(items) == 1
+    assert items[0]["kind"] == "skill-candidate"
+    assert "recurs in 10 distinct cycles" in items[0]["evidence"]
+    completed = tmp_path / "demand" / "completed.json"
+    completed.parent.mkdir(parents=True, exist_ok=True)
+    completed.write_text(json.dumps({"entries": {items[0]["id"]: {"ts": "2026-08-10T00:00:00Z"}}}), encoding="utf-8")
+    collected = demand.collect_demand(tmp_path, None)
+    assert not any(item["id"] == items[0]["id"] for item in collected)
+
+
+def test_candidate_kind_is_ordered_before_hypothesis(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    _write_rows(tmp_path, _rows())
+    monkeypatch.setattr(demand, "_priority_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_ledger_defects", lambda *_: [])
+    monkeypatch.setattr(demand, "_result_file_defects", lambda *_: [])
+    monkeypatch.setattr(demand, "_compile_defects", lambda *_: [])
+    monkeypatch.setattr(demand, "_heldout_defect_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_validator_defect_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_tamper_defect_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_repair_unused_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_goal_gap_items", lambda *_: [{"kind": "goal-gap", "id": "gap", "summary": "gap", "evidence": "", "affected_path": "", "vector": "V1", "direction": ""}])
+    monkeypatch.setattr(demand, "_hypothesis_items", lambda *_: [{"kind": "hypothesis", "id": "hyp", "summary": "hyp", "evidence": "", "affected_path": "", "vector": "", "direction": ""}])
+    monkeypatch.setattr(demand, "_decay_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_reflection_items", lambda *_: [])
+    kinds = [item["kind"] for item in demand.collect_demand(tmp_path, None)]
+    assert kinds == ["goal-gap", "skill-candidate", "hypothesis"]
+
+
+def test_existing_skill_suppresses_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    _write_rows(tmp_path, _rows())
+    skill = tmp_path / "skills" / "repeat-review" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Repeat review\n\nread:scripts/*.py exec:pytest edit:scripts/*.py\n", encoding="utf-8")
+    assert mine(tmp_path, tmp_path) == []
+
+
+def test_no_llm_dependency_and_window_is_bounded(tmp_path, monkeypatch):
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_WINDOW_DAYS", "30")
+    source = Path("nanobot/runtime/skill_candidate_mining.py").read_text(encoding="utf-8")
+    assert not any(token in source for token in ("openai", "litellm", "LLMProvider"))
+    _write_rows(tmp_path, [{**_rows(1)[0], "ts": "2020-01-01T00:00:00Z"}])
+    assert mine(tmp_path, None) == []


### PR DESCRIPTION
## Summary
Implements #1006 deterministic recurring-action skill-candidate mining over the prerequisite #1005 action index.

`nanobot/runtime/skill_candidate_mining.py` is stdlib-only and 162 LOC. It scans the trailing configurable action-index window (plain and gzip JSONL), counts contiguous n-grams of length 2..5 by distinct cycle and day, applies configurable thresholds (defaults 8 cycles / 3 days), suppresses built-in/operator-denied trivial patterns, collapses qualifying subsequences in favor of the longest form, and skips sequences already represented by an existing skills/*/SKILL.md. It exposes a small CLI run immediately after the action-index extractor in the existing systemd service.

`demand.py` adds only the collection hook and emits `skill-candidate` after goal-gap and before hypothesis. Existing completed-demand suppression applies to the stable item ID, so integrated skill candidates are suppressed by the normal completion lifecycle.

## Key mechanism grep
Before opening this PR:
`git diff origin/main...HEAD | grep -ni -E 'skill-candidate|skill_candidate'`
matched the demand kind, collection hook, deny-set registration, miner, action-index service pickup, and tests.

## Acceptance criteria -> named tests
- 3-step recurrence / longest form / counts / sample cycles -> `test_longest_recurrent_ngram_collapses_prefix`
- Sub-sequence collapse -> same test (exactly one candidate)
- Trivial deny-list and below-threshold -> `test_trivial_and_below_threshold_patterns_are_suppressed`
- Demand kind + ordering -> `test_candidate_enters_demand_and_completed_candidate_is_suppressed`, `test_candidate_kind_is_ordered_before_hypothesis`
- Integrated-skill/existing skill suppression -> `test_existing_skill_suppresses_candidate` and completed sidecar assertion
- No LLM -> `test_no_llm_dependency_and_window_is_bounded`; source contains no provider/LLM imports
- Deny-set -> `nanobot/runtime/runtime_deny.py` registration and source test coverage

Focused validation: `tests/test_skill_candidate_mining.py tests/test_action_index.py tests/test_demand.py`: 140 passed; ruff and diff checks passed. Full pytest is required before merge; known Windows baseline failures will be listed exactly.