### PR TITLE
fix: keep usage evidence feed fresh across bridge cycles

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1783,7 +1783,20 @@ async def _main_impl_body():
     # (this function runs exactly once per process, per `main()`'s docstring),
     # right after the concurrency lock in `main()` is held, before anything
     # else touches the shared checkout.
-    _prune_cycle_tags(STATE_DIR.parent / 'eeebot-self-evolving')
+    _selfevo_repo_early = STATE_DIR.parent / 'eeebot-self-evolving'
+    _prune_cycle_tags(_selfevo_repo_early)
+
+    # #1083: keep usage evidence and serves confirmation refreshed once per
+    # bridge run (fail-open, watermark-gated by 6h/git_head). Bypassed previously
+    # whenever queued requests, already_handled, or early gate skips returned
+    # before demand.collect_demand() was reached.
+    try:
+        from nanobot.runtime import usage_evidence
+
+        usage_evidence.refresh_usage(STATE_DIR, _selfevo_repo_early)
+        usage_evidence.confirm_serves(STATE_DIR, _selfevo_repo_early)
+    except Exception:
+        pass
 
     outbox = load_json(STATE_DIR / 'outbox' / 'report.index.json') or {}
     goals = load_json(STATE_DIR / 'goals' / 'registry.json') or {}

--- a/tests/test_bridge_goal_bootstrap.py
+++ b/tests/test_bridge_goal_bootstrap.py
@@ -167,3 +167,46 @@ class TestBacklogSnapshotCalledEveryRun:
         monkeypatch.setattr(bridge, "write_backlog_snapshot", _boom)
 
         assert asyncio.run(bridge._main_impl()) == 0
+
+
+class TestUsageEvidenceRefreshedEveryRun:
+    def test_usage_evidence_refreshed_on_already_handled_and_no_goal_paths(self, tmp_path, monkeypatch):
+        """#1083: refresh_usage and confirm_serves run early in _main_impl_body,
+        so usage feeds do not go stale when bridge returns early."""
+        from nanobot.runtime import usage_evidence
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _set_common_paths(monkeypatch, state_dir, tmp_path)
+
+        calls = []
+
+        def _mock_refresh(s, r):
+            calls.append(("refresh_usage", s, r))
+
+        def _mock_confirm(s, r):
+            calls.append(("confirm_serves", s, r))
+
+        monkeypatch.setattr(usage_evidence, "refresh_usage", _mock_refresh)
+        monkeypatch.setattr(usage_evidence, "confirm_serves", _mock_confirm)
+
+        assert asyncio.run(bridge._main_impl()) == 0
+        assert len(calls) == 2
+        assert calls[0][0] == "refresh_usage"
+        assert calls[1][0] == "confirm_serves"
+
+    def test_usage_evidence_failure_never_breaks_the_cycle_result(self, tmp_path, monkeypatch):
+        """#1083: fail-open defense for usage refresh at start of cycle."""
+        from nanobot.runtime import usage_evidence
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _set_common_paths(monkeypatch, state_dir, tmp_path)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("usage refresh boom")
+
+        monkeypatch.setattr(usage_evidence, "refresh_usage", _boom)
+        monkeypatch.setattr(usage_evidence, "confirm_serves", _boom)
+
+        assert asyncio.run(bridge._main_impl()) == 0


### PR DESCRIPTION
Closes #1083\n\n## Root cause\nThe usage producer was not removed by #1066/#1069. The sole production call was buried in , which is skipped when  sees queued requests or returns early from proposal gating. The bridge could therefore complete cycles without invoking ; its fail-open wrapper hid the missed refresh.\n\n## Fix\n- invoke  and  once at the start of , before queue/gate/goal early exits;\n- preserve the existing six-hour/git-head watermark and 12-hour scorecard freshness contract; repeated calls remain cheap;\n- preserve the demand call for compatibility and keep all usage evidence fail-open.\n\n## Validation\n- focused bridge/usage/demand tests: 233 passed\n- reviewer verdict: APPROVE\n- full pytest and CI will be reported before merge\n- no gate policy, deny-set, goals.md, validator_harness.py, lessons modules, or fabricated usage events changed.