### PR TITLE
fix: remove scorecard decay scan from #1044

### DIFF
--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -306,7 +306,6 @@ _RECOMPUTE_MINUTES = 30
 _MAX_GZ_FILES = 7  # bounded archive read — rotation-aware, never unbounded
 _MAX_HISTORY_LINES = 400  # bounded history read (one line per recompute)
 _MAX_HISTORY_BYTES = 512 * 1024  # 512KB size-based history rotation threshold (#1040)
-_DECAY_DAYS = 14  # kept in sync with demand._DECAY_DAYS
 
 # Trend-gap parameters for tokens_per_integration: worsening more than
 # _TREND_WORSEN_FACTOR vs the mean of the prior window is a gap.
@@ -882,18 +881,12 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
             if entry.get("confirmed") is True and str(entry.get("signal") or "") in harness_signals:
                 confirmed += 1
 
-    decay_candidates = 0
     owner_live_inventory = 0
     owner_live_active = 0
     owner_live_ratio_val = None
     try:
         from nanobot.runtime import usage_evidence
 
-        decay_candidates = len(
-            usage_evidence.stale_artifacts(
-                Path(state_dir), selfevo_repo, older_than_days=_DECAY_DAYS, now=now
-            )
-        )
         ol_res = usage_evidence.owner_live_ratio(
             Path(state_dir), selfevo_repo, now=now
         )
@@ -906,7 +899,6 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
         "completed_declared": declared,
         "completed_confirmed": confirmed,
         "confirmed_ratio": _ratio(confirmed, declared),
-        "decay_candidates": decay_candidates,
         "owner_live_inventory": owner_live_inventory,
         "owner_live_active": owner_live_active,
         "owner_live_ratio": owner_live_ratio_val,

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -552,6 +552,9 @@ class TestQualityAndValue:
         assert value["completed_declared"] == 3
         assert value["completed_confirmed"] == 1
         assert value["confirmed_ratio"] == round(1 / 3, 4)
+        # The scorecard no longer performs the expensive stale-artifact scan;
+        # decay_candidates remains an independent loop_metrics_report metric.
+        assert "decay_candidates" not in value
         # value keys
         assert "completed_declared" in value
         assert "completed_confirmed" in value


### PR DESCRIPTION
Closes #1044\n\n## Corrective scope\n- remove scorecard value.decay_candidates and its usage_evidence.stale_artifacts scan; this eliminates one full repo/git scan per scorecard recompute;\n- preserve scripts/loop_metrics_report.py's independent decay_candidates metric and report contract;\n- add an assertion that the scorecard value section no longer exposes the field.\n\nThis follows live verification showing the first #1044 release still emitted the field in latest.json. No lessons modules, lesson-write bridge path, or evolution_tree.py touched.\n\nValidation: scorecard + heldout tests 97 passed; ruff and diff check clean. Full CI will be checked before merge.