### PR TITLE
perf(runtime): reduce repeated cycle I/O

### DIFF
--- a/nanobot/runtime/benchmark_evidence.py
+++ b/nanobot/runtime/benchmark_evidence.py
@@ -140,6 +140,7 @@ _IMPROVEMENT_ABS_TOL = 1e-6
 # because an optimization claim may need to look back further than 7 days
 # to find its pre-integration snapshot).
 _MAX_HISTORY_LINES = 3000
+_MAX_HISTORY_ARCHIVES_READ = 5
 
 # #822: the noise floor for a harness-run causal microbench entry
 # (nanobot/runtime/heldout/microbench.py) to count as a genuine win on the
@@ -312,14 +313,36 @@ def _history_snapshots(state_dir: Path) -> list[dict[str, Any]]:
     not fatal) never raise into the caller."""
     out: list[dict[str, Any]] = []
     try:
+        import gzip
+        from collections import deque
+
         path = Path(state_dir) / "scorecard" / "history.jsonl"
-        if not path.is_file():
-            return out
-        lines = path.read_text(encoding="utf-8").splitlines()[-_MAX_HISTORY_LINES:]
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
+        d: deque[str] = deque(maxlen=_MAX_HISTORY_LINES)
+
+        archive_dir = path.parent / "archive"
+        if archive_dir.is_dir():
+            try:
+                archives = sorted(archive_dir.glob("*.jsonl.gz"))
+            except Exception:
+                archives = []
+            for gz_path in archives[-_MAX_HISTORY_ARCHIVES_READ:]:
+                try:
+                    with gzip.open(gz_path, "rt", encoding="utf-8", errors="replace") as gz_fh:
+                        for line in gz_fh:
+                            line = line.strip()
+                            if line:
+                                d.append(line)
+                except Exception:
+                    continue
+
+        if path.is_file():
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        d.append(line)
+
+        for line in d:
             try:
                 row = json.loads(line)
             except Exception:

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -150,6 +150,64 @@ def _is_real_result(result: dict) -> bool:
     return True
 
 
+# #1040: Module-level cache of parsed result entries keyed by (results_dir_str, mtime)
+# to avoid repeated scandir passes across bridge invocation stages.
+_RESULT_ENTRIES_CACHE: dict[str, tuple[float, list[tuple[Path, dict, float]]]] = {}
+
+
+def _clear_result_entries_cache() -> None:
+    """Clear the module-level result entries cache (called at start of bridge runs)."""
+    _RESULT_ENTRIES_CACHE.clear()
+
+
+def _iter_result_entries(results_dir: 'Path',
+                         entries: 'list[tuple[Path, dict, float]] | None' = None,
+                         use_cache: bool = True) -> list[tuple[Path, dict, float]]:
+    """Scan results_dir in a single os.scandir pass and yield (path, data, mtime).
+
+    #1040: Replaces multiple separate glob/scandir sweeps across results consumers.
+    Supports cached entries or module-level mtime cache to avoid multi-pass scandir.
+    """
+    if entries is not None:
+        return entries
+    if not results_dir or not results_dir.exists():
+        return []
+
+    r_key = str(results_dir)
+    try:
+        cur_mtime = results_dir.stat().st_mtime
+    except Exception:
+        cur_mtime = 0.0
+
+    if use_cache and r_key in _RESULT_ENTRIES_CACHE:
+        cached_mtime, cached_entries = _RESULT_ENTRIES_CACHE[r_key]
+        if cached_mtime == cur_mtime:
+            return cached_entries
+
+    records: list[tuple[Path, dict, float]] = []
+    try:
+        with os.scandir(str(results_dir)) as it:
+            for entry in it:
+                if not entry.name.endswith('.json'):
+                    continue
+                try:
+                    if not entry.is_file():
+                        continue
+                    mtime = entry.stat().st_mtime
+                    p = Path(entry.path)
+                    data = json.loads(p.read_text(encoding='utf-8'))
+                    if isinstance(data, dict):
+                        records.append((p, data, mtime))
+                except Exception:
+                    continue
+    except Exception:
+        return []
+
+    if use_cache:
+        _RESULT_ENTRIES_CACHE[r_key] = (cur_mtime, records)
+    return records
+
+
 def find_pending_request() -> tuple[Path | None, dict]:
     """Find the oldest queued subagent request not yet handled by a real executor."""
     req_dir = STATE_DIR / 'subagents' / 'requests'
@@ -159,15 +217,13 @@ def find_pending_request() -> tuple[Path | None, dict]:
     # Collect request_ids/paths that have REAL results (not blocked stubs)
     real_handled: set[str] = set()
     result_dir = STATE_DIR / 'subagents' / 'results'
-    if result_dir.exists():
-        for rp in result_dir.glob('*.json'):
-            rd = load_json(rp) or {}
-            if not _is_real_result(rd):
-                continue  # skip blocked stubs — still eligible for bridge
-            if rid := rd.get('request_id') or rd.get('verification_task_id'):
-                real_handled.add(rid)
-            if rpath := rd.get('request_path'):
-                real_handled.add(str(rpath))
+    for _rp, rd, _mtime in _iter_result_entries(result_dir):
+        if not _is_real_result(rd):
+            continue  # skip blocked stubs — still eligible for bridge
+        if rid := rd.get('request_id') or rd.get('verification_task_id'):
+            real_handled.add(rid)
+        if rpath := rd.get('request_path'):
+            real_handled.add(str(rpath))
 
     # Also check bridge's own handled markers (those ARE real LLM runs)
     if BRIDGE_STATE_DIR.exists():
@@ -205,6 +261,7 @@ def _get_previous_attempts(
     backlog_title: str,
     cycle_id: str,
     max_attempts: int = 3,
+    entries: 'list[tuple[Path, dict, float]] | None' = None,
 ) -> list[dict]:
     """Return last N bridge result entries for the same backlog_title or cycle.
 
