### PR TITLE
fix(action-index): stop per-call archive rebuilds

### DIFF
--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -32,6 +32,7 @@ import json
 import os
 import re
 import shutil
+import time
 from contextvars import ContextVar, Token
 from datetime import datetime, timezone
 from itertools import count
@@ -254,14 +255,36 @@ def record_llm_prompt(
         prompts_dir.mkdir(parents=True, exist_ok=True)
 
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        # #1005: distill the previous day's complete cycle records before
-        # rotation gzips them.  The extractor is its own stdlib-only module;
-        # this small hook makes the timer a safety net rather than the only
-        # chance to observe a file before it disappears.
+        # #1005 / #1059: distill complete cycle records into durable action index.
+        # Bounded to recent days (yesterday + today) and rate-limited via a persistent
+        # marker file under writable state/action_index to avoid repeated scans during
+        # burst LLM invocations across separate processes in a single cycle.
         try:
-            from nanobot.runtime.action_index import build_action_index
+            state_root = prompts_dir.parent.parent
+            index_dir = state_root / "action_index"
+            index_dir.mkdir(parents=True, exist_ok=True)
+            marker_file = index_dir / ".last_hook_run"
+            rate_limit_secs = float(os.environ.get("LLM_ACTION_INDEX_HOOK_MIN_INTERVAL", "60"))
 
-            build_action_index(prompts_dir.parent.parent, prompts_dir)
+            should_run = True
+            now_epoch = time.time()
+            if marker_file.exists():
+                try:
+                    mtime = marker_file.stat().st_mtime
+                    if now_epoch - mtime < rate_limit_secs:
+                        should_run = False
+                except OSError:
+                    # Fail-open on marker stat errors
+                    should_run = True
+
+            if should_run:
+                try:
+                    marker_file.touch(exist_ok=True)
+                except OSError:
+                    pass
+                from nanobot.runtime.action_index import build_action_index
+
+                build_action_index(state_root, prompts_dir, max_days=2)
         except Exception:
             pass
         _rotate_and_prune(prompts_dir, today, _prompts_retention_days())

--- a/nanobot/runtime/action_index.py
+++ b/nanobot/runtime/action_index.py
@@ -243,6 +243,7 @@ def build_action_index(
     state_root: Path,
     prompts_dir: Path | None = None,
     *,
+    max_days: int | None = None,
     force_regenerate: bool = False,
 ) -> dict[str, int]:
     """Extract present prompt files into the durable index; never raises.
@@ -253,6 +254,11 @@ def build_action_index(
     the corrected path stripping (including state_root).  Only days whose
     source prompt file still exists are regenerated; day-files with no source
     are left intact to preserve history.
+
+    #1059: skips historical prompt day files whose durable index file already
+    exists (unless force_regenerate is True).  Only the newest/today file
+    (and unindexed days) are parsed.  Accepts optional ``max_days`` to bound
+    inspection window when called from synchronous hooks.
     """
     force_regenerate = force_regenerate or os.environ.get("ACTION_INDEX_FORCE_REGEN", "") == "1"
     summary = {
@@ -270,12 +276,16 @@ def build_action_index(
         index_dir = state_root / "action_index"
         index_dir.mkdir(parents=True, exist_ok=True)
 
+        prompt_files = _prompt_files(prompts_dir)
+        if not prompt_files:
+            return summary
+
         # F4: forced regeneration — delete existing day-files whose source
         # prompt day-file still exists so they are rebuilt with corrected
         # workspace_roots (state_root stripped → "state/*.ext" templates).
         if force_regenerate:
             prompt_days: set[str] = set()
-            for path in _prompt_files(prompts_dir):
+            for path in prompt_files:
                 day = _day_from_name(path.name)
                 if day:
                     prompt_days.add(day)
@@ -288,18 +298,42 @@ def build_action_index(
                     except OSError:
                         pass
 
+        # Collect existing indexed cycles and indexed days
         existing: set[str] = set()
+        indexed_days: set[str] = set()
         for path in _prompt_files(index_dir):
+            day = _day_from_name(path.name)
+            if day:
+                indexed_days.add(day)
             for row in _iter_jsonl(path):
                 if row.get("cycle_id"):
                     existing.add(str(row["cycle_id"]))
+
+        # Filter prompt files by max_days if specified (from newest distinct calendar days)
+        # Multiple files can exist for the same day (e.g. .jsonl and .jsonl.gz); group by day.
+        valid_prompt_files = [p for p in prompt_files if _day_from_name(p.name)]
+        if max_days is not None and max_days > 0:
+            distinct_days = sorted({_day_from_name(p.name) for p in valid_prompt_files if _day_from_name(p.name)})
+            selected_days = set(distinct_days[-max_days:])
+            valid_prompt_files = [p for p in valid_prompt_files if _day_from_name(p.name) in selected_days]
+
+        # Newest day in prompts can still gain cycles (e.g. today or latest active)
+        newest_day = _day_from_name(valid_prompt_files[-1].name) if valid_prompt_files else None
+
         ledger = _ledger_by_cycle(state_root)
         workspace_roots = _known_workspace_roots(state_root)
         grouped: dict[str, tuple[str, str, list[str]]] = {}
-        for path in _prompt_files(prompts_dir):
+        for path in valid_prompt_files:
             day = _day_from_name(path.name)
             if not day:
                 continue
+
+            # #1059: Day-level skip before opening large/gzipped prompt files!
+            # If the index for this day already exists and it's not the newest day
+            # that could still receive new cycles, skip opening it completely.
+            if not force_regenerate and day in indexed_days and day != newest_day:
+                continue
+
             summary["prompt_files"] += 1
             file_stats = {"skipped": 0}
             for record in _iter_jsonl(path, file_stats):
@@ -345,6 +379,7 @@ def build_action_index(
     except Exception:
         pass
     return summary
+
 
 
 def main() -> int:

--- a/tests/test_action_index.py
+++ b/tests/test_action_index.py
@@ -81,3 +81,55 @@ def test_malformed_records_counted_and_backfill_processes_two_days(tmp_path: Pat
     assert {p.name for p in (tmp_path / "action_index").glob("*.jsonl")} == {
         "2026-08-24.jsonl", "2026-08-25.jsonl"
     }
+
+
+def test_skips_fully_indexed_historical_day_files_without_opening(tmp_path: Path, monkeypatch):
+    """Issue #1059: historical day files that are already fully indexed must not be opened."""
+    import gzip
+
+    # 3 prompt day files: 2026-08-23, 2026-08-24, 2026-08-25
+    _seed_ledger(tmp_path, "c-23", "Day 23")
+    _seed_ledger(tmp_path, "c-24", "Day 24")
+    _seed_ledger(tmp_path, "c-25", "Day 25")
+
+    _write(tmp_path / "llm_calls" / "prompts" / "2026-08-23.jsonl.gz", [
+        {"cycle_id": "c-23", "seq": 1, "messages": [{"role": "assistant", "tool_calls": []}]},
+    ])
+    _write(tmp_path / "llm_calls" / "prompts" / "2026-08-24.jsonl.gz", [
+        {"cycle_id": "c-24", "seq": 1, "messages": [{"role": "assistant", "tool_calls": []}]},
+    ])
+    _write(tmp_path / "llm_calls" / "prompts" / "2026-08-25.jsonl", [
+        {"cycle_id": "c-25", "seq": 1, "messages": [{"role": "assistant", "tool_calls": []}]},
+    ])
+
+    # Index already exists for 2026-08-23 and 2026-08-24
+    _write(tmp_path / "action_index" / "2026-08-23.jsonl.gz", [
+        {"cycle_id": "c-23", "ts": "2026-08-23T00:00:00Z", "task_title": "Day 23", "outcome": "success", "actions": []}
+    ])
+    _write(tmp_path / "action_index" / "2026-08-24.jsonl.gz", [
+        {"cycle_id": "c-24", "ts": "2026-08-24T00:00:00Z", "task_title": "Day 24", "outcome": "success", "actions": []}
+    ])
+
+    opened_paths: list[str] = []
+    real_open = open
+    real_gzip_open = gzip.open
+
+    def tracking_open(file, *args, **kwargs):
+        opened_paths.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    def tracking_gzip_open(filename, *args, **kwargs):
+        opened_paths.append(str(filename))
+        return real_gzip_open(filename, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", tracking_open)
+    monkeypatch.setattr(gzip, "open", tracking_gzip_open)
+
+    summary = build_action_index(tmp_path)
+    assert summary["written"] == 1
+
+    prompt_opens = [p for p in opened_paths if "prompts" in p]
+    # Old days (23 and 24) must NOT have been opened at all!
+    assert not any("2026-08-23" in p for p in prompt_opens), f"Opened 2026-08-23: {prompt_opens}"
+    assert not any("2026-08-24" in p for p in prompt_opens), f"Opened 2026-08-24: {prompt_opens}"
+    assert any("2026-08-25" in p for p in prompt_opens), f"Did not open 2026-08-25: {prompt_opens}"

--- a/tests/test_llm_prompt_recording.py
+++ b/tests/test_llm_prompt_recording.py
@@ -283,3 +283,62 @@ def test_llm_prompt_inspect_date_filter(tmp_path):
     records = llm_prompt_inspect.load_records(prompts_dir, date="2026-07-01")
     assert len(records) == 1
     assert records[0]["cycle_id"] == "a"
+
+
+def test_telemetry_hook_passes_max_days_and_rate_limits(tmp_path, monkeypatch):
+    """Issue #1059: telemetry prompt hook only scans recent days and enforces rate limit."""
+    from nanobot.observability.llm_telemetry import call_context, record_llm_prompt
+
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path / "state" / "llm_calls"))
+
+    calls = []
+
+    def mock_build_action_index(state_root, prompts_dir=None, *, max_days=None, force_regenerate=False):
+        calls.append({"max_days": max_days, "prompts_dir": prompts_dir})
+        return {}
+
+    monkeypatch.setattr("nanobot.runtime.action_index.build_action_index", mock_build_action_index)
+
+    # First call triggers indexer with max_days=2 (yesterday + today)
+    with call_context("cycle-1", "coordinator"):
+        record_llm_prompt(
+            messages=_sample_messages(), content="1", reasoning_content=None,
+            finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+        )
+
+    assert len(calls) == 1
+    assert calls[0]["max_days"] == 2
+    assert (tmp_path / "state" / "action_index" / ".last_hook_run").exists()
+
+    # Immediate second call in burst should be rate-limited and skip build_action_index
+    with call_context("cycle-1", "coordinator"):
+        record_llm_prompt(
+            messages=_sample_messages(), content="2", reasoning_content=None,
+            finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+        )
+
+    assert len(calls) == 1  # Rate-limited!
+
+
+def test_telemetry_hook_failure_still_writes_prompt(tmp_path, monkeypatch):
+    """Failure in action index hook must not prevent recording prompt file."""
+    from nanobot.observability.llm_telemetry import call_context, record_llm_prompt
+
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path / "state" / "llm_calls"))
+
+    def crashing_build_action_index(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("nanobot.runtime.action_index.build_action_index", crashing_build_action_index)
+
+    with call_context("cycle-fail", "coordinator"):
+        record_llm_prompt(
+            messages=_sample_messages(), content="saved", reasoning_content=None,
+            finish_reason="stop", model="m", prompt_tokens=1, completion_tokens=1,
+        )
+
+    prompts = list((tmp_path / "state" / "llm_calls" / "prompts").glob("*.jsonl"))
+    assert len(prompts) == 1
+    lines = prompts[0].read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["cycle_id"] == "cycle-fail"


### PR DESCRIPTION
Closes #1059

- skip indexed historical prompt days before opening/decompressing
- bound synchronous hook to newest two distinct calendar days
- rate-limit hook with persistent state/action_index/.last_hook_run marker
- preserve daily full-corpus indexer semantics and per-cycle skipped_existing
- add opener, rate-limit, failure-containment, and restored regression coverage

Validation: focused action-index and prompt-recording tests pass; Ruff and diff check pass.