### PR TITLE
test: harden test infra and atomic runtime writes (#1043)

### DIFF
--- a/nanobot/runtime/_io.py
+++ b/nanobot/runtime/_io.py
@@ -11,6 +11,7 @@ variants under distinct names rather than silently unifying behavior.
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -61,6 +62,18 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def write_json_atomic(path: Path, payload: Any, *, indent: int = 2) -> None:
+    """Write *payload* as indented JSON to *path* atomically using tmp + os.replace.
+
+    Creates parent directories if needed. Writes to a sibling temporary file
+    and replaces *path* via ``os.replace`` so readers never see partial content.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp.{os.getpid()}")
+    tmp_path.write_text(json.dumps(payload, indent=indent, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp_path, path)
 
 
 def read_json_strict(path: Path) -> dict[str, Any]:

--- a/nanobot/runtime/archive.py
+++ b/nanobot/runtime/archive.py
@@ -12,10 +12,11 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from nanobot.runtime._io import write_json_atomic
 
 MAX_ARCHIVE_ENTRIES = 200
 STALL_WINDOW = 5          # check last N cycles for stall detection
@@ -124,9 +125,8 @@ class CycleArchive:
 
     def save(self, path: Path) -> None:
         """Persist archive to JSON (newest-first list)."""
-        path.parent.mkdir(parents=True, exist_ok=True)
         data = [e.as_dict() for e in self._entries]
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        write_json_atomic(path, data)
 
     def load(self, path: Path) -> None:
         """Load archive from JSON.  Tolerates missing / corrupt file (starts empty)."""
@@ -220,8 +220,7 @@ def record_stepping_stone(
         entries.sort(key=lambda e: float(e.get("ts") or 0.0), reverse=True)
         entries = entries[:_STEPPING_STONES_MAX]
 
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        write_json_atomic(path, entries)
     except Exception:
         pass  # steering archive is non-blocking (#844)
 

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3447,17 +3447,12 @@ def _record_runtime_slice_candidate(
         'recommended_next_action': 'operator_review_then_product_pr',
     }
     try:
+        from nanobot.runtime._io import write_json_atomic
+
         path = state_dir / 'promotions' / f'{candidate_id}.json'
         latest_path = state_dir / 'promotions' / 'latest.json'
-        path.parent.mkdir(parents=True, exist_ok=True)
-        serialized = json.dumps(record, indent=2)
-        # Atomic write
-        tmp_path = path.with_suffix(f'.tmp.{os.getpid()}')
-        tmp_path.write_text(serialized, encoding='utf-8')
-        tmp_path.replace(path)
-        tmp_latest = latest_path.with_suffix(f'.tmp.{os.getpid()}')
-        tmp_latest.write_text(serialized, encoding='utf-8')
-        tmp_latest.replace(latest_path)
+        write_json_atomic(path, record)
+        write_json_atomic(latest_path, record)
         try:
             from nanobot.runtime.promotions_rotation import rotate_promotions
             rotate_promotions(state_dir / 'promotions')
@@ -4382,7 +4377,9 @@ def _write_bridge_completed_result(
     }
 
     try:
-        result_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding='utf-8')
+        from nanobot.runtime._io import write_json_atomic
+
+        write_json_atomic(result_path, payload)
         print(f'bridge-result: wrote {result_status} result to {result_path.name}')
     except Exception as exc:
         print(f'bridge-result: failed to write result: {exc}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest configuration and test-suite initialization.
+
+Rationale:
+When running pytest or python against this repository in environments where another
+`tests` package might be present in site-packages or sys.path, we must ensure that
+the local workspace `tests/` directory is resolved and importable as `tests.*`.
+This allows tests that import helper utilities or fixtures across test modules
+(e.g., `from tests.test_cycle_ledger import ...` or `from tests.test_llm_proposer import ...`)
+to work reliably during test discovery and execution without requiring ad-hoc sys.path mutations
+in every individual test file.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root and local tests directory are at the top of sys.path
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _REPO_ROOT / "tests"
+
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# If 'tests' was already imported (e.g. from site-packages), extend its __path__
+# to include our local tests directory, or re-point it so tests.<module> imports work.
+if "tests" in sys.modules:
+    _tests_mod = sys.modules["tests"]
+    if hasattr(_tests_mod, "__path__"):
+        if str(_TESTS_DIR) not in _tests_mod.__path__:
+            _tests_mod.__path__.insert(0, str(_TESTS_DIR))
+else:
+    # If not yet imported, importing it will use sys.path which starts with _REPO_ROOT.
+    # We can also explicitly import and ensure __path__ includes _TESTS_DIR.
+    import tests  # noqa: F401
+
+    if hasattr(tests, "__path__") and str(_TESTS_DIR) not in tests.__path__:
+        tests.__path__.insert(0, str(_TESTS_DIR))

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,7 +1,178 @@
+"""Substantive test coverage for nanobot.config.schema and nanobot.runtime.schemas."""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from nanobot.config.schema import (
+    AgentsConfig,
+    Config,
+    ExecToolConfig,
+    GatewayConfig,
+    MCPServerConfig,
+    SubagentToolConfig,
+    ToolsConfig,
+    WebSearchConfig,
+    WebToolsConfig,
+)
+from nanobot.runtime.schemas import (
+    CycleHealth,
+    CycleReport,
+    PromotionCandidate,
+)
 
 
 def test_tools_config_exposes_subagent_compatibility_section():
-    from nanobot.config.schema import ToolsConfig
-
     cfg = ToolsConfig()
     assert cfg.subagent.max_running == 1
+    assert cfg.subagent.model == "un/qwen3.6-27b-mtp"
+    assert cfg.subagent.api_base == ""
+    assert cfg.subagent.harness_max_iterations == 8
+    assert cfg.subagent.harness_max_tool_calls == 24
+
+
+def test_tools_config_edge_cases_custom_subagent_and_exec():
+    custom_subagent = SubagentToolConfig(
+        max_running=10,
+        model="custom/test-model",
+        api_base="https://custom.api.local",
+        harness_max_iterations=16,
+        harness_max_tool_calls=48,
+    )
+    custom_exec = ExecToolConfig(
+        enable=False,
+        timeout=180,
+        path_append="/custom/bin",
+    )
+    custom_mcp = {
+        "mcp_server_1": MCPServerConfig(
+            type="stdio",
+            command="node",
+            args=["index.js"],
+            tool_timeout=45,
+            enabled_tools=["tool_a", "tool_b"],
+        )
+    }
+    cfg = ToolsConfig(
+        subagent=custom_subagent,
+        exec=custom_exec,
+        web=WebToolsConfig(
+            proxy="http://proxy.local:8080",
+            search=WebSearchConfig(provider="custom", api_key="secret-key", max_results=10),
+        ),
+        restrict_to_workspace=True,
+        mcp_servers=custom_mcp,
+    )
+    assert cfg.subagent.max_running == 10
+    assert cfg.subagent.model == "custom/test-model"
+    assert cfg.subagent.api_base == "https://custom.api.local"
+    assert cfg.subagent.harness_max_iterations == 16
+    assert cfg.subagent.harness_max_tool_calls == 48
+    assert cfg.exec.enable is False
+    assert cfg.exec.timeout == 180
+    assert cfg.exec.path_append == "/custom/bin"
+    assert cfg.web.proxy == "http://proxy.local:8080"
+    assert cfg.web.search.provider == "custom"
+    assert cfg.web.search.api_key == "secret-key"
+    assert cfg.web.search.max_results == 10
+    assert cfg.restrict_to_workspace is True
+    assert "mcp_server_1" in cfg.mcp_servers
+    assert cfg.mcp_servers["mcp_server_1"].enabled_tools == ["tool_a", "tool_b"]
+
+
+def test_config_root_defaults_and_validation():
+    cfg = Config()
+    assert isinstance(cfg.agents, AgentsConfig)
+    assert isinstance(cfg.tools, ToolsConfig)
+    assert isinstance(cfg.gateway, GatewayConfig)
+    assert cfg.gateway.port == 18790
+    assert cfg.gateway.host == "0.0.0.0"
+    assert cfg.gateway.heartbeat.enabled is True
+    assert cfg.gateway.heartbeat.interval_s == 1800
+    assert cfg.workspace_path.name == "workspace"
+
+    # MCPServerConfig validation
+    mcp = MCPServerConfig(
+        type="stdio",
+        command="node",
+        args=["server.js"],
+        env={"NODE_ENV": "test"},
+    )
+    assert mcp.command == "node"
+    assert mcp.args == ["server.js"]
+    assert mcp.env == {"NODE_ENV": "test"}
+
+    # Invalid type raises ValidationError
+    with pytest.raises(ValidationError):
+        MCPServerConfig(type="invalid_type")  # type: ignore[arg-type]
+
+
+def test_runtime_schemas_cycle_report_typed_dict():
+    report: CycleReport = {
+        "schema_version": "1.0.0",
+        "cycle_id": "c-2026-04-01-001",
+        "cycle_started_utc": "2026-04-01T00:00:00Z",
+        "cycle_ended_utc": "2026-04-01T00:05:00Z",
+        "goal_id": "g-1043",
+        "goal_text": "Improve test stability and io atomic helper",
+        "current_task_id": "t-1",
+        "result_status": "success",
+        "decision": "promote",
+        "improvement_score": 0.98,
+        "promotion_candidate_id": "cand-1043",
+        "review_status": "passed",
+        "evidence_ref_id": "ev-1043",
+        "experiment": {"type": "code"},
+        "follow_through": {"status": "complete"},
+        "result": {"exit_code": 0},
+    }
+    assert report["schema_version"] == "1.0.0"
+    assert report["cycle_id"] == "c-2026-04-01-001"
+    assert report["goal_id"] == "g-1043"
+    assert report["improvement_score"] == 0.98
+    assert report["decision"] == "promote"
+    assert report["result"]["exit_code"] == 0
+
+
+def test_runtime_schemas_promotion_candidate_and_cycle_health():
+    candidate: PromotionCandidate = {
+        "schema_version": "1.0.0",
+        "promotion_candidate_id": "cand-1043",
+        "review_status": "approved",
+        "decision": "promoted",
+        "decision_reason": "All checks passed cleanly",
+        "candidate_path": "/path/to/candidate",
+        "artifact_path": "/path/to/artifact",
+        "readiness_checks": {"lint": True, "tests": True},
+        "readiness_reasons": ["clean lint", "all tests pass"],
+        "recommended_next_action": "merge",
+        "governance_packet": {"approver": "governor"},
+        "decision_record": "dr-1043",
+        "accepted_record": "ar-1043",
+        "promotion_provenance": {"commit": "abc123"},
+    }
+    assert candidate["promotion_candidate_id"] == "cand-1043"
+    assert candidate["review_status"] == "approved"
+    assert candidate["decision"] == "promoted"
+    assert candidate["readiness_checks"]["tests"] is True
+
+    health: CycleHealth = {
+        "schema_version": "1.0.0",
+        "runtime_state_source": "coordinator",
+        "runtime_state_root": "/var/run/nanobot",
+        "latest_cycle_id": "c-2026-04-01-001",
+        "latest_report_path": "/var/run/nanobot/report.json",
+        "latest_subagent_telemetry_id": "telem-001",
+        "latest_subagent_telemetry_path": "/var/run/nanobot/telem.json",
+        "service_status": {"daemon": "running"},
+        "failed_units_count": 0,
+        "promotion_readiness": {"ready": True},
+        "severity": "info",
+        "exit_code": 0,
+        "next_recommended_action": "continue",
+        "success_signals": {"healthcheck": "ok"},
+    }
+    assert health["severity"] == "info"
+    assert health["exit_code"] == 0
+    assert health["failed_units_count"] == 0
+    assert health["service_status"]["daemon"] == "running"

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,108 @@
+"""Tests for runtime self-evolution probe slash commands in nanobot.runtime.probes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nanobot.bus.events import InboundMessage
+from nanobot.runtime.probes import handle_probe_command
+
+
+def _make_msg(content: str = "hello") -> InboundMessage:
+    return InboundMessage(
+        channel="telegram",
+        chat_id="chat-42",
+        sender_id="user-1",
+        content=content,
+        metadata={"source": "test"},
+    )
+
+
+def test_handle_probe_command_cap_status(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    msg = _make_msg("/cap_status")
+    res = handle_probe_command(workspace, "test-model", msg, "/cap_status")
+
+    assert res is not None
+    assert res.channel == "telegram"
+    assert res.chat_id == "chat-42"
+    assert "autonomy: runtime-command-router" in res.content
+    assert "model: test-model" in res.content
+    assert f"workspace: {workspace}" in res.content
+    assert "telegram_runtime_dispatch: True" in res.content
+
+
+def test_handle_probe_command_tiny_runtime_check(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    msg = _make_msg("/workspace experiment tiny-runtime-check")
+    res = handle_probe_command(workspace, "test-model", msg, "/workspace experiment tiny-runtime-check")
+
+    assert res is not None
+    assert res.channel == "telegram"
+    assert res.chat_id == "chat-42"
+    assert "action_id: workspace.experiment.tiny_runtime_check" in res.content
+    assert "written: True" in res.content
+    assert "executed: True" in res.content
+    assert "verified: True" in res.content
+
+    artifact = workspace / "state" / "telegram_live_probe" / "tiny-runtime-check.json"
+    assert artifact.exists()
+    data = json.loads(artifact.read_text(encoding="utf-8"))
+    assert data["action_id"] == "workspace.experiment.tiny_runtime_check"
+    assert data["channel"] == "telegram"
+    assert data["chat_id"] == "chat-42"
+    assert data["written"] is True
+    assert data["executed"] is True
+    assert data["verified"] is True
+
+
+def test_handle_probe_command_sub_run_bounded_and_unbounded(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    msg = _make_msg("/sub_run")
+
+    # Bounded branch: profile=research_only, budget=micro, non-empty task
+    res_bounded = handle_probe_command(
+        workspace,
+        "test-model",
+        msg,
+        "/sub_run --profile research_only --budget micro evaluate test coverage",
+    )
+    assert res_bounded is not None
+    assert "bounded: True" in res_bounded.content
+    assert "profile: research_only" in res_bounded.content
+    assert "budget: micro" in res_bounded.content
+    assert "task: evaluate test coverage" in res_bounded.content
+    assert "execution_state: accepted_for_bounded_runtime_dispatch" in res_bounded.content
+
+    artifact = workspace / "state" / "telegram_live_probe" / "sub_run_micro.json"
+    assert artifact.exists()
+    data = json.loads(artifact.read_text(encoding="utf-8"))
+    assert data["bounded"] is True
+    assert data["execution_state"] == "accepted_for_bounded_runtime_dispatch"
+    assert data["task"] == "evaluate test coverage"
+
+    # Unbounded branch: different profile/budget
+    res_unbounded = handle_probe_command(
+        workspace,
+        "test-model",
+        msg,
+        "/sub_run --profile full_agent --budget large do whatever",
+    )
+    assert res_unbounded is not None
+    assert "bounded: False" in res_unbounded.content
+    assert "profile: full_agent" in res_unbounded.content
+    assert "budget: large" in res_unbounded.content
+    assert "execution_state: rejected_by_policy" in res_unbounded.content
+
+    data_unbounded = json.loads(artifact.read_text(encoding="utf-8"))
+    assert data_unbounded["bounded"] is False
+    assert data_unbounded["execution_state"] == "rejected_by_policy"
+
+
+def test_handle_probe_command_fallthrough_none(tmp_path: Path):
+    workspace = tmp_path / "workspace"
+    msg = _make_msg("just a regular user chat message")
+
+    assert handle_probe_command(workspace, "test-model", msg, "hello bot") is None
+    assert handle_probe_command(workspace, "test-model", msg, "/unknown_command") is None
+    assert handle_probe_command(workspace, "test-model", msg, "/sub_run invalid args") is None

--- a/tests/test_runtime_io.py
+++ b/tests/test_runtime_io.py
@@ -1,0 +1,97 @@
+"""Unit tests for nanobot.runtime._io utilities."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime._io import (
+    load_json_dict,
+    read_json_strict,
+    utc_iso_raw,
+    utc_now,
+    write_json,
+    write_json_atomic,
+)
+
+
+def test_write_json_atomic_creates_parent_and_writes_valid_json(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "sub" / "data.json"
+    payload = {"status": "ok", "items": [1, 2, 3], "unicode": "тест"}
+
+    write_json_atomic(target, payload)
+
+    assert target.exists()
+    assert load_json_dict(target) == payload
+
+
+def test_write_json_atomic_interrupted_write_preserves_old_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "config.json"
+    original_payload = {"version": 1, "state": "initial"}
+    write_json_atomic(target, original_payload)
+
+    assert load_json_dict(target) == original_payload
+
+    # Simulate an error during serialization before writing/replacement
+    class UnserializableObject:
+        pass
+
+    with pytest.raises(TypeError):
+        write_json_atomic(target, {"version": 2, "bad": UnserializableObject()})
+
+    # The original file must remain untouched and valid
+    assert load_json_dict(target) == original_payload
+
+    # Also simulate failure in os.replace
+    def failing_replace(src: Path | str, dst: Path | str) -> None:
+        raise OSError("Simulated disk error during replace")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+
+    with pytest.raises(OSError, match="Simulated disk error"):
+        write_json_atomic(target, {"version": 3, "state": "failed_replace"})
+
+    # The original file must remain untouched and valid
+    assert load_json_dict(target) == original_payload
+
+
+def test_write_json_and_load_json_dict(tmp_path: Path) -> None:
+    target = tmp_path / "plain.json"
+    payload = {"key": "value", "num": 42}
+    write_json(target, payload)
+    assert load_json_dict(target) == payload
+
+
+def test_load_json_dict_missing_or_invalid(tmp_path: Path) -> None:
+    missing = tmp_path / "nonexistent.json"
+    assert load_json_dict(missing) is None
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("not json", encoding="utf-8")
+    assert load_json_dict(invalid) is None
+
+    not_dict = tmp_path / "list.json"
+    not_dict.write_text("[1, 2, 3]", encoding="utf-8")
+    assert load_json_dict(not_dict) is None
+
+
+def test_read_json_strict(tmp_path: Path) -> None:
+    valid = tmp_path / "valid.json"
+    valid.write_text('{"a": 1}', encoding="utf-8")
+    assert read_json_strict(valid) == {"a": 1}
+
+    missing = tmp_path / "missing.json"
+    with pytest.raises(Exception):
+        read_json_strict(missing)
+
+
+def test_utc_helpers() -> None:
+    now = utc_now()
+    assert now.tzinfo is not None
+    iso_str = utc_iso_raw(now)
+    assert isinstance(iso_str, str)
+    assert "T" in iso_str
+    assert iso_str.endswith("Z") or "+00:00" not in iso_str


### PR DESCRIPTION
## Summary

Closes #1043.

- Adds an intentional committed `tests/conftest.py` with documented import-resolution rationale, eliminating the need for an untracked tests-shadow shim.
- Expands `tests/test_config_schema.py` with substantive `runtime.schemas` and `ToolsConfig` default/custom/validation assertions.
- Adds complete `handle_probe_command` branch and fallthrough coverage in `tests/test_probes.py`, with all artifacts under `tmp_path`.
- Adds `_io.write_json_atomic` using sibling temporary output plus `os.replace`, with interrupted serialization/replacement tests proving the previous file remains valid.
- Migrates archive persistence and only the two authorized bridge call-sites: `_record_runtime_slice_candidate` and `_write_bridge_completed_result`.

## Scope and safety

No gate policy, deny-set, goals, identity, secrets, or unrelated bridge refactors were changed. The bridge diff is limited to the two named call-sites.

## Validation

- Focused runtime/test-infra suites: `76 passed`.
- Full pytest collection: `777 items collected`, zero collection errors without any untracked conftest.
- Full local pytest: baseline Windows failures only, outside touched files (git default-branch fixture assumptions, POSIX `fcntl`, and other known platform-specific tests); no #1043 test failures.
- Ruff clean on all touched files.
