### PR TITLE
fix(demand): harden skill candidate sidecar pipeline

### DIFF
--- a/host/eeepc/systemd/eeebot-action-index.service
+++ b/host/eeepc/systemd/eeebot-action-index.service
@@ -13,5 +13,6 @@ ExecStartPost=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.skill_candidat
 ProtectHome=false
 ProtectSystem=strict
 ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/action_index
+ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/demand
 NoNewPrivileges=true
 PrivateTmp=true

--- a/nanobot/runtime/action_index.py
+++ b/nanobot/runtime/action_index.py
@@ -96,6 +96,11 @@ def _known_workspace_roots(state_root: Path | None = None) -> tuple[str, ...]:
         os.environ.get("RELEASE_ROOT", ""),
         str(state_root.parent / "eeebot-self-evolving") if state_root else "",
         "/opt/eeepc-agent/runtimes/self-evolving-agent/current",
+        # F4: also strip state_root so reads of state/*.json etc. become
+        # "state/*.ext" templates rather than the legacy "var/*.ext" pattern
+        # that resulted when the full /var/lib/... path was not recognized.
+        str(state_root.parent) if state_root else "",
+        str(state_root) if state_root else "",
     ):
         if value:
             root = posixpath.normpath(value.replace("\\", "/")).rstrip("/")
@@ -234,8 +239,22 @@ def _rotate_and_prune(index_dir: Path, today: str) -> None:
                 pass
 
 
-def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dict[str, int]:
-    """Extract present prompt files into the durable index; never raises."""
+def build_action_index(
+    state_root: Path,
+    prompts_dir: Path | None = None,
+    *,
+    force_regenerate: bool = False,
+) -> dict[str, int]:
+    """Extract present prompt files into the durable index; never raises.
+
+    F4: when ``force_regenerate=True`` (or env ``ACTION_INDEX_FORCE_REGEN=1``)
+    existing index day-files are deleted and rebuilt from source prompts that
+    are still present, so stale ``var/*`` legacy templates are rewritten with
+    the corrected path stripping (including state_root).  Only days whose
+    source prompt file still exists are regenerated; day-files with no source
+    are left intact to preserve history.
+    """
+    force_regenerate = force_regenerate or os.environ.get("ACTION_INDEX_FORCE_REGEN", "") == "1"
     summary = {
         "prompt_files": 0,
         "cycles": 0,
@@ -244,11 +263,31 @@ def build_action_index(state_root: Path, prompts_dir: Path | None = None) -> dic
         "skipped_incomplete": 0,
         "skipped_write_error": 0,
         "malformed_records": 0,
+        "force_regenerated": 0,
     }
     try:
         prompts_dir = prompts_dir or state_root / "llm_calls" / "prompts"
         index_dir = state_root / "action_index"
         index_dir.mkdir(parents=True, exist_ok=True)
+
+        # F4: forced regeneration — delete existing day-files whose source
+        # prompt day-file still exists so they are rebuilt with corrected
+        # workspace_roots (state_root stripped → "state/*.ext" templates).
+        if force_regenerate:
+            prompt_days: set[str] = set()
+            for path in _prompt_files(prompts_dir):
+                day = _day_from_name(path.name)
+                if day:
+                    prompt_days.add(day)
+            for path in list(_prompt_files(index_dir)):
+                day = _day_from_name(path.name)
+                if day and day in prompt_days:
+                    try:
+                        path.unlink(missing_ok=True)
+                        summary["force_regenerated"] += 1
+                    except OSError:
+                        pass
+
         existing: set[str] = set()
         for path in _prompt_files(index_dir):
             for row in _iter_jsonl(path):
@@ -312,9 +351,15 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Build the durable per-cycle action index")
     parser.add_argument("--state-root", type=Path, default=None)
     parser.add_argument("--prompts-dir", type=Path, default=None)
