### PR TITLE
feat(retention): bound runtime state and telemetry

### DIFF
--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -203,6 +203,125 @@ def _rotate_and_prune(prompts_dir: Path, today: str, retention_days: int) -> Non
             continue
 
 
+MAX_LLM_PROMPT_PAYLOAD_BYTES = 32 * 1024  # 32KB per-record cap (#1039)
+
+
+def _cap_payload_record(record: dict[str, Any], max_bytes: int = MAX_LLM_PROMPT_PAYLOAD_BYTES) -> dict[str, Any]:
+    """Ensure record JSON serialization does not exceed max_bytes.
+
+    If the serialized record exceeds max_bytes, trims heavy string/list fields
+    (messages, content, reasoning_content) and adds ``truncated: True`` to the record (#1039).
+    """
+    serialized = json.dumps(record, ensure_ascii=False, default=str)
+    if len(serialized.encode("utf-8")) <= max_bytes:
+        return record
+
+    rec = dict(record)
+    rec["truncated"] = True
+
+    # First pass: trim message content
+    messages = rec.get("messages")
+    if isinstance(messages, list):
+        trimmed_msgs = []
+        for msg in messages:
+            if isinstance(msg, dict):
+                m_copy = dict(msg)
+                m_content = m_copy.get("content")
+                if isinstance(m_content, str) and len(m_content) > 1000:
+                    m_copy["content"] = m_content[:1000] + "…[truncated]"
+                trimmed_msgs.append(m_copy)
+            else:
+                trimmed_msgs.append(msg)
+        rec["messages"] = trimmed_msgs
+
+    # Trim reasoning_content if large
+    reasoning = rec.get("reasoning_content")
+    if isinstance(reasoning, str) and len(reasoning) > 1000:
+        rec["reasoning_content"] = reasoning[:1000] + "…[truncated]"
+
+    # Trim content if large
+    content = rec.get("content")
+    if isinstance(content, str) and len(content) > 2000:
+        rec["content"] = content[:2000] + "…[truncated]"
+
+    serialized = json.dumps(rec, ensure_ascii=False, default=str)
+    if len(serialized.encode("utf-8")) <= max_bytes:
+        return rec
+
+    # Second pass: aggressively trim intermediate messages
+    if isinstance(rec.get("messages"), list) and len(rec["messages"]) > 2:
+        rec["messages"] = [rec["messages"][0], {"role": "system", "content": "…[intermediate messages omitted]"}, rec["messages"][-1]]
+
+    # Third pass: drop message list to single summary
+    serialized = json.dumps(rec, ensure_ascii=False, default=str)
+    if len(serialized.encode("utf-8")) > max_bytes:
+        rec["messages"] = [{"role": "info", "content": "…[payload truncated to fit 32KB budget]"}]
+        if isinstance(rec.get("content"), str):
+            rec["content"] = rec["content"][:500] + "…[truncated]"
+        if isinstance(rec.get("reasoning_content"), str):
+            rec["reasoning_content"] = rec["reasoning_content"][:500] + "…[truncated]"
+
+    # Fourth pass: if any field (including cycle_id, model, component, etc.) makes the payload exceed max_bytes,
+    # trim all non-essential and long fields progressively until it fits strictly within max_bytes.
+    serialized = json.dumps(rec, ensure_ascii=False, default=str)
+    if len(serialized.encode("utf-8")) > max_bytes:
+        for k in list(rec.keys()):
+            if k not in ("truncated", "ts", "seq"):
+                if isinstance(rec[k], str) and len(rec[k]) > 100:
+                    rec[k] = rec[k][:100] + "…[truncated]"
+                elif isinstance(rec[k], (list, dict)):
+                    rec[k] = "…[truncated]"
+
+    # Hard emergency clamp: if STILL over max_bytes (e.g. huge cycle_id or keys), hard-clamp every string
+    serialized = json.dumps(rec, ensure_ascii=False, default=str)
+    if len(serialized.encode("utf-8")) > max_bytes:
+        for k in list(rec.keys()):
+            if k not in ("truncated", "seq"):
+                if isinstance(rec[k], str):
+                    rec[k] = rec[k][:20] + "…[truncated]"
+                elif isinstance(rec[k], (list, dict)):
+                    rec[k] = "…[truncated]"
+
+    return rec
+
+
+def _format_capped_jsonl_line(record: dict[str, Any], max_bytes: int = MAX_LLM_PROMPT_PAYLOAD_BYTES) -> str:
+    """Format and serialize record after secret redaction ensuring total UTF-8 encoded bytes <= max_bytes."""
+    record = _cap_payload_record(record, max_bytes=max_bytes)
+    raw_json = json.dumps(record, ensure_ascii=False, default=str)
+    redacted = _redact_secrets(raw_json)
+
+    # In case secret redaction slightly altered size or if record is still over max_bytes
+    if len(redacted.encode("utf-8")) <= max_bytes:
+        return redacted
+
+    # If post-redaction still exceeds max_bytes, reduce budget and re-serialize
+    reduced_budget = max(512, max_bytes - (len(redacted.encode("utf-8")) - max_bytes) - 256)
+    rec = _cap_payload_record(record, max_bytes=reduced_budget)
+    redacted = _redact_secrets(json.dumps(rec, ensure_ascii=False, default=str))
+
+    # Absolute guarantee clamp on UTF-8 bytes
+    if len(redacted.encode("utf-8")) > max_bytes:
+        # Fallback minimal valid JSON line
+        minimal_rec = {
+            "ts": record.get("ts", ""),
+            "cycle_id": str(record.get("cycle_id", ""))[:50],
+            "component": str(record.get("component", ""))[:50],
+            "seq": record.get("seq", 0),
+            "truncated": True,
+            "error": "…[record payload exceeded max budget after redaction]",
+        }
+        redacted = _redact_secrets(json.dumps(minimal_rec, ensure_ascii=False, default=str))
+        if len(redacted.encode("utf-8")) > max_bytes:
+            # Ultimate safety fallback if minimal_rec somehow exceeded budget
+            minimal_rec["cycle_id"] = "truncated"
+            minimal_rec["component"] = "truncated"
+            redacted = _redact_secrets(json.dumps(minimal_rec, ensure_ascii=False, default=str))
+
+    return redacted
+
+
+
 def record_llm_prompt(
     *,
     messages: list[dict[str, Any]],
@@ -249,7 +368,7 @@ def record_llm_prompt(
             "reasoning_content": reasoning_content,
         }
 
-        line = _redact_secrets(json.dumps(record, ensure_ascii=False, default=str))
+        line = _format_capped_jsonl_line(record)
 
         prompts_dir = _llm_calls_dir() / "prompts"
         prompts_dir.mkdir(parents=True, exist_ok=True)

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3448,8 +3448,21 @@ def _record_runtime_slice_candidate(
     }
     try:
         path = state_dir / 'promotions' / f'{candidate_id}.json'
+        latest_path = state_dir / 'promotions' / 'latest.json'
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(record, indent=2), encoding='utf-8')
+        serialized = json.dumps(record, indent=2)
+        # Atomic write
+        tmp_path = path.with_suffix(f'.tmp.{os.getpid()}')
+        tmp_path.write_text(serialized, encoding='utf-8')
+        tmp_path.replace(path)
+        tmp_latest = latest_path.with_suffix(f'.tmp.{os.getpid()}')
+        tmp_latest.write_text(serialized, encoding='utf-8')
+        tmp_latest.replace(latest_path)
+        try:
+            from nanobot.runtime.promotions_rotation import rotate_promotions
+            rotate_promotions(state_dir / 'promotions')
+        except Exception:
+            pass
     except Exception:
         pass
     return candidate_id

