### PR TITLE
feat(runtime): add bounded reflection prompt hints (#1008)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1293,6 +1293,7 @@ def build_task(req: dict, goal_text: str, report_source: str,
 
     # Build lessons context block from coordinator-injected cards
     lessons_context = req.get('lessons_context') or {}
+    reflection_hints = lessons_context.get('reflection_hints') or []
     lessons_lines: list[str] = []
     if lessons_context.get('relevant_error'):
         err = lessons_context['relevant_error']
@@ -1310,6 +1311,12 @@ def build_task(req: dict, goal_text: str, report_source: str,
             f"ID: {less.get('id')}  Title: {less.get('title')}",
             f"Approach: {less.get('approach', '')}",
             f"Reusable insight: {less.get('reusable_insight', '')}",
+            '',
+        ]
+    if reflection_hints:
+        lessons_lines += [
+            '## Recent reflections (how past cycles worked — steering hints)',
+            *[f'- {str(h)[:200]}' for h in reflection_hints[:3]],
             '',
         ]
 

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -41,6 +41,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
 from nanobot.runtime import archive, demand, existence_index, hypothesis_backlog, system_map
 from nanobot.runtime.cycle_ledger import append_event
 from nanobot.runtime.goal_text_utils import (
@@ -50,7 +51,7 @@ from nanobot.runtime.goal_text_utils import (
 )
 from nanobot.runtime.lessons_context import build_lessons_context
 from nanobot.runtime.model_registry import resolve_model
-from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
+from nanobot.runtime.reflection_context import build_reflection_hints
 
 ENABLED_ENV = "SELFEVO_LLM_PROPOSER_ENABLED"
 _RELEASE_ROOT_DEFAULT = "/opt/eeepc-agent/runtimes/self-evolving-agent/current"
@@ -2486,6 +2487,9 @@ def write_request(
     artifact_path.write_text(json.dumps(artifact_payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
     lessons_context = build_lessons_context(selfevo_repo, task_title, target_path)
+    reflection_hints = build_reflection_hints(state_dir, task_title, target_path)
+    if reflection_hints:
+        lessons_context["reflection_hints"] = reflection_hints
 
     request_id = f"llm-proposer-{cycle_id}"
     request_dir = _requests_dir(state_dir)

--- a/nanobot/runtime/reflection_context.py
+++ b/nanobot/runtime/reflection_context.py
@@ -1,0 +1,100 @@
+"""Bounded, steering-only hints from the reflector journal (#1008)."""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+_MAX_HINTS = 3
+_MAX_HINT_CHARS = 200
+_MAX_SECTION_CHARS = 800
+_MAX_TAIL_BYTES = 128_000
+_TTL_DAYS = 7
+_WORD_RE = re.compile(r"[A-Za-z0-9_/-]{4,}")
+
+
+def _words(value: Any) -> set[str]:
+    return {x.lower() for x in _WORD_RE.findall(str(value or ""))}
+
+
+def _parse(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt.replace(tzinfo=dt.tzinfo or timezone.utc).astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def _tail_lines(path: Path) -> list[str]:
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            fh.seek(max(0, size - _MAX_TAIL_BYTES))
+            data = fh.read()
+        return data.decode("utf-8", errors="replace").splitlines()
+    except Exception:
+        return []
+
+
+def build_reflection_hints(
+    state_dir: Path,
+    task_title: str,
+    target_path: str = "",
+    *,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return up to three recent matching journal hints, fail-open."""
+    try:
+        now = now or datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=_TTL_DAYS)
+        task_words = _words(f"{task_title} {target_path}")
+        if not task_words:
+            return []
+        path = Path(state_dir) / "reflector" / "reflections.jsonl"
+        candidates: list[tuple[int, str, str]] = []
+        for line in reversed(_tail_lines(path)):
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if not isinstance(row, dict):
+                continue
+            ts = _parse(row.get("ts") or row.get("created_at") or row.get("timestamp"))
+            if ts is None or ts < cutoff:
+                continue
+            text = str(row.get("approach_hint") or row.get("error_pattern") or row.get("detail") or row.get("summary") or "").strip()
+            if not text:
+                continue
+            shared = len(task_words & _words(f"{row.get('task_title','')} {row.get('target_path','')} {text}"))
+            if not shared:
+                continue
+            kind = str(row.get("kind") or "")
+            preferred = 1 if kind in {"approach_hint", "error_pattern"} or row.get("approach_hint") or row.get("error_pattern") else 0
+            candidates.append((preferred * 100 + shared, ts.isoformat(), text[:_MAX_HINT_CHARS]))
+        candidates.sort(key=lambda x: (-x[0], x[1]), reverse=False)
+        out: list[str] = []
+        total = 0
+        for _score, _ts, text in candidates:
+            if text in out:
+                continue
+            rendered = f"- {text}"
+            if total + len(rendered) + (1 if out else 0) > _MAX_SECTION_CHARS:
+                continue
+            out.append(text)
+            total += len(rendered) + (1 if len(out) > 1 else 0)
+            if len(out) >= _MAX_HINTS:
+                break
+        return out
+    except Exception:
+        return []
+
+
+def render_reflection_hints(hints: list[str]) -> str:
+    if not hints:
+        return ""
+    return "## Recent reflections (steering hints)\n" + "\n".join(f"- {h[:_MAX_HINT_CHARS]}" for h in hints)[:_MAX_SECTION_CHARS] + "\n"

--- a/tests/test_reflection_context.py
+++ b/tests/test_reflection_context.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime.bridge import build_task
+from nanobot.runtime.reflection_context import build_reflection_hints, render_reflection_hints
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _row(text: str, days: int = 0, kind: str = "approach_hint") -> dict:
+    ts = datetime.now(timezone.utc) - timedelta(days=days)
+    return {"ts": ts.isoformat().replace("+00:00", "Z"), "kind": kind, "task_title": "timeout bridge", "approach_hint": text}
+
+
+def test_selects_recent_relevant_bounded_hints(tmp_path: Path) -> None:
+    _write(tmp_path / "reflector/reflections.jsonl", [_row("old timeout", 8), _row("new timeout approach", 1), _row("other timeout error", 0, "error_pattern")])
+    hints = build_reflection_hints(tmp_path, "fix timeout bridge", now=datetime.now(timezone.utc))
+    assert hints == ["new timeout approach", "other timeout error"]
+    assert len(hints) <= 3 and all(len(x) <= 200 for x in hints)
+
+
+def test_missing_corrupt_and_expired_are_empty(tmp_path: Path) -> None:
+    assert build_reflection_hints(tmp_path, "timeout bridge") == []
+    path = tmp_path / "reflector/reflections.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text("not json\n", encoding="utf-8")
+    assert build_reflection_hints(tmp_path, "timeout bridge") == []
+    _write(path, [_row("expired timeout", 8)])
+    assert build_reflection_hints(tmp_path, "timeout bridge") == []
+
+
+def test_prompt_renders_section_only_when_hints_exist(tmp_path: Path) -> None:
+    req = {"task_title": "Fix timeout bridge", "request_id": "r", "cycle_id": "c", "goal_id": "g", "source_artifact": "", "lessons_context": {"reflection_hints": ["use bounded timeout"]}}
+    prompt = build_task(req, goal_text="goal", report_source="source", state_dir=tmp_path)
+    assert "## Recent reflections" in prompt and "use bounded timeout" in prompt
+    req["lessons_context"] = {"reflection_hints": []}
+    without = build_task(req, goal_text="goal", report_source="source", state_dir=tmp_path)
+    assert "## Recent reflections" not in without
+
+
+def test_render_empty_is_absent() -> None:
+    assert render_reflection_hints([]) == ""


### PR DESCRIPTION
## Summary

Closes #1008.

- Adds `nanobot/runtime/reflection_context.py` to read only a bounded tail of `state/reflector/reflections.jsonl`, apply a seven-day TTL, keyword-match task title/target path, prefer `approach_hint`/`error_pattern`, and cap output at three hints / 200 chars per hint / 800 chars total.
- Injects hints inside the existing `lessons_context` request field, preserving the canonical request schema and rendering at the existing lessons-card prompt location.
- Missing, corrupt, expired, or irrelevant journal data returns no section and preserves prompt behavior.
- Reflection content remains steering-only.

## Validation

- Focused lessons/reflection/proposer tests: `210 passed`.
- Ruff clean on changed modules/tests.
- No gate policy, deny-set, goals, identity, secrets, or unrelated bridge regions changed.

## Live verification plan

After merge/deploy, inspect `state/llm_calls/prompts/` for a real recent-reflection hint. If no relevant live journal entry is available, record fixture evidence plus live byte-identical absence and leave the issue at `status:test`.
