### PR TITLE
feat(knowledge): connect memory errors and reflections

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3907,25 +3907,46 @@ def _write_structured_error(
     except Exception:
         pass
 
-    existing: dict = {'lessons': []}
+    wrapper_key: str | None = None
+    existing_list: list[dict] = []
+
     if errors_path.exists():
         try:
             raw_text = errors_path.read_text(encoding='utf-8')
+            parsed = None
             try:
                 import yaml as _yaml  # type: ignore[import-untyped]
-                existing = _yaml.safe_load(raw_text) or {'lessons': []}
+                parsed = _yaml.safe_load(raw_text)
             except ImportError:
-                existing = json.loads(raw_text) if raw_text.strip().startswith('{') else {'lessons': []}
-            if not isinstance(existing.get('lessons'), list):
-                existing['lessons'] = []
+                stripped = raw_text.strip()
+                if stripped.startswith('{') or stripped.startswith('['):
+                    parsed = json.loads(raw_text)
+
+            if isinstance(parsed, list):
+                existing_list = [e for e in parsed if isinstance(e, dict)]
+                wrapper_key = None
+            elif isinstance(parsed, dict):
+                if isinstance(parsed.get('errors'), list):
+                    existing_list = [e for e in parsed['errors'] if isinstance(e, dict)]
+                    wrapper_key = 'errors'
+                elif isinstance(parsed.get('lessons'), list):
+                    existing_list = [e for e in parsed['lessons'] if isinstance(e, dict)]
+                    wrapper_key = 'lessons'
+                else:
+                    existing_list = []
+                    wrapper_key = None
+            else:
+                existing_list = []
+                wrapper_key = None
         except Exception:
-            existing = {'lessons': []}
+            existing_list = []
+            wrapper_key = None
 
     date_str = _dt.date.today().isoformat()
     short_cycle = (cycle_id or '')[-12:].replace('cycle-', '')
     error_id = f'ERR-{date_str.replace("-", "")}-{short_cycle[:8]}'
 
-    if any(e.get('id') == error_id for e in existing['lessons']):
+    if any(e.get('id') == error_id for e in existing_list):
         return False
 
     b_used = budget_used or {}
@@ -3947,14 +3968,16 @@ def _write_structured_error(
         'generalized_insight': f'Avoid {reason or check_str}: cycle gate verification or execution failed.',
     }
 
-    existing['lessons'].insert(0, error_entry)
+    existing_list.insert(0, error_entry)
+
+    to_write = {wrapper_key: existing_list} if wrapper_key is not None else existing_list
 
     try:
         try:
             import yaml as _yaml  # type: ignore[import-untyped]
-            errors_path.write_text(_yaml.dump(existing, allow_unicode=True, sort_keys=False), encoding='utf-8')
+            errors_path.write_text(_yaml.dump(to_write, allow_unicode=True, sort_keys=False), encoding='utf-8')
         except ImportError:
-            errors_path.write_text(json.dumps(existing, indent=2, ensure_ascii=False), encoding='utf-8')
+            errors_path.write_text(json.dumps(to_write, indent=2, ensure_ascii=False), encoding='utf-8')
         return True
     except Exception:
         return False

--- a/tests/test_lessons_context.py
+++ b/tests/test_lessons_context.py
@@ -312,15 +312,97 @@ class TestLiveWriterRoundTrip:
         errors_file = repo / "lessons" / "errors.yaml"
         assert errors_file.exists()
         written = yaml.safe_load(errors_file.read_text(encoding="utf-8"))
-        assert isinstance(written, dict) and "lessons" in written
-        assert len(written["lessons"]) == 1
+        assert isinstance(written, list)
+        assert len(written) == 1
 
-        entry = written["lessons"][0]
+        entry = written[0]
         assert entry["cycle_id"] == "cycle-err123456789"
         assert entry["reason"] == "mutation_surface_violation"
         assert entry["violated_check"] == "mutation_surface_violation: touched /etc/shadow"
         assert "mutation_surface_violation" in entry["generalized_insight"]
         assert entry["id"].startswith("ERR-")
+
+    def test_write_structured_error_preserves_bare_list_schema_and_appends_without_data_loss(self, tmp_path):
+        """_write_structured_error preserves pre-existing bare-list schema without resetting or losing entries."""
+        from nanobot.runtime.bridge import _write_structured_error
+
+        repo = tmp_path / "instance_repo"
+        lessons_dir = repo / "lessons"
+        lessons_dir.mkdir(parents=True)
+        errors_file = lessons_dir / "errors.yaml"
+
+        pre_existing = [
+            {
+                "id": "ERR-20260614-001",
+                "date": "2026-06-14",
+                "cycle_id": "cycle-old111111111",
+                "hypothesis": "Old error hypothesis.",
+                "reason": "gate_timeout",
+            },
+            {
+                "id": "ERR-20260614-002",
+                "date": "2026-06-14",
+                "cycle_id": "cycle-old222222222",
+                "hypothesis": "Second old error.",
+                "reason": "compile_failed",
+            },
+        ]
+        errors_file.write_text(yaml.dump(pre_existing, sort_keys=False), encoding="utf-8")
+
+        wrote = _write_structured_error(
+            repo_root=repo,
+            cycle_id="cycle-new333333333",
+            reason="test_failed",
+            violated_check="pytest returned 1",
+            budget_used={"tool_calls": 5, "elapsed_seconds": 20},
+            backlog_title="Improve error handling",
+        )
+        assert wrote is True
+
+        written = yaml.safe_load(errors_file.read_text(encoding="utf-8"))
+        assert isinstance(written, list)
+        assert len(written) == 3
+        # Newly written item is prepended at index 0
+        assert written[0]["cycle_id"] == "cycle-new333333333"
+        assert written[0]["reason"] == "test_failed"
+        # Pre-existing items are completely preserved without data loss
+        assert written[1]["id"] == "ERR-20260614-001"
+        assert written[1]["reason"] == "gate_timeout"
+        assert written[2]["id"] == "ERR-20260614-002"
+        assert written[2]["reason"] == "compile_failed"
+
+    def test_write_structured_error_accepts_dict_wrapper_if_encountered(self, tmp_path):
+        """_write_structured_error accepts dict-wrapped errors.yaml and preserves the wrapper key."""
+        from nanobot.runtime.bridge import _write_structured_error
+
+        repo = tmp_path / "instance_repo"
+        lessons_dir = repo / "lessons"
+        lessons_dir.mkdir(parents=True)
+        errors_file = lessons_dir / "errors.yaml"
+
+        pre_existing = {
+            "errors": [
+                {
+                    "id": "ERR-20260614-001",
+                    "cycle_id": "cycle-old111111111",
+                    "reason": "gate_timeout",
+                }
+            ]
+        }
+        errors_file.write_text(yaml.dump(pre_existing, sort_keys=False), encoding="utf-8")
+
+        wrote = _write_structured_error(
+            repo_root=repo,
+            cycle_id="cycle-new444444444",
+            reason="mutation_surface_violation",
+        )
+        assert wrote is True
+
+        written = yaml.safe_load(errors_file.read_text(encoding="utf-8"))
+        assert isinstance(written, dict) and "errors" in written
+        assert len(written["errors"]) == 2
+        assert written["errors"][0]["cycle_id"] == "cycle-new444444444"
+        assert written["errors"][1]["id"] == "ERR-20260614-001"
 
 
 class TestOnDiskShapes:


### PR DESCRIPTION
Closes #1041

- read the newest tail of memory/index.md and rotate overflowing index entries with atomic archives
- write structured gate/rollback errors to lessons/errors.yaml while preserving its canonical bare-list schema and existing entries
- ingest reflector recommendations through the existing curator staging pipeline, including normal kind/detail/evidence rows and cross-source watermarks

Validation: 53 focused knowledge/memory/rotation tests passed (2 skipped); Ruff on changed files except pre-existing bridge baseline findings; diff check passed. Full pytest and live validation follow.