@@ -219,22 +276,12 @@ def _get_previous_attempts(
     subagent prompt so it knows what the prior session did (and why it failed).
     """
     results_dir = state_dir / 'subagents' / 'results'
-    if not results_dir.exists():
-        return []
-
-    import os as _os
     import json as _json
     import re as _re2
     candidates: list[tuple[float, dict]] = []
     title_words = [w.lower() for w in _re2.findall(r'[A-Za-z]{4,}', backlog_title)] if backlog_title else []
 
-    for entry in _os.scandir(str(results_dir)):
-        if not entry.name.endswith('.json') or not entry.is_file():
-            continue
-        try:
-            data = _json.loads(Path(entry.path).read_text(encoding='utf-8'))
-        except Exception:
-            continue
+    for _p, data, mtime in _iter_result_entries(results_dir, entries=entries):
         if data.get('materialized_from') != 'bridge_llm_execution':
             continue
 
@@ -266,7 +313,7 @@ def _get_previous_attempts(
             is_match = data.get('cycle_id') == cycle_id
 
         if is_match:
-            candidates.append((entry.stat().st_mtime, data))
+            candidates.append((mtime, data))
 
     candidates.sort(key=lambda x: x[0], reverse=True)
     return [d for _, d in candidates[:max_attempts]]
@@ -285,7 +332,8 @@ def _duplicate_check_title(req: dict, backlog_title: str) -> str:
     return backlog_title or req.get('task_title') or req.get('semantic_task_id') or ''
 
 
-def _migrate_backlog_title_in_results(results_dir: 'Path') -> int:
+def _migrate_backlog_title_in_results(results_dir: 'Path',
+                                      entries: 'list[tuple[Path, dict, float]] | None' = None) -> int:
     """One-time migration: backfill backlog_title into existing bridge result files.
 
     Iterates bridge_llm_execution results that lack backlog_title and reads the
@@ -296,33 +344,32 @@ def _migrate_backlog_title_in_results(results_dir: 'Path') -> int:
         return 0
     import json as _json
     updated = 0
-    for f in results_dir.glob('*.json'):
-        if not f.is_file():
-            continue
-        try:
-            data = _json.loads(f.read_text(encoding='utf-8'))
-        except Exception:
-            continue
-        if data.get('materialized_from') != 'bridge_llm_execution':
-            continue
-        if 'backlog_title' in data:
-            continue  # already migrated
-        src = data.get('source_artifact', '')
-        if not src:
-            continue
-        try:
-            art = _json.loads(Path(src).read_text(encoding='utf-8'))
-            title = (art.get('next_bounded_candidate') or {}).get('title', '')
-        except Exception:
-            continue
-        if not title:
-            continue
-        data['backlog_title'] = title
-        try:
-            f.write_text(_json.dumps(data, indent=2, ensure_ascii=False), encoding='utf-8')
-            updated += 1
-        except Exception:
-            pass
+    try:
+        for f, data, _mtime in _iter_result_entries(results_dir, entries=entries):
+            if data.get('materialized_from') != 'bridge_llm_execution':
+                continue
+            if 'backlog_title' in data:
+                continue  # already migrated
+            src = data.get('source_artifact', '')
+            if not src:
+                continue
+            try:
+                art = _json.loads(Path(src).read_text(encoding='utf-8'))
+                title = (art.get('next_bounded_candidate') or {}).get('title', '')
+            except Exception:
+                continue
+            if not title:
+                continue
+            data['backlog_title'] = title
+            try:
+                f.write_text(_json.dumps(data, indent=2, ensure_ascii=False), encoding='utf-8')
+                updated += 1
+            except Exception:
+                pass
+    except Exception:
+        pass
+    if updated > 0:
+        _clear_result_entries_cache()
     return updated
 
 
@@ -1165,7 +1212,9 @@ def dump_spawn_prompts(
 
 
 def _recent_activity_context(
-    state_dir: 'Path | None', selfevo_repo_root: 'Path | None'
+    state_dir: 'Path | None',
+    selfevo_repo_root: 'Path | None',
+    entries: 'list[tuple[Path, dict, float]] | None' = None,
 ) -> str:
     """Build a '## Recent activity (do not repeat)' block for the proposal prompt (#713).
 
@@ -1200,37 +1249,30 @@ def _recent_activity_context(
 
         if state_dir is not None:
             results_dir = state_dir / 'subagents' / 'results'
-            if results_dir.exists():
-                import json as _json
-                rejected: list[tuple[float, str]] = []
-                for entry in results_dir.glob('*.json'):
-                    if not entry.is_file():
-                        continue
-                    try:
-                        data = _json.loads(entry.read_text(encoding='utf-8'))
-                    except Exception:
-                        continue
-                    reason = (data.get('rollback') or {}).get('reason')
-                    status = data.get('result_status')
-                    if not reason and status not in ('blocked', 'no_commit'):
-                        continue
-                    title = (
-                        data.get('backlog_title')
-                        or data.get('task_title')
-                        or data.get('cycle_id')
-                        or '(untitled)'
-                    )
-                    note = reason or status or 'rejected'
-                    rejected.append((entry.stat().st_mtime, f'{title}: {note}'))
-                rejected.sort(key=lambda x: x[0], reverse=True)
-                top = [text for _, text in rejected[:5]]
-                if top:
-                    if lines:
-                        lines.append('')
-                    lines.append(
-                        'Recently rejected / no-commit (proxy signal, not exhaustive):'
-                    )
-                    lines.extend(f'- {t}' for t in top)
+            # #1040: use cached or single-pass result entries
+            rejected: list[tuple[float, str]] = []
+            for entry_path, data, mtime in _iter_result_entries(results_dir, entries=entries):
+                reason = (data.get('rollback') or {}).get('reason')
+                status = data.get('result_status')
+                if not reason and status not in ('blocked', 'no_commit'):
+                    continue
+                title = (
+                    data.get('backlog_title')
+                    or data.get('task_title')
+                    or data.get('cycle_id')
+                    or '(untitled)'
+                )
+                note = reason or status or 'rejected'
+                rejected.append((mtime, f'{title}: {note}'))
+            rejected.sort(key=lambda x: x[0], reverse=True)
+            top = [text for _, text in rejected[:5]]
+            if top:
+                if lines:
+                    lines.append('')
+                lines.append(
+                    'Recently rejected / no-commit (proxy signal, not exhaustive):'
+                )
+                lines.extend(f'- {t}' for t in top)
 
         if not lines:
             return ''
@@ -1711,6 +1753,7 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
 
 
 async def _main_impl_body():
+    _clear_result_entries_cache()
     set_config_path(CONFIG_PATH)
     config = load_config(CONFIG_PATH)
     # #721: bounded, fail-open tag pruning — run once per bridge invocation
@@ -3642,6 +3685,7 @@ def _recent_failure_match(
     window_hours: 'float | None' = None,
     max_scan: int = 10,
     target_path: 'str | None' = None,
+    entries: 'list[tuple[Path, dict, float]] | None' = None,
 ) -> 'str | None':
     """Return the title of a recently-failed/rejected result that
     ``dup_check_title`` matches, or None (#716; #757 return type — the
@@ -3716,24 +3760,12 @@ def _recent_failure_match(
         now = _time_fail.time()
         cutoff = now - (hours * 3600.0)
 
-        candidates: list[tuple[float, Path]] = []
-        for entry in results_dir.glob('*.json'):
-            try:
-                if not entry.is_file():
-                    continue
-                mtime = entry.stat().st_mtime
-            except Exception:
-                continue
-            candidates.append((mtime, entry))
-        # Most-recently-modified first, bounded to max_scan before any content check.
-        candidates.sort(key=lambda x: x[0], reverse=True)
+        # #1040: use cached or single-pass result entries (already newest-first)
+        all_entries = _iter_result_entries(results_dir, entries=entries)
+        candidates = sorted(all_entries, key=lambda x: x[2], reverse=True)
 
-        for mtime, entry in candidates[:max_scan]:
+        for entry_path, data, mtime in candidates[:max_scan]:
             if mtime < cutoff:
-                continue
-            try:
-                data = json.loads(entry.read_text(encoding='utf-8'))
-            except Exception:
                 continue
             reason = (data.get('rollback') or {}).get('reason')
             status = data.get('result_status')

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -150,9 +150,9 @@ def _is_real_result(result: dict) -> bool:
     return True
 
 
-# #1040: Module-level cache of parsed result entries keyed by (results_dir_str, mtime)
+# #1040: Module-level cache of parsed result entries keyed by results_dir_str
 # to avoid repeated scandir passes across bridge invocation stages.
-_RESULT_ENTRIES_CACHE: dict[str, tuple[float, list[tuple[Path, dict, float]]]] = {}
+_RESULT_ENTRIES_CACHE: dict[str, list[tuple[Path, dict, float]]] = {}
 
 
 def _clear_result_entries_cache() -> None:
@@ -166,7 +166,7 @@ def _iter_result_entries(results_dir: 'Path',
     """Scan results_dir in a single os.scandir pass and yield (path, data, mtime).
 
     #1040: Replaces multiple separate glob/scandir sweeps across results consumers.
-    Supports cached entries or module-level mtime cache to avoid multi-pass scandir.
+    Supports cached entries or module-level cache to avoid multi-pass scandir.
     """
     if entries is not None:
         return entries
@@ -174,15 +174,9 @@ def _iter_result_entries(results_dir: 'Path',
         return []
 
     r_key = str(results_dir)
-    try:
-        cur_mtime = results_dir.stat().st_mtime
-    except Exception:
-        cur_mtime = 0.0
 
     if use_cache and r_key in _RESULT_ENTRIES_CACHE:
-        cached_mtime, cached_entries = _RESULT_ENTRIES_CACHE[r_key]
-        if cached_mtime == cur_mtime:
-            return cached_entries
+        return _RESULT_ENTRIES_CACHE[r_key]
 
     records: list[tuple[Path, dict, float]] = []
     try:
@@ -204,7 +198,7 @@ def _iter_result_entries(results_dir: 'Path',
         return []
 
     if use_cache:
-        _RESULT_ENTRIES_CACHE[r_key] = (cur_mtime, records)
+        _RESULT_ENTRIES_CACHE[r_key] = records
     return records
 
 

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -315,6 +315,34 @@ def _make_item(
     }
 
 
+_MAX_LEDGER_BYTES = 2 * 1024 * 1024  # 2MB size limit (#1040)
+
+
+def _load_ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
+    """Load and parse ledger rows from ``state_dir/ledger/cycles.jsonl``.
+
+    Bounded to ``_MAX_LEDGER_BYTES``. Returns a list of parsed JSON dict rows.
+    """
+    try:
+        ledger = Path(state_dir) / "ledger" / "cycles.jsonl"
+        if not ledger.is_file() or ledger.stat().st_size > _MAX_LEDGER_BYTES:
+            return []
+        rows: list[dict[str, Any]] = []
+        for line in ledger.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+                if isinstance(row, dict):
+                    rows.append(row)
+            except Exception:
+                continue
+        return rows
+    except Exception:
+        return []
+
+
 def _read_json(path: Path, default: Any) -> Any:
     try:
         if not path.is_file():
@@ -449,26 +477,21 @@ def _priority_items(state_dir: Path, selfevo_repo: Path | None) -> list[dict[str
 
 
 def _ledger_defects(
-    state_dir: Path, now: datetime, *, limit: int | None = _MAX_LEDGER_DEFECTS
+    state_dir: Path,
+    now: datetime,
+    *,
+    limit: int | None = _MAX_LEDGER_DEFECTS,
+    ledger_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, str]]:
     """Terminal ledger outcome rows with a real failure in the last 48h.
     ``skipped-*`` outcomes are the dedup stack working, not defects."""
     items: list[dict[str, str]] = []
     seen_summaries: set[str] = set()
     try:
-        path = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if not path.is_file():
-            return []
         cutoff = now - timedelta(hours=_DEFECT_WINDOW_HOURS)
         matching_rows: list[dict[str, Any]] = []
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
+        rows = ledger_rows if ledger_rows is not None else _load_ledger_rows(state_dir)
+        for row in rows:
             if not isinstance(row, dict) or row.get("phase") != "outcome":
                 continue
             outcome = str(row.get("outcome") or "").strip().lower()
@@ -501,7 +524,12 @@ def _ledger_defects(
         return items
 
 
-def _skipped_cycle_ids(state_dir: Path, now: datetime) -> set[str]:
+def _skipped_cycle_ids(
+    state_dir: Path,
+    now: datetime,
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> set[str]:
     """Cycle ids whose terminal ledger outcome is ``skipped-*`` in the defect
     window. Their result files are dedup bookkeeping, not defects (#760
     roll-out fix: a blocked-by-dedup result masqueraded as demand and kept
@@ -509,18 +537,9 @@ def _skipped_cycle_ids(state_dir: Path, now: datetime) -> set[str]:
     case a bookkeeping result is presented as demand again, never a crash."""
     skipped: set[str] = set()
     try:
-        path = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if not path.is_file():
-            return skipped
         cutoff = now - timedelta(hours=_DEFECT_WINDOW_HOURS)
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
+        rows = ledger_rows if ledger_rows is not None else _load_ledger_rows(state_dir)
+        for row in rows:
             if not isinstance(row, dict) or row.get("phase") != "outcome":
                 continue
             if not str(row.get("outcome") or "").strip().lower().startswith("skipped"):
@@ -537,7 +556,11 @@ def _skipped_cycle_ids(state_dir: Path, now: datetime) -> set[str]:
 
 
 def _result_file_defects(
-    state_dir: Path, now: datetime, *, limit: int | None = _MAX_RESULT_FILE_DEFECTS
+    state_dir: Path,
+    now: datetime,
+    *,
+    limit: int | None = _MAX_RESULT_FILE_DEFECTS,
+    ledger_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, str]]:
     """Failed/blocked subagent result files with error text — bounded to the
     :data:`_MAX_RESULT_FILES` most recently modified files.
@@ -552,7 +575,7 @@ def _result_file_defects(
         if not results_dir.is_dir():
             return []
         cutoff_ts = (now - timedelta(hours=_DEFECT_WINDOW_HOURS)).timestamp()
-        skipped_cycles = _skipped_cycle_ids(state_dir, now)
+        skipped_cycles = _skipped_cycle_ids(state_dir, now, ledger_rows=ledger_rows)
         entries = [p for p in results_dir.glob("*.json") if p.is_file()]
         try:
             entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
@@ -1140,6 +1163,7 @@ def _goal_gap_items(
     selfevo_repo: Path | None,
     *,
     limit: int | None = None,
+    ledger_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, str]]:
     """Scorecard metrics violating their goal-derived target, as demand
     (#765). The gap list comes from ``scorecard.goal_gaps`` — deterministic,
@@ -1214,7 +1238,7 @@ def _goal_gap_items(
             gap_rows.append({**gap, "id": item["id"]})
         try:
             from nanobot.runtime import goal_gap_futility
-            futile_ids = goal_gap_futility.futile_gap_ids(state_dir, gap_rows)
+            futile_ids = goal_gap_futility.futile_gap_ids(state_dir, gap_rows, ledger_rows=ledger_rows)
             if futile_ids:
                 items = [item for item in items if item.get("id") not in futile_ids]
         except Exception:
@@ -1298,6 +1322,7 @@ def _hypothesis_items(
     selfevo_repo: Path | None,
     *,
     limit: int | None = 1,
+    ledger_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, str]]:
     items: list[dict[str, str]] = []
     seen: set[str] = set()
@@ -1376,7 +1401,7 @@ def _hypothesis_items(
         try:
             from nanobot.runtime import hypothesis_backlog
 
-            if hypothesis_backlog.has_in_flight_experiment(state_dir):
+            if hypothesis_backlog.has_in_flight_experiment(state_dir, ledger_rows=ledger_rows):
                 return []
         except Exception:
             pass
@@ -1480,7 +1505,86 @@ def retired_skill_paths_in_cooldown(state_dir: Path, now: datetime) -> dict[str,
         return {}
 
 
-def _completed_repair_count_for_skill(state_dir: Path, rel: str) -> int:
+def _repair_skill_counts(
+    state_dir: Path,
+    rel_paths: list[str],
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+    completed_entries: dict[str, Any] | None = None,
+) -> dict[str, int]:
+    """Batch-calculate integrated repair counts for multiple skill paths (#1040).
+
+    Computes repair IDs across all paths and scans ledger_rows once instead of
+    rescanning rows for every individual skill file.
+    """
+    try:
+        if not rel_paths:
+            return {}
+        path_to_repair_ids: dict[str, set[str]] = {}
+        all_repair_to_path: dict[str, str] = {}
+        for rel in rel_paths:
+            ids = {
+                item_id("defect", summary[:_MAX_SUMMARY_CHARS])
+                for summary in (
+                    f"repair: exercise never-read skill {rel} — wire or improve it, do not build a new one-shot",
+                    f"repair: re-wire idle skill {rel} — extend or consume it, do not build a new one-shot",
+                    f"repair: exercise never-read skill {rel}",
+                    f"repair: re-wire idle skill {rel}",
+                )
+            }
+            path_to_repair_ids[rel] = ids
+            for d_id in ids:
+                all_repair_to_path[d_id] = rel
+
+        completed = (
+            completed_entries
+            if completed_entries is not None
+            else _load_completed(state_dir).get("entries", {})
+        )
+        counts: dict[str, int] = {rel: 0 for rel in rel_paths}
+        for demand_id in completed:
+            rel = all_repair_to_path.get(str(demand_id))
+            if rel:
+                counts[rel] += 1
+
+        cycle_proposed: dict[str, str] = {}
+        successful_cycles_by_rel: dict[str, set[str]] = {rel: set() for rel in rel_paths}
+        rows = ledger_rows if ledger_rows is not None else _load_ledger_rows(state_dir)
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            cycle_id = str(row.get("cycle_id") or "").strip()
+            if not cycle_id:
+                continue
+            phase = row.get("phase")
+            if phase == "proposed":
+                d_id = str(row.get("demand_id") or "")
+                if d_id in all_repair_to_path:
+                    cycle_proposed[cycle_id] = d_id
+            elif (
+                phase == "outcome"
+                and str(row.get("outcome") or "").strip().lower() == "success"
+                and cycle_id in cycle_proposed
+            ):
+                d_id = cycle_proposed[cycle_id]
+                rel = all_repair_to_path.get(d_id)
+                if rel:
+                    successful_cycles_by_rel[rel].add(cycle_id)
+
+        for rel in rel_paths:
+            counts[rel] += len(successful_cycles_by_rel[rel])
+        return counts
+    except Exception:
+        return {rel: 0 for rel in rel_paths}
+
+
+def _completed_repair_count_for_skill(
+    state_dir: Path,
+    rel: str,
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+    completed_entries: dict[str, Any] | None = None,
+) -> int:
     """Count integrated repair-unused cycles for the exact skill path.
 
     The completed sidecar is the durable summary for ordinary demand reads, but
@@ -1490,47 +1594,13 @@ def _completed_repair_count_for_skill(state_dir: Path, rel: str) -> int:
     and tests.  Never trust a path from a sidecar as a workspace skill: callers
     enumerate real ``skills/*/SKILL.md`` files.
     """
-    try:
-        repair_ids = {
-            item_id("defect", summary[:_MAX_SUMMARY_CHARS])
-            for summary in (
-                f"repair: exercise never-read skill {rel} — wire or improve it, do not build a new one-shot",
-                f"repair: re-wire idle skill {rel} — extend or consume it, do not build a new one-shot",
-                f"repair: exercise never-read skill {rel}",
-                f"repair: re-wire idle skill {rel}",
-            )
-        }
-        completed = _load_completed(state_dir).get("entries", {})
-        completed_ids = {
-            str(demand_id)
-            for demand_id in completed
-            if str(demand_id) in repair_ids
-        }
-        cycle_ids: set[str] = set()
-        proposed: dict[str, str] = {}
-        ledger = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if ledger.is_file():
-            for line in ledger.read_text(encoding="utf-8").splitlines():
-                try:
-                    row = json.loads(line)
-                except Exception:
-                    continue
-                if not isinstance(row, dict):
-                    continue
-                cycle_id = str(row.get("cycle_id") or "").strip()
-                if not cycle_id:
-                    continue
-                if row.get("phase") == "proposed" and str(row.get("demand_id") or "") in repair_ids:
-                    proposed[cycle_id] = str(row.get("demand_id"))
-                elif (
-                    row.get("phase") == "outcome"
-                    and str(row.get("outcome") or "").strip().lower() == "success"
-                    and cycle_id in proposed
-                ):
-                    cycle_ids.add(cycle_id)
-        return len(completed_ids) + len(cycle_ids)
-    except Exception:
-        return 0
+    counts = _repair_skill_counts(
+        state_dir,
+        [rel],
+        ledger_rows=ledger_rows,
+        completed_entries=completed_entries,
+    )
+    return counts.get(rel, 0)
 
 
 # ─── kind: defect — repair-unused / fix_skill (#845) ───────────────────────
@@ -1542,6 +1612,7 @@ def _repair_unused_items(
     now: datetime,
     *,
     limit: int | None = _MAX_REPAIR_UNUSED_ITEMS,
+    ledger_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, str]]:
     """Recently-idle existing skills as a narrow ``defect`` repair demand
     (#845, OpenSpace fix_skill). A ``scripts/*.py`` whose harness-observed
@@ -1597,11 +1668,21 @@ def _repair_unused_items(
         last_reads = skill_fitness.last_confirmed_skill_reads(state_dir)
         skills_root = Path(selfevo_repo) / "skills"
         if skills_root.is_dir():
-            for skill_file in sorted(skills_root.glob("*/SKILL.md")):
+            skill_files = [
+                sf for sf in sorted(skills_root.glob("*/SKILL.md"))
+                if sf.is_file() and sf.relative_to(selfevo_repo).as_posix().startswith("skills/")
+            ]
+            all_skill_rels = [sf.relative_to(selfevo_repo).as_posix() for sf in skill_files]
+            cached_completed = _load_completed(state_dir).get("entries", {})
+            batch_repair_counts = _repair_skill_counts(
+                state_dir,
+                all_skill_rels,
+                ledger_rows=ledger_rows,
+                completed_entries=cached_completed,
+            )
+            for skill_file in skill_files:
                 rel = skill_file.relative_to(selfevo_repo).as_posix()
                 skill_name = skill_file.parent.name
-                if not skill_file.is_file() or not rel.startswith("skills/"):
-                    continue
                 last_read = last_reads.get(skill_name)
                 created_raw = usage_evidence._git_creation_iso(selfevo_repo, rel)
                 created = usage_evidence._parse_ts(created_raw) if created_raw else None
@@ -1610,7 +1691,7 @@ def _repair_unused_items(
                     if created is None or (now - created).days < _SKILL_NEVER_READ_GRACE_DAYS:
                         continue
                     # #958: never-read past grace — check retirement condition
-                    repair_count = _completed_repair_count_for_skill(state_dir, rel)
+                    repair_count = batch_repair_counts.get(rel, 0)
                     if repair_count >= _SKILL_RETIRE_AFTER_REPAIR_CYCLES:
                         summary = (
                             f"retire skill {rel}: fold anything reusable into docs/ or "
@@ -1673,7 +1754,11 @@ def completed_demand_ids(state_dir: Path) -> set[str]:
         return set()
 
 
-def _fold_completed(state_dir: Path) -> set[str]:
+def _fold_completed(
+    state_dir: Path,
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> set[str]:
     """Fold (proposed(demand_id) → same-cycle terminal ``outcome: success``)
     ledger pairs into the completed-demand sidecar and return all completed
     ids (#773, live P14 evidence 2026-07-15/16).
@@ -1741,23 +1826,46 @@ def _fold_completed(state_dir: Path) -> set[str]:
         # Archives first (oldest information), current file last, so the
         # current file's rows win on any same-cycle collision. Fail-open per
         # file: an unreadable file contributes no rows.
+        # When `ledger_rows` is passed (e.g. from `collect_demand`), only
+        # inspect archives on cold-start (empty entries sidecar) to avoid
+        # re-reading/decompressing gzip files on every cycle (#1040).
         ledger_dir = Path(state_dir) / "ledger"
-        try:
-            archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"), reverse=True)
-        except Exception:
-            archives = []
-        for gz_path in reversed(archives[:_FOLD_MAX_GZ_FILES]):
+        if ledger_rows is None or not entries:
             try:
-                with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
-                    _consume(fh.read().splitlines())
+                archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"), reverse=True)
             except Exception:
-                continue
-        current = ledger_dir / "cycles.jsonl"
-        if current.is_file():
-            try:
-                _consume(current.read_text(encoding="utf-8").splitlines())
-            except Exception:
-                pass
+                archives = []
+            for gz_path in reversed(archives[:_FOLD_MAX_GZ_FILES]):
+                try:
+                    with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
+                        _consume(fh.read().splitlines())
+                except Exception:
+                    continue
+        if ledger_rows is not None:
+            for row in ledger_rows:
+                if not isinstance(row, dict):
+                    continue
+                cycle_id = str(row.get("cycle_id") or "").strip()
+                if not cycle_id:
+                    continue
+                phase = row.get("phase")
+                if phase == "proposed":
+                    demand_id = str(row.get("demand_id") or "").strip()
+                    if demand_id:
+                        demand_by_cycle[cycle_id] = demand_id
+                    serves = str(row.get("serves") or "").strip()
+                    if serves:
+                        serves_by_cycle[cycle_id] = serves
+                elif phase == "outcome":
+                    if str(row.get("outcome") or "").strip().lower() == "success":
+                        success_by_cycle[cycle_id] = row
+        else:
+            current = ledger_dir / "cycles.jsonl"
+            if current.is_file():
+                try:
+                    _consume(current.read_text(encoding="utf-8").splitlines())
+                except Exception:
+                    pass
         changed = False
         for cycle_id, demand_id in demand_by_cycle.items():
             if demand_id in entries:
@@ -1781,6 +1889,11 @@ def _fold_completed(state_dir: Path) -> set[str]:
             _write_json(_completed_path(state_dir), data)
         return set(entries.keys())
     except Exception:
+        if ledger_rows is not None:
+            try:
+                return set(_load_completed(Path(state_dir))["entries"].keys())
+            except Exception:
+                return set()
         return completed_demand_ids(state_dir)
 
 
@@ -1823,7 +1936,11 @@ def _runtime_release_id() -> str:
         return ""
 
 
-def _latest_success_ts(state_dir: Path) -> datetime | None:
+def _latest_success_ts(
+    state_dir: Path,
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> datetime | None:
     """Timestamp of the newest terminal ``outcome: success`` ledger row, or
     ``None``. Any successful integration resets exhaustion (#771) — HEAD
     moves on integration anyway; this makes the reset explicit and immediate,
@@ -1832,17 +1949,8 @@ def _latest_success_ts(state_dir: Path) -> datetime | None:
     discipline as the other ledger readers; fail-open to ``None``."""
     latest: datetime | None = None
     try:
-        path = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if not path.is_file():
-            return None
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
+        rows = ledger_rows if ledger_rows is not None else _load_ledger_rows(state_dir)
+        for row in rows:
             if not isinstance(row, dict) or row.get("phase") != "outcome":
                 continue
             if str(row.get("outcome") or "").strip().lower() != "success":
@@ -1855,22 +1963,17 @@ def _latest_success_ts(state_dir: Path) -> datetime | None:
         return latest
 
 
-def _self_dedup_reject_ts_by_demand_id(state_dir: Path) -> dict[str, list[datetime]]:
+def _self_dedup_reject_ts_by_demand_id(
+    state_dir: Path,
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> dict[str, list[datetime]]:
     """Timestamps of ``proposer_reject``/``self_dedup`` ledger rows per
     ``demand_id`` (#762 rows extended with ``demand_id`` by #760)."""
     out: dict[str, list[datetime]] = {}
     try:
-        path = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if not path.is_file():
-            return out
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
+        rows = ledger_rows if ledger_rows is not None else _load_ledger_rows(state_dir)
+        for row in rows:
             if not isinstance(row, dict):
                 continue
             if row.get("phase") != "proposer_reject" or row.get("reason") != "self_dedup":
@@ -1891,6 +1994,7 @@ def _filter_exhausted(
     head: str | None,
     *,
     now: datetime | None = None,
+    ledger_rows: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, str]]:
     """Drop exhausted items; exhaustion resets (#771) on any of: a newer
     successful integration, a runtime release change, a repo HEAD move, or
@@ -1909,8 +2013,8 @@ def _filter_exhausted(
         now = now or datetime.now(timezone.utc)
         data = _load_exhausted(state_dir)
         entries: dict[str, Any] = data["entries"]
-        rejects = _self_dedup_reject_ts_by_demand_id(state_dir)
-        success_ts = _latest_success_ts(state_dir)
+        rejects = _self_dedup_reject_ts_by_demand_id(state_dir, ledger_rows=ledger_rows)
+        success_ts = _latest_success_ts(state_dir, ledger_rows=ledger_rows)
         release = _runtime_release_id()
         now_iso = now.isoformat().replace("+00:00", "Z")
         changed = False
@@ -2062,7 +2166,7 @@ def _reflection_items(
 # ─── public entrypoint ──────────────────────────────────────────────────────
 
 
-def _uncapped(builder: Any, *args: Any) -> list[dict[str, str]]:
+def _uncapped(builder: Any, *args: Any, **kwargs: Any) -> list[dict[str, str]]:
     """Call a lane builder without its presentation cap.
 
     The fallback preserves compatibility with older test doubles and optional
@@ -2070,11 +2174,11 @@ def _uncapped(builder: Any, *args: Any) -> list[dict[str, str]]:
     accept ``limit`` explicitly.
     """
     try:
-        return builder(*args, limit=None)
+        return builder(*args, limit=None, **kwargs)
     except TypeError as exc:
         if "limit" not in str(exc):
             raise
-        return builder(*args)
+        return builder(*args, **kwargs)
 
 
 def collect_demand(
@@ -2110,21 +2214,24 @@ def collect_demand(
         except Exception:
             pass
 
+        # #1040: parse cycles.jsonl once per collect_demand and thread through helpers
+        ledger_rows = _load_ledger_rows(state_dir)
+
         items: list[dict[str, str]] = []
         seen_ids: set[str] = set()
         for batch in (
             _priority_items(state_dir, selfevo_repo),
-            _uncapped(_ledger_defects, state_dir, now),
-            _uncapped(_result_file_defects, state_dir, now),
+            _uncapped(_ledger_defects, state_dir, now, ledger_rows=ledger_rows),
+            _uncapped(_result_file_defects, state_dir, now, ledger_rows=ledger_rows),
             _uncapped(_compile_defects, state_dir, selfevo_repo, head),
             _uncapped(_heldout_defect_items, state_dir),
             _uncapped(_validator_defect_items, state_dir),
             _uncapped(_tamper_defect_items, state_dir, selfevo_repo),
-            _uncapped(_repair_unused_items, state_dir, selfevo_repo, now),
-            _uncapped(_goal_gap_items, state_dir, selfevo_repo),
+            _uncapped(_repair_unused_items, state_dir, selfevo_repo, now, ledger_rows=ledger_rows),
+            _uncapped(_goal_gap_items, state_dir, selfevo_repo, ledger_rows=ledger_rows),
             _uncapped(_artifact_gap_items, state_dir, selfevo_repo),
             _skill_candidate_items(state_dir, selfevo_repo),
-            _uncapped(_hypothesis_items, state_dir, selfevo_repo),
+            _uncapped(_hypothesis_items, state_dir, selfevo_repo, ledger_rows=ledger_rows),
             _uncapped(_decay_items, state_dir, selfevo_repo, now),
             _uncapped(_reflection_items, state_dir, now),
         ):
@@ -2148,7 +2255,7 @@ def collect_demand(
         # #925: validator-harness defects get the same treatment for the same
         # reason — their summary is constant per script, so permanent
         # suppression would silence a validator that breaks again later.
-        completed = _fold_completed(state_dir)
+        completed = _fold_completed(state_dir, ledger_rows=ledger_rows)
         if completed:
             try:
                 from nanobot.runtime import reflector
@@ -2180,7 +2287,7 @@ def collect_demand(
                         kept.append(item)  # TTL elapsed — the condition may have recurred
             items = kept
 
-        result = _filter_exhausted(state_dir, items, head, now=now)
+        result = _filter_exhausted(state_dir, items, head, now=now, ledger_rows=ledger_rows)
 
         # #1038: Apply per-kind caps AFTER completed/exhausted folds so that
         # completed/exhausted items in the front of a lane do not push out live items.

--- a/nanobot/runtime/goal_gap_futility.py
+++ b/nanobot/runtime/goal_gap_futility.py
@@ -87,10 +87,16 @@ def _rows(state_dir: Path) -> list[dict[str, Any]]:
         return []
 
 
-def _integrated_count(state_dir: Path, gap_id: str, after: datetime) -> int:
+def _integrated_count(
+    state_dir: Path,
+    gap_id: str,
+    after: datetime,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> int:
     proposed: set[str] = set()
     successful: set[str] = set()
-    for row in _rows(state_dir):
+    rows = ledger_rows if ledger_rows is not None else _rows(state_dir)
+    for row in rows:
         cycle = str(row.get("cycle_id") or "").strip()
         if not cycle:
             continue
@@ -141,7 +147,13 @@ def _emit(state_dir: Path, record: dict[str, Any], futile: bool) -> None:
         pass
 
 
-def _update(state_dir: Path, gap: dict[str, Any], records: dict[str, dict[str, Any]], now: datetime) -> bool:
+def _update(
+    state_dir: Path,
+    gap: dict[str, Any],
+    records: dict[str, dict[str, Any]],
+    now: datetime,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> bool:
     gap_id = str(gap.get("id") or "").strip()
     if not gap_id:
         return False
@@ -178,7 +190,7 @@ def _update(state_dir: Path, gap: dict[str, Any], records: dict[str, dict[str, A
     record["metric"] = str(gap.get("metric") or record.get("metric") or "")
     record["current_metric"] = gap.get("current")
     record["metric_delta"] = _delta(record.get("first_metric"), gap.get("current"))
-    record["attempt_count"] = _integrated_count(state_dir, gap_id, first_seen)
+    record["attempt_count"] = _integrated_count(state_dir, gap_id, first_seen, ledger_rows=ledger_rows)
     now_futile = (
         record["attempt_count"] >= _threshold()
         and not _improved(str(gap.get("direction") or ""), record.get("first_metric"), gap.get("current"))
@@ -195,12 +207,21 @@ def _update(state_dir: Path, gap: dict[str, Any], records: dict[str, dict[str, A
     return now_futile
 
 
-def futile_gap_ids(state_dir: Path, gaps: list[dict[str, Any]]) -> set[str]:
+def futile_gap_ids(
+    state_dir: Path,
+    gaps: list[dict[str, Any]],
+    *,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> set[str]:
     """Update current gaps and return the IDs currently suppressed."""
     try:
         records = _load(state_dir)
         now = datetime.now(timezone.utc)
-        result = {str(gap.get("id")) for gap in gaps if _update(state_dir, gap, records, now)}
+        result = {
+            str(gap.get("id"))
+            for gap in gaps
+            if _update(state_dir, gap, records, now, ledger_rows=ledger_rows)
+        }
         _save(state_dir, records)
         return {item for item in result if item}
     except Exception:

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -94,9 +94,17 @@ def _write_json(path: Path, data: Any) -> None:
         pass
 
 
+_MAX_LEDGER_BYTES = 2 * 1024 * 1024
+
+
 def _load_ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
     path = Path(state_dir) / "ledger" / "cycles.jsonl"
     if not path.is_file():
+        return []
+    try:
+        if path.stat().st_size > _MAX_LEDGER_BYTES:
+            return []
+    except Exception:
         return []
     rows: list[dict[str, Any]] = []
     try:
@@ -567,7 +575,12 @@ def lifecycle_counts(state_dir: Path) -> dict[str, int]:
         return {}
 
 
-def has_in_flight_experiment(state_dir: Path, *, now: datetime | None = None) -> bool:
+def has_in_flight_experiment(
+    state_dir: Path,
+    *,
+    now: datetime | None = None,
+    ledger_rows: list[dict[str, Any]] | None = None,
+) -> bool:
     """True iff some ``active``-status hypothesis candidate has a
     ``'proposed'`` ledger row (``serves: hypothesis <ref>``) whose
     ``cycle_id`` has NOT YET produced a terminal ``'outcome'`` row AND whose
@@ -610,7 +623,7 @@ def has_in_flight_experiment(state_dir: Path, *, now: datetime | None = None) ->
         if not active_keys:
             return False
 
-        rows = _load_ledger_rows(state_dir)
+        rows = ledger_rows if ledger_rows is not None else _load_ledger_rows(state_dir)
         outcome_cycle_ids: set[str] = set()
         proposed_cycle_ts: dict[str, datetime | None] = {}
         for row in rows:

--- a/nanobot/runtime/loop_explorer.py
+++ b/nanobot/runtime/loop_explorer.py
@@ -51,6 +51,7 @@ EXPLORER_SCHEMA = "loop-explorer-v1"
 
 _MAX_EVENTS = 200
 _MAX_HISTORY_ENTRIES = 100
+_MAX_HISTORY_ARCHIVES_READ = 5
 _MAX_GZ_FILES = 7  # bounded archive read — same discipline as scorecard
 _REGEN_MINUTES = 30
 _WATERMARK_SCHEMA = "loop-explorer-watermark-v1"
@@ -282,32 +283,55 @@ def build_model(state_dir: Path) -> dict[str, Any]:
 
         series: list[dict[str, Any]] = []
         try:
+            import gzip
+            from collections import deque
+
             history_path = Path(state_dir) / "scorecard" / "history.jsonl"
-            if history_path.is_file():
-                lines = history_path.read_text(encoding="utf-8").splitlines()
-                for line in lines[-_MAX_HISTORY_ENTRIES:]:
-                    line = line.strip()
-                    if not line:
-                        continue
+            d: deque[str] = deque(maxlen=_MAX_HISTORY_ENTRIES)
+
+            archive_dir = history_path.parent / "archive"
+            if archive_dir.is_dir():
+                try:
+                    archives = sorted(archive_dir.glob("*.jsonl.gz"))
+                except Exception:
+                    archives = []
+                for gz_path in archives[-_MAX_HISTORY_ARCHIVES_READ:]:
                     try:
-                        snap = json.loads(line)
+                        with gzip.open(gz_path, "rt", encoding="utf-8", errors="replace") as gz_fh:
+                            for line in gz_fh:
+                                line = line.strip()
+                                if line:
+                                    d.append(line)
                     except Exception:
                         continue
-                    if not isinstance(snap, dict):
-                        continue
-                    series.append(
-                        {
-                            "ts": snap.get("computed_at_utc"),
-                            "integrations": (snap.get("loop") or {}).get("integrations"),
-                            "tokens_per_integration": (snap.get("cost") or {}).get(
-                                "tokens_per_integration"
-                            ),
-                            "heldout_gap": (snap.get("heldout") or {}).get("heldout_gap"),
-                            "repeat_failure_rate": (snap.get("loop") or {}).get(
-                                "repeat_failure_rate"
-                            ),
-                        }
-                    )
+
+            if history_path.is_file():
+                with open(history_path, "r", encoding="utf-8", errors="replace") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if line:
+                            d.append(line)
+
+            for line in d:
+                try:
+                    snap = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(snap, dict):
+                    continue
+                series.append(
+                    {
+                        "ts": snap.get("computed_at_utc"),
+                        "integrations": (snap.get("loop") or {}).get("integrations"),
+                        "tokens_per_integration": (snap.get("cost") or {}).get(
+                            "tokens_per_integration"
+                        ),
+                        "heldout_gap": (snap.get("heldout") or {}).get("heldout_gap"),
+                        "repeat_failure_rate": (snap.get("loop") or {}).get(
+                            "repeat_failure_rate"
+                        ),
+                    }
+                )
         except Exception:
             pass
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -305,6 +305,7 @@ _WINDOW_DAYS = 7
 _RECOMPUTE_MINUTES = 30
 _MAX_GZ_FILES = 7  # bounded archive read — rotation-aware, never unbounded
 _MAX_HISTORY_LINES = 400  # bounded history read (one line per recompute)
+_MAX_HISTORY_BYTES = 512 * 1024  # 512KB size-based history rotation threshold (#1040)
 _DECAY_DAYS = 14  # kept in sync with demand._DECAY_DAYS
 
 # Trend-gap parameters for tokens_per_integration: worsening more than
@@ -1249,27 +1250,78 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
 
 
 def _read_history(state_dir: Path) -> list[dict[str, Any]]:
-    """Bounded read of ``history.jsonl`` — the newest
-    :data:`_MAX_HISTORY_LINES` lines only. Fail-open to ``[]``."""
+    """Bounded read of ``history.jsonl`` (and newest archive if rotated) —
+    the newest :data:`_MAX_HISTORY_LINES` lines only.
+
+    #1040: Uses streaming line-by-line reading into a deque with maxlen to avoid
+    loading unbounded full text into memory, plus checks rotated archive to
+    ensure trend evaluation across rotation boundaries."""
     out: list[dict[str, Any]] = []
     try:
+        import gzip
+        from collections import deque
+
         path = _history_path(state_dir)
-        if not path.is_file():
-            return out
-        lines = path.read_text(encoding="utf-8").splitlines()[-_MAX_HISTORY_LINES:]
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
+        d: deque[str] = deque(maxlen=_MAX_HISTORY_LINES)
+
+        # If current history has fewer than _MAX_HISTORY_LINES, read newest archives
+        # to ensure trend metrics across rotation boundaries.
+        archive_dir = path.parent / "archive"
+        if archive_dir.is_dir():
+            try:
+                archives = sorted(archive_dir.glob("*.jsonl.gz"))
+            except Exception:
+                archives = []
+            for gz_path in archives[-5:]:
+                try:
+                    with gzip.open(gz_path, "rt", encoding="utf-8", errors="replace") as gz_fh:
+                        for line in gz_fh:
+                            line = line.strip()
+                            if line:
+                                d.append(line)
+                except Exception:
+                    continue
+
+        if path.is_file():
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        d.append(line)
+
+        for line in d:
             try:
                 row = json.loads(line)
+                if isinstance(row, dict):
+                    out.append(row)
             except Exception:
                 continue
-            if isinstance(row, dict):
-                out.append(row)
         return out
     except Exception:
         return out
+
+
+def _rotate_history_if_needed(path: Path, max_bytes: int = _MAX_HISTORY_BYTES) -> None:
+    """#1040: Rotate history.jsonl if it exceeds max_bytes to keep memory/IO bounded
+    while keeping trend windows across rotation boundaries."""
+    try:
+        if not path.is_file() or path.stat().st_size <= max_bytes:
+            return
+        import gzip
+        import shutil
+
+        archive_dir = path.parent / "archive"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        ts_str = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        archive_file = archive_dir / f"history-{ts_str}.jsonl.gz"
+        tmp_archive = archive_dir / f".tmp.history-{ts_str}.jsonl.gz"
+        with open(path, "rb") as f_in, gzip.open(tmp_archive, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+        tmp_archive.replace(archive_file)
+        # Empty the active history file
+        path.write_text("", encoding="utf-8")
+    except Exception:
+        pass
 
 
 def _metric_value(snapshot: dict[str, Any], section: str, metric: str) -> Any:
@@ -1490,8 +1542,11 @@ def compute_scorecard(
         try:
             path = _history_path(state_dir)
             path.parent.mkdir(parents=True, exist_ok=True)
+            # #1040: omit control_plane from history lines to save I/O while keeping it in latest.json
+            history_row = {k: v for k, v in snapshot.items() if k != "control_plane"}
             with open(path, "a", encoding="utf-8") as fh:
-                fh.write(json.dumps(snapshot, ensure_ascii=False) + "\n")
+                fh.write(json.dumps(history_row, ensure_ascii=False) + "\n")
+            _rotate_history_if_needed(path)
         except Exception:
             pass
 

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -308,7 +308,13 @@ def _output_paths_from_header(script: Path) -> list[str]:
     return [m.rstrip("./") for m in _OUTPUT_PATH_RE.findall(header)]
 
 
-def _output_signal(script: Path, state_dir: Path, selfevo_repo: Path) -> str | None:
+def _output_signal(
+    script: Path,
+    state_dir: Path,
+    selfevo_repo: Path,
+    *,
+    sidecar_data: dict[str, Any] | None = None,
+) -> str | None:
     """``used:output`` — newest mtime among existing output artifacts the
     script's header names. ``state/X`` resolves under ``state_dir``,
     ``docs/X`` under the instance repo.
@@ -321,16 +327,20 @@ def _output_signal(script: Path, state_dir: Path, selfevo_repo: Path) -> str | N
     file, git unavailable) the gate is skipped and the mtime is accepted.
     """
     try:
+        header_tokens = _output_paths_from_header(script)[:20]
+        if not header_tokens:
+            return None
+
         # Resolve the script's repo-relative path for git creation lookup.
         try:
             rel = script.relative_to(selfevo_repo).as_posix()
         except ValueError:
             rel = f"scripts/{script.name}"
-        git_created_iso = _git_creation_iso(selfevo_repo, rel)
+        git_created_iso = _git_creation_iso(selfevo_repo, rel, sidecar_data=sidecar_data)
         git_created = _parse_ts(git_created_iso)  # None → gate skipped
 
         newest: str | None = None
-        for token in _output_paths_from_header(script)[:20]:
+        for token in header_tokens:
             if token.startswith("state/"):
                 candidate = Path(state_dir) / token[len("state/"):]
             else:
@@ -463,7 +473,11 @@ def _is_confirmable_path(rel: str) -> bool:
     return any(rel.startswith(f"{d}/") for d in _SCRIPT_DIRS) and rel.endswith(".py")
 
 
-def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
+def _reference_index(
+    state_dir: Path,
+    selfevo_repo: Path,
+    sidecar_data: dict[str, Any] | None = None,
+) -> dict[str, str]:
     """Map <dir>/<name>.py -> newest mtime of a committed file that
     REFERENCES it, from the integrated repo tree (#838). A reference is:
       - another scripts/ or surfaces/*.py importing its module stem (not itself, not a
@@ -505,7 +519,7 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
                 continue  # test files are not consumers (#838)
             exec_ts_iso = (
                 _pycache_signal(consumer)
-                or _output_signal(consumer, state_dir, repo)
+                or _output_signal(consumer, state_dir, repo, sidecar_data=sidecar_data)
                 or _harness_run_signal(consumer, state_dir, repo)
             )
             if exec_ts_iso is None:
@@ -513,7 +527,7 @@ def _reference_index(state_dir: Path, selfevo_repo: Path) -> dict[str, str]:
             # #1034 birth-use grace: a consumer execution during the first day
             # after its creation is its birth self-test, not independent use.
             rel_consumer = f"{consumer.parent.name}/{consumer.name}"
-            created = _parse_ts(_git_creation_iso(repo, rel_consumer))
+            created = _parse_ts(_git_creation_iso(repo, rel_consumer, sidecar_data=sidecar_data))
             executed = _parse_ts(exec_ts_iso)
             if created is not None and executed is not None and executed < created + _BIRTH_USE_GRACE:
                 continue
@@ -615,7 +629,7 @@ def refresh_usage(state_dir: Path, selfevo_repo: Path | None) -> dict[str, Any]:
 
         entries: dict[str, Any] = data["entries"]
         touched_map = _touched_from_results(state_dir)
-        ref_index = _reference_index(state_dir, repo) if _reference_signal_enabled() else {}
+        ref_index = _reference_index(state_dir, repo, sidecar_data=data) if _reference_signal_enabled() else {}
 
         script_files: list[Path] = []
         for dirname in _SCRIPT_DIRS:
@@ -628,7 +642,7 @@ def refresh_usage(state_dir: Path, selfevo_repo: Path | None) -> dict[str, Any]:
             pyc = _pycache_signal(script)
             if pyc is not None:
                 used_candidates.append((pyc, "pycache"))
-            output = _output_signal(script, state_dir, repo)
+            output = _output_signal(script, state_dir, repo, sidecar_data=data)
             if output is not None:
                 used_candidates.append((output, "output"))
             ref = ref_index.get(rel)
@@ -995,29 +1009,53 @@ def _git_last_commit_iso(selfevo_repo: Path, rel: str) -> str | None:
         return None
 
 
-def _git_creation_iso(selfevo_repo: Path, rel: str) -> str | None:
+def _git_creation_iso(
+    selfevo_repo: Path,
+    rel: str,
+    *,
+    sidecar_data: dict[str, Any] | None = None,
+) -> str | None:
     """Creation date of ``rel`` — the author date of the FIRST commit that
-    added it (last line of ``git log --diff-filter=A --follow``). ``None``
-    on any failure (fail-open toward not flagging)."""
+    added it. ``None`` on any failure (fail-open toward not flagging).
+
+    #1040: Memoized in sidecar_data["created_cache"]. Keyed by ``rel`` (since
+    file creation dates in git history are immutable across commits), with
+    backward compatibility for legacy ``head:rel`` keys. Also removes costly
+    --follow.
+    """
+    head = _git_head(selfevo_repo)
+    if sidecar_data is not None:
+        cache = sidecar_data.setdefault("created_cache", {})
+        if isinstance(cache, dict):
+            # Check immutable rel key first, then fallback to legacy head:rel key
+            cached_val = cache.get(rel)
+            if cached_val is None and head:
+                cached_val = cache.get(f"{head}:{rel}")
+            if cached_val is not None:
+                return cached_val
+
+    val: str | None = None
     try:
         result = subprocess.run(
             [
                 "git", "-C", str(selfevo_repo), "log",
-                "--diff-filter=A", "--follow", "--format=%aI", "--", rel,
+                "--diff-filter=A", "--format=%aI", "--", rel,
             ],
             capture_output=True,
             text=True,
             timeout=10,
         )
-        if result.returncode != 0:
-            return None
-        lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
-        if not lines:
-            return None
-        parsed = _parse_ts(lines[-1])
-        return _iso(parsed) if parsed is not None else None
+        if result.returncode == 0:
+            lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+            if lines:
+                parsed = _parse_ts(lines[-1])
+                val = _iso(parsed) if parsed is not None else None
     except Exception:
-        return None
+        val = None
+
+    if sidecar_data is not None and isinstance(sidecar_data.get("created_cache"), dict):
+        sidecar_data["created_cache"][rel] = val
+    return val
 
 
 def _is_archived_stub(script: Path) -> bool:
@@ -1134,7 +1172,8 @@ def owner_live_ratio(
                 signal = str(entry.get("signal") or "")
                 last_used = _parse_ts(entry.get("last_used"))
                 if signal in HARNESS_SIGNALS and last_used is not None:
-                    created = _parse_ts(_git_creation_iso(repo, rel))
+                    usage_data = _load_usage(Path(state_dir))
+                    created = _parse_ts(_git_creation_iso(repo, rel, sidecar_data=usage_data))
                     if created is None or created < _EVIDENCE_EPOCH:
                         live_count += 1
                     elif last_used >= created + _BIRTH_USE_GRACE:
@@ -1156,6 +1195,7 @@ def stale_artifacts(
     *,
     older_than_days: int,
     now: datetime | None = None,
+    sidecar_data: dict[str, Any] | None = None,
 ) -> list[dict[str, str]]:
     """``scripts/*.py`` artifacts whose ``last_used`` AND ``last_touched``
     are both older than ``older_than_days`` — the decay-candidate input for
@@ -1194,7 +1234,8 @@ def stale_artifacts(
             return []
         repo = Path(selfevo_repo)
         cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
-        entries = _load_usage(Path(state_dir)).get("entries") or {}
+        usage_data = sidecar_data or _load_usage(Path(state_dir))
+        entries = usage_data.get("entries") or {}
         protected = _decay_protected_paths() | _heldout_contracted_paths()
         out: list[dict[str, str]] = []
         script_files: list[Path] = []
@@ -1223,7 +1264,7 @@ def stale_artifacts(
             # last_used inside the birth-grace window is the creation
             # cycle's own self-test, not consumption — treat it as never
             # used. The git call only runs for otherwise-stale scripts.
-            created = _parse_ts(_git_creation_iso(repo, rel))
+            created = _parse_ts(_git_creation_iso(repo, rel, sidecar_data=usage_data))
             if created is None or created >= _EVIDENCE_EPOCH:
                 if last_used is None or (
                     created is not None

--- a/tests/test_bridge_recent_activity_context.py
+++ b/tests/test_bridge_recent_activity_context.py
@@ -100,7 +100,7 @@ def test_results_scandir_single_pass(tmp_path: Path, monkeypatch):
 
     def counting_scandir(path):
         nonlocal scandir_calls
-        if "results" in str(path):
+        if str(path) == str(results_dir):
             scandir_calls += 1
         return orig_scandir(path)
 
@@ -151,7 +151,7 @@ def test_bridge_composition_single_scandir_across_all_consumers(tmp_path: Path, 
 
     def counting_scandir(path):
         nonlocal scandir_calls
-        if "results" in str(path):
+        if str(path) == str(results_dir):
             scandir_calls += 1
         return orig_scandir(path)
 

--- a/tests/test_bridge_recent_activity_context.py
+++ b/tests/test_bridge_recent_activity_context.py
@@ -5,6 +5,7 @@ completed or recently rejected work.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from nanobot.runtime.bridge import _recent_activity_context, build_task
@@ -73,3 +74,126 @@ def test_recent_activity_fail_open(tmp_path: Path):
     ctx = _recent_activity_context(state_dir=missing_state, selfevo_repo_root=missing_repo)
 
     assert ctx == ""
+
+
+def test_results_scandir_single_pass(tmp_path: Path, monkeypatch):
+    """#1040: _iter_result_entries performs a single os.scandir pass across result entries."""
+    from nanobot.runtime import bridge
+
+    bridge._clear_result_entries_cache()
+    state_dir = tmp_path / "state"
+    results_dir = state_dir / "subagents" / "results"
+    results_dir.mkdir(parents=True)
+    for i in range(5):
+        (results_dir / f"r{i}.json").write_text(
+            json.dumps({
+                "request_id": f"req_{i}",
+                "materialized_from": "bridge_llm_execution",
+                "backlog_title": f"Task {i}",
+                "cycle_id": f"c{i}",
+            }),
+            encoding="utf-8",
+        )
+
+    orig_scandir = os.scandir
+    scandir_calls = 0
+
+    def counting_scandir(path):
+        nonlocal scandir_calls
+        if "results" in str(path):
+            scandir_calls += 1
+        return orig_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", counting_scandir)
+    entries = bridge._iter_result_entries(results_dir)
+    assert len(entries) == 5
+    assert scandir_calls == 1
+
+    # find_pending_request uses the single-pass helper and reuses cached results
+    monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+    monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagents" / "bridge")
+    (state_dir / "subagents" / "requests").mkdir(parents=True)
+    (state_dir / "subagents" / "requests" / "req_99.json").write_text(
+        json.dumps({"request_id": "req_99"}),
+        encoding="utf-8",
+    )
+    p, d = bridge.find_pending_request()
+    assert p is not None
+    # No extra scandir was made on results_dir
+    assert scandir_calls == 1
+
+
+def test_bridge_composition_single_scandir_across_all_consumers(tmp_path: Path, monkeypatch):
+    """#1040: All bridge results consumers reuse the cached/single scan pass."""
+    from nanobot.runtime import bridge
+
+    bridge._clear_result_entries_cache()
+    state_dir = tmp_path / "state"
+    results_dir = state_dir / "subagents" / "results"
+    results_dir.mkdir(parents=True)
+    for i in range(3):
+        (results_dir / f"r{i}.json").write_text(
+            json.dumps({
+                "request_id": f"req_{i}",
+                "materialized_from": "bridge_llm_execution",
+                "backlog_title": f"Create test for module {i}",
+                "task_title": f"Create test for module {i}",
+                "summary": f"Create test for module {i}",
+                "cycle_id": f"c{i}",
+                "result_status": "blocked",
+                "rollback": {"reason": "smoke_failed"},
+            }),
+            encoding="utf-8",
+        )
+
+    orig_scandir = os.scandir
+    scandir_calls = 0
+
+    def counting_scandir(path):
+        nonlocal scandir_calls
+        if "results" in str(path):
+            scandir_calls += 1
+        return orig_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", counting_scandir)
+    monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+    monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagents" / "bridge")
+    (state_dir / "subagents" / "requests").mkdir(parents=True)
+    (state_dir / "subagents" / "requests" / "req_99.json").write_text(
+        json.dumps({"request_id": "req_99"}),
+        encoding="utf-8",
+    )
+
+    # 1. find_pending_request
+    p, _ = bridge.find_pending_request()
+    assert p is not None
+    assert scandir_calls == 1
+
+    # 2. _get_previous_attempts reuses cache
+    prev = bridge._get_previous_attempts(state_dir=state_dir, backlog_title="Create test for module 0", cycle_id="c99")
+    assert len(prev) >= 1
+    assert scandir_calls == 1
+
+    # 3. _migrate_backlog_title_in_results reuses cache
+    mig = bridge._migrate_backlog_title_in_results(results_dir)
+    assert mig == 0
+    assert scandir_calls == 1
+
+    # 4. _recent_activity_context reuses cache
+    act = bridge._recent_activity_context(state_dir=state_dir, selfevo_repo_root=None)
+    assert "Recently rejected" in act
+    assert scandir_calls == 1
+
+    # 5. _recent_failure_match reuses cache
+    match = bridge._recent_failure_match(
+        dup_check_title="Create test for module 0",
+        state_dir=state_dir,
+    )
+    assert match is not None
+    assert scandir_calls == 1
+
+    # Invocations can be cleared for isolation
+    bridge._clear_result_entries_cache()
+    entries = bridge._iter_result_entries(results_dir)
+    assert len(entries) == 3
+    assert scandir_calls == 2

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -2777,3 +2777,28 @@ class TestIssue1038DemandLanesReproduction:
         artifacts = [item for item in result if item["kind"] == "artifact-gap"]
         assert len(artifacts) == 1
         assert artifacts[0]["id"] == item2["id"]
+
+class TestIssue1040DemandIODiet:
+    """#1040: cycle I/O diet test suite."""
+
+    def test_collect_demand_parses_ledger_file_once(self, tmp_path, monkeypatch):
+        """#1040: collect_demand should parse active cycles.jsonl once in demand helpers."""
+        state_dir = _state_dir(tmp_path)
+        for i in range(5):
+            cycle_ledger.append_event(
+                state_dir,
+                {"phase": "outcome", "cycle_id": f"c{i}", "outcome": "failed", "reason": f"err{i}", "ts": _now_iso(10 - i)},
+            )
+
+        orig_load = demand._load_ledger_rows
+        load_count = 0
+
+        def counting_load(sd):
+            nonlocal load_count
+            load_count += 1
+            return orig_load(sd)
+
+        monkeypatch.setattr(demand, "_load_ledger_rows", counting_load)
+        items = demand.collect_demand(state_dir, None)
+        assert items
+        assert load_count == 1

--- a/tests/test_loop_explorer.py
+++ b/tests/test_loop_explorer.py
@@ -297,6 +297,32 @@ def test_render_ansi_empty_model(tmp_path: Path, monkeypatch) -> None:
     assert "no loop events recorded yet" in out
 
 
+def test_build_model_reads_scorecard_archive_series(tmp_path: Path) -> None:
+    _fixture_state(tmp_path)
+    state_dir = tmp_path
+    history_dir = state_dir / "scorecard"
+    archive_dir = history_dir / "archive"
+    archive_dir.mkdir(parents=True)
+    import gzip
+
+    with gzip.open(archive_dir / "history-20260801T000000Z.jsonl.gz", "wt", encoding="utf-8") as gz_fh:
+        gz_fh.write(
+            json.dumps(
+                {
+                    "schema_version": "scorecard-v1",
+                    "computed_at_utc": _iso(minutes_ago=14400),
+                    "loop": {"integrations": 1, "repeat_failure_rate": 0.0},
+                    "cost": {"tokens_per_integration": 500.0},
+                    "heldout": {"heldout_gap": 0.0},
+                }
+            )
+            + "\n"
+        )
+    model = loop_explorer.build_model(state_dir)
+    assert len(model["scorecard_series"]) >= 1
+    assert model["scorecard_series"][0]["integrations"] == 1
+
+
 # ─── update_explorer ────────────────────────────────────────────────────────
 
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -656,8 +656,12 @@ class TestWatermarkAndPersistence:
         assert len(history_lines) == 2
         latest = json.loads((state_dir / "scorecard" / "latest.json").read_text(encoding="utf-8"))
         assert latest["schema_version"] == "scorecard-v1"
-        # latest.json holds exactly the newest snapshot (overwritten, not appended).
-        assert latest == json.loads(history_lines[-1])
+        # latest.json holds exactly the newest snapshot (overwritten, not appended);
+        # history.jsonl omits control_plane to keep line sizes bounded (#1040).
+        history_last = json.loads(history_lines[-1])
+        assert history_last == {k: v for k, v in latest.items() if k != "control_plane"}
+        assert "control_plane" not in history_last
+        assert "control_plane" in latest
 
     def test_fail_open_on_unreadable_everything(self, tmp_path):
         """A file where the ledger dir should be, corrupt sidecars, a bogus
@@ -1389,3 +1393,90 @@ class TestFeedFreshness:
         assert gap["current"] == 1
         assert gap["target"] == 0
         assert "host_metrics" in gap["lever_hint"]
+
+    def test_history_trend_metric_across_rotation_boundary(self, tmp_path):
+        """#1040: trend metrics (e.g. tokens_per_integration) span across rotation
+        boundary by reading both rotated archive and active history."""
+        state_dir = tmp_path / "state"
+        _write_ledger(
+            state_dir,
+            [{"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": _iso(10)}],
+        )
+        _write_telemetry(
+            state_dir,
+            NOW.strftime("%Y-%m-%d"),
+            [{"ts": _iso(5), "prompt_tokens": 1500, "completion_tokens": 500}],
+        )
+        # Create rotated archive with older history (mean = 1000.0)
+        history_dir = state_dir / "scorecard"
+        archive_dir = history_dir / "archive"
+        archive_dir.mkdir(parents=True)
+        import gzip
+        with gzip.open(archive_dir / "history-20260801T000000Z.jsonl.gz", "wt", encoding="utf-8") as gz_fh:
+            for days_ago, tpi in ((12, 850.0), (10, 950.0)):
+                gz_fh.write(
+                    json.dumps(
+                        {
+                            "schema_version": "scorecard-v1",
+                            "computed_at_utc": _iso(days_ago=days_ago),
+                            "cost": {"tokens_per_integration": tpi},
+                        }
+                    )
+                    + "\n"
+                )
+        # Active history file has recent history (mean = 1200.0)
+        with open(history_dir / "history.jsonl", "w", encoding="utf-8") as fh:
+            for days_ago, tpi in ((9, 1200.0),):
+                fh.write(
+                    json.dumps(
+                        {
+                            "schema_version": "scorecard-v1",
+                            "computed_at_utc": _iso(days_ago=days_ago),
+                            "cost": {"tokens_per_integration": tpi},
+                        }
+                    )
+                    + "\n"
+                )
+        snap = scorecard.compute_scorecard(state_dir, None, force=True)
+        gaps = {g["metric"]: g for g in snap["gaps"]}
+        assert "tokens_per_integration" in gaps
+        gap = gaps["tokens_per_integration"]
+        assert gap["vector"] == "V1"
+        assert gap["current"] == 2000.0  # current (2000) > 1.5 * baseline (~1000)
+        assert gap["target"] == 1500.0
+
+    def test_read_history_reads_multiple_rotated_archives(self, tmp_path):
+        state_dir = tmp_path / "state"
+        history_dir = state_dir / "scorecard"
+        archive_dir = history_dir / "archive"
+        archive_dir.mkdir(parents=True)
+        import gzip
+
+        for idx, tag in enumerate(["20260801T000000Z", "20260802T000000Z"]):
+            with gzip.open(archive_dir / f"history-{tag}.jsonl.gz", "wt", encoding="utf-8") as gz_fh:
+                gz_fh.write(
+                    json.dumps(
+                        {
+                            "schema_version": "scorecard-v1",
+                            "computed_at_utc": _iso(days_ago=15 - idx),
+                            "cost": {"tokens_per_integration": 100.0 + idx},
+                        }
+                    )
+                    + "\n"
+                )
+        with open(history_dir / "history.jsonl", "w", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "schema_version": "scorecard-v1",
+                        "computed_at_utc": _iso(days_ago=1),
+                        "cost": {"tokens_per_integration": 300.0},
+                    }
+                )
+                + "\n"
+            )
+
+        rows = scorecard._read_history(state_dir)
+        assert len(rows) == 3
+        tpis = [r["cost"]["tokens_per_integration"] for r in rows]
+        assert tpis == [100.0, 101.0, 300.0]

--- a/tests/test_skill_candidate_mining.py
+++ b/tests/test_skill_candidate_mining.py
@@ -75,18 +75,18 @@ def test_candidate_kind_is_ordered_before_hypothesis(tmp_path, monkeypatch):
     _write_rows(tmp_path, _rows())
     # F2: pre-write sidecar so demand path reads it
     write_sidecar(tmp_path, None)
-    monkeypatch.setattr(demand, "_priority_items", lambda *_: [])
-    monkeypatch.setattr(demand, "_ledger_defects", lambda *_: [])
-    monkeypatch.setattr(demand, "_result_file_defects", lambda *_: [])
-    monkeypatch.setattr(demand, "_compile_defects", lambda *_: [])
-    monkeypatch.setattr(demand, "_heldout_defect_items", lambda *_: [])
-    monkeypatch.setattr(demand, "_validator_defect_items", lambda *_: [])
-    monkeypatch.setattr(demand, "_tamper_defect_items", lambda *_: [])
-    monkeypatch.setattr(demand, "_repair_unused_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_priority_items", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_ledger_defects", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_result_file_defects", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_compile_defects", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_heldout_defect_items", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_validator_defect_items", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_tamper_defect_items", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_repair_unused_items", lambda *_, **__: [])
     monkeypatch.setattr(demand, "_goal_gap_items", lambda *_, **__: [{"kind": "goal-gap", "id": "gap", "summary": "gap", "evidence": "", "affected_path": "", "vector": "V1", "direction": ""}])
     monkeypatch.setattr(demand, "_hypothesis_items", lambda *_, **__: [{"kind": "hypothesis", "id": "hyp", "summary": "hyp", "evidence": "", "affected_path": "", "vector": "", "direction": ""}])
-    monkeypatch.setattr(demand, "_decay_items", lambda *_: [])
-    monkeypatch.setattr(demand, "_reflection_items", lambda *_: [])
+    monkeypatch.setattr(demand, "_decay_items", lambda *_, **__: [])
+    monkeypatch.setattr(demand, "_reflection_items", lambda *_, **__: [])
     kinds = [item["kind"] for item in demand.collect_demand(tmp_path, None)]
     assert kinds == ["goal-gap", "skill-candidate", "hypothesis"]
 

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -1685,3 +1685,59 @@ class TestOwnerLiveRatioAndSurfaces:
         assert res["inventory"] == 4
         assert res["live"] == 3
         assert res["ratio"] == 0.75
+
+    def test_git_creation_memoization_zero_subprocess_on_second_refresh(self, tmp_path, monkeypatch):
+        """#1040: second refresh on unchanged repo uses memoized git creation dates and makes 0 git subprocess calls."""
+        state_dir = _state_dir(tmp_path)
+        repo = _repo_with_files(
+            tmp_path,
+            {
+                "scripts/consumer.py": "import s1\nx = 1\n",
+                "scripts/s1.py": "print(1)\n",
+            },
+        )
+        # Give consumer.py a pycache execution signal so _reference_index inspects its creation
+        _give_pycache(repo / "scripts" / "consumer.py")
+
+        # First refresh populates sidecar with created_cache
+        res1 = usage_evidence.refresh_usage(state_dir, repo)
+        assert len(res1["entries"]) >= 0
+        sidecar = json.loads((state_dir / "usage" / "last_used.json").read_text(encoding="utf-8"))
+        assert "created_cache" in sidecar
+        assert "scripts/consumer.py" in sidecar["created_cache"]
+
+        # Track subprocess.run calls
+        orig_run = subprocess.run
+        git_log_calls = 0
+
+        def counting_run(*args, **kwargs):
+            nonlocal git_log_calls
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, (list, tuple)) and len(cmd) > 1 and cmd[0] == "git" and "log" in cmd:
+                git_log_calls += 1
+            return orig_run(*args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", counting_run)
+        # Advance time to force refresh past watermark
+        monkeypatch.setattr(usage_evidence, "_RESCAN_HOURS", 0)
+        res2 = usage_evidence.refresh_usage(state_dir, repo)
+        assert len(res2["entries"]) >= 0
+        assert git_log_calls == 0
+
+    def test_git_creation_backward_compatibility_with_legacy_head_keys(self, tmp_path):
+        """#1040: legacy head:rel key in created_cache is respected when rel key is missing."""
+        repo = _repo_with_files(
+            tmp_path,
+            {
+                "scripts/consumer.py": "import s1\nx = 1\n",
+                "scripts/s1.py": "print(1)\n",
+            },
+        )
+        head = usage_evidence._git_head(repo)
+        sidecar_data = {
+            "created_cache": {
+                f"{head}:scripts/consumer.py": "2026-08-01T00:00:00Z",
+            },
+        }
+        val = usage_evidence._git_creation_iso(repo, "scripts/consumer.py", sidecar_data=sidecar_data)
+        assert val == "2026-08-01T00:00:00Z"


### PR DESCRIPTION
Closes #1040

- parse cycles.jsonl once per collect_demand and thread rows through demand helpers
- reuse one cached os.scandir result set across bridge result consumers per invocation
- memoize immutable git creation dates by path and remove expensive --follow lookups
- stream bounded scorecard/benchmark/explorer history tails, read rotated archives, rotate oversized history, and omit control_plane from history rows

Validation: 416 focused runtime tests passed; Ruff/diff checks passed for changed AC modules (pre-existing bridge lint baseline documented). Full pytest and live host evidence follow.