### PR TITLE
fix: complete prune backlog heldout fixture

### DIFF
--- a/nanobot/runtime/heldout/checkers.py
+++ b/nanobot/runtime/heldout/checkers.py
@@ -195,6 +195,14 @@ def check_prune_failed_backlog(ctx: CheckContext) -> tuple[str, str]:
     backlog_dir = ctx.tmp_dir / "state" / "hypotheses"
     backlog_dir.mkdir(parents=True, exist_ok=True)
     (backlog_dir / "backlog.json").write_text('{"entries": []}\n', encoding="utf-8")
+    memory_dir = ctx.tmp_dir / "memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / "HISTORY.md").write_text(
+        "# History\n\n[2026-07-16 10:00] cycle-hx1 outcome=success\n", encoding="utf-8"
+    )
+    (memory_dir / "MEMORY.md").write_text(
+        "# Memory\n\n## Active backlog — pick one each session\n", encoding="utf-8"
+    )
     proc = _run(ctx)
     if proc.returncode != 0:
         return FAIL, f"exited {proc.returncode}: {_stderr_tail(proc)}"

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -293,6 +293,33 @@ class TestRunner:
         assert data["results"]["scripts/prune_failed_backlog.py"]["status"] == "fail"
         assert "stdout does not mention" in data["results"]["scripts/prune_failed_backlog.py"]["evidence"]
 
+    def test_prune_failed_backlog_checker_fixture_contract(self, tmp_path, monkeypatch):
+        """Checker fixture contract: verifies that check_prune_failed_backlog sets up
+        the required state/ledger, state/hypotheses/backlog.json, and memory/HISTORY.md."""
+        observed = {}
+
+        def _fake_run(ctx):
+            observed["ledger"] = (ctx.tmp_dir / "state" / "ledger" / "cycles.jsonl").is_file()
+            observed["backlog"] = (ctx.tmp_dir / "state" / "hypotheses" / "backlog.json").is_file()
+            observed["history"] = (ctx.tmp_dir / "memory" / "HISTORY.md").is_file()
+            observed["memory"] = (ctx.tmp_dir / "memory" / "MEMORY.md").is_file()
+            return subprocess.CompletedProcess(
+                args=["dummy"], returncode=0, stdout="backlog pruning: 0 items pruned, ok\n", stderr=""
+            )
+
+        monkeypatch.setattr(checkers, "_run", _fake_run)
+        repo = _make_repo(tmp_path, {"prune_failed_backlog.py": PRUNE_OK})
+        ctx = checkers.CheckContext(
+            tmp_dir=tmp_path / "sandbox",
+            script=repo / "scripts" / "prune_failed_backlog.py",
+        )
+        status, evidence = checkers.check_prune_failed_backlog(ctx)
+        assert status == "pass"
+        assert observed["ledger"] is True
+        assert observed["backlog"] is True
+        assert observed["history"] is True
+        assert observed["memory"] is True
+
     def test_head_time_watermark_no_op(self, tmp_path, monkeypatch):
         calls = {"n": 0}
 


### PR DESCRIPTION
Closes #1080\n\n## Summary\n- create minimal valid memory/HISTORY.md and MEMORY.md in prune_failed_backlog checker fixture;\n- add a contract test proving required ledger, backlog, and memory inputs exist before execution.\n\nThis removes the false  heldout failure without changing target behavior or scoring.\n\n## Validation\n- tests/test_heldout.py: 37 passed\n- related scorecard/stop/cleanup tests: passed\n- ruff and git diff --check: clean\n- reviewer verdict: APPROVE\n- live heldout verification will be captured after deploy.