+    parser.add_argument(
+        "--force-regen",
+        action="store_true",
+        default=False,
+        help="F4: delete and rebuild existing index day-files whose source prompt file still exists",
+    )
     args = parser.parse_args()
     state_root = args.state_root or Path(os.environ.get("STATE_DIR", Path.home() / ".nanobot"))
-    summary = build_action_index(state_root, args.prompts_dir)
+    summary = build_action_index(state_root, args.prompts_dir, force_regenerate=args.force_regen)
     print("action-index: " + " ".join(f"{key}={value}" for key, value in summary.items()))
     return 0
 

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1192,11 +1192,16 @@ def _hypothesis_has_evidence(entry: dict[str, Any], selfevo_repo: Path | None) -
 
 
 def _skill_candidate_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str, str]]:
-    """Read deterministic recurring-action skill candidates (#1006)."""
+    """Read deterministic recurring-action skill candidates (#1006).
+
+    F2: reads ONLY from the pre-computed sidecar written by the daily
+    action-index job (``skill_candidate_mining.write_sidecar``).  No
+    mining scan occurs in the cycle path.
+    """
     try:
         from nanobot.runtime import skill_candidate_mining
         items = []
-        for candidate in skill_candidate_mining.mine(state_dir, selfevo_repo):
+        for candidate in skill_candidate_mining.read_sidecar(state_dir):
             sequence = candidate.get("sequence") or []
             text = " -> ".join(str(x) for x in sequence)
             evidence = (

--- a/nanobot/runtime/skill_candidate_mining.py
+++ b/nanobot/runtime/skill_candidate_mining.py
@@ -1,9 +1,21 @@
-"""Deterministic recurring-action skill candidate miner (#1006)."""
+"""Deterministic recurring-action skill candidate miner (#1006).
+
+Architecture (F2): mining runs in the DAILY job (ExecStartPost on the
+action-index service) and writes a sidecar at
+``state/demand/skill_candidates.json``.  ``demand.py`` reads only that
+sidecar — no mining occurs in the cycle path.
+
+Sidecar schema: ``{"schema": "skill-candidates-v1", "written_at": <iso>,
+"candidates": [{"sequence": [...], "cycles": N, "days": N, "samples": [...]}]}``.
+The top-N cap (default 3, env ``SELFEVO_SKILL_CANDIDATE_TOP_N``) is applied
+before writing, so demand presentation always has a bounded load.
+"""
 from __future__ import annotations
 
 import gzip
 import json
 import os
+import tempfile
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -14,10 +26,45 @@ _DEFAULT_MIN_CYCLES = 8
 _DEFAULT_MIN_DAYS = 3
 _MAX_SAMPLES = 3
 _DEFAULT_NGRAMS = (2, 3, 4, 5)
+_DEFAULT_TOP_N = 3
+
+_SIDECAR_SCHEMA = "skill-candidates-v1"
+
+# F3: a candidate must contain at least one state-changing or executing action.
+# Pure read/list n-grams are denied categorically (not via enumerated deny-list).
+_MEANINGFUL_PREFIXES = ("exec:", "edit:", "write:")
+
+# F4: legacy var/* templates polluted by pre-#1011 backfill.  Miner skips any
+# action template that starts with "var/" regardless of suffix.
+_LEGACY_VAR_PREFIX = "var/"
+
 _TRIVIAL = frozenset({
     ("exec:pytest", "exec:git-commit"),
     ("exec:pytest", "exec:git-commit", "exec:git-push"),
 })
+
+
+def _is_meaningful(sequence: tuple[str, ...]) -> bool:
+    """F3: true iff the sequence contains at least one exec/edit/write action."""
+    return any(a.startswith(_MEANINGFUL_PREFIXES) for a in sequence)
+
+
+def _has_legacy_var(sequence: tuple[str, ...]) -> bool:
+    """F4: true iff any action's path template is a legacy var/* form.
+
+    Action templates have the form ``prefix:path_template`` (e.g.
+    ``read:var/*.py``) or just a bare template (e.g. ``var/lib/*``).  Both
+    patterns are matched: the part after the first colon must not start with
+    ``var/``, and the whole token must not start with ``var/`` either.
+    """
+    for a in sequence:
+        # bare var/* token (no colon)
+        if a.startswith(_LEGACY_VAR_PREFIX):
+            return True
+        # prefix:var/* e.g. read:var/*.py
+        if ":" in a and a.split(":", 1)[1].startswith(_LEGACY_VAR_PREFIX):
+            return True
+    return False
 
 
 def _trivial_patterns() -> frozenset[tuple[str, ...]]:
@@ -102,10 +149,16 @@ def _existing_skill_match(sequence: tuple[str, ...], selfevo_repo: Path | None) 
 
 
 def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, Any]]:
