### PR TITLE
fix(reflections): extract nested hints (#1089)

### DIFF
--- a/nanobot/runtime/reflection_context.py
+++ b/nanobot/runtime/reflection_context.py
@@ -1,4 +1,4 @@
-"""Bounded, steering-only hints from the reflector journal (#1008)."""
+"""Bounded, steering-only hints from the reflector journal (#1008, #1089)."""
 from __future__ import annotations
 
 import json
@@ -41,6 +41,70 @@ def _tail_lines(path: Path) -> list[str]:
         return []
 
 
+def _extract_items(row: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """Extract candidate (text, kind, evidence) tuples from a reflection row."""
+    extracted: list[tuple[str, str, str]] = []
+
+    # 1. Nested recommendations from live journal schema
+    recs = row.get("recommendations")
+    if isinstance(recs, list):
+        for item in recs:
+            if not isinstance(item, dict):
+                continue
+            kind = str(item.get("kind") or ("approach_hint" if item.get("approach_hint") else ""))
+            text = str(
+                item.get("approach_hint")
+                or (item.get("detail") if kind == "approach_hint" or not kind else "")
+                or item.get("text")
+                or ""
+            ).strip()
+            if not text and item.get("error_pattern"):
+                text = str(item.get("error_pattern")).strip()
+                if not kind:
+                    kind = "error_pattern"
+            if text:
+                evidence = str(item.get("evidence") or "")
+                extracted.append((text, kind, evidence))
+
+    # 2. Nested findings from live journal schema
+    findings = row.get("findings")
+    if isinstance(findings, list):
+        for item in findings:
+            if not isinstance(item, dict):
+                continue
+            kind = str(item.get("kind") or ("error_pattern" if item.get("error_pattern") else ""))
+            text = str(
+                item.get("error_pattern")
+                or (item.get("detail") if kind == "error_pattern" or not kind else "")
+                or item.get("text")
+                or ""
+            ).strip()
+            if not text and item.get("approach_hint"):
+                text = str(item.get("approach_hint")).strip()
+                if not kind:
+                    kind = "approach_hint"
+            if text:
+                evidence = str(item.get("evidence") or "")
+                extracted.append((text, kind, evidence))
+
+    # 3. Flat row fields (legacy schema or direct flat rows)
+    flat_kind = str(
+        row.get("kind")
+        or ("approach_hint" if row.get("approach_hint") else ("error_pattern" if row.get("error_pattern") else ""))
+    )
+    flat_text = str(
+        row.get("approach_hint")
+        or row.get("error_pattern")
+        or row.get("detail")
+        or (row.get("summary") if not extracted else "")
+        or ""
+    ).strip()
+    if flat_text and not any(t == flat_text for t, _, _ in extracted):
+        extracted.append((flat_text, flat_kind, str(row.get("evidence") or "")))
+
+    return extracted
+
+
 def build_reflection_hints(
     state_dir: Path,
     task_title: str,
@@ -67,15 +131,28 @@ def build_reflection_hints(
             ts = _parse(row.get("ts") or row.get("created_at") or row.get("timestamp"))
             if ts is None or ts < cutoff:
                 continue
-            text = str(row.get("approach_hint") or row.get("error_pattern") or row.get("detail") or row.get("summary") or "").strip()
-            if not text:
+            items = _extract_items(row)
+            if not items:
                 continue
-            shared = len(task_words & _words(f"{row.get('task_title','')} {row.get('target_path','')} {text}"))
-            if not shared:
-                continue
-            kind = str(row.get("kind") or "")
-            preferred = 1 if kind in {"approach_hint", "error_pattern"} or row.get("approach_hint") or row.get("error_pattern") else 0
-            candidates.append((preferred * 100 + shared, ts.isoformat(), text[:_MAX_HINT_CHARS]))
+            for text, kind, evidence in items:
+                if not text:
+                    continue
+                shared = len(
+                    task_words
+                    & _words(
+                        f"{row.get('task_title','')} {row.get('target_path','')} {row.get('summary','')} {evidence} {text}"
+                    )
+                )
+                if not shared:
+                    continue
+                preferred = (
+                    1
+                    if kind in {"approach_hint", "error_pattern"}
+                    or row.get("approach_hint")
+                    or row.get("error_pattern")
+                    else 0
+                )
+                candidates.append((preferred * 100 + shared, ts.isoformat(), text[:_MAX_HINT_CHARS]))
         candidates.sort(key=lambda x: (-x[0], x[1]), reverse=False)
         out: list[str] = []
         total = 0
@@ -97,4 +174,9 @@ def build_reflection_hints(
 def render_reflection_hints(hints: list[str]) -> str:
     if not hints:
         return ""
-    return "## Recent reflections (steering hints)\n" + "\n".join(f"- {h[:_MAX_HINT_CHARS]}" for h in hints)[:_MAX_SECTION_CHARS] + "\n"
+    return (
+        "## Recent reflections (steering hints)\n"
+        + "\n".join(f"- {h[:_MAX_HINT_CHARS]}" for h in hints)[:_MAX_SECTION_CHARS]
+        + "\n"
+    )
+

--- a/tests/test_reflection_context.py
+++ b/tests/test_reflection_context.py
@@ -46,3 +46,94 @@ def test_prompt_renders_section_only_when_hints_exist(tmp_path: Path) -> None:
 
 def test_render_empty_is_absent() -> None:
     assert render_reflection_hints([]) == ""
+
+
+def test_extracts_nested_recommendations_and_findings_from_live_journal(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    ts = now.isoformat().replace("+00:00", "Z")
+    live_journal_row = {
+        "cycle_id": "cycle-2026-08-26-001",
+        "created_at": ts,
+        "summary": "Evaluation completed with timeout in websocket transport",
+        "task_title": "Fix websocket reconnect",
+        "target_path": "nanobot/transport/ws.py",
+        "findings": [
+            {
+                "kind": "error_pattern",
+                "detail": "Unhandled websocket timeout exception during handshake",
+                "evidence": "cycle-2026-08-26-001 traceback",
+            },
+            {
+                "kind": "good_practice",
+                "detail": "Cleaned up dangling asyncio sockets on failure",
+            },
+        ],
+        "recommendations": [
+            {
+                "kind": "approach_hint",
+                "detail": "Use asyncio.timeout around the initial websocket handshake",
+                "evidence": "tests/test_ws.py",
+            },
+            {
+                "kind": "instruction_change",
+                "detail": "Update AGENTS.md with socket teardown guide",
+            },
+        ],
+        "followed_previous": [],
+    }
+    _write(tmp_path / "reflector/reflections.jsonl", [live_journal_row])
+    hints = build_reflection_hints(tmp_path, "websocket handshake timeout", "nanobot/transport/ws.py", now=now)
+    assert len(hints) == 2
+    assert "Use asyncio.timeout around the initial websocket handshake" in hints
+    assert "Unhandled websocket timeout exception during handshake" in hints
+
+
+def test_dedupes_and_caps_hints(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    ts = now.isoformat().replace("+00:00", "Z")
+    row = {
+        "cycle_id": "c1",
+        "created_at": ts,
+        "recommendations": [
+            {"kind": "approach_hint", "detail": "shared duplicate hint detail"},
+            {"kind": "approach_hint", "detail": "shared duplicate hint detail"},
+            {"kind": "approach_hint", "detail": "second unique hint detail"},
+            {"kind": "approach_hint", "detail": "third unique hint detail"},
+            {"kind": "approach_hint", "detail": "fourth unique hint detail"},
+        ],
+    }
+    _write(tmp_path / "reflector/reflections.jsonl", [row])
+    hints = build_reflection_hints(tmp_path, "hint detail task", now=now)
+    assert len(hints) == 3
+    assert len(set(hints)) == 3
+    assert hints[0] == "shared duplicate hint detail"
+
+
+def test_extracts_nested_explicit_approach_hint_and_error_pattern_keys(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    ts = now.isoformat().replace("+00:00", "Z")
+    live_journal_row = {
+        "cycle_id": "cycle-2026-08-26-002",
+        "created_at": ts,
+        "task_title": "Fix memory leak in subscriber",
+        "target_path": "nanobot/bus/subscriber.py",
+        "findings": [
+            {
+                "error_pattern": "Unclosed event loop subscription listener",
+                "evidence": "traceback in worker log",
+            }
+        ],
+        "recommendations": [
+            {
+                "approach_hint": "Unsubscribe listener during shutdown handler",
+                "evidence": "subscriber lifecycle docs",
+            }
+        ],
+    }
+    _write(tmp_path / "reflector/reflections.jsonl", [live_journal_row])
+    hints = build_reflection_hints(tmp_path, "subscriber shutdown leak", "nanobot/bus/subscriber.py", now=now)
+    assert len(hints) == 2
+    assert "Unsubscribe listener during shutdown handler" in hints
+    assert "Unclosed event loop subscription listener" in hints
+
+


### PR DESCRIPTION
## Summary

Fixes #1089 by binding the reflection-hints selector to the reflector journal schema actually emitted in production.

- Extracts `recommendations[].kind=approach_hint` and `findings[].kind=error_pattern` with their `detail` text.
- Supports explicit nested `approach_hint` / `error_pattern` keys as well.
- Preserves legacy flat-field support.
- Generic `summary` fallback is used only when no nested/flat candidate exists, so it cannot displace real nested hints.
- Preserves bounded tail reads, seven-day TTL, keyword matching, kind preference, deduplication, caps, fail-open behavior, and `lessons_context` request schema.

## Verification

- `python -m pytest --import-mode=importlib tests/test_reflection_context.py tests/test_reflector.py -q` — `17 passed`.
- Ruff on changed files — passed.
- `git diff --check` — passed.
- Read-only Opus review — approved.
