### PR TITLE
fix: restore usage evidence feed refresh

### DIFF
--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -60,6 +60,7 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -223,7 +224,19 @@ def _read_json(path: Path, default: Any) -> Any:
 def _write_json(path: Path, data: Any) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2, ensure_ascii=False)
+                fh.write("\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, str(path))
+        finally:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
     except Exception:
         pass
 

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -1741,3 +1741,41 @@ class TestOwnerLiveRatioAndSurfaces:
         }
         val = usage_evidence._git_creation_iso(repo, "scripts/consumer.py", sidecar_data=sidecar_data)
         assert val == "2026-08-01T00:00:00Z"
+
+    def test_refresh_usage_replaces_unwritable_target_file_in_writable_dir(self, tmp_path, monkeypatch):
+        """#1083: atomic write via tempfile + os.replace succeeds when existing file is unwritable."""
+        repo = _repo_with_files(
+            tmp_path,
+            {
+                "scripts/task.py": "print('ok')\n",
+            },
+        )
+        state_dir = tmp_path / "state"
+        usage_dir = state_dir / "usage"
+        usage_dir.mkdir(parents=True, exist_ok=True)
+        target = usage_dir / "last_used.json"
+
+        stale_data = {
+            "schema": usage_evidence.USAGE_SCHEMA,
+            "scanned_at_utc": "2026-08-01T00:00:00Z",
+            "git_head": "old-head",
+            "entries": {},
+        }
+        target.write_text(json.dumps(stale_data), encoding="utf-8")
+
+        # Simulate root-owned / unwritable target file by making direct write_text fail with PermissionError.
+        orig_write_text = Path.write_text
+
+        def unwritable_target_write_text(self, *args, **kwargs):
+            if self.resolve() == target.resolve():
+                raise PermissionError(13, "Permission denied (simulated root-owned file)")
+            return orig_write_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", unwritable_target_write_text)
+        monkeypatch.setattr(usage_evidence, "_RESCAN_HOURS", 0)
+        res = usage_evidence.refresh_usage(state_dir, repo)
+
+        assert res["scanned_at_utc"] != "2026-08-01T00:00:00Z"
+        persisted = json.loads(target.read_text(encoding="utf-8"))
+        assert persisted["scanned_at_utc"] == res["scanned_at_utc"]
+        assert persisted["git_head"] == usage_evidence._git_head(repo)


### PR DESCRIPTION
Closes #1083\n\n## Root cause\nThe usage refresh call was present but conditional: it lived only inside , which early-exit bridge paths skipped. After moving refresh to the bridge start in PR #1084, the live sidecar still stayed stale because  was  while its parent directory was writable by .  used direct , which failed open on the existing inode; the exception was swallowed and  remained stale.\n\nThe regression window contained #1066/#1069, but neither removed the call; the actual failure was the interaction of early-return placement and the root-owned sidecar inode.\n\n## Fix\n- write usage JSON through a same-directory temporary file, flush/fsync, then ;\n- preserve fail-open semantics, six-hour refresh watermark, and scorecard twelve-hour freshness contract;\n- add regression coverage for a target write failure with a writable parent directory.\n\n## Validation\n- focused usage/bridge/demand tests: 234 passed\n- ruff and git diff --check: clean\n- reviewer verdict: APPROVE\n- full pytest and CI will be reported before merge\n\nNo secrets, fabricated usage events, validator_harness.py, lessons modules, gate policy, deny-set, or goals.md were changed.