-    """Return longest qualifying recurring n-grams; fail-open to empty."""
+    """Return longest qualifying recurring n-grams; fail-open to empty.
+
+    F3: candidates must contain at least one exec/edit/write action.
+    F4: actions matching var/* legacy templates are rejected entirely.
+    Results are ranked by (cycles × days) descending, then capped to top-N.
+    """
     try:
         min_cycles = _int_env("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", _DEFAULT_MIN_CYCLES)
         min_days = _int_env("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", _DEFAULT_MIN_DAYS)
+        top_n = _int_env("SELFEVO_SKILL_CANDIDATE_TOP_N", _DEFAULT_TOP_N)
         stats: dict[tuple[str, ...], dict[str, Any]] = defaultdict(lambda: {"cycles": set(), "days": set(), "samples": []})
         for row in _iter_rows(Path(state_dir), _int_env("SELFEVO_SKILL_CANDIDATE_WINDOW_DAYS", _DEFAULT_WINDOW_DAYS)):
             cycle = str(row.get("cycle_id") or "")
@@ -114,6 +167,9 @@ def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, An
                 continue
             seen = set(_grams([str(a) for a in row["actions"]]))
             for gram in seen:
+                # F4: skip any gram containing a legacy var/* template
+                if _has_legacy_var(gram):
+                    continue
                 stats[gram]["cycles"].add(cycle)
                 stats[gram]["days"].add(day)
                 if len(stats[gram]["samples"]) < _MAX_SAMPLES:
@@ -124,6 +180,7 @@ def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, An
             if len(data["cycles"]) >= min_cycles
             and len(data["days"]) >= min_days
             and gram not in trivial
+            and _is_meaningful(gram)  # F3: categorical pure-read/list denial
         }
         selected = {}
         for gram, data in qualifying.items():
@@ -132,6 +189,11 @@ def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, An
             if _existing_skill_match(gram, selfevo_repo):
                 continue
             selected[gram] = data
+        # Rank by (cycles × days) descending for deterministic top-N selection
+        ranked = sorted(
+            selected.items(),
+            key=lambda item: (-len(item[1]["cycles"]) * len(item[1]["days"]), item[0]),
+        )
         return [
             {
                 "sequence": list(gram),
@@ -139,8 +201,68 @@ def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, An
                 "days": len(data["days"]),
                 "samples": data["samples"],
             }
-            for gram, data in sorted(selected.items(), key=lambda item: (-len(item[0]), item[0]))
+            for gram, data in ranked[:top_n]
         ]
+    except Exception:
+        return []
+
+
+def _sidecar_path(state_dir: Path) -> Path:
+    return Path(state_dir) / "demand" / "skill_candidates.json"
+
+
+def write_sidecar(state_dir: Path, selfevo_repo: Path | None = None) -> dict[str, Any]:
+    """Mine candidates and write the sidecar (F1+F2: daily job entry point).
+
+    Returns a summary dict for CLI output.
+    """
+    candidates = mine(state_dir, selfevo_repo)
+    sidecar = {
+        "schema": _SIDECAR_SCHEMA,
+        "written_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "candidates": candidates,
+    }
+    path = _sidecar_path(state_dir)
+    temporary: str | None = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(sidecar, indent=2, ensure_ascii=False) + "\n"
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False
+        ) as fh:
+            temporary = fh.name
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temporary, path)
+        temporary = None
+    except OSError:
+        pass
+    finally:
+        if temporary:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+    return {"written": len(candidates), "path": str(path)}
+
+
+def read_sidecar(state_dir: Path) -> list[dict[str, Any]]:
+    """Read candidates from the sidecar (F2: demand cycle path entry point).
+
+    Returns empty list on any error or missing/stale sidecar.
+    """
+    try:
+        path = _sidecar_path(state_dir)
+        if not path.is_file():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schema") != _SIDECAR_SCHEMA:
+            return []
+        candidates = data.get("candidates")
+        if not isinstance(candidates, list):
+            return []
+        return candidates
     except Exception:
         return []
 
