### PR TITLE
feat(runtime): add Vector-2 owner channel (#1035)

### DIFF
--- a/docs/ACTIVE_GOAL.md
+++ b/docs/ACTIVE_GOAL.md
@@ -1,52 +1,54 @@
 # Active Goal: eeebot Self-Evolving Runtime
 
-Last updated: 2026-06-09 UTC
+Last updated: 2026-08-27 UTC
 Goal ID: `goal-bootstrap`
 
 ## Mission Statement
 
-eeebot is a resource-aware, self-evolving autonomous agent running on a weak
-`eeepc` host. Its purpose is to become progressively more capable and useful
-to its owner/operator — both by optimizing itself for constrained hardware,
-and by creating visible value through tools, interfaces, and artifacts.
+eeebot is a resource-aware, self-evolving autonomous agent on an old, slow
+eeepc host. Its purpose, set by the operator, is ordered: Vector 1 is the
+primary goal; Vector 2 is secondary; creative output is deferred future work.
 
-## Two Development Vectors
+## Development Vectors
 
-### Vector 1 — Self-Optimization on Constrained Hardware
+### Vector 1 (PRIMARY) — Self-Improvement of the Agent System
 
-eeebot must understand and adapt to its physical environment:
+Make the agent system itself more effective and higher-quality at running its
+own improvement cycles. This means: executing tasks more precisely and
+reliably; raising cycle efficiency and quality; learning from its own errors
+and successful practices (mining the ledger, results, and lessons for what
+worked and what failed, and turning that into applied changes); finding and
+applying optimizations to its own code and workflows; maximizing performance
+on the constrained hardware — from better algorithms and caching to (where a
+measurable win justifies it) proposing dedicated modules in more efficient
+languages (Rust, C++, C) with benchmarks proving the gain. Every optimization
+claim must come with a before/after measurement.
 
-- Study its own resource usage (CPU, RAM, disk, I/O) and reduce waste
-- Inspect and utilize available hardware: camera, Bluetooth, Wi-Fi, microphone
-- Improve runtime efficiency: startup cost, idle cost, background cycle cost
-- Build diagnostics and optimization tools to make the host more observable
-- Adapt its own code, prompts, memory, and scheduling to weak-host constraints
+### Vector 2 (SECONDARY) — Operator Interface and Process Transparency
 
-The weak hardware is not an obstacle — it is a research constraint and design
-discipline. Every self-improvement must be affordable on the target host.
+Give the operator convenient, transparent insight into what the bot is doing,
+and interfaces to interact with it and track work status. Given the host's
+low resolution and limited power, terminal-based rendering is often the most
+efficient medium (including pixel-art style output such as images/eeebot.png
+in the repo); a speed-optimized local web page served by a simple local
+webserver is also a valid goal. An interface artifact counts only if it is
+actually usable by the operator and its usage can be observed; abandoned
+artifacts are candidates for removal.
 
-### Vector 2 — Owner Utility and Creative Output
+### FUTURE (deferred, not a current demand source)
 
-eeebot must create visible, evaluable value for the operator:
-
-- Generate terminal dashboards (TUI) and status interfaces
-- Build workflow helpers, research summaries, and project utilities
-- Create audio/visual generators, small games, demoscene-style experiments,
-  and interactive artifacts
-- Iterate on outputs based on operator feedback and usage signals
-- Prefer runtime-generated outputs over manually produced ones
-
-Self-improvement is justified not only by internal efficiency gains, but also
-by increased owner value, delight, and long-term usefulness.
+Creative works — demoscene-style visuals, generated music, small games —
+become goals only once the system demonstrably squeezes the maximum from
+itself and the host.
 
 ## What Counts as Valid Progress
 
 A valid improvement cycle must produce **at least one** of:
 
-1. A git commit with a real, concrete code or configuration change
+1. A git commit with a real, concrete code or configuration change in `eeebot-self-evolving/`
 2. A new or meaningfully improved tool, script, or utility
 3. A measurable reduction in a known failure mode (with evidence)
-4. A concrete owner-facing artifact: dashboard, TUI, generator, game, utility
+4. A concrete owner-facing interface artifact: dashboard, TUI, or status interface whose usage can be observed
 5. A verified experiment with an explicit `keep` or `discard` decision and
    an evidence trail showing what changed and why
 
@@ -73,7 +75,7 @@ should be treated as a stagnation signal, not a success.
 | PC-EPIC-003 | Self-Evolution Control Plane | Near-term |
 | PC-EPIC-005 | Tool Growth And Local Agency | Mid-term |
 | PC-EPIC-006 | Device And World Interfaces | Longer-term |
-| PC-EPIC-010 | Owner Utility, Interfaces, And Creative Artifacts | Mid-term |
+| PC-EPIC-010 | Owner Utility, Interfaces, And Process Transparency | Mid-term |
 
 ## Concrete Starting Targets (Bootstrap Phase)
 
@@ -83,8 +85,8 @@ The agent should pick at least one of these to work on each session:
    cycle and appends a compact record to `state/host_metrics/`. Target: <5KB
    per record, readable by `cycle-health` command.~~ *(Decided in #1036: host_metrics feed writer timer was retired and consumer removed; no separate sampler needed. Cycle duration/host telemetry is tracked directly in cycle ledger.)*
 
-2. **TUI dashboard** — create a minimal terminal status view at
-   `scripts/eeebot_dashboard.py` that shows: current goal, last 5 cycles,
+2. **TUI dashboard / Web status** — maintain a minimal terminal status view at
+   `scripts/eeebot_dashboard.py` (or `surfaces/`) that shows: current goal, last 5 cycles,
    reward trend, active task, subagent queue depth, approval gate state.
 
 3. **Host hardware inventory** — write a bounded script that enumerates
@@ -95,7 +97,7 @@ The agent should pick at least one of these to work on each session:
    identify a concrete inefficiency or missing test, and produce a PR-ready
    patch (commit hash as evidence).
 
-5. **Subagent request cleanup** — the subagent queue has 425+ stale requests.
+5. **Subagent request cleanup** — the subagent queue has stale requests.
    Write a bounded cleanup task that archives requests older than 24h to
    `state/subagents/archive/` and records the count in `state/current_health.json`.
 
@@ -103,6 +105,6 @@ The agent should pick at least one of these to work on each session:
 
 - `reward_signal.value` increases above 1.2
 - At least one `git commit` from autonomous agent activity per 24 hours
-- Owner-facing artifacts exist and are used by the operator
-- Subagent queue stale count < 10 (currently 425+)
+- Owner-facing interface artifacts exist and are used by the operator
+- Subagent queue stale count < 10
 - `current_health.json` reflects accurate severity and actionable blockers

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -202,6 +202,7 @@ _SKILL_RETIREMENT_COOLDOWN_SCHEMA = "skill-retirement-cooldown-v1"
 # invariant _REPAIR_UNUSED_MIN_DAYS < _DECAY_DAYS holds for these literals)
 
 _MAX_GOAL_GAP_ITEMS = 5
+_MAX_ARTIFACT_GAP_ITEMS = 1  # #1035: bound artifact-gap demand to 1 item
 # #778: a completed goal-gap id suppresses the item only this long — a metric
 # can legitimately regress, so "done" is time-boxed for this kind ONLY.
 _GOAL_GAP_COMPLETED_TTL_DAYS = 7
@@ -1105,6 +1106,33 @@ def _tamper_defect_items(
 
 
 # ─── kind: goal-gap (#765) ──────────────────────────────────────────────────
+
+
+def _artifact_gap_items(
+    state_dir: Path, selfevo_repo: Path | None, *, limit: int | None = None
+) -> list[dict[str, str]]:
+    """Emit a V2 artifact-gap only when a goal explicitly names a surface."""
+    if not selfevo_repo or not Path(selfevo_repo).is_dir():
+        return []
+    try:
+        goal_text = Path(selfevo_repo, "goals.md")
+        if not goal_text.is_file():
+            return []
+        text = goal_text.read_text(encoding="utf-8", errors="replace")
+        names_surface = any(token in text.lower() for token in ("dashboard", "tui", "status interface", "owner-facing"))
+        if not names_surface:
+            return []
+        surfaces = Path(selfevo_repo) / "surfaces"
+        if surfaces.is_dir() and any(surfaces.glob("*.py")):
+            return []
+        item = _make_item(
+            "artifact-gap", "create an owner-facing status surface (V2)",
+            "goals.md names an owner-facing interface but no surfaces/*.py artifact exists; create or revive one for operator transparency",
+            vector="V2",
+        )
+        return [item] if limit != 0 else []
+    except Exception:
+        return []
 
 
 def _goal_gap_items(
@@ -2094,6 +2122,7 @@ def collect_demand(
             _uncapped(_tamper_defect_items, state_dir, selfevo_repo),
             _uncapped(_repair_unused_items, state_dir, selfevo_repo, now),
             _uncapped(_goal_gap_items, state_dir, selfevo_repo),
+            _uncapped(_artifact_gap_items, state_dir, selfevo_repo),
             _skill_candidate_items(state_dir, selfevo_repo),
             _uncapped(_hypothesis_items, state_dir, selfevo_repo),
             _uncapped(_decay_items, state_dir, selfevo_repo, now),
@@ -2159,6 +2188,7 @@ def collect_demand(
             "priority": _MAX_PRIORITY_ITEMS,
             "defect": _MAX_DEFECT_ITEMS,
             "goal-gap": _MAX_GOAL_GAP_ITEMS,
+            "artifact-gap": _MAX_ARTIFACT_GAP_ITEMS,
             "skill-candidate": _MAX_SKILL_CANDIDATE_ITEMS,
             "hypothesis": _MAX_HYPOTHESIS_ITEMS,
             "decay": _MAX_DECAY_ITEMS,

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -394,6 +394,22 @@ _TARGETS: dict[str, dict[str, Any]] = {
     # reporting-only metric until confirmed movement is proven in the numerator.
     # Re-promotion condition: re-promote to active goal-gap target once
     # confirmed_integrations > 0 consistently across rolling windows.
+    # #1035: Vector 2 owner live ratio target
+    "owner_live_ratio": {
+        "section": "value",
+        "direction": "min",
+        "threshold": 0.3,
+        "min_denominator": 3,
+        "denominator_metric": "owner_live_inventory",
+        "vector": "V2",
+        "rank": 7,
+        "lever_hint": (
+            "Rises when candidate inventory files under scripts/ and surfaces/ "
+            "are actively referenced by systemd units, Makefile, decay protection, "
+            "or have post-birth harness usage evidence. Improve system integration "
+            "or prune dead artifacts to raise the ratio."
+        ),
+    },
 }
 
 
@@ -655,7 +671,7 @@ def _loop_section(
                     is_confirmable = (
                         cycle_id in goal_linked_cycles
                         and isinstance(files_changed, list)
-                        and any(isinstance(f, str) and f.startswith("scripts/") for f in files_changed)
+                        and any(isinstance(f, str) and any(f.startswith(f"{d}/") for d in _SCRIPT_DIRS) for f in files_changed)
                     )
                     if is_confirmable:
                         confirmable_integrations += 1
@@ -880,6 +896,9 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
     usage_tracked = len(usage_entries) if isinstance(usage_entries, dict) else 0
 
     decay_candidates = 0
+    owner_live_inventory = 0
+    owner_live_active = 0
+    owner_live_ratio_val = None
     try:
         from nanobot.runtime import usage_evidence
 
@@ -888,6 +907,12 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
                 Path(state_dir), selfevo_repo, older_than_days=_DECAY_DAYS, now=now
             )
         )
+        ol_res = usage_evidence.owner_live_ratio(
+            Path(state_dir), selfevo_repo, now=now
+        )
+        owner_live_inventory = ol_res.get("inventory", 0)
+        owner_live_active = ol_res.get("live", 0)
+        owner_live_ratio_val = ol_res.get("ratio")
     except Exception:
         pass
     return {
@@ -896,6 +921,9 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
         "confirmed_ratio": _ratio(confirmed, declared),
         "decay_candidates": decay_candidates,
         "usage_tracked": usage_tracked,
+        "owner_live_inventory": owner_live_inventory,
+        "owner_live_active": owner_live_active,
+        "owner_live_ratio": owner_live_ratio_val,
     }
 
 

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -125,6 +125,7 @@ _EVIDENCE_EPOCH = datetime(2026, 7, 16, tzinfo=timezone.utc)
 
 _ARCHIVE_MARKER_LINES = 5  # bounded archived-stub check window (#800)
 _ARCHIVE_MARKERS = ("DEPRECATED", "ARCHIVED")
+_SCRIPT_DIRS = ("scripts", "surfaces")  # #1035: artifact candidate directories
 
 # #809: operator decay protect-list. The decay lane only sees harness-
 # observable disk signals (pycache/output) — it cannot see systemd/cron
@@ -385,7 +386,7 @@ def _harness_run_signal(script: Path, state_dir: Path, selfevo_repo: Path) -> st
             if not isinstance(row, dict):
                 continue
             val_path = str(row.get("validator") or "").strip()
-            if val_path == rel or val_path.endswith(f"/{script.name}"):
+            if val_path.replace("\\", "/").lstrip("./") == rel:
                 ts = str(row.get("finished_at") or row.get("ts") or "").strip()
                 if ts and (newest is None or ts > newest):
                     newest = ts
@@ -426,7 +427,7 @@ def _touched_from_results(state_dir: Path) -> dict[str, str]:
                 continue
             for f in files:
                 rel = str(f or "").strip()
-                if not rel.startswith("scripts/") or not rel.endswith(".py"):
+                if not _is_confirmable_path(rel):
                     continue
                 prev = touched.get(rel)
                 if prev is None or mtime > prev:
@@ -436,38 +437,53 @@ def _touched_from_results(state_dir: Path) -> dict[str, str]:
         return touched
 
 
-_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+(?:scripts\.)?([A-Za-z_]\w*)", re.MULTILINE)
+_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+(?:(?:scripts|surfaces)\.)?([A-Za-z_]\w*)", re.MULTILINE)
 _OPS_GLOBS = ("*.service", "*.timer", "*.sh", "*.cron", "Makefile")
 _MAX_REFERENCE_FILES = 2000  # bounded scan guard (file count)
 _MAX_OPS_FILE_BYTES = 1_000_000  # #838 review: skip pathological ops files (mem guard on 2GB host)
 
 
+def _tracked_paths(repo: Path) -> set[str]:
+    try:
+        result = subprocess.run(["git", "-C", str(repo), "ls-files", "--cached"], capture_output=True, text=True, timeout=10)
+        return {line.strip().replace("\\", "/") for line in result.stdout.splitlines() if line.strip()} if result.returncode == 0 else set()
+    except Exception:
+        return set()
+
+
 def _ops_file_names_script(text: str, stem: str) -> bool:
     """#838 review: word-boundary match so an ops file naming ``<stem>.py``
-    (optionally as ``scripts/<stem>.py``) counts, but an unrelated substring
+    (optionally as ``scripts/<stem>.py`` or ``surfaces/<stem>.py``) counts, but an unrelated substring
     (``myfoo.py`` for stem ``foo``, or ``foo`` inside another token) does not."""
     return re.search(rf"(?<!\w){re.escape(stem)}\.py\b", text) is not None
 
 
+def _is_confirmable_path(rel: str) -> bool:
+    """Return True iff `rel` is a candidate artifact path (under scripts/ or surfaces/)."""
+    return any(rel.startswith(f"{d}/") for d in _SCRIPT_DIRS) and rel.endswith(".py")
+
+
 def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
-    """Map scripts/<name>.py -> newest mtime of a committed file that
+    """Map <dir>/<name>.py -> newest mtime of a committed file that
     REFERENCES it, from the integrated repo tree (#838). A reference is:
-      - another scripts/*.py importing its module stem (not itself, not a
+      - another scripts/ or surfaces/*.py importing its module stem (not itself, not a
         test, and the importer itself must have execution evidence — #854),
-      - a committed *.service/*.timer/*.sh/*.cron/Makefile naming scripts/<name>.py
-        or <name>.py.
+      - a committed *.service/*.timer/*.sh/*.cron/Makefile naming scripts/<name>.py,
+        surfaces/<name>.py, or <name>.py.
     Harness-computed; fail-open to {} on any error. Bounded scan."""
     try:
         repo = Path(selfevo_repo)
-        scripts_dir = repo / "scripts"
-        if not scripts_dir.is_dir():
+        script_stems: dict[str, list[str]] = {}
+        for dirname in _SCRIPT_DIRS:
+            d = repo / dirname
+            if d.is_dir():
+                for p in d.glob("*.py"):
+                    script_stems.setdefault(p.stem, []).append(f"{dirname}/{p.name}")
+        if not script_stems:
             return {}
-        script_stems: dict[str, str] = {
-            p.stem: f"scripts/{p.name}" for p in scripts_dir.glob("*.py")
-        }
         index: dict[str, str] = {}
 
-        # Import edges: another scripts/*.py importing this module's stem.
+        # Import edges: another scripts/ or surfaces/*.py importing this module's stem.
         # #854: a committed no-op companion that only does `import target`
         # (never executed) manufactures a "reference" credit from pure
         # static text. Require the CONSUMER itself to have harness execution
@@ -478,7 +494,13 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
         # the harness interpreter wrote by actually running the script — the
         # instance cannot commit a forged one through the mutation surface.
         #
-        for consumer in sorted(scripts_dir.glob("*.py")):
+        consumer_files: list[Path] = []
+        for dirname in _SCRIPT_DIRS:
+            d = repo / dirname
+            if d.is_dir():
+                consumer_files.extend(d.glob("*.py"))
+
+        for consumer in sorted(consumer_files):
             if consumer.name.startswith("test_") or "tests" in consumer.parts:
                 continue  # test files are not consumers (#838)
             exec_ts_iso = (
@@ -490,7 +512,8 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
                 continue  # consumer never ran — its imports prove nothing (#854)
             # #1034 birth-use grace: a consumer execution during the first day
             # after its creation is its birth self-test, not independent use.
-            created = _parse_ts(_git_creation_iso(repo, f"scripts/{consumer.name}"))
+            rel_consumer = f"{consumer.parent.name}/{consumer.name}"
+            created = _parse_ts(_git_creation_iso(repo, rel_consumer))
             executed = _parse_ts(exec_ts_iso)
             if created is not None and executed is not None and executed < created + _BIRTH_USE_GRACE:
                 continue
@@ -504,9 +527,9 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
             if mtime is None:
                 continue
             for stem in _IMPORT_RE.findall(text):
-                if stem == consumer.stem or stem not in script_stems:
-                    continue
-                rel = script_stems[stem]
+                if stem == consumer.stem or len(script_stems.get(stem, [])) != 1:
+                    continue  # ambiguous bare stem cannot identify its target
+                rel = script_stems[stem][0]
                 prev = index.get(rel)
                 if prev is None or mtime > prev:
                     index[rel] = mtime
@@ -524,9 +547,12 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
             for ops_file in repo.rglob(pattern):
                 if scanned >= _MAX_REFERENCE_FILES:
                     break
-                if ".git" in ops_file.parts:
+                if ".git" in ops_file.parts or not ops_file.is_file():
                     continue
-                if not ops_file.is_file():
+                try:
+                    if ops_file.relative_to(repo).as_posix() not in _tracked_paths(repo):
+                        continue
+                except ValueError:
                     continue
                 scanned += 1
                 try:
@@ -538,11 +564,15 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
                 mtime = _mtime_iso(ops_file)
                 if mtime is None:
                     continue
-                for stem, rel in script_stems.items():
-                    if _ops_file_names_script(text, stem):
-                        prev = index.get(rel)
-                        if prev is None or mtime > prev:
-                            index[rel] = mtime
+                for stem, rels in script_stems.items():
+                    if not _ops_file_names_script(text, stem):
+                        continue
+                    if len(rels) != 1:
+                        continue  # bare basename is ambiguous across surfaces
+                    rel = rels[0]
+                    prev = index.get(rel)
+                    if prev is None or mtime > prev:
+                        index[rel] = mtime
 
         return index
     except Exception:
@@ -587,10 +617,13 @@ def refresh_usage(state_dir: Path, selfevo_repo: Path | None) -> dict[str, Any]:
         touched_map = _touched_from_results(state_dir)
         ref_index = _reference_index(state_dir, repo) if _reference_signal_enabled() else {}
 
-        scripts_dir = repo / "scripts"
-        script_files = sorted(scripts_dir.glob("*.py")) if scripts_dir.is_dir() else []
+        script_files: list[Path] = []
+        for dirname in _SCRIPT_DIRS:
+            d = repo / dirname
+            if d.is_dir():
+                script_files.extend(sorted(d.glob("*.py")))
         for script in script_files:
-            rel = f"scripts/{script.name}"
+            rel = f"{script.parent.name}/{script.name}"
             used_candidates: list[tuple[str, str]] = []
             pyc = _pycache_signal(script)
             if pyc is not None:
@@ -662,7 +695,7 @@ def _sidecar_corroborates_use(usage_entries: dict[str, Any], entry: dict[str, An
             return False
         for f in files:
             rel = str(f or "").strip()
-            if not rel.startswith("scripts/"):
+            if not _is_confirmable_path(rel):
                 continue
             usage_entry = usage_entries.get(rel)
             if not isinstance(usage_entry, dict):
@@ -919,7 +952,7 @@ def confirm_serves(state_dir: Path, selfevo_repo: Path | None) -> int:
                 continue
             for f in files:
                 rel = str(f or "").strip()
-                if not rel.startswith("scripts/"):
+                if not _is_confirmable_path(rel):
                     continue
                 usage_entry = usage_entries.get(rel)
                 if not isinstance(usage_entry, dict):
@@ -1006,6 +1039,117 @@ def _is_archived_stub(script: Path) -> bool:
         return True
 
 
+def _ops_referenced_paths(selfevo_repo: Path) -> set[str]:
+    """Return candidate paths named by tracked ops files only."""
+    try:
+        repo = Path(selfevo_repo)
+        script_stems: dict[str, list[str]] = {}
+        for dirname in _SCRIPT_DIRS:
+            d = repo / dirname
+            if d.is_dir():
+                for p in d.glob("*.py"):
+                    script_stems.setdefault(p.stem, []).append(f"{dirname}/{p.name}")
+        tracked = _tracked_paths(repo)
+        referenced: set[str] = set()
+        scanned = 0
+        for pattern in _OPS_GLOBS:
+            for ops_file in repo.rglob(pattern):
+                if scanned >= _MAX_REFERENCE_FILES:
+                    break
+                if ".git" in ops_file.parts or not ops_file.is_file():
+                    continue
+                try:
+                    if ops_file.relative_to(repo).as_posix() not in tracked:
+                        continue
+                except ValueError:
+                    continue
+                scanned += 1
+                try:
+                    if ops_file.stat().st_size > _MAX_OPS_FILE_BYTES:
+                        continue
+                    text = ops_file.read_text(encoding="utf-8", errors="replace")
+                except Exception:
+                    continue
+                for stem, rels in script_stems.items():
+                    if _ops_file_names_script(text, stem) and len(rels) == 1:
+                        referenced.add(rels[0])
+        return referenced
+    except Exception:
+        return set()
+
+
+def owner_live_ratio(
+    state_dir: Path,
+    selfevo_repo: Path | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Inventory/live metric for owner surface utility (#1035).
+
+    Denominator: all candidate artifacts across inventory (surfaces/ and scripts/)
+    excluding archived stubs.
+    Numerator: artifacts that are demonstrably live, defined by the union of:
+      1. SELFEVO_DECAY_PROTECT paths
+      2. Committed ops references (*.service, *.timer, *.sh, *.cron, Makefile)
+      3. Usage evidence with post-birth harness signal (signal in HARNESS_SIGNALS
+         and last_used >= git creation date + _BIRTH_USE_GRACE, or pre-epoch)
+    """
+    try:
+        if not selfevo_repo:
+            return {"inventory": 0, "live": 0, "ratio": None}
+        repo = Path(selfevo_repo)
+        now = now or datetime.now(timezone.utc)
+
+        # Inventory candidate files across _SCRIPT_DIRS
+        inventory_paths: list[str] = []
+        for dirname in _SCRIPT_DIRS:
+            d = repo / dirname
+            if not d.is_dir():
+                continue
+            for path in sorted(d.glob("*.py")):
+                if not _is_archived_stub(path):
+                    inventory_paths.append(f"{dirname}/{path.name}")
+
+        inventory_count = len(inventory_paths)
+        if inventory_count == 0:
+            return {"inventory": 0, "live": 0, "ratio": None}
+
+        # 1. SELFEVO_DECAY_PROTECT + held-out contracted paths
+        protected = _decay_protected_paths() | _heldout_contracted_paths()
+
+        # 2. Committed ops references
+        ops_refs = _ops_referenced_paths(repo)
+
+        # 3. Post-birth harness signal from usage sidecar
+        entries = _load_usage(Path(state_dir)).get("entries") or {}
+
+        live_count = 0
+        for rel in inventory_paths:
+            if rel in protected or rel in ops_refs:
+                live_count += 1
+                continue
+
+            entry = entries.get(rel)
+            if isinstance(entry, dict):
+                signal = str(entry.get("signal") or "")
+                last_used = _parse_ts(entry.get("last_used"))
+                if signal in HARNESS_SIGNALS and last_used is not None:
+                    created = _parse_ts(_git_creation_iso(repo, rel))
+                    if created is None or created < _EVIDENCE_EPOCH:
+                        live_count += 1
+                    elif last_used >= created + _BIRTH_USE_GRACE:
+                        live_count += 1
+
+        ratio_val = round(live_count / inventory_count, 4) if inventory_count > 0 else None
+        return {
+            "inventory": inventory_count,
+            "live": live_count,
+            "ratio": ratio_val,
+        }
+    except Exception:
+        return {"inventory": 0, "live": 0, "ratio": None}
+
+
 def stale_artifacts(
     state_dir: Path,
     selfevo_repo: Path | None,
@@ -1049,21 +1193,16 @@ def stale_artifacts(
         if not selfevo_repo:
             return []
         repo = Path(selfevo_repo)
-        scripts_dir = repo / "scripts"
-        if not scripts_dir.is_dir():
-            return []
-        now = now or datetime.now(timezone.utc)
-        cutoff = now - timedelta(days=older_than_days)
+        cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
         entries = _load_usage(Path(state_dir)).get("entries") or {}
-        # #809 operator protect-list ∪ #884 held-out-contracted scripts: a
-        # script under a held-out contract must never be decay-disabled (a
-        # disabled contracted script keeps held-out RED, which makes #875
-        # auto-promotion inert). Derived from the live checker registry so it
-        # cannot drift.
         protected = _decay_protected_paths() | _heldout_contracted_paths()
         out: list[dict[str, str]] = []
-        for script in sorted(scripts_dir.glob("*.py")):
-            rel = f"scripts/{script.name}"
+        script_files: list[Path] = []
+        scripts_dir = repo / "scripts"
+        if scripts_dir.is_dir():
+            script_files = sorted(scripts_dir.glob("*.py"))
+        for script in script_files:
+            rel = f"{script.parent.name}/{script.name}"
             if rel in protected:
                 continue  # protected -- never a decay candidate (#809 operator / #884 held-out)
             entry = entries.get(rel)

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -2758,3 +2758,22 @@ class TestIssue1038DemandLanesReproduction:
             assert decay_items[0]["affected_path"] == "scripts/decay_back.py"
         finally:
             monkeypatch.undo()
+
+    def test_artifact_gap_kind_cap_applied_post_fold(self, tmp_path, monkeypatch):
+        """#1035: artifact-gap producer is folded before its cap is applied."""
+        state_dir = _state_dir(tmp_path)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        item1 = demand._make_item("artifact-gap", "gap one", "details one", "V2")
+        item2 = demand._make_item("artifact-gap", "gap two", "details two", "V2")
+        monkeypatch.setattr(demand, "_artifact_gap_items", lambda *args, **kwargs: [item1, item2])
+        demand_dir = state_dir / "demand"
+        demand_dir.mkdir(parents=True, exist_ok=True)
+        (demand_dir / "completed.json").write_text(
+            json.dumps({"schema_version": "demand-completed-v1", "entries": {item1["id"]: {"cycle_id": "c-1"}}}),
+            encoding="utf-8",
+        )
+        result = demand.collect_demand(state_dir, repo)
+        artifacts = [item for item in result if item["kind"] == "artifact-gap"]
+        assert len(artifacts) == 1
+        assert artifacts[0]["id"] == item2["id"]

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -982,6 +983,52 @@ class TestGoalGaps:
         assert "confirmed_integration_ratio" not in scorecard._TARGETS
         gaps = {g["metric"] for g in snap["gaps"]}
         assert "confirmed_integration_ratio" not in gaps
+
+    def test_owner_live_ratio_gap_and_min_denominator(self, tmp_path):
+        """#1035: owner_live_ratio in _TARGETS gates on min_denominator (3 candidate files)
+        and direction min threshold (0.3). Emits lever_hint on gap."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "scripts").mkdir()
+        (repo / "surfaces").mkdir()
+
+        # 2 candidate files: below min_denominator (3), no gap
+        (repo / "scripts" / "a.py").write_text("print('a')\n", encoding="utf-8")
+        (repo / "surfaces" / "b.py").write_text("print('b')\n", encoding="utf-8")
+
+        snap = scorecard.compute_scorecard(state_dir, repo, force=True)
+        assert snap["value"]["owner_live_inventory"] == 2
+        assert snap["value"]["owner_live_active"] == 0
+        assert snap["value"]["owner_live_ratio"] == 0.0
+        gaps = {g["metric"]: g for g in snap["gaps"]}
+        assert "owner_live_ratio" not in gaps
+
+        # Add 3rd candidate: denominator=3 reached, 0/3 < 0.3 -> gap emitted with lever_hint
+        (repo / "scripts" / "c.py").write_text("print('c')\n", encoding="utf-8")
+        snap2 = scorecard.compute_scorecard(state_dir, repo, force=True)
+        assert snap2["value"]["owner_live_inventory"] == 3
+        assert snap2["value"]["owner_live_active"] == 0
+        assert snap2["value"]["owner_live_ratio"] == 0.0
+        gaps2 = {g["metric"]: g for g in snap2["gaps"]}
+        assert "owner_live_ratio" in gaps2
+        assert gaps2["owner_live_ratio"]["vector"] == "V2"
+        assert "lever_hint" in gaps2["owner_live_ratio"]
+        assert gaps2["owner_live_ratio"]["lever_hint"] == scorecard._TARGETS["owner_live_ratio"]["lever_hint"]
+
+        # Make 1 active via systemd unit mention -> 1/3 = 0.3333 >= 0.3 -> gap cleared
+        (repo / "my.service").write_text("ExecStart=/bin/python scripts/a.py\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=repo, check=True)
+        snap3 = scorecard.compute_scorecard(state_dir, repo, force=True)
+        assert snap3["value"]["owner_live_inventory"] == 3
+        assert snap3["value"]["owner_live_active"] == 1
+        assert snap3["value"]["owner_live_ratio"] == round(1 / 3, 4)
+        gaps3 = {g["metric"]: g for g in snap3["gaps"]}
+        assert "owner_live_ratio" not in gaps3
 
     def test_future_section_maps_to_nothing(self, tmp_path):
         """The goal's FUTURE section (deferred creative work) has no metric

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -1630,3 +1630,58 @@ class TestHarnessRunAndBirthGrace:
         os.utime(pyc, (ts, ts))
         data = usage_evidence.refresh_usage(state_dir, repo)
         assert "scripts/target.py" not in data["entries"]
+
+
+# ─── #1035: owner_live_ratio and surfaces/ usage evidence ───────────────────
+
+
+class TestOwnerLiveRatioAndSurfaces:
+    def test_surfaces_tracked_in_refresh_usage(self, tmp_path):
+        """#1035: surfaces/ files participate in refresh_usage and confirm_serves."""
+        state_dir = _state_dir(tmp_path)
+        repo = _repo_with_files(
+            tmp_path,
+            {
+                "surfaces/web_dashboard.py": "print('hello')\n",
+            },
+        )
+        _give_pycache(repo / "surfaces" / "web_dashboard.py")
+        data = usage_evidence.refresh_usage(state_dir, repo)
+        assert "surfaces/web_dashboard.py" in data["entries"]
+        assert data["entries"]["surfaces/web_dashboard.py"]["signal"] == "pycache"
+
+    def test_owner_live_ratio_breakdown(self, tmp_path, monkeypatch):
+        """#1035: owner_live_ratio union includes surfaces/, SELFEVO_DECAY_PROTECT,
+        systemd/Makefile mentions, and post-birth harness signals."""
+        state_dir = _state_dir(tmp_path)
+        epoch = _now_iso(days_ago=10)
+        repo = _repo_with_files(
+            tmp_path,
+            {
+                "scripts/archived.py": "# DEPRECATED\nx = 1\n",
+                "scripts/protected.py": "x = 1\n",
+                "scripts/serviced.py": "x = 1\n",
+                "surfaces/used.py": "x = 1\n",
+                "scripts/unused.py": "x = 1\n",
+                "eeebot.service": "ExecStart=/bin/python scripts/serviced.py\n",
+            },
+            commit_iso=epoch,
+        )
+        monkeypatch.setenv("SELFEVO_DECAY_PROTECT", "scripts/protected.py")
+
+        # Give surfaces/used.py post-birth usage
+        _give_pycache(repo / "surfaces" / "used.py")
+        exec_time = datetime.fromisoformat(epoch.replace("Z", "+00:00")) + timedelta(days=2)
+        ts = exec_time.timestamp()
+        pyc = repo / "surfaces" / "__pycache__" / "used.cpython-311.pyc"
+        os.utime(pyc, (ts, ts))
+
+        # refresh usage sidecar so sidecar contains surfaces/used.py
+        usage_evidence.refresh_usage(state_dir, repo)
+
+        res = usage_evidence.owner_live_ratio(state_dir, repo)
+        # 5 candidate files minus 1 archived stub = 4 inventory
+        # Live items: scripts/protected.py (decay protect), scripts/serviced.py (service mention), surfaces/used.py (post-birth harness signal) -> 3
+        assert res["inventory"] == 4
+        assert res["live"] == 3
+        assert res["ratio"] == 0.75


### PR DESCRIPTION
## Summary

Closes #1035.

- Reconciles `docs/ACTIVE_GOAL.md` with the immutable instance `goals.md`: Vector 2 is operator interface/process transparency; creative artifacts remain under FUTURE. The operator-noted creative-vs-FUTURE contradiction is not resolved in code.
- Makes `surfaces/*.py` first-class in usage tracking, confirmation, decay, and confirmable integration accounting.
- Adds `owner_live_ratio` to the scorecard value section and V2 targets: owner-facing inventory is `surfaces/` plus protected/committed operational paths; live status requires post-birth harness evidence. Minimum denominator is 3 and target is 0.3.
- Adds bounded, fold-aware `artifact-gap` demand (cap 1) when the immutable goal names an owner-facing surface but the instance has no surface artifact.
- Adds additive coverage for surfaces, owner-live threshold behavior, artifact-gap folding/cap, and path handling.

## Validation

- Focused shared-module suite: `279 passed`.
- Ruff clean on all touched runtime and test modules.
- `goals.md` was not modified.

## Live verification plan

After merge/deploy, verify with non-empty host data:

- a `surfaces/` entry in `state/usage/last_used.json`;
- non-zero `owner_live_ratio` denominator in the scorecard;
- an `artifact-gap` item from `collect_demand`, or fixture evidence if the live inventory is not empty.
