### PR TITLE
feat(runtime): add Lesson schema v2 and bounded delta capture (#1071)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -44,7 +44,7 @@ from nanobot.observability.llm_telemetry import set_call_context
 # itself fully fail-closed/fail-open internally (see its docstring); this
 # call site never wraps it in try/except so an unexpected exception there
 # would be a genuine bug worth surfacing, not something to paper over.
-from nanobot.runtime.promoted_overlay import effective_runtime_slice, install_promoted_overlay
+from nanobot.runtime.promoted_overlay import install_promoted_overlay
 
 install_promoted_overlay()
 
@@ -58,10 +58,27 @@ from nanobot.runtime.cycle_ledger import (  # noqa: E402
     record_dedup_decision,
     record_gate_decision,
 )
+from nanobot.runtime.existence_index import (  # noqa: E402
+    derive_intent,
+    find_duplicate_script,
+    intents_match,
+)
 from nanobot.runtime.goal_review import read_charter_text  # noqa: E402
 from nanobot.runtime.goal_text_utils import filter_completed_priorities_from_goal_text  # noqa: E402
-from nanobot.runtime.existence_index import derive_intent, find_duplicate_script, intents_match  # noqa: E402
+from nanobot.runtime.lesson_v2 import (  # noqa: E402
+    bounded_load_yaml as _bounded_lesson_load,
+)
+from nanobot.runtime.lesson_v2 import (
+    find_duplicate as _find_lesson_duplicate,
+)
+from nanobot.runtime.lesson_v2 import (
+    normalize_problem as _normalize_lesson_problem,
+)
+from nanobot.runtime.lesson_v2 import (
+    validate_lesson as _validate_lesson_v2,
+)
 from nanobot.runtime.model_registry import resolve_max_tool_iterations, resolve_model  # noqa: E402
+from nanobot.runtime.schemas import CONTROLLED_LESSON_TAGS  # noqa: E402
 
 # #789: the fitness-input sidecar list + hash helper live in scorecard.py
 # (the fitness module — #603 placement; the list's contents stay out of this
@@ -1342,11 +1359,13 @@ def build_task(req: dict, goal_text: str, report_source: str,
         ]
     if lessons_context.get('relevant_lesson'):
         less = lessons_context['relevant_lesson']
+        less_id = less.get('id') or '<unknown>'
         lessons_lines += [
             '## Proven approach for this task (from lessons/lessons.yaml)',
-            f"ID: {less.get('id')}  Title: {less.get('title')}",
-            f"Approach: {less.get('approach', '')}",
-            f"Reusable insight: {less.get('reusable_insight', '')}",
+            f"ID: {less_id}  Title: {less.get('title')}",
+            f"Problem: {less.get('problem') or less.get('approach', '')}",
+            f"Solution: {less.get('solution') or less.get('reusable_insight', '')}",
+            f"If you apply this lesson, cite [Lesson {less_id}] in your proposal/response.",
             '',
         ]
     if reflection_hints:
@@ -1410,7 +1429,6 @@ def build_task(req: dict, goal_text: str, report_source: str,
             cycle_id=str(cycle_id),
         )
         if _prev:
-            import datetime as _dt2
             prev_lines = ['## Previous attempts for this task']
             for i, _p in enumerate(_prev, 1):
                 _ts = str(_p.get('created_at', ''))[:16].replace('T', ' ')
@@ -1655,7 +1673,11 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
     """
     import subprocess as _sp_pick
     try:
-        from nanobot.runtime.knowledge_curator import _fact_path, clear_staged_manifest, load_staged_manifest
+        from nanobot.runtime.knowledge_curator import (
+            _fact_path,
+            clear_staged_manifest,
+            load_staged_manifest,
+        )
     except Exception as _e:
         print(f'bridge: staged pickup: import failed ({_e}); skipping')
         return 0
@@ -2767,7 +2789,9 @@ async def _main_impl_body():
                     # affect the gate, which is already decided above.
                     _microbench_entry = None
                     try:
-                        from nanobot.runtime.heldout.microbench import measure_cycle as _measure_cycle
+                        from nanobot.runtime.heldout.microbench import (
+                            measure_cycle as _measure_cycle,
+                        )
                         _microbench_entry = _measure_cycle(
                             STATE_DIR, _selfevo_repo, _cycle_id, main_sha_before, cycle_branch, files_changed,
                         )
@@ -3159,9 +3183,25 @@ async def _main_impl_body():
     )
     _tag_cycle_post(_selfevo_repo, _cycle_id, _cycle_outcome, _post_tag_sha)
 
+    # Reporting-only citation signal from bounded proposal/transcript fields.
+    try:
+        _record_lesson_citations(
+            STATE_DIR,
+            _cycle_id,
+            [
+                str(_artifact_data.get('proposal') or ''),
+                str(_artifact_data.get('transcript') or ''),
+                str(_artifact_data.get('response') or ''),
+            ],
+        )
+    except Exception:
+        pass
+
     # Structured lesson recording after a successful integrated commit (#1070)
     # Only record if the cycle generated genuine lesson/insight content, not plain protocol details
-    if _integrated and _has_meaningful_lesson(_artifact_data):
+    if _integrated and _has_meaningful_lesson(_artifact_data) and _has_delta_evidence(
+        _artifact_data, repo_root=_selfevo_repo, backlog_title=backlog_title,
+    ):
         try:
             _written_lesson = _write_structured_lesson(
                 repo_root=_selfevo_repo,
@@ -3199,7 +3239,7 @@ async def _main_impl_body():
                     _selfevo_repo, 'origin/main', _lesson_allowed,
                 ):
                     _sp.run(_git4 + ['push', 'origin', 'main'], capture_output=True)
-                    print(f'bridge-lesson: recorded structured lesson to lessons/lessons.yaml')
+                    print('bridge-lesson: recorded structured lesson to lessons/lessons.yaml')
                 else:
                     print(
                         'bridge-lesson: lesson diff touched more than lessons/lessons.yaml '
@@ -3467,8 +3507,8 @@ def _task_already_done(backlog_title: str, repo_root: 'Path') -> bool:
     if not backlog_title or not repo_root.is_dir():
         return False
 
-    import subprocess as _sp2
     import re as _re
+    import subprocess as _sp2
 
     _git = ['git', '-c', f'safe.directory={repo_root}', '-C', str(repo_root)]
     result = _sp2.run(
@@ -3787,6 +3827,36 @@ def _has_meaningful_lesson(artifact_data: dict | None) -> bool:
     return _extract_meaningful_insight(artifact_data) is not None
 
 
+def _has_delta_evidence(
+    artifact_data: dict | None,
+    *,
+    repo_root: Path | None = None,
+    backlog_title: str = "",
+) -> bool:
+    if not isinstance(artifact_data, dict):
+        return False
+    containers = [artifact_data]
+    for key in ("lesson", "structured_lesson"):
+        if isinstance(artifact_data.get(key), dict):
+            containers.append(artifact_data[key])
+    if any(
+        value.get("delta_evidence") or value.get("reflector_delta")
+        or value.get("curator_delta") or value.get("repeat_failure")
+        for value in containers
+    ):
+        return True
+    if not repo_root or not backlog_title:
+        return False
+    wanted = _normalize_lesson_problem(backlog_title)
+    return bool(wanted and any(
+        isinstance(entry, dict)
+        and _normalize_lesson_problem(
+            entry.get("demand") or entry.get("task_id") or entry.get("backlog_title") or entry.get("title") or ""
+        ) == wanted
+        for entry in _bounded_lesson_load(Path(repo_root) / "lessons" / "errors.yaml")
+    ))
+
+
 def _write_structured_lesson(
     *,
     repo_root: Path,
@@ -3804,7 +3874,9 @@ def _write_structured_lesson(
     import datetime as _dt
 
     insight = _extract_meaningful_insight(artifact_data)
-    if not insight:
+    if not insight or not _has_delta_evidence(
+        artifact_data, repo_root=repo_root, backlog_title=backlog_title,
+    ):
         return False
 
     lessons_path = repo_root / 'lessons' / 'lessons.yaml'
@@ -3846,19 +3918,51 @@ def _write_structured_lesson(
         or artifact_data.get('concrete_improvement_statement', '')
         or f'Implementing "{backlog_title}" improves operator value.'
     )
-
+    problem = str(artifact_data.get('problem') or hypothesis).strip()
+    solution = str(artifact_data.get('solution') or insight).strip()
+    raw_tags = artifact_data.get('tags') or ['runtime']
+    tags = [str(tag).lower() for tag in raw_tags] if isinstance(raw_tags, list) else []
+    if not problem or not solution or not tags or any(tag not in CONTROLLED_LESSON_TAGS for tag in tags):
+        return False
+    severity = str(artifact_data.get('severity') or 'medium').lower()
+    if severity not in {'low', 'medium', 'high', 'critical'}:
+        return False
+    evidence = artifact_data.get('evidence') or [cycle_id]
+    if isinstance(evidence, str):
+        evidence = [evidence]
+    if not isinstance(evidence, list) or not all(isinstance(item, (str, dict)) for item in evidence):
+        return False
     lesson: dict = {
+        'schema_version': 2,
         'id': lesson_id,
+        'title': str(artifact_data.get('title') or backlog_title)[:200],
+        'problem': problem[:400],
+        'solution': solution[:400],
+        'tags': tags,
+        'severity': severity,
+        'seen_count': 1,
+        'first_seen': date_str,
+        'last_seen': date_str,
+        'evidence': evidence[:20],
+        # Legacy fields retained for fail-open readers.
         'date': date_str,
         'cycle_id': cycle_id,
         'task_id': backlog_title[:80] if backlog_title else 'unknown',
         'hypothesis': str(hypothesis)[:300],
         'result': f'Committed {commits_pushed} commit(s): ' + ', '.join(files_changed[:5]),
+        'approach': solution[:400],
         'generalized_insight': insight,
+        'reusable_insight': insight,
         'files_changed': files_changed[:10],
     }
-
-    existing['lessons'].insert(0, lesson)  # newest-first
+    if not _validate_lesson_v2(lesson):
+        return False
+    duplicate = _find_lesson_duplicate(problem, existing['lessons'])
+    if duplicate is not None:
+        duplicate['seen_count'] = int(duplicate.get('seen_count') or 1) + 1
+        duplicate['last_seen'] = date_str
+    else:
+        existing['lessons'].insert(0, lesson)  # newest-first
 
     try:
         try:
@@ -3887,6 +3991,7 @@ def _write_structured_error(
     """
     import datetime as _dt
     import json
+
     from nanobot.runtime.lessons_rotation import rotate_lessons_file
 
     lessons_dir = repo_root / 'lessons'
@@ -4001,8 +4106,8 @@ def _auto_seed_backlog_from_research(
 
     Returns True if MEMORY.md was updated.
     """
-    import re as _re
     import json as _json
+    import re as _re
 
     if not _active_backlog_is_empty(memory_text):
         return False
@@ -4200,7 +4305,7 @@ def _try_mark_backlog_done(
     if not in_active_done:
         text = _re.sub(
             rf'(###\s+Priority\s+\d+:\s+{title_escaped})',
-            rf'\1 [Done]',
+            r'\1 [Done]',
             text,
             count=1,
         )
@@ -4292,7 +4397,7 @@ def _write_bridge_completed_result(
     result_path = results_dir / f'result-{safe_id}.json'
 
     if result_status == 'already_done':
-        summary = f'Task already done — detected in git log; skipped re-execution.'
+        summary = 'Task already done — detected in git log; skipped re-execution.'
     elif commits_pushed:
         summary = (
             f'Bridge subagent committed {commits_pushed} change(s): '
@@ -4310,7 +4415,7 @@ def _write_bridge_completed_result(
             ]
         elif result_status == 'already_done':
             key_learnings = [
-                f'Task was detected as already done in git log. '
+                'Task was detected as already done in git log. '
                 'Marked [Done] in MEMORY.md. No subagent spawn needed.',
             ]
         else:

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2789,9 +2789,7 @@ async def _main_impl_body():
                     # affect the gate, which is already decided above.
                     _microbench_entry = None
                     try:
-                        from nanobot.runtime.heldout.microbench import (
-                            measure_cycle as _measure_cycle,
-                        )
+                        from nanobot.runtime.heldout.microbench import measure_cycle as _measure_cycle
                         _microbench_entry = _measure_cycle(
                             STATE_DIR, _selfevo_repo, _cycle_id, main_sha_before, cycle_branch, files_changed,
                         )

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -25,11 +25,13 @@ import os
 import re
 import shutil
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
 from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
+from nanobot.runtime.lesson_v2 import atomic_write_yaml, bounded_load_yaml, find_duplicate
 from nanobot.runtime.model_registry import resolve_model
 
 MAX_WRITES_DEFAULT = 3
@@ -509,6 +511,70 @@ def _collect_stage_items(
     return items, writes
 
 
+def promote_reflector_recommendations_to_v2(
+    workspace: Path, state_dir: Path, *, max_items: int = 2,
+) -> int:
+    """Promote bounded reflector error/approach deltas into v2 lessons."""
+    state_dir = Path(state_dir)
+    candidates = [
+        state_dir / "reflector" / "reflections.jsonl",
+        state_dir / "state" / "reflector" / "reflections.jsonl",
+        state_dir / "reflections.jsonl",
+    ]
+    path = next((p for p in candidates if p.is_file()), None)
+    if not path:
+        # Fallback glob for nested state paths
+        matches = list(state_dir.glob("**/reflector/reflections.jsonl"))
+        if matches:
+            path = matches[0]
+        else:
+            return 0
+    try:
+        stat = path.stat()
+        if stat.st_size > 512 * 1024 or time.time() - stat.st_mtime > 90 * 86400:
+            return 0
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()[-50:] if line.strip()]
+    except Exception:
+        return 0
+    target = Path(workspace) / "lessons" / "lessons.yaml"
+    existing = bounded_load_yaml(target)
+    if not existing and target.exists():
+        try:
+            import yaml
+
+            raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+            existing = raw.get("lessons", []) if isinstance(raw, dict) else raw if isinstance(raw, list) else []
+        except Exception:
+            existing = []
+    count = 0
+    for row in reversed(rows):
+        if count >= max_items or not isinstance(row, dict):
+            break
+        for item in row.get("recommendations", []):
+            if count >= max_items or not isinstance(item, dict) or item.get("kind") not in {"error_pattern", "approach_hint"}:
+                continue
+            detail = str(item.get("detail") or "").strip()
+            if not detail:
+                continue
+            card = {"schema_version": 2, "id": f"LESS-REF-{row.get('cycle_id', 'unknown')[-12:]}",
+                    "title": detail[:200], "problem": detail[:400],
+                    "solution": f"Apply the reflected {item['kind'].replace('_', ' ')}.",
+                    "tags": ["reflector"], "severity": "medium", "seen_count": 1,
+                    "first_seen": datetime.now(timezone.utc).date().isoformat(),
+                    "last_seen": datetime.now(timezone.utc).date().isoformat(),
+                    "evidence": [str(row.get("cycle_id") or "reflector")]}
+            duplicate = find_duplicate(card["problem"], existing)
+            if duplicate is not None:
+                duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
+                duplicate["last_seen"] = card["last_seen"]
+            else:
+                existing.insert(0, card)
+            count += 1
+    if count:
+        atomic_write_yaml(target, {"lessons": existing})
+    return count
+
+
 def run_curation(
     workspace: Path,
     state_dir: Path,
@@ -520,6 +586,7 @@ def run_curation(
 ) -> dict[str, Any]:
     """Run one fail-open curator pass. Writes staged dir only — never the workspace. (#1001)"""
     workspace, state_dir = Path(workspace), Path(state_dir)
+    promote_reflector_recommendations_to_v2(workspace, state_dir, max_items=2)
     wm_path = state_dir / "curator" / "watermark.json"
     old = _safe_json(wm_path, {})
     watermark = str(old.get("last_processed") or old.get("last_processed_id") or "") if isinstance(old, dict) else ""

--- a/nanobot/runtime/lesson_v2.py
+++ b/nanobot/runtime/lesson_v2.py
@@ -1,0 +1,158 @@
+"""Bounded Lesson schema v2 helpers (#1071).
+
+A v2 lesson is a problem-to-solution record. The module is intentionally
+stdlib-first and contains no LLM or timer behavior; callers decide which
+validated delta is allowed to mint a lesson.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from nanobot.runtime.schemas import CONTROLLED_LESSON_TAGS, LESSON_SEVERITIES
+
+_MAX_FILE_BYTES = 2 * 1024 * 1024
+_MAX_FILE_AGE_DAYS = 90
+_MAX_ENTRIES = 200
+_WORD_RE = re.compile(r"[a-z]{3,}")
+
+
+def validate_lesson(card: Any) -> bool:
+    """Validate required v2 fields, controlled tags, severity, and evidence."""
+    if not isinstance(card, dict):
+        return False
+    if not isinstance(card.get("problem"), str) or not card["problem"].strip():
+        return False
+    if not isinstance(card.get("solution"), str) or not card["solution"].strip():
+        return False
+    tags = card.get("tags")
+    if not isinstance(tags, list) or not tags or any(tag not in CONTROLLED_LESSON_TAGS for tag in tags):
+        return False
+    if card.get("severity", "medium") not in LESSON_SEVERITIES:
+        return False
+    evidence = card.get("evidence", [])
+    return isinstance(evidence, (list, dict))
+
+
+def normalize_problem(text: Any) -> str:
+    """Lowercase problem text and remove digits, paths, and punctuation."""
+    value = str(text or "").lower()
+    value = re.sub(r"[a-z]:[\\/][a-z0-9_.\\/-]+", " ", value)
+    value = re.sub(r"(?:^|\s)/[a-z0-9_.\\/-]+", " ", value)
+    value = re.sub(r"\b[a-z0-9_.-]+/[a-z0-9_.\\/-]+", " ", value)
+    value = re.sub(r"\d+", " ", value)
+    value = re.sub(r"[^a-z\s]", " ", value)
+    return " ".join(value.split())
+
+
+def problem_hash(text: Any) -> str:
+    normalized = normalize_problem(text)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest() if normalized else ""
+
+
+def keyword_jaccard(first: Any, second: Any) -> float:
+    left = set(_WORD_RE.findall(normalize_problem(first)))
+    right = set(_WORD_RE.findall(normalize_problem(second)))
+    return len(left & right) / len(left | right) if left and right else 0.0
+
+
+def find_duplicate(problem: Any, entries: list[dict[str, Any]], threshold: float = 0.8) -> dict[str, Any] | None:
+    digest = problem_hash(problem)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        existing = entry.get("problem") or entry.get("hypothesis") or entry.get("title")
+        if digest and problem_hash(existing) == digest:
+            return entry
+        if keyword_jaccard(problem, existing) >= threshold:
+            return entry
+    return None
+
+
+def bounded_load_yaml(
+    path: Path,
+    *,
+    max_bytes: int = _MAX_FILE_BYTES,
+    max_age_days: float = _MAX_FILE_AGE_DAYS,
+) -> list[dict[str, Any]]:
+    """Stat-check before opening/parsing and return only newest bounded entries."""
+    try:
+        stat = path.stat()
+        if stat.st_size > max_bytes or (
+            max_age_days > 0 and time.time() - stat.st_mtime > max_age_days * 86400
+        ):
+            return []
+        import yaml
+        value = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if isinstance(value, dict):
+            value = value.get("lessons") or value.get("errors") or []
+        return [item for item in value[:_MAX_ENTRIES] if isinstance(item, dict)] if isinstance(value, list) else []
+    except Exception:
+        return []
+
+
+def atomic_write_yaml(path: Path, value: Any) -> None:
+    """Write YAML atomically, preserving the existing fail-open boundary."""
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(yaml.safe_dump(value, allow_unicode=True, sort_keys=False))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(name, path)
+    finally:
+        try:
+            os.unlink(name)
+        except FileNotFoundError:
+            pass
+
+
+def record_citations(
+    state_dir: Path,
+    cycle_id: str,
+    texts: list[str],
+    *,
+    max_chars: int = 64_000,
+) -> list[str]:
+    """Grep bounded proposal/transcript text and atomically record usage rows."""
+    ids: set[str] = set()
+    pattern = re.compile(r"\[Lesson\s+([A-Za-z0-9_-]+)\]", re.IGNORECASE)
+    for text in texts:
+        ids.update(pattern.findall(str(text or "")[:max_chars]))
+    if not ids:
+        return []
+    path = Path(state_dir) / "lesson_usage" / "citations.jsonl"
+    try:
+        rows: list[dict[str, str]] = []
+        if path.exists():
+            stat = path.stat()
+            if stat.st_size <= _MAX_FILE_BYTES:
+                rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+                rows = [row for row in rows if isinstance(row, dict)][-_MAX_ENTRIES:]
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        rows.extend({"lesson_id": lesson_id, "cycle_id": cycle_id, "ts": now} for lesson_id in sorted(ids))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write("".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows[-_MAX_ENTRIES:]))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(name, path)
+        finally:
+            try:
+                os.unlink(name)
+            except FileNotFoundError:
+                pass
+        return sorted(ids)
+    except Exception:
+        return []

--- a/nanobot/runtime/lessons_context.py
+++ b/nanobot/runtime/lessons_context.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any
 
@@ -81,6 +82,9 @@ def _cap(text: Any, limit: int) -> str:
     return str(text or "")[:limit]
 
 
+_MAX_FILE_AGE_DAYS = 90
+
+
 def _safe_load_yaml(path: Path) -> list[dict[str, Any]]:
     """Minimal, standalone re-implementation of lessons.py's loader.
 
@@ -99,7 +103,10 @@ def _safe_load_yaml(path: Path) -> list[dict[str, Any]]:
         if not _YAML_OK or not path.exists():
             return []
         try:
-            if path.stat().st_size > _MAX_FILE_BYTES:
+            stat = path.stat()
+            if stat.st_size > _MAX_FILE_BYTES:
+                return []
+            if time.time() - stat.st_mtime > _MAX_FILE_AGE_DAYS * 86400:
                 return []
         except OSError:
             return []
@@ -235,6 +242,9 @@ def build_lessons_context(
                 "title": _cap(less.get("title"), _TITLE_CAP),
                 "approach": _cap(less.get("approach"), _TEXT_CAP),
                 "reusable_insight": _cap(less.get("reusable_insight"), _TEXT_CAP),
+                **({"problem": _cap(less.get("problem"), _TEXT_CAP),
+                    "solution": _cap(less.get("solution"), _TEXT_CAP)}
+                   if less.get("problem") and less.get("solution") else {}),
             }
 
         return result

--- a/nanobot/runtime/schemas.py
+++ b/nanobot/runtime/schemas.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from typing import Any, TypedDict
 
+CONTROLLED_LESSON_TAGS: frozenset[str] = frozenset({
+    "architecture", "config", "curator", "docs", "gate", "git", "infra",
+    "lint", "perf", "prompt", "reflector", "refactor", "rotation", "runtime",
+    "security", "sidecar", "state", "subagent", "test", "tooling",
+})
+LESSON_SEVERITIES: tuple[str, ...] = ("low", "medium", "high", "critical")
+
+
 class CycleReport(TypedDict, total=False):
     schema_version: str
     cycle_id: str
@@ -53,3 +61,17 @@ class CycleHealth(TypedDict, total=False):
     exit_code: int
     next_recommended_action: str
     success_signals: dict[str, Any]
+
+
+class LessonV2(TypedDict, total=False):
+    schema_version: int
+    id: str
+    title: str
+    problem: str
+    solution: str
+    tags: list[str]
+    severity: str
+    seen_count: int
+    first_seen: str
+    last_seen: str
+    evidence: list[str] | dict[str, Any]

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -1,0 +1,131 @@
+"""Acceptance tests for Lesson schema v2 (#1071)."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import yaml
+
+from nanobot.runtime.bridge import _write_structured_lesson, build_task
+from nanobot.runtime.knowledge_curator import promote_reflector_recommendations_to_v2
+from nanobot.runtime.lesson_v2 import (
+    bounded_load_yaml,
+    find_duplicate,
+    keyword_jaccard,
+    normalize_problem,
+    record_citations,
+    validate_lesson,
+)
+from nanobot.runtime.schemas import CONTROLLED_LESSON_TAGS
+
+
+def _base_artifact(**extra: object) -> dict:
+    value = {
+        "problem": "Parser failed on large input",
+        "solution": "Process input incrementally",
+        "tags": ["runtime"],
+        "severity": "medium",
+        "evidence": ["cycle-resolved"],
+        "reusable_insight": "Incremental processing avoids memory exhaustion.",
+        "delta_evidence": "errors-to-integrated-resolution",
+    }
+    value.update(extra)
+    return value
+
+
+def test_schema_rejects_missing_required_fields_and_unknown_tags() -> None:
+    card = _base_artifact(id="LESS-1")
+    assert validate_lesson(card)
+    assert not validate_lesson({**card, "problem": ""})
+    assert not validate_lesson({**card, "solution": ""})
+    assert not validate_lesson({**card, "tags": ["not-controlled"]})
+    assert set(("runtime", "reflector", "test")) <= CONTROLLED_LESSON_TAGS
+
+
+def test_normalization_and_dedup() -> None:
+    assert normalize_problem("Error in /var/log/app.py line 42 code 500") == "error in line code"
+    existing = [{"id": "LESS-1", "problem": "Error in C:/tmp/app.py line 99 code 404"}]
+    assert find_duplicate("Error in /var/log/app.py line 42 code 500", existing)
+    assert keyword_jaccard("parser timeout failure", "parser timeout failure") == 1.0
+
+
+def test_plain_success_does_not_mint_but_delta_pair_does(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    artifact = _base_artifact()
+    artifact.pop("delta_evidence")
+    assert not _write_structured_lesson(
+        repo_root=repo, cycle_id="cycle-plain", backlog_title="Parser task",
+        files_changed=["scripts/parser.py"], commits_pushed=1, artifact_data=artifact,
+    )
+    errors = repo / "lessons" / "errors.yaml"
+    errors.parent.mkdir()
+    errors.write_text(yaml.safe_dump([{"task_id": "Parser task", "reason": "parser failure"}]), encoding="utf-8")
+    assert _write_structured_lesson(
+        repo_root=repo, cycle_id="cycle-resolved", backlog_title="Parser task",
+        files_changed=["scripts/parser.py"], commits_pushed=1, artifact_data=artifact,
+    )
+    data = yaml.safe_load((repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    lesson = data["lessons"][0]
+    assert validate_lesson(lesson)
+    assert lesson["problem"] and lesson["solution"] and lesson["tags"]
+
+
+def test_dedup_increments_seen_count_without_append(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    artifact = _base_artifact()
+    assert _write_structured_lesson(repo_root=repo, cycle_id="cycle-a", backlog_title="Parser", files_changed=[], commits_pushed=1, artifact_data=artifact)
+    assert _write_structured_lesson(repo_root=repo, cycle_id="cycle-b", backlog_title="Parser", files_changed=[], commits_pushed=1, artifact_data=artifact)
+    data = yaml.safe_load((repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    assert len(data["lessons"]) == 1
+    assert data["lessons"][0]["seen_count"] == 2
+
+
+def test_citations_are_bounded_and_reporting_only(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    cited = record_citations(state, "cycle-1", ["proposal [Lesson LESS-1]", "x" * 100_000])
+    assert cited == ["LESS-1"]
+    rows = [json.loads(line) for line in (state / "lesson_usage" / "citations.jsonl").read_text().splitlines()]
+    assert rows == [{"lesson_id": "LESS-1", "cycle_id": "cycle-1", "ts": rows[0]["ts"]}]
+
+
+def test_bounded_reader_skips_before_open(tmp_path: Path, monkeypatch) -> None:
+    old = tmp_path / "old.yaml"
+    old.write_text("lessons:\n  - problem: old\n", encoding="utf-8")
+    stamp = time.time() - 100 * 86400
+    os.utime(old, (stamp, stamp))
+    opened = False
+    original = Path.read_text
+    def counted(self: Path, *args: object, **kwargs: object) -> str:
+        nonlocal opened
+        opened = True
+        return original(self, *args, **kwargs)
+    monkeypatch.setattr(Path, "read_text", counted)
+    assert bounded_load_yaml(old) == []
+    assert not opened
+
+
+def test_curator_promotes_reflector_delta(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state" / "reflector"
+    workspace.mkdir()
+    state.mkdir(parents=True)
+    (state / "reflections.jsonl").write_text(json.dumps({
+        "cycle_id": "cycle-reflect",
+        "recommendations": [{"kind": "approach_hint", "detail": "Use bounded parser reads"}],
+    }) + "\n", encoding="utf-8")
+    assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    assert validate_lesson(lessons["lessons"][0])
+
+
+def test_prompt_includes_lesson_citation_instruction() -> None:
+    task = build_task(
+        {"task_title": "Parser task", "request_id": "r", "cycle_id": "c", "goal_id": "g",
+         "lessons_context": {"relevant_lesson": {"id": "LESS-1", "title": "Parser", "problem": "bad", "solution": "good"}}},
+        "goal", "report",
+    )
+    assert "[Lesson LESS-1]" in task

--- a/tests/test_lessons_context.py
+++ b/tests/test_lessons_context.py
@@ -282,6 +282,25 @@ class TestLiveWriterRoundTrip:
                 "reusable_insight": "Digest ledger lines iteratively to avoid high memory spikes",
             },
         )
+        # #1071: meaningful content alone is not a delta trigger.
+        assert wrote is False
+
+        (repo / "lessons").mkdir(parents=True, exist_ok=True)
+        (repo / "lessons" / "errors.yaml").write_text(
+            yaml.dump([{"task_id": "Improve dashboard ledger digest helper", "reason": "prior failure"}]),
+            encoding="utf-8",
+        )
+        wrote = _write_structured_lesson(
+            repo_root=repo,
+            cycle_id="cycle-resolved123456",
+            backlog_title="Improve dashboard ledger digest helper",
+            files_changed=["scripts/eeebot_dashboard.py"],
+            commits_pushed=1,
+            artifact_data={
+                "hypothesis": "Improve dashboard ledger digest helper for faster reads",
+                "reusable_insight": "Digest ledger lines iteratively to avoid high memory spikes",
+            },
+        )
         assert wrote is True
 
         # Sanity: confirm the writer really did produce the dict-wrapped,
@@ -290,7 +309,8 @@ class TestLiveWriterRoundTrip:
         written = yaml.safe_load((repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
         assert isinstance(written, dict) and "lessons" in written
         raw_entry = written["lessons"][0]
-        assert "title" not in raw_entry
+        assert raw_entry["schema_version"] == 2
+        assert raw_entry["problem"] and raw_entry["solution"] and raw_entry["tags"]
         assert "tool_calls" not in raw_entry
         assert "elapsed_seconds" not in raw_entry
         assert "hypothesis" in raw_entry and "generalized_insight" in raw_entry
@@ -306,7 +326,7 @@ class TestLiveWriterRoundTrip:
 
         assert "relevant_lesson" in result
         less = result["relevant_lesson"]
-        assert set(less.keys()) == {"id", "title", "approach", "reusable_insight"}
+        assert {"id", "title", "approach", "reusable_insight"} <= set(less.keys())
         assert less["id"]
         assert less["title"]  # non-blank: derived from hypothesis
         assert "dashboard ledger digest helper" in less["title"].lower()


### PR DESCRIPTION
## Summary

Implements #1071 Lesson schema v2 with bounded, delta-driven knowledge capture.

- Adds a documented `LessonV2` schema and controlled tag glossary.
- Keeps #1070's noise fix: protocol-only success and meaningful content without an approved delta do not mint lessons.
- Adds positive errors-to-resolution delta minting, v2 validation, evidence, deduplication, and `seen_count`/`last_seen` refresh.
- Normalizes deduplication input by lowercasing and removing digits/paths, then uses exact normalized match or keyword similarity.
- Renders v2 problem/solution cards and a `[Lesson <id>]` citation instruction in proposer prompts.
- Records bounded citation usage as reporting-only JSONL sidecar data; no fitness integration or new timers/LLM calls.
- Promotes bounded reflector `error_pattern`/`approach_hint` recommendations through the existing curator run.
- Applies stat/age checks before lesson/reflection parsing and preserves legacy context/rotation behavior.

## Scope and safety

- `nanobot/runtime/evolution_tree.py` is untouched.
- Gate policy, deny-set, `goals.md`, and `IDENTITY.md` are untouched.
- No secrets or root junk are included.

## Verification

- Focused lesson/context/rotation/curator/reflector suite: `83 passed, 2 skipped`.
- Ruff on all lesson-specific changed files: passed.
- `git diff --check`: passed.
- Reviewer verdict: no blocking findings.

Full pytest and CI are required before merge. Live deployment will be coordinated with the #1072/#1044 owner; if no natural v2 trigger fires, live status should be recorded honestly with fixture evidence.
