### PR TITLE
fix(strategist): preserve durable hypotheses

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1219,9 +1219,11 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
     items: list[dict[str, str]] = []
     seen: set[str] = set()
     try:
+        durable = _read_json(Path(state_dir) / "hypotheses" / "durable.json", None)
+        durable_entries = durable.get("entries") if isinstance(durable, dict) else None
         backlog = _read_json(Path(state_dir) / "hypotheses" / "backlog.json", None)
-        entries = backlog.get("entries") if isinstance(backlog, dict) else None
-        for entry in entries or []:
+        entries = (durable_entries or []) + (backlog.get("entries", []) if isinstance(backlog, dict) else [])
+        for entry in entries:
             if not isinstance(entry, dict):
                 continue
             title = str(entry.get("task_title") or entry.get("title") or "").strip()

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -187,10 +187,23 @@ def _research_candidates(state_dir: Path) -> list[dict[str, str]]:
     return out
 
 
+def _durable_candidates(state_dir: Path) -> list[dict[str, str]]:
+    data = _read_json(Path(state_dir) / "hypotheses" / "durable.json", None)
+    entries = data.get("entries") if isinstance(data, dict) else []
+    out = []
+    for entry in entries if isinstance(entries, list) else []:
+        if isinstance(entry, dict):
+            key = _candidate_key(entry)
+            title = str(entry.get("task_title") or entry.get("title") or "").strip()
+            if key and title:
+                out.append({"key": key, "title": title, "source": "durable"})
+    return out
+
+
 def _all_candidates(state_dir: Path) -> list[dict[str, str]]:
     seen: set[str] = set()
     out: list[dict[str, str]] = []
-    for cand in _backlog_candidates(state_dir) + _research_candidates(state_dir):
+    for cand in _durable_candidates(state_dir) + _backlog_candidates(state_dir) + _research_candidates(state_dir):
         if cand["key"] in seen:
             continue
         seen.add(cand["key"])
@@ -690,11 +703,12 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
         existing_titles.add(lookup_key)
         appended += 1
 
-    if len(entries) > DURABLE_MAX_ENTRIES:
+    trimmed = len(entries) > DURABLE_MAX_ENTRIES
+    if trimmed:
         entries = entries[-DURABLE_MAX_ENTRIES:]
         backlog_data["entries"] = entries
 
-    if appended > 0:
+    if appended > 0 or trimmed:
         backlog_data["updated_at"] = now_iso
         backlog_data["entries"] = entries
 

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -57,6 +57,7 @@ from typing import Any
 
 TOP_N = 5
 MAX_SECTION_CHARS = 1200
+DURABLE_MAX_ENTRIES = 20
 STALE_AFTER_DAYS = 14
 STALE_AFTER_UNTOUCHED_CYCLES = 50
 # #878: how many "supported" hypotheses (newest verdict first) goal_review
@@ -642,14 +643,14 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
     state_dir = Path(state_dir)
     hypotheses_dir = state_dir / "hypotheses"
     hypotheses_dir.mkdir(parents=True, exist_ok=True)
-    backlog_path = hypotheses_dir / "backlog.json"
+    backlog_path = hypotheses_dir / "durable.json"
 
     raw_data = _read_json(backlog_path, None)
     if isinstance(raw_data, dict) and isinstance(raw_data.get("entries"), list):
         backlog_data = dict(raw_data)
         entries = list(backlog_data.get("entries") or [])
     else:
-        backlog_data = {"schema": "hypothesis-backlog-v1", "entries": []}
+        backlog_data = {"schema": "hypothesis-durable-v1", "entries": []}
         entries = []
 
     # Map existing titles / keys to avoid duplicate additions
@@ -688,6 +689,10 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
         entries.append(entry_record)
         existing_titles.add(lookup_key)
         appended += 1
+
+    if len(entries) > DURABLE_MAX_ENTRIES:
+        entries = entries[-DURABLE_MAX_ENTRIES:]
+        backlog_data["entries"] = entries
 
     if appended > 0:
         backlog_data["updated_at"] = now_iso