--- a/nanobot/runtime/promotions_rotation.py
+++ b/nanobot/runtime/promotions_rotation.py
@@ -1,0 +1,194 @@
+"""Promotions directory rotation and retention pruning (#1039).
+
+Rotates historical promotion candidate JSON files in ``state/promotions/``:
+- Active records are JSON files (e.g. ``promotion-runtime-cycle-*.json`` or custom candidate IDs).
+- Files modified before the current calendar day (UTC) are compressed to
+  ``state/promotions/archive/promotions-YYYY-MM-DD.jsonl.gz``.
+- Archives older than ``PROMOTIONS_RETENTION_DAYS`` (default 90) are pruned.
+- ``latest.json`` is preserved directly in ``state/promotions/`` and not archived.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:  # pragma: no cover - fcntl is POSIX-only; the host is always Linux
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+PROMOTIONS_RETENTION_DAYS_DEFAULT = 90
+_ARCHIVE_NAME_PATTERN = re.compile(r"^promotions-(\d{4}-\d{2}-\d{2})\.jsonl\.gz$")
+
+
+class _NullLock:
+    """Sentinel when fcntl is unavailable."""
+
+    def close(self) -> None:
+        pass
+
+
+def _acquire_promotions_lock(promotions_dir: Path):
+    """Acquire exclusive flock on promotions_dir / '.rotation.lock'."""
+    if fcntl is None:
+        return _NullLock()
+    try:
+        lock_path = promotions_dir / ".rotation.lock"
+        handle = open(lock_path, "a+")
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        return handle
+    except OSError:
+        return _NullLock()
+
+
+def _promotions_retention_days() -> int:
+    raw = os.environ.get("EEEBOT_PROMOTIONS_RETENTION_DAYS", "")
+    if raw.isdigit():
+        val = int(raw)
+        if val > 0:
+            return val
+    return PROMOTIONS_RETENTION_DAYS_DEFAULT
+
+
+def rotate_promotions(
+    promotions_dir: Path,
+    *,
+    today: str | None = None,
+    retention_days: int | None = None,
+) -> dict[str, int]:
+    """Rotate prior-day promotion candidate files into dated gzip archives and prune old archives.
+
+    Returns stats dict: {"archived_files": int, "pruned_archives": int}.
+    """
+    promotions_dir = Path(promotions_dir)
+    if not promotions_dir.exists() or not promotions_dir.is_dir():
+        return {"archived_files": 0, "pruned_archives": 0}
+
+    now_utc = datetime.now(timezone.utc)
+    if today is None:
+        today = now_utc.strftime("%Y-%m-%d")
+    if retention_days is None:
+        retention_days = _promotions_retention_days()
+
+    archive_dir = promotions_dir / "archive"
+    archived_count = 0
+    pruned_count = 0
+
+    lock = _acquire_promotions_lock(promotions_dir)
+    try:
+        # 1. Group candidate files by prior-day modification date
+        # Candidates are .json files directly under promotions_dir, except latest.json
+        day_groups: dict[str, list[Path]] = {}
+        try:
+            for entry in promotions_dir.iterdir():
+                if not entry.is_file():
+                    continue
+                if not entry.name.endswith(".json"):
+                    continue
+                if entry.name == "latest.json":
+                    continue
+                try:
+                    mtime_utc = datetime.fromtimestamp(entry.stat().st_mtime, tz=timezone.utc)
+                    file_day = mtime_utc.strftime("%Y-%m-%d")
+                except OSError:
+                    continue
+
+                if file_day < today:
+                    day_groups.setdefault(file_day, []).append(entry)
+        except OSError:
+            pass
+
+        # 2. Append/write to dated gzip archive and remove original files
+        if day_groups:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            for day_str, file_paths in sorted(day_groups.items()):
+                gz_path = archive_dir / f"promotions-{day_str}.jsonl.gz"
+                records: list[dict] = []
+                for fpath in sorted(file_paths):
+                    try:
+                        content = fpath.read_text(encoding="utf-8")
+                        data = json.loads(content)
+                        if isinstance(data, dict):
+                            records.append(data)
+                    except Exception:
+                        # If corrupt/unreadable json, wrap raw text as fallback
+                        try:
+                            records.append({"raw_filename": fpath.name, "raw_content": fpath.read_text(encoding="utf-8", errors="replace")})
+                        except Exception:
+                            pass
+
+                if records:
+                    # Read existing records if archive already exists
+                    existing_lines: list[bytes] = []
+                    if gz_path.exists():
+                        try:
+                            with gzip.open(gz_path, "rb") as gz_in:
+                                existing_lines = gz_in.readlines()
+                        except Exception:
+                            existing_lines = []
+
+                    # Atomic write of combined archive
+                    tmp_fd, tmp_path_str = tempfile.mkstemp(
+                        prefix="promotions_gz_",
+                        suffix=".tmp",
+                        dir=archive_dir,
+                    )
+                    try:
+                        with os.fdopen(tmp_fd, "wb") as raw_out:
+                            with gzip.open(raw_out, "wb") as gz_out:
+                                for eline in existing_lines:
+                                    gz_out.write(eline)
+                                for rec in records:
+                                    line_bytes = (json.dumps(rec, sort_keys=True) + "\n").encode("utf-8")
+                                    gz_out.write(line_bytes)
+                        os.replace(tmp_path_str, gz_path)
+                    except Exception:
+                        if os.path.exists(tmp_path_str):
+                            try:
+                                os.unlink(tmp_path_str)
+                            except OSError:
+                                pass
+                        continue
+
+                    for fpath in file_paths:
+                        try:
+                            fpath.unlink(missing_ok=True)
+                            archived_count += 1
+                        except OSError:
+                            pass
+
+        # 3. Prune old archives beyond retention_days
+        if archive_dir.exists() and archive_dir.is_dir():
+            try:
+                today_dt = datetime.strptime(today, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+                for entry in archive_dir.iterdir():
+                    if not entry.is_file():
+                        continue
+                    match = _ARCHIVE_NAME_PATTERN.match(entry.name)
+                    if not match:
+                        continue
+                    file_day_str = match.group(1)
+                    try:
+                        file_dt = datetime.strptime(file_day_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+                        age_days = (today_dt - file_dt).days
+                        if age_days > retention_days:
+                            entry.unlink(missing_ok=True)
+                            pruned_count += 1
+                    except Exception:
+                        continue
+            except Exception:
+                pass
+    finally:
+        try:
+            lock.close()
+        except Exception:
+            pass
+
+    return {"archived_files": archived_count, "pruned_archives": pruned_count}
+

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -1060,9 +1060,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     reports_dir = state_root / "reports"
     outbox_dir = state_root / "outbox"
     goals_dir = state_root / "goals"
-    goal_history_dir = goals_dir / "history"
     promotions_dir = state_root / "promotions"
-    experiments_dir = state_root / "experiments"
     hypotheses_dir = state_root / "hypotheses"
     subagents_dir = state_root / "subagents"
     credits_dir = state_root / "credits"
@@ -1071,7 +1069,6 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     current_goal_path = goals_dir / "current.json"
     active_goal_path = goals_dir / "active.json"
     latest_goal = current_goal_path if current_goal_path.exists() else active_goal_path if active_goal_path.exists() else _latest_json_file(goals_dir, "*.json")
-    latest_goal_history = _latest_json_file(goal_history_dir, "cycle-*.json")
     if source_kind == "host_control_plane":
         latest_outbox = (
             _latest_json_file(outbox_dir, "report.index.json")
@@ -1081,7 +1078,6 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     else:
         latest_outbox = _latest_json_file(outbox_dir, "latest.json") or _latest_json_file(outbox_dir, "*.json")
     latest_promotion = _latest_json_file(promotions_dir, "latest.json") or _latest_json_file(promotions_dir, "*.json")
-    latest_experiment = _latest_json_file(experiments_dir, "latest.json") or _latest_json_file(experiments_dir, "*.json")
     latest_hypothesis_backlog = _latest_json_file(hypotheses_dir, "backlog.json") or _latest_json_file(hypotheses_dir, "*.json")
     latest_subagent = _latest_json_file(subagents_dir, "*.json")
     latest_credits = _latest_json_file(credits_dir, "latest.json") or _latest_json_file(credits_dir, "*.json")
@@ -1089,11 +1085,9 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     report_data = _safe_read_json(latest_report)
     current_goal_data = _safe_read_json(current_goal_path)
     active_goal_data = _safe_read_json(active_goal_path)
-    goal_history_data = _safe_read_json(latest_goal_history)
-    goal_data = current_goal_data or active_goal_data or goal_history_data or _safe_read_json(latest_goal)
+    goal_data = current_goal_data or active_goal_data or _safe_read_json(latest_goal)
     outbox_data = _safe_read_json(latest_outbox)
     promotion_data = _safe_read_json(latest_promotion)
-    experiment_data = _safe_read_json(latest_experiment)
     hypothesis_backlog_data = _safe_read_json(latest_hypothesis_backlog)
     subagent_data = _safe_read_json(latest_subagent)
     credits_data = _safe_read_json(latest_credits)
@@ -1209,14 +1203,9 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     task_plan_schema_version = None
     task_feedback_decision = None
     task_plan_path = str(current_goal_path) if current_goal_path.exists() else (str(active_goal_path) if active_goal_path.exists() else str(latest_goal) if latest_goal else None)
-    task_history_path = str(latest_goal_history) if latest_goal_history else None
+    task_history_path = None
     if isinstance(current_goal_data, dict):
         task_plan = current_goal_data
-    elif isinstance(goal_history_data, dict):
-        task_plan = goal_history_data
-    if isinstance(goal_history_data, dict):
-        task_history = goal_history_data
-    elif isinstance(current_goal_data, dict):
         task_history = current_goal_data
     if isinstance(task_plan, dict):
         current_task_id = task_plan.get("current_task_id") or task_plan.get("currentTaskId")
@@ -1253,7 +1242,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     subagent_rollup_from_files = None
     selfevo_current_state = None
     experiment = None
-    experiment_path = str(latest_experiment) if latest_experiment else None
+    experiment_path = None
     experiment_budget = None
     experiment_budget_used = None
     experiment_reward_signal = None
@@ -1377,9 +1366,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
             else (len(list(subagents_dir.glob("*.json"))) if subagents_dir.exists() else 0)
         )
 
-    if isinstance(experiment_data, dict):
-        experiment = experiment_data
-    elif isinstance(report_data, dict):
+    if isinstance(report_data, dict):
         experiment = report_data.get("experiment") if isinstance(report_data.get("experiment"), dict) else experiment
     if isinstance(experiment, dict):
         experiment_path = experiment.get("experiment_path") or experiment.get("experimentPath") or experiment_path
@@ -1668,7 +1655,7 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         # — an absent file is just absent, not an error.
         "outbox_decommissioned": isinstance(outbox_data, dict),
         "promotion_decommissioned": isinstance(promotion_data, dict),
-        "experiment_decommissioned": isinstance(experiment_data, dict),
+        "experiment_decommissioned": False,
         "credits_decommissioned": isinstance(credits_data, dict),
         "subagent_telemetry_root": str(subagents_dir) if subagents_dir.exists() else None,
         "subagent_telemetry_count": subagent_telemetry_count,

--- a/scripts/cleanup_subagent_queue.py
+++ b/scripts/cleanup_subagent_queue.py
@@ -14,9 +14,8 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-
 
 # Metadata files in subagents root that are NOT queue items
 _METADATA_FILES = {"archive_latest.json", "queue_index.json", "index.json"}
@@ -37,8 +36,9 @@ def _parse_timestamp(ts: str | None) -> datetime | None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Archive stale subagent requests")
+    parser = argparse.ArgumentParser(description="Archive stale subagent requests and prune old archives")
     parser.add_argument("--hours", type=int, default=24, help="Age threshold in hours (default: 24)")
+    parser.add_argument("--archive-retention-days", type=int, default=30, help="Retention period for subagents/archive files in days (default: 30) (#1039)")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be archived without moving files")
     parser.add_argument("--state-root", type=str, default=None, help="Override state root path")
     parser.add_argument("--max-queue", type=int, default=9, help="Max remaining queue size; archive oldest to reach this (default: 9)")
@@ -90,11 +90,6 @@ def main() -> int:
                 targets.append(p)
 
     for req_path in sorted(targets, key=lambda x: x.name):
-        try:
-            payload = json.loads(req_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            payload = {}
-
         # Determine age from file mtime since created_at is often null
         file_mtime = datetime.fromtimestamp(req_path.stat().st_mtime, tz=timezone.utc)
 
@@ -158,6 +153,24 @@ def main() -> int:
                 file_mtime = datetime.fromtimestamp(req_path.stat().st_mtime, tz=timezone.utc)
                 print(f"  WOULD ARCHIVE (count): {req_path.name} (modified: {file_mtime.isoformat()})")
 
+    # Age-based pruning of subagents/archive directory (#1039: default 30 days)
+    pruned_archive_count = 0
+    if archive_dir.exists() and args.archive_retention_days > 0:
+        archive_cutoff = _utc_now() - timedelta(days=args.archive_retention_days)
+        for arch_file in sorted(archive_dir.glob("*.json"), key=lambda x: x.name):
+            if arch_file.name in _METADATA_FILES:
+                continue
+            try:
+                arch_mtime = datetime.fromtimestamp(arch_file.stat().st_mtime, tz=timezone.utc)
+                if arch_mtime < archive_cutoff:
+                    if args.dry_run:
+                        print(f"  WOULD PRUNE ARCHIVE: {arch_file.name} (modified: {arch_mtime.isoformat()})")
+                    else:
+                        arch_file.unlink(missing_ok=True)
+                        pruned_archive_count += 1
+            except OSError as e:
+                print(f"  ERROR pruning archive file {arch_file.name}: {e}", file=sys.stderr)
+
     # Update health file
     health = {}
     if health_path.exists():
@@ -170,6 +183,7 @@ def main() -> int:
     health["last_subagent_cleanup_timestamp"] = _utc_now().isoformat()
     health["subagent_cleanup_count"] = health.get("subagent_cleanup_count", 0) + archived
     health["subagent_archive_count"] = len(list(archive_dir.glob("*.json")))
+    health["subagent_archive_pruned_count"] = health.get("subagent_archive_pruned_count", 0) + pruned_archive_count
     health["subagent_requests_remaining"] = len(list(requests_dir.glob("*.json"))) if requests_dir.exists() else 0
     # Record total remaining queue count (root + requests + results) for monitoring
     # Exclude metadata files from the count
@@ -187,6 +201,7 @@ def main() -> int:
 
     result = {
         "archived": archived,
+        "pruned_archive": pruned_archive_count,
         "kept": skipped,
         "errors": errors,
         "dry_run": args.dry_run,
@@ -198,7 +213,7 @@ def main() -> int:
     if args.json:
         print(json.dumps(result, indent=2, ensure_ascii=False))
     else:
-        print(f"Cleanup complete: {archived} archived, {skipped} kept, {errors} errors")
+        print(f"Cleanup complete: {archived} archived, {pruned_archive_count} pruned from archive, {skipped} kept, {errors} errors")
         if args.dry_run:
             print("(dry-run mode — no files were moved)")
     # NOTE: Lessons compilation is now handled in real-time by the coordinator

--- a/scripts/compile_project_lessons.py
+++ b/scripts/compile_project_lessons.py
@@ -86,7 +86,7 @@ def main():
         filtered_artifacts = []
         for path_str in artifact_paths:
             p_str = str(path_str)
-            if any(term in p_str for term in ["state/reports/", "state/goals/", "state/subagents/", "state/experiments/", "state/approvals/"]):
+            if any(term in p_str for term in ["state/reports/", "state/goals/", "state/subagents/", "state/approvals/"]):
                 continue
             filtered_artifacts.append(path_str)
             

--- a/tests/test_capability_reporting.py
+++ b/tests/test_capability_reporting.py
@@ -12,8 +12,6 @@ def test_runtime_state_exposes_capabilities_snapshot(tmp_path: Path):
     (state / 'reports' / 'evolution-20260422T000000Z.json').write_text(json.dumps({'result_status': 'BLOCK'}), encoding='utf-8')
     (state / 'outbox').mkdir(parents=True)
     (state / 'outbox' / 'latest.json').write_text(json.dumps({'approval_gate': {'state': 'missing'}, 'next_hint': 'approval gate missing; refresh manually'}), encoding='utf-8')
-    (state / 'experiments').mkdir(parents=True)
-    (state / 'experiments' / 'latest.json').write_text(json.dumps({'budget': {'max_requests': 2, 'max_tool_calls': 12, 'max_timeout_seconds': 10}, 'budget_used': {'requests': 2, 'tool_calls': 12, 'elapsed_seconds': 10}}), encoding='utf-8')
     (state / 'subagents').mkdir(parents=True)
     (state / 'subagents' / 'sub-1.json').write_text(json.dumps({'goal_id': 'goal-bootstrap', 'cycle_id': 'cycle-1', 'current_task_id': 'record-reward', 'report_path': '/workspace/state/reports/evolution-1.json', 'status': 'ok', 'task_reward_signal': {'value': 1.0}, 'task_feedback_decision': {'mode': 'stable'}}), encoding='utf-8')
 
@@ -27,8 +25,8 @@ def test_runtime_state_exposes_capabilities_snapshot(tmp_path: Path):
     assert caps['runtime_state']['reason'] == 'loaded'
     assert caps['memory_discipline']['state'] == 'active'
     assert caps['memory_discipline']['reason'] == 'system_prompt_cap_and_media_guard'
-    assert caps['cycle_budget']['state'] == 'degraded'
-    assert caps['cycle_budget']['reason'] == 'requests_at_limit,tool_calls_at_limit,timeout_at_limit'
+    assert caps['cycle_budget']['state'] == 'available'
+    assert caps['cycle_budget']['reason'] == 'within_limits'
     corr = runtime['subagent_correlation']
     assert corr['goal_id'] == 'goal-bootstrap'
     assert corr['cycle_id'] == 'cycle-1'

--- a/tests/test_cleanup_subagent_queue.py
+++ b/tests/test_cleanup_subagent_queue.py
@@ -164,3 +164,29 @@ def test_json_output_mode_dry_run(cleanup_mod, tmp_path, capsys):
     payload = json.loads(captured.out[json_start:])
     assert payload["dry_run"] is True
     assert f.exists()  # nothing actually moved
+
+
+def test_archive_pruning_30_days(cleanup_mod, tmp_path):
+    """Issue #1039: purge files from subagents/archive/ older than archive_retention_days (default 30d)."""
+    archive_dir = tmp_path / "subagents" / "archive"
+    archive_dir.mkdir(parents=True)
+
+    old_file = _make_fresh_file(archive_dir, "req-old.json")
+    _age_file(old_file, 35 * 24)  # 35 days old
+
+    recent_file = _make_fresh_file(archive_dir, "req-recent.json")
+    _age_file(recent_file, 10 * 24)  # 10 days old
+
+    # Also make an archive_latest.json file which must NOT be deleted
+    meta_file = _make_fresh_file(archive_dir, "archive_latest.json")
+    _age_file(meta_file, 40 * 24)
+
+    rc = _run_main(
+        cleanup_mod,
+        ["--archive-retention-days", "30", "--state-root", str(tmp_path)],
+    )
+
+    assert rc == 0
+    assert not old_file.exists()
+    assert recent_file.exists()
+    assert meta_file.exists()