@@ -148,13 +270,13 @@ def mine(state_dir: Path, selfevo_repo: Path | None = None) -> list[dict[str, An
 def main() -> int:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Mine recurring action sequences for skill candidates")
+    parser = argparse.ArgumentParser(description="Mine recurring action sequences and write skill-candidate sidecar")
     parser.add_argument("--state-root", type=Path, default=None)
     parser.add_argument("--repo", type=Path, default=None)
     args = parser.parse_args()
     state = args.state_root or Path(os.environ.get("STATE_DIR", Path.home() / ".nanobot"))
-    candidates = mine(state, args.repo)
-    print(json.dumps({"candidates": candidates, "count": len(candidates)}, ensure_ascii=False))
+    summary = write_sidecar(state, args.repo)
+    print(json.dumps(summary, ensure_ascii=False))
     return 0
 
 

--- a/tests/test_skill_candidate_mining.py
+++ b/tests/test_skill_candidate_mining.py
@@ -4,7 +4,12 @@ import json
 from pathlib import Path
 
 from nanobot.runtime import demand
-from nanobot.runtime.skill_candidate_mining import mine
+from nanobot.runtime.skill_candidate_mining import (
+    _has_legacy_var,
+    _is_meaningful,
+    mine,
+    write_sidecar,
+)
 
 
 def _write_rows(state: Path, rows: list[dict]) -> None:
@@ -27,6 +32,7 @@ def _rows(count: int = 10) -> list[dict]:
 def test_longest_recurrent_ngram_collapses_prefix(tmp_path, monkeypatch):
     monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
     monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_TOP_N", "10")
     _write_rows(tmp_path, _rows())
     candidates = mine(tmp_path, None)
     assert len(candidates) == 1
@@ -50,6 +56,8 @@ def test_candidate_enters_demand_and_completed_candidate_is_suppressed(tmp_path,
     monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
     monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
     _write_rows(tmp_path, _rows())
+    # F1+F2: write sidecar first, then demand reads it
+    write_sidecar(tmp_path, None)
     items = demand._skill_candidate_items(tmp_path, None)
     assert len(items) == 1
     assert items[0]["kind"] == "skill-candidate"
@@ -65,6 +73,8 @@ def test_candidate_kind_is_ordered_before_hypothesis(tmp_path, monkeypatch):
     monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
     monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
     _write_rows(tmp_path, _rows())
+    # F2: pre-write sidecar so demand path reads it
+    write_sidecar(tmp_path, None)
     monkeypatch.setattr(demand, "_priority_items", lambda *_: [])
     monkeypatch.setattr(demand, "_ledger_defects", lambda *_: [])
     monkeypatch.setattr(demand, "_result_file_defects", lambda *_: [])
@@ -97,3 +107,232 @@ def test_no_llm_dependency_and_window_is_bounded(tmp_path, monkeypatch):
     assert not any(token in source for token in ("openai", "litellm", "LLMProvider"))
     _write_rows(tmp_path, [{**_rows(1)[0], "ts": "2020-01-01T00:00:00Z"}])
     assert mine(tmp_path, None) == []
+
+
+# ── F1: top-N cap regression ─────────────────────────────────────────────────
+
+def test_f1_top_n_cap_default_three(tmp_path, monkeypatch):
+    """F1: write_sidecar caps candidates to top-N (default 3)."""
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    # Produce 4+ distinct qualifying sequences by using 4 different 3-grams
+    rows = []
+    for i in range(10):
+        rows.append({
+            "cycle_id": f"cycle-a-{i}",
+            "ts": f"2026-08-{i + 1:02d}T12:00:00Z",
+            "actions": ["exec:git-log", "exec:grep", "edit:scripts/*.py"],
+        })
+        rows.append({
+            "cycle_id": f"cycle-b-{i}",
+            "ts": f"2026-08-{i + 1:02d}T13:00:00Z",
+            "actions": ["exec:find", "exec:grep", "write:scripts/*.py"],
+        })
+        rows.append({
+            "cycle_id": f"cycle-c-{i}",
+            "ts": f"2026-08-{i + 1:02d}T14:00:00Z",
+            "actions": ["exec:python3", "exec:grep", "edit:tests/*.py"],
+        })
+        rows.append({
+            "cycle_id": f"cycle-d-{i}",
+            "ts": f"2026-08-{i + 1:02d}T15:00:00Z",
+            "actions": ["exec:sed", "exec:grep", "write:tests/*.py"],
+        })
+    _write_rows(tmp_path, rows)
+    summary = write_sidecar(tmp_path, None)
+    assert summary["written"] <= 3
+    sidecar_data = json.loads((tmp_path / "demand" / "skill_candidates.json").read_text(encoding="utf-8"))
+    assert len(sidecar_data["candidates"]) <= 3
+    assert sidecar_data["schema"] == "skill-candidates-v1"
+
+
+def test_f1_sidecar_write_is_atomic(tmp_path, monkeypatch):
+    """F1: sidecar publication replaces the file atomically."""
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    _write_rows(tmp_path, _rows())
+    write_sidecar(tmp_path, None)
+    sidecar = tmp_path / "demand" / "skill_candidates.json"
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["schema"] == "skill-candidates-v1"
+    assert not list(sidecar.parent.glob(f".{sidecar.name}.*.tmp"))
+
+
+def test_f1_sidecar_ranked_by_cycles_times_days(tmp_path, monkeypatch):
+    """F1: sidecar candidates are ranked by cycles×days descending."""
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_TOP_N", "10")
+    # Sequence A: 10 cycles over 10 distinct days (score 100)
+    # Sequence B: 8 cycles over 5 distinct days (score 40)
+    rows = []
+    for i in range(10):
+        rows.append({
+            "cycle_id": f"cycle-a-{i}",
+            "ts": f"2026-08-{i + 1:02d}T12:00:00Z",
+            "actions": ["exec:git-log", "exec:grep", "edit:scripts/*.py"],
+        })
+    for i in range(8):
+        rows.append({
+            "cycle_id": f"cycle-b-{i}",
+            "ts": f"2026-08-{(i % 5) + 1:02d}T13:00:00Z",
+            "actions": ["exec:find", "exec:grep", "write:scripts/*.py"],
+        })
+    _write_rows(tmp_path, rows)
+    candidates = mine(tmp_path, None)
+    assert len(candidates) >= 2
+    # highest score must come first
+    assert candidates[0]["cycles"] * candidates[0]["days"] >= candidates[1]["cycles"] * candidates[1]["days"]
+
+
+# ── F2: no mining in cycle path regression ────────────────────────────────────
+
+def test_f2_collect_demand_does_not_call_mine(tmp_path, monkeypatch):
+    """F2: collect_demand must not invoke mine() — only reads the sidecar."""
+    import nanobot.runtime.skill_candidate_mining as scm
+
+    def _mine_should_not_be_called(*args, **kwargs):
+        raise AssertionError("mine() was called from the cycle path — F2 regression")
+
+    monkeypatch.setattr(scm, "mine", _mine_should_not_be_called)
+    # No sidecar written → read_sidecar returns [] → no candidates, no mine() call
+    result = demand._skill_candidate_items(tmp_path, None)
+    assert result == []
+
+    # With a sidecar present: still must not call mine()
+    sidecar_path = tmp_path / "demand" / "skill_candidates.json"
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text(json.dumps({
+        "schema": "skill-candidates-v1",
+        "written_at": "2026-08-26T00:00:00Z",
+        "candidates": [{
+            "sequence": ["exec:grep", "edit:scripts/*.py"],
+            "cycles": 10,
+            "days": 5,
+            "samples": ["cycle-1"],
+        }],
+    }), encoding="utf-8")
+    result2 = demand._skill_candidate_items(tmp_path, None)
+    assert len(result2) == 1
+    assert result2[0]["kind"] == "skill-candidate"
+
+
+# ── F3: categorical pure-read/list denial ─────────────────────────────────────
+
+def test_f3_pure_read_ngram_is_rejected(tmp_path, monkeypatch):
+    """F3: n-grams with only read/list actions must never qualify as candidates."""
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    rows = [
+        {
+            "cycle_id": f"cycle-{i}",
+            "ts": f"2026-08-{i + 1:02d}T12:00:00Z",
+            "actions": ["read:scripts/*.py", "read:tests/*.py", "list:*"],
+        }
+        for i in range(1, 11)
+    ]
+    _write_rows(tmp_path, rows)
+    candidates = mine(tmp_path, None)
+    # all grams are pure read/list → nothing qualifies
+    assert candidates == []
+
+
+def test_f3_is_meaningful_helper():
+    """F3: _is_meaningful correctly identifies meaningful vs pure-read sequences."""
+    assert _is_meaningful(("exec:pytest", "read:scripts/*.py"))
+    assert _is_meaningful(("edit:scripts/*.py", "read:tests/*.py"))
+    assert _is_meaningful(("write:scripts/*.py",))
+    assert not _is_meaningful(("read:scripts/*.py", "read:tests/*.py"))
+    assert not _is_meaningful(("list:*", "read:var/*.py"))
+
+
+# ── F4: legacy var/* template denial ─────────────────────────────────────────
+
+def test_f4_legacy_var_template_ignored_by_miner(tmp_path, monkeypatch):
+    """F4: action templates starting with var/ must be skipped by the miner."""
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "8")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "3")
+    rows = [
+        {
+            "cycle_id": f"cycle-{i}",
+            "ts": f"2026-08-{i + 1:02d}T12:00:00Z",
+            "actions": ["read:var/*.py", "exec:cd", "exec:cd"],
+        }
+        for i in range(1, 11)
+    ]
+    _write_rows(tmp_path, rows)
+    candidates = mine(tmp_path, None)
+    # var/* grams must be excluded
+    for candidate in candidates:
+        for action in candidate["sequence"]:
+            assert not action.startswith("var/"), f"Legacy var/* action leaked: {action}"
+
+
+def test_f4_has_legacy_var_helper():
+    """F4: _has_legacy_var detects legacy templates."""
+    assert _has_legacy_var(("read:var/*.py", "exec:cd"))
+    assert _has_legacy_var(("var/lib/something",))
+    assert not _has_legacy_var(("read:scripts/*.py", "exec:grep"))
+    assert not _has_legacy_var(("exec:cd", "edit:tests/*.py"))
+
+
+def test_f4_state_root_stripped_produces_state_template(tmp_path):
+    """F4: action_index strips state_root so paths produce state/* templates."""
+    from nanobot.runtime.action_index import _known_workspace_roots, _path_template
+    state_root = tmp_path / "state"
+    workspace_roots = _known_workspace_roots(state_root)
+    # A path inside state_root should strip to a relative path
+    test_path = str(state_root / "demand" / "skill_candidates.json")
+    result = _path_template(test_path, workspace_roots)
+    # Must not start with "var/" — should be stripped to something relative
+    assert result is not None
+    assert not result.startswith("var/"), f"Path template leaked var/: {result}"
+
+
+def test_f4_force_regen_rebuilds_existing_day_files(tmp_path):
+    """F4: force_regenerate=True deletes and rebuilds day files from source prompts."""
+    from datetime import datetime, timezone
+
+    from nanobot.runtime.action_index import build_action_index
+
+    # Use today's date to prevent immediate archival (archive_cutoff > 7 days ago)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # Create a fake prompt day file
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    prompt_path = prompts_dir / f"{today}.jsonl"
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir()
+    # Write a ledger row
+    cycle_id = "cycle-force-regen-test"
+    (ledger_dir / "cycles.jsonl").write_text(
+        json.dumps({"cycle_id": cycle_id, "phase": "outcome", "outcome": "success", "ts": f"{today}T12:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    # Write a prompt with a tool call
+    msg = {"role": "assistant", "tool_calls": [{"function": {"name": "exec", "arguments": '{"command": "grep foo scripts/"}'}}]}
+    prompt_path.write_text(
+        json.dumps({"cycle_id": cycle_id, "messages": [msg], "seq": 1}) + "\n",
+        encoding="utf-8",
+    )
+    # First normal build
+    s1 = build_action_index(tmp_path, prompts_dir)
+    assert s1["written"] == 1
+
+    # The day file should be a plain .jsonl (today, not archived)
+    index_file = tmp_path / "action_index" / f"{today}.jsonl"
+    assert index_file.exists(), "Index file should be a plain .jsonl for today's date"
+
+    # Insert stale content into the day file
+    original = index_file.read_text(encoding="utf-8")
+    index_file.write_text(
+        original + json.dumps({"cycle_id": "stale-extra", "ts": "", "actions": ["var/stale"]}) + "\n",
+        encoding="utf-8",
+    )
+
+    # Force regen should delete and rebuild from source
+    s2 = build_action_index(tmp_path, prompts_dir, force_regenerate=True)
+    assert s2["force_regenerated"] >= 1
+    rebuilt = [json.loads(line) for line in index_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+    # stale-extra should be gone
+    assert not any(r.get("cycle_id") == "stale-extra" for r in rebuilt)


### PR DESCRIPTION
## Summary
Fix-pass for #1006 review defects F1-F4.

- **F1:** the daily miner writes `state/demand/skill_candidates.json`, capped to top-N (default 3, env-tunable), ranked deterministically by `cycles * days`; publication uses same-directory temp file + `os.replace`.
- **F2:** demand reads only the sidecar; no index scan/mining occurs in the bridge cycle path. The action-index service runs mining only in its daily `ExecStartPost`.
- **F3:** pure `read:*`/`list:*` n-grams are categorically rejected; selected sequences require at least one `exec:*`, `edit:*`, or `write:*` action.
- **F4:** action-index normalization strips `state_root`; explicit `--force-regen` rebuilds only day files whose source prompts remain; the recurring systemd service stays incremental (no daily force rewrite); miner ignores legacy `var/*` templates.

## Required mechanism grep
`git diff origin/main...HEAD | grep -ni -E 'skill_candidates\.json|exec:|edit:|write:'`
Expected matches include the sidecar path/schema, meaningful-action rule, sidecar tests, and demand/service integration.

## Tests / acceptance mapping
- F1 cap/ranking/atomic publication: `test_f1_top_n_cap_default_three`, `test_f1_sidecar_ranked_by_cycles_times_days`, `test_f1_sidecar_write_is_atomic`
- F2 sidecar-only cycle path: `test_f2_collect_demand_does_not_call_mine`
- F3 categorical meaningful action rule: `test_f3_pure_read_ngram_is_rejected`, `test_f3_is_meaningful_helper`
- F4 state-root normalization, explicit force regeneration, and legacy var suppression: `test_f4_state_root_stripped_produces_state_template`, `test_f4_force_regen_rebuilds_existing_day_files`, `test_f4_legacy_var_template_ignored_by_miner`

Focused validation after fix: 150 passed; ruff and `git diff --check` passed. Full pytest and CI matrix required before merge. Known local Windows/platform baseline failures will be listed exactly if present.