### PR TITLE
fix(runtime): complete targeted reflector reprocess (#1007)

### DIFF
--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -219,13 +219,14 @@ def run_reflector(state_dir: Path, *, llm: Callable[[list[dict[str, str]], str],
     # A previously skipped cycle is eligible again when its retained plain or
     # gzip transcript is now discoverable; only keep the skip terminal when no
     # transcript exists in either archive form.
+    result["candidates"] = len(candidates)
+    prompts = _prompt_records(state_dir, candidates)
     candidates = [
         row for row in candidates
         if str(row.get("cycle_id") or "") not in skipped_ids
         or str(row.get("cycle_id") or "") in prompts
     ]
     result["candidates"] = len(candidates)
-    prompts = _prompt_records(state_dir, candidates)
     proposed = {str(row.get("cycle_id")): row for row in rows if row.get("phase") == "proposed"}
     for outcome in candidates:
         cycle_id = str(outcome["cycle_id"])


### PR DESCRIPTION
Fixes the live NameError found during #1007 reprocess: retained skipped-cycle filtering now occurs after targeted candidate-date transcript lookup. Focused tests: 7 passed. Grep: `git diff origin/main...HEAD | rg -n "_prompt_records|skipped_pruned|prompts"` confirms lookup/filter ordering. No unrelated golden changes.