--- a/tests/test_llm_prompt_recording.py
+++ b/tests/test_llm_prompt_recording.py
@@ -342,3 +342,75 @@ def test_telemetry_hook_failure_still_writes_prompt(tmp_path, monkeypatch):
     lines = prompts[0].read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0])["cycle_id"] == "cycle-fail"
+
+
+def test_record_llm_prompt_payload_cap_truncates_oversized_payload(tmp_path, monkeypatch):
+    """Issue #1039: record_llm_prompt caps payload at ~32KB and adds truncated: true."""
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    # Create a 60KB message content
+    huge_text = "A" * 60_000
+    messages = [{"role": "user", "content": huge_text}]
+
+    record_llm_prompt(
+        messages=messages, content="large output" * 500, reasoning_content="reasoning" * 500,
+        finish_reason="stop", model="m", prompt_tokens=1000, completion_tokens=1000,
+    )
+
+    prompts = list((tmp_path / "prompts").glob("*.jsonl"))
+    assert len(prompts) == 1
+    raw = prompts[0].read_text(encoding="utf-8").strip()
+    assert len(raw.encode("utf-8")) <= 32 * 1024  # Strictly <= 32KB
+
+    record = json.loads(raw)
+    assert record.get("truncated") is True
+    assert "[truncated]" in raw
+
+
+def test_record_llm_prompt_payload_cap_guarantees_budget_with_huge_cycle_id_and_redaction(tmp_path, monkeypatch):
+    """Issue #1039: Even with huge cycle_id, component, model, and secret patterns, final line is <=32KB and redacted."""
+    from nanobot.observability.llm_telemetry import _format_capped_jsonl_line, call_context
+
+    monkeypatch.setenv("LLM_CALLS_DIR", str(tmp_path))
+
+    huge_cycle_id = "cycle-sk-ant-api03-" + ("X" * 40_000)
+    huge_component = "comp-ghp_" + ("Y" * 40_000)
+    huge_model = "model-Bearer-secret-" + ("Z" * 10_000)
+    huge_secret_msg = "api_key=sk-ant-api03-" + ("1" * 30_000)
+
+    with call_context(huge_cycle_id, huge_component):
+        record_llm_prompt(
+            messages=[{"role": "user", "content": huge_secret_msg}],
+            content="response-" + ("W" * 20_000),
+            reasoning_content="reasoning-" + ("R" * 20_000),
+            finish_reason="stop",
+            model=huge_model,
+            prompt_tokens=1000,
+            completion_tokens=1000,
+        )
+
+    prompts = list((tmp_path / "prompts").glob("*.jsonl"))
+    assert len(prompts) == 1
+    raw = prompts[0].read_text(encoding="utf-8").strip()
+    assert len(raw.encode("utf-8")) <= 32 * 1024  # Guaranteed <= 32KB
+    assert "sk-ant-api03-" not in raw
+    assert "ghp_" not in raw
+
+    record = json.loads(raw)
+    assert record.get("truncated") is True
+
+    # Also directly test extreme fallback branch in _format_capped_jsonl_line with secrets in cycle_id and component
+    forced_fallback_rec = {
+        "ts": "2026-08-27T00:00:00Z",
+        "cycle_id": "sk-ant-api03-extremely-secret-key-1234567890",
+        "component": "ghp_111122223333444455556666777788889999",
+        "seq": 1,
+        "huge_field": "H" * 50_000,
+    }
+    # Force minimal_rec fallback path with tiny max_bytes budget
+    fallback_line = _format_capped_jsonl_line(forced_fallback_rec, max_bytes=300)
+    assert len(fallback_line.encode("utf-8")) <= 300
+    assert "sk-ant-api03-" not in fallback_line
+    assert "ghp_111122223333444455556666777788889999" not in fallback_line
+    parsed_fallback = json.loads(fallback_line)
+    assert parsed_fallback.get("truncated") is True

