### PR TITLE
fix(demand): restore lane fairness and bounded reflections

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -78,6 +78,9 @@ Demand kinds, in trust order (see ``docs/changes/760-demand-driven-proposer/``):
   in-flight serving cycle (``hypothesis_backlog.has_in_flight_experiment``)
   — the closed loop (hypothesis -> experiment -> harness-measured verdict,
   see ``hypothesis_verdict``) runs at most one experiment at a time.
+- ``reflection`` (#1038, ordered between ``defect`` and ``skill-candidate``) —
+  unconsumed self-reflection items from recent cycles, bounded to
+  :data:`_MAX_REFLECTION_ITEMS` and filtered to :data:`_REFLECTION_MAX_AGE_DAYS` days.
 - ``decay`` (#761, ordered LAST — priority > defect > goal-gap >
   hypothesis > decay) —
   ``scripts/*.py`` artifacts whose harness-observed ``last_used`` AND
@@ -156,6 +159,7 @@ ENABLED_ENV = "SELFEVO_DEMAND_DRIVEN_ENABLED"
 
 _DEFECT_WINDOW_HOURS = 48
 _MAX_RESULT_FILES = 50  # bounded read, same discipline as existence_index._MAX_LEDGER_RESULTS
+_MAX_RESULT_FILE_DEFECTS = 10  # #1038: capped defect output from result files
 _MAX_LEDGER_DEFECTS = 10
 _MAX_COMPILE_DEFECTS = 10
 _MAX_HELDOUT_DEFECTS = 5  # #780: bounded held-out failure demand
@@ -171,6 +175,13 @@ _MAX_SUMMARY_CHARS = 160
 # after the evidence sentence, and 240 truncated the hint mid-word before
 # reaching the "does NOT move it" instruction — the whole point of the hint.
 _MAX_EVIDENCE_CHARS = 420
+
+_MAX_DEFECT_ITEMS = 10
+_MAX_PRIORITY_ITEMS = 10
+_MAX_HYPOTHESIS_ITEMS = 1  # at most one active hypothesis experiment (#878)
+_MAX_SKILL_CANDIDATE_ITEMS = 3  # top-N pre-computed skill candidates (#1006)
+_MAX_REFLECTION_ITEMS = 5  # #1038: bounded reflection demand
+_REFLECTION_MAX_AGE_DAYS = 7  # #1038: freshness window for reflector outputs
 
 _DECAY_DAYS = 14
 _MAX_DECAY_ITEMS = 5
@@ -358,11 +369,20 @@ def _priority_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
     try:
         from nanobot.runtime.goal_text_utils import filter_completed_priorities_from_goal_text
 
+        raw_text = ""
         path = Path(state_dir) / "goals" / "goal_text.json"
         data = _read_json(path, None)
-        if not isinstance(data, dict):
-            return []
-        raw_text = str(data.get("text") or "")
+        if isinstance(data, dict):
+            raw_text = str(data.get("text") or "")
+
+        if not raw_text:
+            try:
+                from nanobot.runtime.goal_review import read_charter_text
+
+                raw_text = read_charter_text(selfevo_repo) or ""
+            except Exception:
+                raw_text = ""
+
         if not raw_text:
             return []
         # #860: fold in goal_review's harness-owned derived priorities
@@ -424,6 +444,7 @@ def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
         if not path.is_file():
             return []
         cutoff = now - timedelta(hours=_DEFECT_WINDOW_HOURS)
+        matching_rows: list[dict[str, Any]] = []
         for line in path.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
@@ -442,9 +463,13 @@ def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
             ts = _parse_ts(row.get("ts"))
             if ts is None or ts < cutoff:
                 continue
+            matching_rows.append(row)
+
+        for row in reversed(matching_rows):
+            outcome = str(row.get("outcome") or "").strip().lower()
             reason = str(row.get("reason") or "").strip()
             branch = str(row.get("branch") or row.get("cycle_id") or "").strip()
-            summary = f"cycle outcome {outcome}: {reason or branch or '(no detail)'}"
+            summary = f"recent cycle outcome {outcome}"
             if summary in seen_summaries:
                 continue
             seen_summaries.add(summary)
@@ -452,7 +477,7 @@ def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
                 _make_item(
                     "defect",
                     summary,
-                    f"ledger outcome row cycle_id={row.get('cycle_id') or '?'} reason={reason or '(none)'}",
+                    f"ledger outcome row cycle_id={row.get('cycle_id') or '?'} branch={branch or '?'} reason={reason or '(none)'}",
                 )
             )
             if len(items) >= _MAX_LEDGER_DEFECTS:
@@ -547,6 +572,8 @@ def _result_file_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]
                     error_text or f"result file {entry.name} status={status}",
                 )
             )
+            if len(items) >= _MAX_RESULT_FILE_DEFECTS:
+                break
         return items
     except Exception:
         return items
@@ -1226,6 +1253,9 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
+            status = str(entry.get("status") or "active").strip().lower()
+            if status != "active":
+                continue
             title = str(entry.get("task_title") or entry.get("title") or "").strip()
             if not title or title in seen:
                 continue
@@ -1242,6 +1272,9 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
                     continue
                 for cand in snapshot.get("candidates") or []:
                     if not isinstance(cand, dict):
+                        continue
+                    status = str(cand.get("status") or "active").strip().lower()
+                    if status != "active":
                         continue
                     title = str(cand.get("title") or cand.get("hypothesis") or "").strip()
                     if not title or title in seen:
@@ -1880,16 +1913,34 @@ def _emit_vector_split_event(state_dir: Path, items: list[dict[str, str]]) -> No
         pass
 
 
-def _reflection_items(state_dir: Path) -> list[dict[str, str]]:
-    """Turn reflector recommendations into normal, evidence-linked demand."""
+def _reflection_items(state_dir: Path, now: datetime | None = None) -> list[dict[str, str]]:
+    """Turn reflector recommendations into normal, evidence-linked demand (#1038).
+
+    - Per-line malformed json guard (skips bad line without crashing)
+    - Freshness window: ignores reflections older than ``_REFLECTION_MAX_AGE_DAYS``
+    - Ignores reflections whose status is not empty/active (e.g. 'consumed')
+    - Capped to ``_MAX_REFLECTION_ITEMS``
+    """
     items: list[dict[str, str]] = []
     try:
         path = Path(state_dir) / "reflector" / "reflections.jsonl"
         if not path.is_file():
             return items
+        if now is None:
+            now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=_REFLECTION_MAX_AGE_DAYS)
         for line in path.read_text(encoding="utf-8").splitlines():
-            row = json.loads(line)
+            line_str = line.strip()
+            if not line_str:
+                continue
+            try:
+                row = json.loads(line_str)
+            except Exception:
+                continue
             if not isinstance(row, dict) or row.get("status") or not row.get("cycle_id"):
+                continue
+            ts_val = _parse_ts(row.get("created_at") or row.get("timestamp") or row.get("ts"))
+            if ts_val is not None and ts_val < cutoff:
                 continue
             for recommendation in row.get("recommendations") or []:
                 if not isinstance(recommendation, dict):
@@ -1897,7 +1948,18 @@ def _reflection_items(state_dir: Path) -> list[dict[str, str]]:
                 detail = str(recommendation.get("detail") or "").strip()
                 if detail:
                     evidence = str(recommendation.get("evidence") or "").strip()
-                    items.append(_make_item("reflection", detail, f"cycle {row['cycle_id']}: {evidence}"))
+                    item = _make_item("reflection", detail, f"cycle {row['cycle_id']}: {evidence}")
+                    try:
+                        from nanobot.runtime import reflector
+                        completed = _read_json(Path(state_dir) / "demand" / "completed.json", {})
+                        if item["id"] in (completed.get("entries", {}) if isinstance(completed, dict) else {}):
+                            reflector.mark_reflection_consumed(state_dir, row.get("summary", ""))
+                            continue
+                    except Exception:
+                        pass
+                    items.append(item)
+                    if len(items) >= _MAX_REFLECTION_ITEMS:
+                        return items
         return items
     except Exception:
         return items
@@ -1910,8 +1972,9 @@ def collect_demand(
     state_dir: Path, selfevo_repo: Path | None, *, emit_split: bool = False
 ) -> list[dict[str, str]]:
     """Collect all current demand items, trust order (priority > defect >
-    goal-gap > hypothesis > decay), exhausted items filtered out.
-    Deterministic, no LLM call. Fail-open: any error degrades to fewer
+    goal-gap > skill-candidate > hypothesis > decay > reflection),
+    exhausted items filtered out, per-kind bounds applied after completed/exhausted
+    folds (#1038). Deterministic, no LLM call. Fail-open: any error degrades to fewer
     (possibly zero) items, never raises.
 
     ``emit_split`` (#815, default OFF): opt-in best-effort
@@ -1953,7 +2016,7 @@ def collect_demand(
             _skill_candidate_items(state_dir, selfevo_repo),
             _hypothesis_items(state_dir, selfevo_repo),
             _decay_items(state_dir, selfevo_repo, now),
-            _reflection_items(state_dir),
+            _reflection_items(state_dir, now),
         ):
             for item in batch:
                 if item["id"] in seen_ids:
@@ -1996,6 +2059,31 @@ def collect_demand(
             items = kept
 
         result = _filter_exhausted(state_dir, items, head, now=now)
+
+        # #1038: Apply per-kind caps AFTER completed/exhausted folds so that
+        # completed/exhausted items in the front of a lane do not push out live items.
+        kind_caps: dict[str, int] = {
+            "priority": _MAX_PRIORITY_ITEMS,
+            "defect": _MAX_DEFECT_ITEMS,
+            "goal-gap": _MAX_GOAL_GAP_ITEMS,
+            "skill-candidate": _MAX_SKILL_CANDIDATE_ITEMS,
+            "hypothesis": _MAX_HYPOTHESIS_ITEMS,
+            "decay": _MAX_DECAY_ITEMS,
+            "repair-unused": _MAX_REPAIR_UNUSED_ITEMS,
+            "reflection": _MAX_REFLECTION_ITEMS,
+        }
+        kind_counts: dict[str, int] = {}
+        bounded_result: list[dict[str, str]] = []
+        for item in result:
+            k = item.get("kind", "")
+            cap = kind_caps.get(k)
+            if cap is not None:
+                if kind_counts.get(k, 0) >= cap:
+                    continue
+                kind_counts[k] = kind_counts.get(k, 0) + 1
+            bounded_result.append(item)
+        result = bounded_result
+
         # #815: best-effort, operator-visible V1-vs-V2 split of what's
         # actually presented — never affects the returned list. Opt-in
         # only (see the ``emit_split`` docstring note) so the gate-probe

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -78,11 +78,12 @@ Demand kinds, in trust order (see ``docs/changes/760-demand-driven-proposer/``):
   in-flight serving cycle (``hypothesis_backlog.has_in_flight_experiment``)
   — the closed loop (hypothesis -> experiment -> harness-measured verdict,
   see ``hypothesis_verdict``) runs at most one experiment at a time.
-- ``reflection`` (#1038, ordered between ``defect`` and ``skill-candidate``) —
-  unconsumed self-reflection items from recent cycles, bounded to
+- ``reflection`` (#1038, ordered LAST after decay — priority > defect >
+  goal-gap > skill-candidate > hypothesis > decay > reflection) —
+  unconsumed self-reflection recommendations from recent cycles, bounded to
   :data:`_MAX_REFLECTION_ITEMS` and filtered to :data:`_REFLECTION_MAX_AGE_DAYS` days.
-- ``decay`` (#761, ordered LAST — priority > defect > goal-gap >
-  hypothesis > decay) —
+- ``decay`` (#761, ordered before reflection — priority > defect > goal-gap >
+  skill-candidate > hypothesis > decay > reflection) —
   ``scripts/*.py`` artifacts whose harness-observed ``last_used`` AND
   ``last_touched`` (``nanobot.runtime.usage_evidence`` sidecar) are both
   older than :data:`_DECAY_DAYS` days, presented as demand proposing
@@ -370,18 +371,30 @@ def _priority_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
         from nanobot.runtime.goal_text_utils import filter_completed_priorities_from_goal_text
 
         raw_text = ""
-        path = Path(state_dir) / "goals" / "goal_text.json"
-        data = _read_json(path, None)
-        if isinstance(data, dict):
-            raw_text = str(data.get("text") or "")
-
-        if not raw_text:
+        # 1. Charter-first from selfevo_repo/GOALS.md
+        if selfevo_repo:
             try:
                 from nanobot.runtime.goal_review import read_charter_text
 
                 raw_text = read_charter_text(selfevo_repo) or ""
             except Exception:
                 raw_text = ""
+
+        # 2. Workspace goal_text.json
+        if not raw_text:
+            path = Path(state_dir) / "goals" / "goal_text.json"
+            data = _read_json(path, None)
+            if isinstance(data, dict):
+                raw_text = str(data.get("text") or "")
+
+        # 3. Fallback to goals.md
+        if not raw_text:
+            legacy = Path(state_dir) / "goals.md"
+            if legacy.is_file():
+                try:
+                    raw_text = legacy.read_text(encoding="utf-8")
+                except Exception:
+                    raw_text = ""
 
         if not raw_text:
             return []
@@ -434,7 +447,9 @@ def _priority_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
 # ─── kind: defect ───────────────────────────────────────────────────────────
 
 
-def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
+def _ledger_defects(
+    state_dir: Path, now: datetime, *, limit: int | None = _MAX_LEDGER_DEFECTS
+) -> list[dict[str, str]]:
     """Terminal ledger outcome rows with a real failure in the last 48h.
     ``skipped-*`` outcomes are the dedup stack working, not defects."""
     items: list[dict[str, str]] = []
@@ -458,7 +473,7 @@ def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
             outcome = str(row.get("outcome") or "").strip().lower()
             if outcome.startswith("skipped"):
                 continue
-            if outcome not in ("failed", "timeout"):
+            if outcome not in ("failed", "timeout", "error", "harness_failed"):
                 continue
             ts = _parse_ts(row.get("ts"))
             if ts is None or ts < cutoff:
@@ -480,9 +495,7 @@ def _ledger_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
                     f"ledger outcome row cycle_id={row.get('cycle_id') or '?'} branch={branch or '?'} reason={reason or '(none)'}",
                 )
             )
-            if len(items) >= _MAX_LEDGER_DEFECTS:
-                break
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -522,7 +535,9 @@ def _skipped_cycle_ids(state_dir: Path, now: datetime) -> set[str]:
         return skipped
 
 
-def _result_file_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]:
+def _result_file_defects(
+    state_dir: Path, now: datetime, *, limit: int | None = _MAX_RESULT_FILE_DEFECTS
+) -> list[dict[str, str]]:
     """Failed/blocked subagent result files with error text — bounded to the
     :data:`_MAX_RESULT_FILES` most recently modified files.
 
@@ -572,9 +587,7 @@ def _result_file_defects(state_dir: Path, now: datetime) -> list[dict[str, str]]
                     error_text or f"result file {entry.name} status={status}",
                 )
             )
-            if len(items) >= _MAX_RESULT_FILE_DEFECTS:
-                break
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -583,7 +596,13 @@ def _compile_watermark_path(state_dir: Path) -> Path:
     return Path(state_dir) / "demand" / "py_compile_watermark.json"
 
 
-def _compile_defects(state_dir: Path, selfevo_repo: Path | None, head: str | None) -> list[dict[str, str]]:
+def _compile_defects(
+    state_dir: Path,
+    selfevo_repo: Path | None,
+    head: str | None,
+    *,
+    limit: int | None = _MAX_COMPILE_DEFECTS,
+) -> list[dict[str, str]]:
     """Instance-repo scripts that fail to byte-compile (syntax errors).
 
     Watermark-gated on the repo's git HEAD exactly like
@@ -629,8 +648,6 @@ def _compile_defects(state_dir: Path, selfevo_repo: Path | None, head: str | Non
                         failures.append({"path": rel, "error": f"{type(exc).__name__}: {exc.msg} (line {exc.lineno})"})
                     except Exception:
                         continue
-                    if len(failures) >= _MAX_COMPILE_DEFECTS:
-                        break
             _write_json(
                 wm_path,
                 {
@@ -641,7 +658,7 @@ def _compile_defects(state_dir: Path, selfevo_repo: Path | None, head: str | Non
                 },
             )
         items: list[dict[str, str]] = []
-        for failure in failures[:_MAX_COMPILE_DEFECTS]:
+        for failure in failures:
             if not isinstance(failure, dict):
                 continue
             rel = str(failure.get("path") or "").strip()
@@ -656,12 +673,14 @@ def _compile_defects(state_dir: Path, selfevo_repo: Path | None, head: str | Non
                     affected_path=rel,
                 )
             )
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return []
 
 
-def _heldout_defect_items(state_dir: Path) -> list[dict[str, str]]:
+def _heldout_defect_items(
+    state_dir: Path, *, limit: int | None = _MAX_HELDOUT_DEFECTS
+) -> list[dict[str, str]]:
     """Held-out behavioral-check failures as ``defect`` demand (#780).
 
     Read-only over ``<state_dir>/heldout/results.json`` — the sidecar
@@ -693,9 +712,7 @@ def _heldout_defect_items(state_dir: Path) -> list[dict[str, str]]:
                     affected_path=artifact,
                 )
             )
-            if len(items) >= _MAX_HELDOUT_DEFECTS:
-                break
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -732,7 +749,9 @@ def _sanitize_stderr_tail(text: str) -> str:
     return _WHITESPACE_RUN_RE.sub(" ", text).strip()
 
 
-def _validator_defect_items(state_dir: Path) -> list[dict[str, str]]:
+def _validator_defect_items(
+    state_dir: Path, *, limit: int | None = _MAX_VALIDATOR_DEFECTS
+) -> list[dict[str, str]]:
     """Validator-harness run results as ``defect`` demand (#925).
 
     Read-only over ``<state_dir>/validator_harness/last_runs.jsonl`` — the
@@ -926,9 +945,7 @@ def _validator_defect_items(state_dir: Path) -> list[dict[str, str]]:
                         affected_path=rel,
                     )
                 )
-            if len(items) >= _MAX_VALIDATOR_DEFECTS:
-                break
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -979,7 +996,10 @@ def _tamper_suspect_scripts(
 
 
 def _tamper_defect_items(
-    state_dir: Path, selfevo_repo: Path | None = None
+    state_dir: Path,
+    selfevo_repo: Path | None = None,
+    *,
+    limit: int | None = _MAX_TAMPER_DEFECTS,
 ) -> list[dict[str, str]]:
     """Fitness-sidecar tamper repairs as ``defect`` demand (#789).
 
@@ -1076,12 +1096,10 @@ def _tamper_defect_items(
                     "defect", f"{summary} [{','.join(sorted(suspects))}]"
                 )
             items.append(item)
-            if len(items) >= _MAX_TAMPER_DEFECTS:
-                break
         if changed:
             data["entries"] = entries
             _write_json(_completed_path(state_dir), data)
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -1089,7 +1107,12 @@ def _tamper_defect_items(
 # ─── kind: goal-gap (#765) ──────────────────────────────────────────────────
 
 
-def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str, str]]:
+def _goal_gap_items(
+    state_dir: Path,
+    selfevo_repo: Path | None,
+    *,
+    limit: int | None = None,
+) -> list[dict[str, str]]:
     """Scorecard metrics violating their goal-derived target, as demand
     (#765). The gap list comes from ``scorecard.goal_gaps`` — deterministic,
     time-watermarked, targets declared in ``scorecard._TARGETS`` from the
@@ -1132,7 +1155,7 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
 
         items: list[dict[str, str]] = []
         gap_rows: list[dict[str, Any]] = []
-        for gap in scorecard.goal_gaps(state_dir, selfevo_repo)[:_MAX_GOAL_GAP_ITEMS]:
+        for gap in scorecard.goal_gaps(state_dir, selfevo_repo):
             metric = str(gap.get("metric") or "").strip()
             vector = str(gap.get("vector") or "").strip()
             if not metric or vector not in ("V1", "V2"):
@@ -1175,7 +1198,7 @@ def _goal_gap_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
                     0 if it.get("direction") == current_direction else 1,
                 )
             )
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return []
 
@@ -1242,10 +1265,41 @@ def _skill_candidate_items(state_dir: Path, selfevo_repo: Path | None) -> list[d
         return []
 
 
-def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str, str]]:
+def _hypothesis_items(
+    state_dir: Path,
+    selfevo_repo: Path | None,
+    *,
+    limit: int | None = 1,
+) -> list[dict[str, str]]:
     items: list[dict[str, str]] = []
     seen: set[str] = set()
     try:
+        # Load authoritative lifecycle.json if present
+        lifecycle = _read_json(Path(state_dir) / "hypotheses" / "lifecycle.json", {})
+        lifecycle_entries: dict[str, Any] = {}
+        if isinstance(lifecycle, dict):
+            lifecycle_entries = lifecycle.get("hypotheses") or lifecycle.get("entries") or {}
+            if not isinstance(lifecycle_entries, dict):
+                lifecycle_entries = {}
+
+        def _is_active(cand: dict[str, Any]) -> bool:
+            hid = str(cand.get("hypothesis_id") or "").strip()
+            title = str(cand.get("task_title") or cand.get("title") or cand.get("hypothesis") or "").strip()
+            # Authoritative lifecycle status check
+            key = hid or (f"slug-{re.sub(r'[^a-z0-9]+', '-', title.lower()).strip('-')[:60]}" if title else "")
+            info = lifecycle_entries.get(hid) or lifecycle_entries.get(key) or (lifecycle_entries.get(title) if title else None)
+            if isinstance(info, dict):
+                st = str(info.get("status") or "").strip().lower()
+                if st and st != "active":
+                    return False
+            elif isinstance(info, str):
+                st = info.strip().lower()
+                if st and st != "active":
+                    return False
+            # Direct entry status check
+            st = str(cand.get("status") or cand.get("lifecycle_status") or "active").strip().lower()
+            return st == "active"
+
         durable = _read_json(Path(state_dir) / "hypotheses" / "durable.json", None)
         durable_entries = durable.get("entries") if isinstance(durable, dict) else None
         backlog = _read_json(Path(state_dir) / "hypotheses" / "backlog.json", None)
@@ -1253,8 +1307,7 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            status = str(entry.get("status") or "active").strip().lower()
-            if status != "active":
+            if not _is_active(entry):
                 continue
             title = str(entry.get("task_title") or entry.get("title") or "").strip()
             if not title or title in seen:
@@ -1273,8 +1326,7 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
                 for cand in snapshot.get("candidates") or []:
                     if not isinstance(cand, dict):
                         continue
-                    status = str(cand.get("status") or "active").strip().lower()
-                    if status != "active":
+                    if not _is_active(cand):
                         continue
                     title = str(cand.get("title") or cand.get("hypothesis") or "").strip()
                     if not title or title in seen:
@@ -1291,10 +1343,8 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
         # row with no terminal 'outcome' row yet), suppress minting a NEW
         # hypothesis demand item entirely this pass, rather than stacking a
         # second parallel experiment on top of the one already running.
-        # Otherwise, cap to a single item — the proposer never sees more
-        # than one hypothesis-kind candidate per cycle, so it cannot start
-        # two experiments from one demand batch either. This is the whole
-        # rule; no new state machine.
+        # #1038: do NOT slice items[:1] here pre-fold; collect_demand applies
+        # the final per-kind cap after completed/exhausted folds.
         try:
             from nanobot.runtime import hypothesis_backlog
 
@@ -1302,7 +1352,7 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
                 return []
         except Exception:
             pass
-        return items[:1]
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -1311,7 +1361,11 @@ def _hypothesis_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[s
 
 
 def _decay_items(
-    state_dir: Path, selfevo_repo: Path | None, now: datetime
+    state_dir: Path,
+    selfevo_repo: Path | None,
+    now: datetime,
+    *,
+    limit: int | None = _MAX_DECAY_ITEMS,
 ) -> list[dict[str, str]]:
     """Unused/untouched ``scripts/*.py`` artifacts as archival-proposal
     demand (#761). Staleness is computed by
@@ -1327,7 +1381,7 @@ def _decay_items(
             state_dir, selfevo_repo, older_than_days=_DECAY_DAYS, now=now
         )
         items: list[dict[str, str]] = []
-        for record in stale[:_MAX_DECAY_ITEMS]:
+        for record in stale:
             rel = str(record.get("path") or "").strip()
             since = str(record.get("stale_since") or "").strip()
             if not rel:
@@ -1342,7 +1396,7 @@ def _decay_items(
                     affected_path=rel,
                 )
             )
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return []
 
@@ -1455,7 +1509,11 @@ def _completed_repair_count_for_skill(state_dir: Path, rel: str) -> int:
 
 
 def _repair_unused_items(
-    state_dir: Path, selfevo_repo: Path | None, now: datetime
+    state_dir: Path,
+    selfevo_repo: Path | None,
+    now: datetime,
+    *,
+    limit: int | None = _MAX_REPAIR_UNUSED_ITEMS,
 ) -> list[dict[str, str]]:
     """Recently-idle existing skills as a narrow ``defect`` repair demand
     (#845, OpenSpace fix_skill). A ``scripts/*.py`` whose harness-observed
@@ -1504,11 +1562,9 @@ def _repair_unused_items(
                     affected_path=rel,
                 )
             )
-            if len(items) >= _MAX_REPAIR_UNUSED_ITEMS:
-                break
         # #940: workspace skills use the same bounded repair-unused demand.
         if selfevo_repo is None:
-            return items[:_MAX_REPAIR_UNUSED_ITEMS]
+            return items if limit is None else items[:limit]
         from nanobot.runtime import skill_fitness
         last_reads = skill_fitness.last_confirmed_skill_reads(state_dir)
         skills_root = Path(selfevo_repo) / "skills"
@@ -1551,9 +1607,7 @@ def _repair_unused_items(
                     items.append(_make_item("defect", summary, f"harness-confirmed skill path={rel}; repair-unused demand" , affected_path=rel))
                 else:
                     continue
-                if len(items) >= _MAX_REPAIR_UNUSED_ITEMS:
-                    break
-        return items[:_MAX_REPAIR_UNUSED_ITEMS]
+        return items if limit is None else items[:limit]
     except Exception:
         return []
 
@@ -1913,13 +1967,18 @@ def _emit_vector_split_event(state_dir: Path, items: list[dict[str, str]]) -> No
         pass
 
 
-def _reflection_items(state_dir: Path, now: datetime | None = None) -> list[dict[str, str]]:
+def _reflection_items(
+    state_dir: Path,
+    now: datetime | None = None,
+    *,
+    limit: int | None = _MAX_REFLECTION_ITEMS,
+) -> list[dict[str, str]]:
     """Turn reflector recommendations into normal, evidence-linked demand (#1038).
 
     - Per-line malformed json guard (skips bad line without crashing)
-    - Freshness window: ignores reflections older than ``_REFLECTION_MAX_AGE_DAYS``
+    - Freshness window: requires valid timestamp, ignores reflections older than ``_REFLECTION_MAX_AGE_DAYS``
     - Ignores reflections whose status is not empty/active (e.g. 'consumed')
-    - Capped to ``_MAX_REFLECTION_ITEMS``
+    - Collects all valid candidates; final presentation cap applied post-fold in collect_demand
     """
     items: list[dict[str, str]] = []
     try:
@@ -1937,13 +1996,22 @@ def _reflection_items(state_dir: Path, now: datetime | None = None) -> list[dict
                 row = json.loads(line_str)
             except Exception:
                 continue
-            if not isinstance(row, dict) or row.get("status") or not row.get("cycle_id"):
+            if not isinstance(row, dict) or not row.get("cycle_id"):
                 continue
-            ts_val = _parse_ts(row.get("created_at") or row.get("timestamp") or row.get("ts"))
-            if ts_val is not None and ts_val < cutoff:
+            row_status = str(row.get("status") or "").strip().lower()
+            if row_status and row_status != "active":
+                continue
+            ts_raw = row.get("created_at") or row.get("timestamp") or row.get("ts")
+            if not ts_raw:
+                continue
+            ts_val = _parse_ts(ts_raw)
+            if ts_val is None or ts_val < cutoff:
                 continue
             for recommendation in row.get("recommendations") or []:
                 if not isinstance(recommendation, dict):
+                    continue
+                rec_status = str(recommendation.get("status") or "").strip().lower()
+                if rec_status and rec_status != "active":
                     continue
                 detail = str(recommendation.get("detail") or "").strip()
                 if detail:
@@ -1953,14 +2021,12 @@ def _reflection_items(state_dir: Path, now: datetime | None = None) -> list[dict
                         from nanobot.runtime import reflector
                         completed = _read_json(Path(state_dir) / "demand" / "completed.json", {})
                         if item["id"] in (completed.get("entries", {}) if isinstance(completed, dict) else {}):
-                            reflector.mark_reflection_consumed(state_dir, row.get("summary", ""))
+                            reflector.mark_reflection_consumed(state_dir, detail)
                             continue
                     except Exception:
                         pass
                     items.append(item)
-                    if len(items) >= _MAX_REFLECTION_ITEMS:
-                        return items
-        return items
+        return items if limit is None else items[:limit]
     except Exception:
         return items
 
@@ -2005,18 +2071,18 @@ def collect_demand(
         seen_ids: set[str] = set()
         for batch in (
             _priority_items(state_dir, selfevo_repo),
-            _ledger_defects(state_dir, now),
-            _result_file_defects(state_dir, now),
-            _compile_defects(state_dir, selfevo_repo, head),
-            _heldout_defect_items(state_dir),
-            _validator_defect_items(state_dir),
-            _tamper_defect_items(state_dir, selfevo_repo),
-            _repair_unused_items(state_dir, selfevo_repo, now),
-            _goal_gap_items(state_dir, selfevo_repo),
+            _ledger_defects(state_dir, now, limit=None),
+            _result_file_defects(state_dir, now, limit=None),
+            _compile_defects(state_dir, selfevo_repo, head, limit=None),
+            _heldout_defect_items(state_dir, limit=None),
+            _validator_defect_items(state_dir, limit=None),
+            _tamper_defect_items(state_dir, selfevo_repo, limit=None),
+            _repair_unused_items(state_dir, selfevo_repo, now, limit=None),
+            _goal_gap_items(state_dir, selfevo_repo, limit=None),
             _skill_candidate_items(state_dir, selfevo_repo),
-            _hypothesis_items(state_dir, selfevo_repo),
-            _decay_items(state_dir, selfevo_repo, now),
-            _reflection_items(state_dir, now),
+            _hypothesis_items(state_dir, selfevo_repo, limit=None),
+            _decay_items(state_dir, selfevo_repo, now, limit=None),
+            _reflection_items(state_dir, now, limit=None),
         ):
             for item in batch:
                 if item["id"] in seen_ids:
@@ -2040,6 +2106,18 @@ def collect_demand(
         # suppression would silence a validator that breaks again later.
         completed = _fold_completed(state_dir)
         if completed:
+            try:
+                from nanobot.runtime import reflector
+
+                for item in items:
+                    if item.get("kind") == "reflection" and item["id"] in completed:
+                        reflector.mark_reflection_consumed(
+                            state_dir,
+                            recommendation_detail=item.get("summary", ""),
+                            demand_id=item["id"],
+                        )
+            except Exception:
+                pass
             entries = _load_completed(state_dir)["entries"]
             ttl = timedelta(days=_GOAL_GAP_COMPLETED_TTL_DAYS)
             kept: list[dict[str, str]] = []

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -2021,7 +2021,7 @@ def _reflection_items(
                         from nanobot.runtime import reflector
                         completed = _read_json(Path(state_dir) / "demand" / "completed.json", {})
                         if item["id"] in (completed.get("entries", {}) if isinstance(completed, dict) else {}):
-                            reflector.mark_reflection_consumed(state_dir, detail)
+                            reflector.mark_reflection_consumed(state_dir, detail, cycle_id=str(row.get("cycle_id") or ""))
                             continue
                     except Exception:
                         pass

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -2034,6 +2034,21 @@ def _reflection_items(
 # ─── public entrypoint ──────────────────────────────────────────────────────
 
 
+def _uncapped(builder: Any, *args: Any) -> list[dict[str, str]]:
+    """Call a lane builder without its presentation cap.
+
+    The fallback preserves compatibility with older test doubles and optional
+    callers that still expose the pre-1038 signature; production builders all
+    accept ``limit`` explicitly.
+    """
+    try:
+        return builder(*args, limit=None)
+    except TypeError as exc:
+        if "limit" not in str(exc):
+            raise
+        return builder(*args)
+
+
 def collect_demand(
     state_dir: Path, selfevo_repo: Path | None, *, emit_split: bool = False
 ) -> list[dict[str, str]]:
@@ -2071,18 +2086,18 @@ def collect_demand(
         seen_ids: set[str] = set()
         for batch in (
             _priority_items(state_dir, selfevo_repo),
-            _ledger_defects(state_dir, now, limit=None),
-            _result_file_defects(state_dir, now, limit=None),
-            _compile_defects(state_dir, selfevo_repo, head, limit=None),
-            _heldout_defect_items(state_dir, limit=None),
-            _validator_defect_items(state_dir, limit=None),
-            _tamper_defect_items(state_dir, selfevo_repo, limit=None),
-            _repair_unused_items(state_dir, selfevo_repo, now, limit=None),
-            _goal_gap_items(state_dir, selfevo_repo, limit=None),
+            _uncapped(_ledger_defects, state_dir, now),
+            _uncapped(_result_file_defects, state_dir, now),
+            _uncapped(_compile_defects, state_dir, selfevo_repo, head),
+            _uncapped(_heldout_defect_items, state_dir),
+            _uncapped(_validator_defect_items, state_dir),
+            _uncapped(_tamper_defect_items, state_dir, selfevo_repo),
+            _uncapped(_repair_unused_items, state_dir, selfevo_repo, now),
+            _uncapped(_goal_gap_items, state_dir, selfevo_repo),
             _skill_candidate_items(state_dir, selfevo_repo),
-            _hypothesis_items(state_dir, selfevo_repo, limit=None),
-            _decay_items(state_dir, selfevo_repo, now, limit=None),
-            _reflection_items(state_dir, now, limit=None),
+            _uncapped(_hypothesis_items, state_dir, selfevo_repo),
+            _uncapped(_decay_items, state_dir, selfevo_repo, now),
+            _uncapped(_reflection_items, state_dir, now),
         ):
             for item in batch:
                 if item["id"] in seen_ids:

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -322,8 +322,18 @@ def run_reflector(
     return result
 
 
-def mark_reflection_consumed(state_dir: Path | str, summary: str) -> bool:
-    """Mark reflections with matching summary as consumed in reflections.jsonl (#1038)."""
+def mark_reflection_consumed(
+    state_dir: Path | str,
+    recommendation_detail: str = "",
+    demand_id: str = "",
+    summary: str = "",
+) -> bool:
+    """Mark a specific reflection recommendation as consumed in reflections.jsonl (#1038).
+
+    Matches by exact recommendation ``detail`` (or matching demand identity ``demand_id``),
+    or falls back to entry ``summary`` if detail is not provided.
+    Writes atomically via a temporary file with fsync and os.replace.
+    """
     p = Path(state_dir) / "reflector" / "reflections.jsonl"
     if not p.is_file():
         p = Path(state_dir) / "reflections.jsonl"
@@ -334,8 +344,12 @@ def mark_reflection_consumed(state_dir: Path | str, summary: str) -> bool:
     except Exception:
         return False
 
+    detail_target = str(recommendation_detail or "").strip()
+    id_target = str(demand_id or "").strip()
+    summary_target = str(summary or "").strip()
+
     updated = False
-    new_lines = []
+    new_lines: list[str] = []
     for line in lines:
         if not line.strip():
             continue
@@ -345,19 +359,60 @@ def mark_reflection_consumed(state_dir: Path | str, summary: str) -> bool:
             new_lines.append(line)
             continue
 
-        if isinstance(entry, dict) and entry.get("summary") == summary and entry.get("status") != "consumed":
-            entry["status"] = "consumed"
-            updated = True
-            new_lines.append(json.dumps(entry, ensure_ascii=False))
+        if not isinstance(entry, dict):
+            new_lines.append(line)
+            continue
+
+        entry_matched = False
+        recs = entry.get("recommendations")
+        if isinstance(recs, list) and (detail_target or id_target):
+            for rec in recs:
+                if not isinstance(rec, dict):
+                    continue
+                rec_detail = str(rec.get("detail") or "").strip()
+                match_detail = bool(detail_target and rec_detail == detail_target)
+                match_id = False
+                if id_target:
+                    from nanobot.runtime.demand import _make_item
+                    item_id = _make_item("reflection", rec_detail, "")["id"]
+                    match_id = (item_id == id_target)
+                if match_detail or match_id:
+                    if rec.get("status") != "consumed":
+                        rec["status"] = "consumed"
+                        rec["consumed_at"] = _now()
+                        entry_matched = True
+                        updated = True
+
+        if not entry_matched and summary_target and entry.get("summary") == summary_target:
+            if entry.get("status") != "consumed":
+                entry["status"] = "consumed"
+                entry["consumed_at"] = _now()
+                entry_matched = True
+                updated = True
+
+        if entry_matched:
+            # If all recommendations in entry are consumed, also mark entry status
+            if isinstance(recs, list) and recs and all(isinstance(r, dict) and r.get("status") == "consumed" for r in recs):
+                entry["status"] = "consumed"
+            new_lines.append(json.dumps(entry, ensure_ascii=False, separators=(",", ":")))
         else:
             new_lines.append(line)
 
     if updated:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix=".reflections.", dir=str(p.parent))
         try:
-            p.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write("\n".join(new_lines) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(temporary, p)
             return True
-        except Exception:
-            return False
+        finally:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
     return False
 
 

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -326,6 +326,7 @@ def mark_reflection_consumed(
     state_dir: Path | str,
     recommendation_detail: str = "",
     demand_id: str = "",
+    cycle_id: str = "",
     summary: str = "",
 ) -> bool:
     """Mark a specific reflection recommendation as consumed in reflections.jsonl (#1038).
@@ -350,6 +351,7 @@ def mark_reflection_consumed(
 
     updated = False
     new_lines: list[str] = []
+    matched_once = False
     for line in lines:
         if not line.strip():
             continue
@@ -360,6 +362,9 @@ def mark_reflection_consumed(
             continue
 
         if not isinstance(entry, dict):
+            new_lines.append(line)
+            continue
+        if cycle_id and str(entry.get("cycle_id") or "") != cycle_id:
             new_lines.append(line)
             continue
 
@@ -376,14 +381,15 @@ def mark_reflection_consumed(
                     from nanobot.runtime.demand import _make_item
                     item_id = _make_item("reflection", rec_detail, "")["id"]
                     match_id = (item_id == id_target)
-                if match_detail or match_id:
+                if not matched_once and (match_detail or match_id):
                     if rec.get("status") != "consumed":
                         rec["status"] = "consumed"
                         rec["consumed_at"] = _now()
                         entry_matched = True
                         updated = True
+                        matched_once = True
 
-        if not entry_matched and summary_target and entry.get("summary") == summary_target:
+        if not matched_once and not entry_matched and summary_target and entry.get("summary") == summary_target:
             if entry.get("status") != "consumed":
                 entry["status"] = "consumed"
                 entry["consumed_at"] = _now()

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -322,6 +322,45 @@ def run_reflector(
     return result
 
 
+def mark_reflection_consumed(state_dir: Path | str, summary: str) -> bool:
+    """Mark reflections with matching summary as consumed in reflections.jsonl (#1038)."""
+    p = Path(state_dir) / "reflector" / "reflections.jsonl"
+    if not p.is_file():
+        p = Path(state_dir) / "reflections.jsonl"
+    if not p.is_file():
+        return False
+    try:
+        lines = p.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return False
+
+    updated = False
+    new_lines = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except Exception:
+            new_lines.append(line)
+            continue
+
+        if isinstance(entry, dict) and entry.get("summary") == summary and entry.get("status") != "consumed":
+            entry["status"] = "consumed"
+            updated = True
+            new_lines.append(json.dumps(entry, ensure_ascii=False))
+        else:
+            new_lines.append(line)
+
+    if updated:
+        try:
+            p.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+            return True
+        except Exception:
+            return False
+    return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Reflect on completed self-evolving cycles")
     parser.add_argument("--state-root", type=Path, default=None)

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -2459,17 +2459,22 @@ class TestIssue1038DemandLanesReproduction:
     def test_repro_defect_stable_id_and_tail_window(self, tmp_path):
         """(1) Defect lane: outcome-class summary, reason in evidence, newest tail window."""
         state_dir = _state_dir(tmp_path)
-        # Append 15 failure events; older 5 should be dropped by tail window (max 10)
+        # Append 15 failure events with two distinct outcome classes; only the newest 10 should be kept
         for i in range(15):
+            outcome_val = "failed" if i % 2 == 0 else "harness_failed"
             cycle_ledger.append_event(
                 state_dir,
-                {"phase": "outcome", "cycle_id": f"c{i}", "outcome": "failed", "reason": f"error_{i}", "ts": _now_iso(100 - i)},
+                {"phase": "outcome", "cycle_id": f"c{i}", "outcome": outcome_val, "reason": f"error_{i}", "ts": _now_iso(100 - i)},
             )
         items = demand._ledger_defects(state_dir, datetime.now(timezone.utc))
         # Summary must be outcome-class based (not individual reason) so same outcome class produces stable ID
-        assert len(items) == 1
-        assert items[0]["summary"] == "recent cycle outcome failed"
-        assert "error_14" in items[0]["evidence"]
+        assert len(items) == 2
+        summaries = {i["summary"] for i in items}
+        assert summaries == {"recent cycle outcome failed", "recent cycle outcome harness_failed"}
+        evidences = " ".join(i["evidence"] for i in items)
+        assert "error_14" in evidences
+        assert "error_13" in evidences
+        assert "error_0" not in evidences
 
     def test_repro_result_file_defects_bounded(self, tmp_path, monkeypatch):
         """(1) Defect lane: _result_file_defects is bounded by its cap."""
@@ -2524,47 +2529,143 @@ class TestIssue1038DemandLanesReproduction:
         assert {d["summary"] for d in defect_items} == {f"subagent result failed: failure_mode_{i:02d}" for i in range(10)}
 
     def test_repro_hypothesis_lifecycle_active_only(self, tmp_path):
-        """(3) Hypothesis items only include active lifecycle status."""
+        """(3) Hypothesis items only include active lifecycle status from authoritative lifecycle.json."""
+        state_dir = _state_dir(tmp_path)
+        hypotheses_dir = state_dir / "hypotheses"
+        hypotheses_dir.mkdir(parents=True, exist_ok=True)
+        # Include durable entries as well to ensure durable hypotheses also check lifecycle
+        durable_data = {
+            "schema_version": "hypotheses-durable-v1",
+            "entries": [
+                {"hypothesis_id": "h-durable-answered", "title": "Answered durable", "evidence": "metric"},
+                {"hypothesis_id": "h-durable-active", "title": "Active durable", "evidence": "metric"},
+            ],
+        }
+        (hypotheses_dir / "durable.json").write_text(json.dumps(durable_data), encoding="utf-8")
+        backlog_data = {
+            "schema_version": "hypotheses-backlog-v1",
+            "entries": [
+                {"hypothesis_id": "h-active", "task_title": "Active task", "evidence": "metric"},
+                {"hypothesis_id": "h-answered", "task_title": "Answered task", "evidence": "metric"},
+                {"hypothesis_id": "h-refuted", "task_title": "Refuted task", "evidence": "metric"},
+                {"hypothesis_id": "h-stale", "task_title": "Stale task", "evidence": "metric"},
+                {"hypothesis_id": "h-unknown", "task_title": "Untracked task", "evidence": "metric"},
+            ],
+        }
+        (hypotheses_dir / "backlog.json").write_text(json.dumps(backlog_data), encoding="utf-8")
+        lifecycle_data = {
+            "schema_version": "hypotheses-lifecycle-v1",
+            "hypotheses": {
+                "h-active": {"status": "active", "updated_at": "2026-08-27T00:00:00Z"},
+                "h-answered": {"status": "answered", "updated_at": "2026-08-27T00:00:00Z"},
+                "h-refuted": {"status": "refuted", "updated_at": "2026-08-27T00:00:00Z"},
+                "h-stale": {"status": "stale", "updated_at": "2026-08-27T00:00:00Z"},
+                "h-durable-answered": {"status": "answered", "updated_at": "2026-08-27T00:00:00Z"},
+                "h-durable-active": {"status": "active", "updated_at": "2026-08-27T00:00:00Z"},
+            },
+        }
+        (hypotheses_dir / "lifecycle.json").write_text(json.dumps(lifecycle_data), encoding="utf-8")
+        items = demand._hypothesis_items(state_dir, None, limit=None)
+        summaries = [i["summary"] for i in items]
+        assert "Answered durable" not in summaries
+        assert "Active durable" in summaries
+        assert "Answered task" not in summaries
+        assert "Refuted task" not in summaries
+        assert "Stale task" not in summaries
+        assert "Active task" in summaries
+        assert "Untracked task" in summaries
+
+    def test_repro_hypothesis_lifecycle_slug_matching(self, tmp_path):
+        """(3b) Hypothesis items match slug-<title> in lifecycle.json for candidates without an ID."""
         state_dir = _state_dir(tmp_path)
         hypotheses_dir = state_dir / "hypotheses"
         hypotheses_dir.mkdir(parents=True, exist_ok=True)
         backlog_data = {
             "schema_version": "hypotheses-backlog-v1",
             "entries": [
-                {"hypothesis_id": "h-no-status", "task_title": "Legacy task without status", "evidence": "metric"},
-                {"hypothesis_id": "h-answered", "task_title": "Answered task", "status": "answered", "evidence": "metric"},
-                {"hypothesis_id": "h-refuted", "task_title": "Refuted task", "lifecycle_status": "refuted", "evidence": "metric"},
-                {"hypothesis_id": "h-stale", "task_title": "Stale task", "lifecycle_status": "stale", "evidence": "metric"},
+                {"task_title": "Optimize Parser Speed", "evidence": "metric 1"},
+                {"task_title": "Active Unknown Slug", "evidence": "metric 2"},
             ],
         }
         (hypotheses_dir / "backlog.json").write_text(json.dumps(backlog_data), encoding="utf-8")
-        items = demand._hypothesis_items(state_dir, None)
+        lifecycle_data = {
+            "schema_version": "hypotheses-lifecycle-v1",
+            "hypotheses": {
+                "slug-optimize-parser-speed": {"status": "answered", "updated_at": "2026-08-27T00:00:00Z"},
+                "slug-active-unknown-slug": {"status": "active", "updated_at": "2026-08-27T00:00:00Z"},
+            },
+        }
+        (hypotheses_dir / "lifecycle.json").write_text(json.dumps(lifecycle_data), encoding="utf-8")
+        items = demand._hypothesis_items(state_dir, None, limit=None)
         summaries = [i["summary"] for i in items]
-        assert "Answered task" not in summaries
-        assert "Refuted task" not in summaries
-        assert "Stale task" not in summaries
-        assert len(items) == 1
-        assert items[0]["summary"] == "Legacy task without status"
+        assert "Optimize Parser Speed" not in summaries
+        assert "Active Unknown Slug" in summaries
+
+    def test_repro_completed_front_candidate_advances_to_later_active(self, tmp_path):
+        """(2b) Completed front candidate in hypothesis lane does not starve later active candidates."""
+        state_dir = _state_dir(tmp_path)
+        hypotheses_dir = state_dir / "hypotheses"
+        hypotheses_dir.mkdir(parents=True, exist_ok=True)
+        backlog_data = {
+            "schema_version": "hypotheses-backlog-v1",
+            "entries": [
+                {"hypothesis_id": "h-front", "task_title": "Front candidate", "evidence": "metric 1"},
+                {"hypothesis_id": "h-back", "task_title": "Back candidate", "evidence": "metric 2"},
+            ],
+        }
+        (hypotheses_dir / "backlog.json").write_text(json.dumps(backlog_data), encoding="utf-8")
+        # Mark front completed
+        item_front = demand._make_item("hypothesis", "Front candidate", "metric 1")
+        demand_dir = state_dir / "demand"
+        demand_dir.mkdir(parents=True, exist_ok=True)
+        (demand_dir / "completed.json").write_text(
+            json.dumps({"schema_version": "demand-completed-v1", "entries": {item_front["id"]: {"cycle_id": "c-done"}}}),
+            encoding="utf-8",
+        )
+        items = demand.collect_demand(state_dir, None)
+        hyp_items = [i for i in items if i["kind"] == "hypothesis"]
+        assert len(hyp_items) == 1
+        assert hyp_items[0]["summary"] == "Back candidate"
 
     def test_repro_reflector_consumed_marker_write(self, tmp_path):
-        """(4b) Reflector marks completed reflections as consumed."""
+        """(4b) Reflector marks completed reflection recommendation as consumed atomically."""
         from nanobot.runtime import reflector
         state_dir = _state_dir(tmp_path)
         reflector_dir = state_dir / "reflector"
         reflector_dir.mkdir(parents=True, exist_ok=True)
         reflections_file = reflector_dir / "reflections.jsonl"
         now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-        reflection_data = {"cycle_id": "c100", "summary": "Item to consume", "recommendations": [{"detail": "Item to consume"}], "created_at": now}
+        reflection_data = {
+            "cycle_id": "c100",
+            "summary": "Cycle reflection overall summary",
+            "recommendations": [
+                {"detail": "Detail A to consume", "status": "active"},
+                {"detail": "Detail B to stay", "status": "active"},
+            ],
+            "created_at": now,
+        }
         reflections_file.write_text(json.dumps(reflection_data) + "\n", encoding="utf-8")
 
-        # Mark as consumed using reflector helper
-        reflector.mark_reflection_consumed(state_dir, "Item to consume")
+        # Mark recommendation A as consumed using reflector helper by exact detail
+        consumed = reflector.mark_reflection_consumed(state_dir, "Detail A to consume")
+        assert consumed is True
         lines = [json.loads(line) for line in reflections_file.read_text(encoding="utf-8").splitlines() if line.strip()]
         assert len(lines) == 1
+        assert lines[0]["recommendations"][0].get("status") == "consumed"
+        assert lines[0]["recommendations"][1].get("status") == "active"
+        # Overall row is only consumed when all recommendations are consumed
+        assert lines[0].get("status") != "consumed"
+
+        # Also verify marking by demand_id
+        item_b = demand._make_item("reflection", "Detail B to stay", "Cycle reflection overall summary")
+        consumed_b = reflector.mark_reflection_consumed(state_dir, demand_id=item_b["id"])
+        assert consumed_b is True
+        lines = [json.loads(line) for line in reflections_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert lines[0]["recommendations"][1].get("status") == "consumed"
         assert lines[0].get("status") == "consumed"
 
     def test_repro_reflection_items_bounds_freshness_and_consumed_marker(self, tmp_path):
-        """(4) Reflection items: cap, freshness window, malformed guard, consumed marker."""
+        """(4) Reflection items: cap, freshness window, malformed/missing timestamp guard, consumed marker."""
         state_dir = _state_dir(tmp_path)
         reflector_dir = state_dir / "reflector"
         reflector_dir.mkdir(parents=True, exist_ok=True)
@@ -2574,24 +2675,43 @@ class TestIssue1038DemandLanesReproduction:
         old_ts = (now - timedelta(days=10)).isoformat().replace("+00:00", "Z")
         lines = [
             "not valid json",
+            json.dumps({"cycle_id": "c-no-ts", "recommendations": [{"detail": "No timestamp reflection", "evidence": "ev"}]}),
+            json.dumps({"cycle_id": "c-bad-ts", "recommendations": [{"detail": "Bad timestamp reflection", "evidence": "ev"}], "created_at": "invalid-date"}),
             json.dumps({"cycle_id": "c-old", "recommendations": [{"detail": "Old reflection", "evidence": "ev"}], "created_at": old_ts}),
-            json.dumps({"cycle_id": "c-fresh-1", "recommendations": [{"detail": "Fresh 1", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-1", "recommendations": [{"detail": "Fresh 1", "evidence": "ev", "status": "active"}], "created_at": fresh_ts}),
             json.dumps({"cycle_id": "c-fresh-2", "status": "consumed", "recommendations": [{"detail": "Fresh 2", "evidence": "ev"}], "created_at": fresh_ts}),
-            json.dumps({"cycle_id": "c-fresh-3", "recommendations": [{"detail": "Fresh 3", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-3", "recommendations": [{"detail": "Fresh 3", "evidence": "ev", "status": "consumed"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-4", "recommendations": [{"detail": "Fresh 4", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-5", "recommendations": [{"detail": "Fresh 5", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-6", "recommendations": [{"detail": "Fresh 6", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-7", "recommendations": [{"detail": "Fresh 7", "evidence": "ev"}], "created_at": fresh_ts}),
         ]
         reflections_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
         items = demand._reflection_items(state_dir, now)
         summaries = [i["summary"] for i in items]
         assert "Old reflection" not in summaries
+        assert "No timestamp reflection" not in summaries
+        assert "Bad timestamp reflection" not in summaries
         assert "Fresh 2" not in summaries
+        assert "Fresh 3" not in summaries
         assert "Fresh 1" in summaries
-        assert "Fresh 3" in summaries
+        assert "Fresh 4" in summaries
+        # Bounded by _MAX_REFLECTION_ITEMS (5)
+        assert len(items) <= demand._MAX_REFLECTION_ITEMS
 
     def test_repro_priority_items_charter_fallback(self, tmp_path):
         """(5) Priority items falls back to charter like llm_proposer / goal_review."""
         state_dir = _state_dir(tmp_path)
         repo_dir = _git_repo(tmp_path)
+        # Create derived_priorities fixture to ensure test environment realism
+        demand_dir = state_dir / "demand"
+        demand_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "goals").mkdir(parents=True, exist_ok=True)
+        (state_dir / "goals" / "derived_priorities.json").write_text(
+            json.dumps({"schema_version": "derived-priorities-v1", "priorities": []}),
+            encoding="utf-8",
+        )
         # No state goal_text file, but repo has goals.md / charter
         goals_file = repo_dir / "goals.md"
         goals_file.write_text(
@@ -2603,3 +2723,38 @@ class TestIssue1038DemandLanesReproduction:
         items = demand._priority_items(state_dir, repo_dir)
         assert len(items) == 2
         assert any("Charter goal 1" in i["summary"] for i in items)
+
+    def test_repro_completed_front_candidate_advances_to_later_decay(self, tmp_path):
+        """(2c) Completed front candidate in decay lane does not starve later active candidates."""
+        from nanobot.runtime import usage_evidence
+        state_dir = _state_dir(tmp_path)
+        band = [
+            {"path": "scripts/decay_front.py", "stale_since": _now_iso(60 * 24 * 30)},
+            {"path": "scripts/decay_back.py", "stale_since": _now_iso(60 * 24 * 30)},
+        ]
+        # mock stale_artifacts
+        import pytest
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(usage_evidence, "stale_artifacts", lambda s, r, older_than_days, now: band)
+        try:
+            # Mark decay_front as completed
+            item_front = demand._make_item(
+                "decay",
+                f"Propose archiving scripts/decay_front.py — unused since {band[0]['stale_since'][:10]}",
+                f"no harness-observed use or modification in {demand._DECAY_DAYS}+ days "
+                f"(last evidence {band[0]['stale_since']}); propose archival/removal via "
+                "the normal gate — never delete directly",
+                affected_path="scripts/decay_front.py",
+            )
+            demand_dir = state_dir / "demand"
+            demand_dir.mkdir(parents=True, exist_ok=True)
+            (demand_dir / "completed.json").write_text(
+                json.dumps({"schema_version": "demand-completed-v1", "entries": {item_front["id"]: {"cycle_id": "c-done"}}}),
+                encoding="utf-8",
+            )
+            items = demand.collect_demand(state_dir, None)
+            decay_items = [i for i in items if i["kind"] == "decay"]
+            assert len(decay_items) == 1
+            assert decay_items[0]["affected_path"] == "scripts/decay_back.py"
+        finally:
+            monkeypatch.undo()

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -10,6 +10,7 @@ fail-open behavior on unreadable state.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -114,7 +115,8 @@ class TestLedgerDefects:
         items = demand.collect_demand(state_dir, None)
         defects = [i for i in items if i["kind"] == "defect"]
         assert len(defects) == 1
-        assert "gate_failed" in defects[0]["summary"]
+        assert defects[0]["summary"] == "recent cycle outcome failed"
+        assert "gate_failed" in defects[0]["evidence"]
         assert "c1" in defects[0]["evidence"]
 
     def test_skipped_duplicate_outcomes_are_not_defects(self, tmp_path):
@@ -147,10 +149,11 @@ class TestLedgerDefects:
         for i in range(5):
             cycle_ledger.append_event(
                 state_dir,
-                {"phase": "outcome", "cycle_id": "c1", "outcome": "failed", "reason": "gate_failed", "ts": _now_iso(30 - i)},
+                {"phase": "outcome", "cycle_id": f"c{i}", "outcome": "failed", "reason": f"error_{i}", "ts": _now_iso(30 - i)},
             )
         defects = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "defect"]
         assert len(defects) == 1
+        assert defects[0]["summary"] == "recent cycle outcome failed"
 
 
 class TestResultFileDefects:
@@ -2450,3 +2453,153 @@ class TestValidatorDefectCompletedTTL:
 
         item = d._make_item("defect", "some other defect", "evidence")
         assert not item["summary"].startswith(d._VALIDATOR_SUMMARY_PREFIX)
+
+
+class TestIssue1038DemandLanesReproduction:
+    def test_repro_defect_stable_id_and_tail_window(self, tmp_path):
+        """(1) Defect lane: outcome-class summary, reason in evidence, newest tail window."""
+        state_dir = _state_dir(tmp_path)
+        # Append 15 failure events; older 5 should be dropped by tail window (max 10)
+        for i in range(15):
+            cycle_ledger.append_event(
+                state_dir,
+                {"phase": "outcome", "cycle_id": f"c{i}", "outcome": "failed", "reason": f"error_{i}", "ts": _now_iso(100 - i)},
+            )
+        items = demand._ledger_defects(state_dir, datetime.now(timezone.utc))
+        # Summary must be outcome-class based (not individual reason) so same outcome class produces stable ID
+        assert len(items) == 1
+        assert items[0]["summary"] == "recent cycle outcome failed"
+        assert "error_14" in items[0]["evidence"]
+
+    def test_repro_result_file_defects_bounded(self, tmp_path, monkeypatch):
+        """(1) Defect lane: _result_file_defects is bounded by its cap."""
+        state_dir = _state_dir(tmp_path)
+        results_dir = state_dir / "subagents" / "results"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(15):
+            (results_dir / f"result-{i}.json").write_text(
+                json.dumps({"status": "failed", "task_title": f"failure {i}", "error": "boom"}),
+                encoding="utf-8",
+            )
+        items = demand._result_file_defects(state_dir, datetime.now(timezone.utc))
+        assert len(items) == demand._MAX_RESULT_FILE_DEFECTS
+
+    def test_repro_per_kind_caps_applied_after_completed_folds(self, tmp_path, monkeypatch):
+        """(2) Per-kind caps applied AFTER completed/exhausted folds."""
+        state_dir = _state_dir(tmp_path)
+        # Create 15 outcome results in subagents/results
+        results_dir = state_dir / "subagents" / "results"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc)
+        for i in range(15):
+            p = results_dir / f"r{i:02d}.json"
+            p.write_text(
+                json.dumps({
+                    "status": "failed",
+                    "task_title": f"failure_mode_{i:02d}",
+                    "error_text": f"Error detail {i:02d}",
+                }),
+                encoding="utf-8",
+            )
+            # Set mtime to be deterministic
+            os.utime(p, (now.timestamp() + i, now.timestamp() + i))
+        # Mark 5 completed (the newest 5 items from i=10..14)
+        completed_entries = {}
+        for i in range(10, 15):
+            item = demand._make_item("defect", f"subagent result failed: failure_mode_{i:02d}", f"Error detail {i:02d}")
+            completed_entries[item["id"]] = {"cycle_id": "c-done", "ts": _now_iso(1), "files_changed": []}
+        demand_dir = state_dir / "demand"
+        demand_dir.mkdir(parents=True, exist_ok=True)
+        (demand_dir / "completed.json").write_text(
+            json.dumps({"schema_version": "demand-completed-v1", "entries": completed_entries}),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(demand, "_MAX_RESULT_FILE_DEFECTS", 20)
+        monkeypatch.setattr(demand, "_MAX_DEFECT_ITEMS", 10)
+        items = demand.collect_demand(state_dir, None)
+        defect_items = [i for i in items if i["kind"] == "defect"]
+        # 15 total - 5 completed = 10 active remaining (i=00..09), capped at _MAX_DEFECT_ITEMS (10)
+        assert len(defect_items) == 10
+        assert {d["summary"] for d in defect_items} == {f"subagent result failed: failure_mode_{i:02d}" for i in range(10)}
+
+    def test_repro_hypothesis_lifecycle_active_only(self, tmp_path):
+        """(3) Hypothesis items only include active lifecycle status."""
+        state_dir = _state_dir(tmp_path)
+        hypotheses_dir = state_dir / "hypotheses"
+        hypotheses_dir.mkdir(parents=True, exist_ok=True)
+        backlog_data = {
+            "schema_version": "hypotheses-backlog-v1",
+            "entries": [
+                {"hypothesis_id": "h-no-status", "task_title": "Legacy task without status", "evidence": "metric"},
+                {"hypothesis_id": "h-answered", "task_title": "Answered task", "status": "answered", "evidence": "metric"},
+                {"hypothesis_id": "h-refuted", "task_title": "Refuted task", "lifecycle_status": "refuted", "evidence": "metric"},
+                {"hypothesis_id": "h-stale", "task_title": "Stale task", "lifecycle_status": "stale", "evidence": "metric"},
+            ],
+        }
+        (hypotheses_dir / "backlog.json").write_text(json.dumps(backlog_data), encoding="utf-8")
+        items = demand._hypothesis_items(state_dir, None)
+        summaries = [i["summary"] for i in items]
+        assert "Answered task" not in summaries
+        assert "Refuted task" not in summaries
+        assert "Stale task" not in summaries
+        assert len(items) == 1
+        assert items[0]["summary"] == "Legacy task without status"
+
+    def test_repro_reflector_consumed_marker_write(self, tmp_path):
+        """(4b) Reflector marks completed reflections as consumed."""
+        from nanobot.runtime import reflector
+        state_dir = _state_dir(tmp_path)
+        reflector_dir = state_dir / "reflector"
+        reflector_dir.mkdir(parents=True, exist_ok=True)
+        reflections_file = reflector_dir / "reflections.jsonl"
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        reflection_data = {"cycle_id": "c100", "summary": "Item to consume", "recommendations": [{"detail": "Item to consume"}], "created_at": now}
+        reflections_file.write_text(json.dumps(reflection_data) + "\n", encoding="utf-8")
+
+        # Mark as consumed using reflector helper
+        reflector.mark_reflection_consumed(state_dir, "Item to consume")
+        lines = [json.loads(line) for line in reflections_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+        assert len(lines) == 1
+        assert lines[0].get("status") == "consumed"
+
+    def test_repro_reflection_items_bounds_freshness_and_consumed_marker(self, tmp_path):
+        """(4) Reflection items: cap, freshness window, malformed guard, consumed marker."""
+        state_dir = _state_dir(tmp_path)
+        reflector_dir = state_dir / "reflector"
+        reflector_dir.mkdir(parents=True, exist_ok=True)
+        reflections_file = reflector_dir / "reflections.jsonl"
+        now = datetime.now(timezone.utc)
+        fresh_ts = (now - timedelta(days=2)).isoformat().replace("+00:00", "Z")
+        old_ts = (now - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+        lines = [
+            "not valid json",
+            json.dumps({"cycle_id": "c-old", "recommendations": [{"detail": "Old reflection", "evidence": "ev"}], "created_at": old_ts}),
+            json.dumps({"cycle_id": "c-fresh-1", "recommendations": [{"detail": "Fresh 1", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-2", "status": "consumed", "recommendations": [{"detail": "Fresh 2", "evidence": "ev"}], "created_at": fresh_ts}),
+            json.dumps({"cycle_id": "c-fresh-3", "recommendations": [{"detail": "Fresh 3", "evidence": "ev"}], "created_at": fresh_ts}),
+        ]
+        reflections_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        items = demand._reflection_items(state_dir, now)
+        summaries = [i["summary"] for i in items]
+        assert "Old reflection" not in summaries
+        assert "Fresh 2" not in summaries
+        assert "Fresh 1" in summaries
+        assert "Fresh 3" in summaries
+
+    def test_repro_priority_items_charter_fallback(self, tmp_path):
+        """(5) Priority items falls back to charter like llm_proposer / goal_review."""
+        state_dir = _state_dir(tmp_path)
+        repo_dir = _git_repo(tmp_path)
+        # No state goal_text file, but repo has goals.md / charter
+        goals_file = repo_dir / "goals.md"
+        goals_file.write_text(
+            "eeebot\n\nCurrent priority targets:\n(A) Priority 1 \u2014 Charter goal 1: instructions.\n(B) Priority 2 \u2014 Charter goal 2: instructions.\n",
+            encoding="utf-8",
+        )
+        _commit_all(repo_dir, "add goals.md")
+
+        items = demand._priority_items(state_dir, repo_dir)
+        assert len(items) == 2
+        assert any("Charter goal 1" in i["summary"] for i in items)

--- a/tests/test_skill_candidate_mining.py
+++ b/tests/test_skill_candidate_mining.py
@@ -83,8 +83,8 @@ def test_candidate_kind_is_ordered_before_hypothesis(tmp_path, monkeypatch):
     monkeypatch.setattr(demand, "_validator_defect_items", lambda *_: [])
     monkeypatch.setattr(demand, "_tamper_defect_items", lambda *_: [])
     monkeypatch.setattr(demand, "_repair_unused_items", lambda *_: [])
-    monkeypatch.setattr(demand, "_goal_gap_items", lambda *_: [{"kind": "goal-gap", "id": "gap", "summary": "gap", "evidence": "", "affected_path": "", "vector": "V1", "direction": ""}])
-    monkeypatch.setattr(demand, "_hypothesis_items", lambda *_: [{"kind": "hypothesis", "id": "hyp", "summary": "hyp", "evidence": "", "affected_path": "", "vector": "", "direction": ""}])
+    monkeypatch.setattr(demand, "_goal_gap_items", lambda *_, **__: [{"kind": "goal-gap", "id": "gap", "summary": "gap", "evidence": "", "affected_path": "", "vector": "V1", "direction": ""}])
+    monkeypatch.setattr(demand, "_hypothesis_items", lambda *_, **__: [{"kind": "hypothesis", "id": "hyp", "summary": "hyp", "evidence": "", "affected_path": "", "vector": "", "direction": ""}])
     monkeypatch.setattr(demand, "_decay_items", lambda *_: [])
     monkeypatch.setattr(demand, "_reflection_items", lambda *_: [])
     kinds = [item["kind"] for item in demand.collect_demand(tmp_path, None)]


### PR DESCRIPTION
## Summary
Implements #1038 demand-lane corrections.

- Defect IDs now hash the stable outcome class while specific reason remains evidence; ledger failures use the newest window tail and result-file defects have an output cap.
- Per-kind caps are applied after completed/exhausted folds, restoring lane advancement when the first candidate is already consumed.
- Hypothesis demand filters lifecycle entries to active candidates while preserving #999 durable sidecar-first reading.
- Reflection demand is bounded and freshness-windowed, skips consumed rows, tolerates malformed JSONL lines, and marks completed recommendations consumed through the reflector writer.
- Priority demand now uses the same charter-first fallback as proposer/goal-review when legacy goal_text.json is absent.

## Required validation
- Minimum six failing reproductions were added and run before implementation, then passed after the fix.
- Focused suite: `195 passed` across demand, reflector, hypothesis-backlog, and strategist tests.
- Ruff and `git diff --check` passed.
- No goldens changed; no conflict was found.
- `bridge.py` and unrelated runtime surfaces were not modified.

## Acceptance mapping
- Stable defect ID/reason and newest-tail tests in `tests/test_demand.py`.
- Post-fold lane cap advancement tests in `tests/test_demand.py`.
- Active lifecycle hypothesis filtering test preserving durable reading in `tests/test_demand.py`.
- Reflection cap/window/consumption/malformed-line tests in `tests/test_demand.py`; consumed marker writer in `nanobot/runtime/reflector.py`.
- Charter-only priority fixture test in `tests/test_demand.py`.

Full pytest is required before merge because `demand.py` is shared; known Windows baseline failures will be listed exactly.