--- a/nanobot/runtime/strategist.py
+++ b/nanobot/runtime/strategist.py
@@ -122,10 +122,19 @@ def _tree_digest(state_root: Path) -> dict[str, Any]:
     while current and current in node_map and len(best) < 20:
         best.append(current)
         current = str(node_map[current].get("parent_sha") or "")
-    depth = tree.get("depth")
-    if not isinstance(depth, int):
-        depth = max((int(n.get("depth", 0)) for n in nodes[:500] if isinstance(n, dict)), default=0)
-    return {"node_count": len(nodes), "depth": max(0, depth), "outcome_mix": outcomes, "current_best_path": best[:20]}
+    chain_depth = len(best)
+    fitness = [node.get("fitness") for node in nodes[:500] if isinstance(node.get("fitness"), dict)]
+    rewards = [float(item["reward"]) for item in fitness if isinstance(item.get("reward"), (int, float))]
+    return {
+        "node_count": len(nodes),
+        "current_best_path": best[:20],
+        "fitness_summary": {
+            "chain_depth": chain_depth,
+            "reward_count": len(rewards),
+            "reward_mean": sum(rewards) / len(rewards) if rewards else None,
+            "reward_max": max(rewards) if rewards else None,
+        },
+    }
 
 def _scorecard_input(state_root: Path) -> dict[str, Any]:
     latest = _load_json(Path(state_root) / "scorecard" / "latest.json", {})

--- a/nanobot/runtime/strategist.py
+++ b/nanobot/runtime/strategist.py
@@ -20,6 +20,7 @@ DEFAULT_H = 3
 DEFAULT_F = 2
 _MAX_SECTION = 8_000
 _MAX_TEXT = 4_000
+_MAX_PROMPT_CHARS = 48_000
 
 def _now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -162,27 +163,25 @@ def _scorecard_input(state_root: Path) -> dict[str, Any]:
 
 def _funnel_input(state_root: Path) -> dict[str, Any]:
     records: dict[str, dict[str, int]] = {}
+    cycle_demands: dict[str, str] = {}
+    rows: list[dict[str, Any]] = []
     ledger = Path(state_root) / "ledger" / "cycles.jsonl"
     ledger_paths = [ledger, *sorted(ledger.parent.glob("cycles-*.jsonl.gz"))]
     for ledger_path in ledger_paths:
-        for line in _read_lines(ledger_path, 500):
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
-            if not isinstance(row, dict):
-                continue
-            demand_id = str(row.get("demand_id") or "").strip()
-            if not demand_id:
-                continue
-            counts = records.setdefault(demand_id, {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0})
-            phase = str(row.get("phase") or "")
-            if phase == "proposed":
-                counts["proposed"] += 1
-            if phase == "outcome" and str(row.get("outcome")) == "success":
-                counts["integrated"] += 1
-            if phase == "proposer_reject" and str(row.get("reason")) == "self_dedup":
-                counts["self_dedup"] += 1
+        rows.extend(json.loads(line) for line in _read_lines(ledger_path, 500) if _json_object(line))
+    for row in rows:
+        demand_id = str(row.get("demand_id") or "").strip()
+        phase = str(row.get("phase") or "")
+        cycle_id = str(row.get("cycle_id") or "").strip()
+        if phase == "proposed" and demand_id:
+            cycle_demands[cycle_id] = demand_id
+            records.setdefault(demand_id, {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0})["proposed"] += 1
+        elif phase == "proposer_reject" and demand_id and str(row.get("reason")) == "self_dedup":
+            records.setdefault(demand_id, {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0})["self_dedup"] += 1
+        elif phase == "outcome" and str(row.get("outcome")) == "success":
+            linked = cycle_demands.get(cycle_id)
+            if linked:
+                records[linked]["integrated"] += 1
     futile = _load_json(Path(state_root) / "demand" / "futility.json", {})
     futile_ids = set(futile.get("futile_gap_ids", [])) if isinstance(futile, dict) else set()
     for demand_id in futile_ids:
@@ -247,7 +246,23 @@ def build_strategist_prompt(inputs: dict[str, Any], watermark: dict[str, Any]) -
             "data_to_collect": "measurements", "insight_criterion": "confirm/refute condition", "priority": "medium"
         }], "futility_advisories": [{"topic_or_direction": "direction id", "reason": "one-line reason"}]
     }}
-    return system, json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    if len(encoded) > _MAX_PROMPT_CHARS:
+        archive = payload["archive"]
+        for key in ("lessons", "prior_decisions", "recent_cycles", "insights", "funnel", "scorecard"):
+            if len(encoded) <= _MAX_PROMPT_CHARS:
+                break
+            value = archive.get(key)
+            if isinstance(value, list):
+                archive[key] = value[: max(1, len(value) // 2)]
+            elif isinstance(value, dict):
+                archive[key] = {k: v for k, v in list(value.items())[: max(1, len(value) // 2)]}
+            elif isinstance(value, str):
+                archive[key] = value[: max(1, len(value) // 2)]
+            encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        if len(encoded) > _MAX_PROMPT_CHARS:
+            encoded = json.dumps({"schema": SCHEMA, "watermark": watermark, "archive": {"truncated": True}}, ensure_ascii=False)
+    return system, encoded
 
 def _text_field(value: Any, limit: int = 1_000) -> bool:
     return isinstance(value, str) and bool(value.strip()) and len(value) <= limit
@@ -324,6 +339,7 @@ def run_strategist(state_root: Path, repo_root: Path, llm: Callable[[list[dict[s
     try:
         inputs = collect_inputs(state_root, repo_root)
         system, user = build_strategist_prompt(inputs, old)
+        decision["prompt_chars"] = len(user)
         raw = (llm or _default_llm)([{"role": "system", "content": system}, {"role": "user", "content": user}], model)
         if hasattr(raw, "content"):
             raw = raw.content
@@ -333,10 +349,13 @@ def run_strategist(state_root: Path, repo_root: Path, llm: Callable[[list[dict[s
         parsed = json.loads(text)
         if not validate_strategist_output(parsed):
             raise ValueError("invalid strategist-hadi-v1 output")
-        counts = _apply(parsed, state_root, _env_int("SELFEVO_STRATEGIST_MAX_HYPOTHESES", DEFAULT_H), _env_int("SELFEVO_STRATEGIST_MAX_FUTILITY", DEFAULT_F))
+        max_h = _env_int("SELFEVO_STRATEGIST_MAX_HYPOTHESES", DEFAULT_H)
+        max_f = _env_int("SELFEVO_STRATEGIST_MAX_FUTILITY", DEFAULT_F)
+        counts = _apply(parsed, state_root, max_h, max_f)
         _atomic_json(Path(state_root) / "strategist" / "watermark.json", {"last_run": decision["timestamp"], "model": model, "total_runs": int(old.get("total_runs", 0)) + 1})
         decision.update({"success": True, "counts": counts, "hypotheses_count": counts["hypotheses_appended"], "advisories_count": counts["advisories_written"], "reason": "valid bounded advisory output applied"})
     except Exception as exc:
+        decision.setdefault("prompt_chars", 0)
         decision.update({"error": str(exc)[:500], "reason": "no writes applied; watermark unchanged"})
         try:
             _append_jsonl(Path(state_root) / "strategist" / "errors.jsonl", {"timestamp": decision["timestamp"], "error": str(exc)[:500]})

--- a/tests/test_strategist.py
+++ b/tests/test_strategist.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nanobot.runtime import demand
 from nanobot.runtime.strategist import (
     SCHEMA,
     _apply,
@@ -59,6 +60,27 @@ def test_collect_inputs(mock_state_and_repo):
     assert len(inputs["recent_cycles"]) == 2
     assert "Improve runtime" in inputs["goals"]
     assert any("check timers" in line for line in inputs["lessons"])
+
+
+def test_durable_hypothesis_survives_backlog_snapshot(tmp_path):
+    """Strategist hypotheses must survive the bridge's queue snapshot rewrite."""
+    from nanobot.runtime.backlog_snapshot import write_backlog_snapshot
+    from nanobot.runtime.hypothesis_backlog import append_hypotheses
+
+    state_root = tmp_path / "state"
+    append_hypotheses(state_root, [{
+        "title": "Durable probe",
+        "hypothesis": "The bounded probe improves the metric",
+        "action": "Run the probe once",
+        "data_to_collect": "metric value",
+        "insight_criterion": "metric improves without regression",
+        "source": "strategist",
+    }])
+    write_backlog_snapshot(state_root)
+
+    items = demand._hypothesis_items(state_root, None)
+    assert any(item["summary"] == "Durable probe" for item in items)
+    assert (state_root / "hypotheses" / "durable.json").is_file()
 
 
 def test_build_strategist_prompt_includes_triz_and_hadi(mock_state_and_repo):
@@ -140,7 +162,7 @@ def test_apply_hypotheses_and_advisories(tmp_path: Path):
     assert counts["advisories_recorded"] == 1
 
     # Check hypotheses file
-    hyp_file = state_root / "hypotheses" / "backlog.json"
+    hyp_file = state_root / "hypotheses" / "durable.json"
     assert hyp_file.exists()
     hyp_data = json.loads(hyp_file.read_text(encoding="utf-8"))
     assert len(hyp_data["entries"]) == 1
@@ -230,6 +252,6 @@ def test_run_strategist_end_to_end(mock_state_and_repo, monkeypatch):
     assert watermark.get("last_model_used", watermark.get("model")) == "cl/test-strategist-model"
 
     # Check hypothesis backlog
-    hyp_data = json.loads((state_root / "hypotheses" / "backlog.json").read_text(encoding="utf-8"))
+    hyp_data = json.loads((state_root / "hypotheses" / "durable.json").read_text(encoding="utf-8"))
     assert len(hyp_data["entries"]) == 1
     assert hyp_data["entries"][0]["title"] == "Subagent isolation"


### PR DESCRIPTION
## Summary
Fix-pass for #999 independent review (`issuecomment-5430760140`).

- Strategist hypotheses now append to strategist-owned `state/hypotheses/durable.json`, capped to 20 FIFO entries with title deduplication. The bridge queue snapshot remains untouched and may regenerate `backlog.json` independently.
- `demand._hypothesis_items` reads durable hypotheses first, then the existing queue snapshot and research sources, using the same evidence gate.
- Strategist tree digest now uses the actual `evolution/tree.json` node schema (`current_sha`, `parent_sha`, `fitness`) and derives the current chain plus reward summary.
- Scorecard history uses `computed_at_utc` and a seven-day cutoff; input readers are byte/line bounded and rotated ledger files are included.
- Strict JSON output is not fence-tolerant; malformed/fenced output leaves watermark and output channels unchanged.

## Required grep
`git diff origin/main...HEAD | grep -ni -E 'durable\\.json|strategist|hypothesis|decisions\\.jsonl'`

Matches include durable sidecar ownership, strategist component, hypothesis append/read integration, strict HADI fields, and the decisions audit journal.

## Acceptance mapping
- Failing-first durability regression: `test_durable_hypothesis_survives_backlog_snapshot` appends a strategist entry, regenerates the queue snapshot, and asserts demand still sees it.
- Durable cap/dedup path: `hypothesis_backlog.append_hypotheses` uses `durable.json`, case-insensitive title deduplication, and a 20-entry FIFO cap.
- Real tree schema: `_tree_digest` consumes `current_sha`/`parent_sha`/`fitness`; tests cover the digest path.
- Strict HADI validation: exact output shape and required `hypothesis`, `action`, `data_to_collect`, `insight_criterion`; malformed/fenced output is rejected.
- Existing role/golden tests remain unchanged.

Focused validation: `176 passed` before the final durability implementation was corrected; latest targeted strategist/demand/hypothesis tests are required before merge. Ruff and diff checks are required. Full pytest and CI matrix required before merge.