--- a/tests/test_promotions_rotation.py
+++ b/tests/test_promotions_rotation.py
@@ -1,0 +1,124 @@
+"""Tests for nanobot/runtime/promotions_rotation.py (#1039)."""
+
+import gzip
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import bridge
+from nanobot.runtime.promotions_rotation import rotate_promotions
+
+
+def test_promotions_rotation_leaves_today_and_latest(tmp_path: Path):
+    promotions_dir = tmp_path / "promotions"
+    promotions_dir.mkdir(parents=True, exist_ok=True)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today_file = promotions_dir / f"cand-{today}-01.json"
+    today_file.write_text(json.dumps({"id": "cand-today-01"}), encoding="utf-8")
+
+    latest_file = promotions_dir / "latest.json"
+    latest_file.write_text(json.dumps({"id": "latest"}), encoding="utf-8")
+
+    # Rotate
+    rotate_promotions(promotions_dir)
+
+    assert today_file.exists()
+    assert latest_file.exists()
+    assert not (promotions_dir / f"cand-{today}-01.json.gz").exists()
+
+
+def test_promotions_rotation_gzips_prior_day_json(tmp_path: Path):
+    promotions_dir = tmp_path / "promotions"
+    promotions_dir.mkdir(parents=True, exist_ok=True)
+
+    old_date = "2026-06-01"
+    old_file = promotions_dir / f"cand-{old_date}-01.json"
+    old_file.write_text(json.dumps({"id": "cand-old-01", "desc": "old promotion"}), encoding="utf-8")
+
+    # Set mtime to past date
+    past_ts = (datetime.now(timezone.utc) - timedelta(days=10)).timestamp()
+    os.utime(old_file, (past_ts, past_ts))
+
+    rotate_promotions(promotions_dir)
+
+    assert not old_file.exists()
+    archive_dir = promotions_dir / "archive"
+    assert archive_dir.exists()
+    gz_files = list(archive_dir.glob("*.jsonl.gz"))
+    assert len(gz_files) == 1
+
+    with gzip.open(gz_files[0], "rt", encoding="utf-8") as f:
+        line = f.readline().strip()
+        data = json.loads(line)
+    assert data["id"] == "cand-old-01"
+
+
+def test_promotions_rotation_prunes_older_than_retention(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("EEEBOT_PROMOTIONS_RETENTION_DAYS", "90")
+    promotions_dir = tmp_path / "promotions"
+    promotions_dir.mkdir(parents=True, exist_ok=True)
+    archive_dir = promotions_dir / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    # 100 days old archive (past retention)
+    very_old_date = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%d")
+    very_old_gz = archive_dir / f"promotions-{very_old_date}.jsonl.gz"
+    with gzip.open(very_old_gz, "wt", encoding="utf-8") as f:
+        f.write(json.dumps({"id": "cand-very-old"}) + "\n")
+    past_ts = (datetime.now(timezone.utc) - timedelta(days=100)).timestamp()
+    os.utime(very_old_gz, (past_ts, past_ts))
+
+    # 30 days old gz (within retention)
+    recent_date = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
+    recent_gz = archive_dir / f"promotions-{recent_date}.jsonl.gz"
+    with gzip.open(recent_gz, "wt", encoding="utf-8") as f:
+        f.write(json.dumps({"id": "cand-recent"}) + "\n")
+    recent_ts = (datetime.now(timezone.utc) - timedelta(days=30)).timestamp()
+    os.utime(recent_gz, (recent_ts, recent_ts))
+
+    rotate_promotions(promotions_dir)
+
+    assert not very_old_gz.exists()
+    assert recent_gz.exists()
+
+
+def test_bridge_record_runtime_slice_candidate_writes_latest_and_rotates(tmp_path: Path):
+    cand_id = bridge._record_runtime_slice_candidate(
+        state_dir=tmp_path,
+        repo_root=tmp_path,
+        cycle_id="cycle-test-123",
+        cycle_branch="cycle/cycle-test-123",
+        base_sha="deadbeef",
+        changed_files=["nanobot/runtime/promotions_rotation.py"],
+    )
+    assert cand_id.startswith("promotion-runtime-")
+    cand_file = tmp_path / "promotions" / f"{cand_id}.json"
+    latest_file = tmp_path / "promotions" / "latest.json"
+
+    assert cand_file.exists()
+    assert latest_file.exists()
+
+    cand_data = json.loads(cand_file.read_text(encoding="utf-8"))
+    latest_data = json.loads(latest_file.read_text(encoding="utf-8"))
+
+    assert cand_data["origin_cycle_id"] == "cycle-test-123"
+    assert latest_data["origin_cycle_id"] == "cycle-test-123"
+    assert cand_data["rollback_record"]["cycle_branch"] == "cycle/cycle-test-123"
+    assert cand_data["rollback_record"]["base_sha"] == "deadbeef"
+    assert latest_data == cand_data
+
+
+def test_promotions_rotation_lock_mechanism(tmp_path: Path, monkeypatch):
+    """Test that promotions rotation acquires and releases lock file properly."""
+    from nanobot.runtime.promotions_rotation import _acquire_promotions_lock
+
+    promotions_dir = tmp_path / "promotions"
+    promotions_dir.mkdir(parents=True)
+
+    lock = _acquire_promotions_lock(promotions_dir)
+    assert lock is not None
+    lock.close()

--- a/tests/test_runtime_state_live.py
+++ b/tests/test_runtime_state_live.py
@@ -144,14 +144,13 @@ def test_legacy_artifacts_present_are_marked_decommissioned(tmp_path: Path):
     state_root = tmp_path / "state"
     _write_json(state_root / "outbox" / "latest.json", {"status": "PASS"})
     _write_json(state_root / "credits" / "latest.json", {"balance": 5, "delta": -1})
-    _write_json(state_root / "experiments" / "latest.json", {"outcome": "keep"})
     _write_json(state_root / "promotions" / "latest.json", {"promotion_candidate_id": "promo-1"})
 
     runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
 
     assert runtime["outbox_decommissioned"] is True
     assert runtime["credits_decommissioned"] is True
-    assert runtime["experiment_decommissioned"] is True
+    assert runtime["experiment_decommissioned"] is False
     assert runtime["promotion_decommissioned"] is True
 
     formatted = format_runtime_state(runtime)
@@ -163,7 +162,7 @@ def test_legacy_artifacts_present_are_marked_decommissioned(tmp_path: Path):
         line.startswith("  Credits source:") and "(decommissioned — frozen data)" in line
         for line in formatted
     )
-    assert any(
+    assert not any(
         line.startswith("  Experiment source:") and "(decommissioned — frozen data)" in line
         for line in formatted
     )


### PR DESCRIPTION
Closes #1039

- add 90-day gzip/prune rotation for runtime promotion candidates and keep latest.json compatibility
- prune subagent archive payloads older than 30 days while preserving metadata
- cap persisted LLM prompt records at 32 KiB with truncation marker and post-redaction guarantee
- remove obsolete state/experiments and goals/history reads from runtime/compiler paths
- preserve the one-time coordinator-era directory cleanup as an approval-gated operational step; no deletion performed yet

Validation: focused retention/telemetry/state tests passed; full pytest has only known Windows/POSIX baseline failures. Opus review approved.