### PR TITLE
fix(hypotheses): recognize demand-served experiments

### DIFF
--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -74,7 +74,7 @@ SUPPORTED_TOP_N = 3
 # lane a release path far short of the stale window.
 IN_FLIGHT_TIMEOUT_DAYS = 3
 
-_HYPOTHESIS_SERVES_RE = re.compile(r"^hypothesis\s+(.+)$", re.IGNORECASE)
+_HYPOTHESIS_SERVES_RE = re.compile(r"^(?:hypothesis|demand)\s+(.+)$", re.IGNORECASE)
 
 
 def _read_json(path: Path, default: Any) -> Any:

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -609,6 +609,15 @@ class TestHasInFlightExperiment:
         )
         assert hypothesis_backlog.has_in_flight_experiment(state_dir) is True
 
+    def test_demand_serves_format_counts_as_in_flight(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "c1", "task_title": "Fix widget", "serves": "demand hypothesis-h1"},
+        )
+        assert hypothesis_backlog.has_in_flight_experiment(state_dir) is True
+
     def test_false_once_outcome_recorded(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])


### PR DESCRIPTION
Follow-up for #999 reviewer finding: normal proposer ledger rows use `serves: demand <hypothesis-id>`. Recognize both demand and hypothesis forms in hypothesis lifecycle/in-flight reconciliation. Added regression test; focused suite passed. No goldens or bridge.py changes.