### PR TITLE
fix: stop recording successful cycle protocol as lessons

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3148,8 +3148,9 @@ async def _main_impl_body():
     )
     _tag_cycle_post(_selfevo_repo, _cycle_id, _cycle_outcome, _post_tag_sha)
 
-    # Structured lesson recording after a successful integrated commit
-    if _integrated:
+    # Structured lesson recording after a successful integrated commit (#1070)
+    # Only record if the cycle generated genuine lesson/insight content, not plain protocol details
+    if _integrated and _has_meaningful_lesson(_artifact_data):
         try:
             _written_lesson = _write_structured_lesson(
                 repo_root=_selfevo_repo,
@@ -3158,7 +3159,6 @@ async def _main_impl_body():
                 files_changed=files_changed,
                 commits_pushed=commits_pushed,
                 artifact_data=_artifact_data,
-                budget_used={},  # not available at this point; set via subagent result
             )
             if _written_lesson:
                 _git4 = _git_cmd(_selfevo_repo)
@@ -3812,28 +3812,44 @@ def _recent_failure_match(
         return None
 
 
-def _derive_insight(
-    files_changed: list[str],
-    tool_calls: int,
-    elapsed_seconds: int,
-) -> str:
-    """Rules-based insight derivation — no LLM required.
+def _extract_meaningful_insight(artifact_data: dict | None) -> str | None:
+    """Extract genuine, explicit reusable insight from artifact data (#1070).
 
-    Returns a reusable insight string based on observable metrics.
+    Plain integrated success cycles that only contain protocol details
+    (commits/files/backlog titles/hypotheses) must not create noise in
+    lessons/lessons.yaml. Only explicit insight fields provided in the artifact
+    are accepted. No static/boilerplate metric insights are generated.
     """
-    if any('scripts/' in f and f.endswith('.py') for f in files_changed) and tool_calls < 20:
-        return f'Short utility scripts implementable in single bridge session ({tool_calls} tool calls).'
-    if elapsed_seconds > 0 and elapsed_seconds < 120:
-        return f'Fast task: completed under 2 minutes ({elapsed_seconds}s), suitable for micro budget.'
-    if any('memory/MEMORY.md' in f for f in files_changed):
-        return 'Memory updates should be paired with code commits to avoid metadata-only cycles.'
-    if any('memory/HISTORY.md' in f for f in files_changed) and not any(
-        f.endswith('.py') or f.endswith('.yaml') for f in files_changed
-    ):
-        return 'HISTORY.md-only cycles provide no reward signal; pair with code changes.'
-    if tool_calls > 30:
-        return f'Complex task ({tool_calls} tool calls): consider splitting into smaller priorities.'
-    return f'Task completed with {tool_calls} tool calls in {elapsed_seconds}s.'
+    if not isinstance(artifact_data, dict):
+        return None
+
+    # Check top-level lesson-like containers first, then top-level artifact
+    containers: list[dict] = []
+    if isinstance(artifact_data.get('lesson'), dict):
+        containers.append(artifact_data['lesson'])
+    if isinstance(artifact_data.get('structured_lesson'), dict):
+        containers.append(artifact_data['structured_lesson'])
+    containers.append(artifact_data)
+
+    keys = (
+        'reusable_insight',
+        'generalized_insight',
+        'key_insight',
+        'concrete_improvement_statement',
+    )
+    for d in containers:
+        for k in keys:
+            val = d.get(k)
+            if isinstance(val, str) and val.strip():
+                s = val.strip()
+                if s.lower() not in {'none', 'n/a', 'na', 'null', 'nil', '{}', '[]'}:
+                    return s
+    return None
+
+
+def _has_meaningful_lesson(artifact_data: dict | None) -> bool:
+    """Check if artifact_data contains a genuine, explicit insight (#1070)."""
+    return _extract_meaningful_insight(artifact_data) is not None
 
 
 def _write_structured_lesson(
@@ -3844,14 +3860,17 @@ def _write_structured_lesson(
     files_changed: list[str],
     commits_pushed: int,
     artifact_data: dict,
-    budget_used: dict,
+    budget_used: dict | None = None,
 ) -> bool:
     """Write a structured lesson entry to lessons/lessons.yaml in eeebot-self-evolving.
 
     Returns True if lesson was written.
     """
     import datetime as _dt
-    import yaml as _yaml  # type: ignore[import-untyped]
+
+    insight = _extract_meaningful_insight(artifact_data)
+    if not insight:
+        return False
 
     lessons_path = repo_root / 'lessons' / 'lessons.yaml'
     lessons_path.parent.mkdir(parents=True, exist_ok=True)
@@ -3887,8 +3906,6 @@ def _write_structured_lesson(
     if any(e.get('id') == lesson_id for e in existing['lessons']):
         return False
 
-    tool_calls = int(budget_used.get('tool_calls', 0))
-    elapsed = int(budget_used.get('elapsed_seconds', 0))
     hypothesis = (
         artifact_data.get('hypothesis')
         or artifact_data.get('concrete_improvement_statement', '')
@@ -3902,9 +3919,7 @@ def _write_structured_lesson(
         'task_id': backlog_title[:80] if backlog_title else 'unknown',
         'hypothesis': str(hypothesis)[:300],
         'result': f'Committed {commits_pushed} commit(s): ' + ', '.join(files_changed[:5]),
-        'tool_calls': tool_calls,
-        'elapsed_seconds': elapsed,
-        'generalized_insight': _derive_insight(files_changed, tool_calls, elapsed),
+        'generalized_insight': insight,
         'files_changed': files_changed[:10],
     }
 

--- a/tests/test_lessons_context.py
+++ b/tests/test_lessons_context.py
@@ -257,6 +257,20 @@ class TestLiveWriterRoundTrip:
         repo = tmp_path / "instance_repo"
         repo.mkdir()
 
+        # Plain artifact without reusable insight returns False and does not write
+        skipped = _write_structured_lesson(
+            repo_root=repo,
+            cycle_id="cycle-plain123456",
+            backlog_title="Improve dashboard ledger digest helper",
+            files_changed=["scripts/eeebot_dashboard.py"],
+            commits_pushed=1,
+            artifact_data={
+                "hypothesis": "Improve dashboard ledger digest helper for faster reads",
+            },
+        )
+        assert skipped is False
+        assert not (repo / "lessons" / "lessons.yaml").exists()
+
         wrote = _write_structured_lesson(
             repo_root=repo,
             cycle_id="cycle-abc123def456",
@@ -265,8 +279,8 @@ class TestLiveWriterRoundTrip:
             commits_pushed=1,
             artifact_data={
                 "hypothesis": "Improve dashboard ledger digest helper for faster reads",
+                "reusable_insight": "Digest ledger lines iteratively to avoid high memory spikes",
             },
-            budget_used={"tool_calls": 5, "elapsed_seconds": 30},
         )
         assert wrote is True
 
@@ -277,7 +291,14 @@ class TestLiveWriterRoundTrip:
         assert isinstance(written, dict) and "lessons" in written
         raw_entry = written["lessons"][0]
         assert "title" not in raw_entry
+        assert "tool_calls" not in raw_entry
+        assert "elapsed_seconds" not in raw_entry
         assert "hypothesis" in raw_entry and "generalized_insight" in raw_entry
+        assert raw_entry["generalized_insight"] == "Digest ledger lines iteratively to avoid high memory spikes"
+
+        # Static rule boilerplate function must be absent (#1070)
+        import nanobot.runtime.bridge as bridge_mod
+        assert not hasattr(bridge_mod, "_derive_insight")
 
         result = build_lessons_context(
             repo, "Improve dashboard ledger digest helper for faster reads"
@@ -290,7 +311,7 @@ class TestLiveWriterRoundTrip:
         assert less["title"]  # non-blank: derived from hypothesis
         assert "dashboard ledger digest helper" in less["title"].lower()
         assert less["approach"]  # non-blank: derived from result
-        assert less["reusable_insight"]  # non-blank: derived from generalized_insight
+        assert less["reusable_insight"] == "Digest ledger lines iteratively to avoid high memory spikes"
 
     def test_write_structured_error_records_in_errors_yaml(self, tmp_path):
         """#1041 Part 2: _write_structured_error records gate failure in lessons/errors.yaml."""
@@ -576,3 +597,46 @@ class TestBridgeIntegration:
 
         assert "Known pitfall" not in task
         assert "Proven approach" not in task
+
+    # Plain protocol fields (title/hypothesis/backlog instructions) inside next_bounded_candidate
+    # do not count as lessons, but explicit concrete_improvement_statement or key_insight inside
+    # containers or top-level count.
+    def test_has_meaningful_lesson_predicate(self):
+        """#1070: Plain integrated success cycles without explicit insight payload
+
+        must not be classified as meaningful lessons. Explicit insights must match.
+        """
+        from nanobot.runtime.bridge import _has_meaningful_lesson
+
+        # None or empty dict
+        assert _has_meaningful_lesson(None) is False
+        assert _has_meaningful_lesson({}) is False
+
+        # Protocol-only / empty structures
+        assert _has_meaningful_lesson({"hypothesis": "Some hypothesis for standard run"}) is False
+        assert _has_meaningful_lesson({"next_bounded_candidate": {"title": "some task"}}) is False
+        assert _has_meaningful_lesson({"next_bounded_candidate": {"title": "some task", "hypothesis": ""}}) is False
+        assert _has_meaningful_lesson({"next_bounded_candidate": {"title": "some task", "hypothesis": "none"}}) is False
+        assert _has_meaningful_lesson({"next_bounded_candidate": {"title": "some task", "hypothesis": "N/A"}}) is False
+
+        # Genuine explicit insights
+        assert _has_meaningful_lesson({
+            "reusable_insight": "Refactored cache to reduce duplicate I/O.",
+        }) is True
+        assert _has_meaningful_lesson({
+            "concrete_improvement_statement": "Refactored cache to reduce duplicate I/O.",
+        }) is True
+        assert _has_meaningful_lesson({
+            "lesson": {
+                "reusable_insight": "Early filtering prevents quadratic memory consumption.",
+            }
+        }) is True
+        assert _has_meaningful_lesson({
+            "structured_lesson": {
+                "generalized_insight": "Early filtering prevents quadratic memory consumption.",
+            }
+        }) is True
+        assert _has_meaningful_lesson({
+            "key_insight": "Atomic replacements avoid corruption during sudden terminations."
+        }) is True
+


### PR DESCRIPTION
Closes #1070\n\n## Summary\n- suppress lessons.yaml writes for plain integrated cycles without explicit insight\n- remove empty budget plumbing and metric fields from success lessons\n- replace static _derive_insight boilerplate with explicit artifact insight only\n- preserve errors.yaml, #678 F6 push guard, and #985 rotation\n\n## Validation\n- focused lesson/context/rotation/curator/bridge tests: 107 passed, 2 skipped\n- reviewer verdict: APPROVE\n- full pytest and CI will be reported before merge\n\n## Grep proof\n- _derive_insight no longer exists in nanobot/runtime/bridge.py; the repeated metric boilerplate cannot be generated.