### PR TITLE
feat(runtime): guard doc-only reflection demand

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1421,6 +1421,16 @@ def build_task(req: dict, goal_text: str, report_source: str,
     if lessons_lines:
         lines += lessons_lines
 
+    # Inject doc-only budget notice if coordinator or demand item supplied one (#1090)
+    doc_budget_notice = req.get('doc_budget_notice') or artifact_data.get('doc_budget_notice') or ''
+    if doc_budget_notice:
+        lines += [
+            '## Value steering notice',
+            str(doc_budget_notice),
+            'Prefer code-bearing improvements (scripts/, runtime/, tests/) that create measurable runtime effects.',
+            '',
+        ]
+
     # Inject previous attempts section so subagent knows what prior sessions did
     if state_dir is not None and backlog_title:
         _prev = _get_previous_attempts(
@@ -3196,6 +3206,7 @@ async def _main_impl_body():
 
     # Reporting-only citation signal from bounded proposal/transcript fields.
     try:
+        from nanobot.runtime.lesson_v2 import record_citations as _record_lesson_citations
         _record_lesson_citations(
             STATE_DIR,
             _cycle_id,

--- a/nanobot/runtime/cycle_ledger.py
+++ b/nanobot/runtime/cycle_ledger.py
@@ -231,14 +231,21 @@ def record_cycle_outcome(
     """
     if outcome not in VALID_OUTCOMES:
         outcome = "failed"
+    row = {
+        "phase": "outcome",
+        "cycle_id": cycle_id or "",
+        "outcome": outcome,
+        "reason": reason or None,
+        "files_changed": list(files_changed or []),
+        "branch": branch or None,
+    }
+    if files_changed is not None:
+        try:
+            from nanobot.runtime.demand import classify_change_tier
+            row["change_tier"] = classify_change_tier(files_changed)
+        except Exception:
+            pass
     append_event(
         state_dir,
-        {
-            "phase": "outcome",
-            "cycle_id": cycle_id or "",
-            "outcome": outcome,
-            "reason": reason or None,
-            "files_changed": list(files_changed or []),
-            "branch": branch or None,
-        },
+        row,
     )

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -273,6 +273,133 @@ def _vector_rank(vector: str) -> int:
 # something with a slash or a dot-extension, e.g. scripts/foo.py, docs/x.md.
 _PATH_TOKEN_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_\-./]*/[A-Za-z0-9_\-./]+|[A-Za-z0-9_\-]+\.[A-Za-z0-9]{1,5}")
 
+# ─── doc-only / code-bearing classification ───────────────────────────────────
+
+_DOC_ONLY_PREFIXES = ("docs/", "lessons/", "memory/")
+_DOC_ONLY_BASENAMES = {"AGENTS.md"}
+_DEFAULT_DOC_ONLY_24H_BUDGET = 5
+_DOC_ONLY_BUDGET_ENV_VAR = "EEEBOT_DOC_ONLY_24H_BUDGET"
+_MAX_LEDGER_BYTES_FOR_DOC_BUDGET = 2 * 1024 * 1024  # 2MB byte cap for 24h rolling read
+
+
+def is_doc_only_path(path: str | Path) -> bool:
+    """Return True if a single path is classified as doc-only.
+
+    Doc-only paths:
+      - Any path starting with (or inside) ``docs/``, ``lessons/``, or ``memory/``
+      - Any file with basename in :data:`_DOC_ONLY_BASENAMES` (i.e. ``AGENTS.md``)
+
+    Fails open (returns False) on empty/invalid inputs.
+    """
+    if not path:
+        return False
+    normalized = str(path).replace("\\", "/").strip().lstrip("/")
+    if not normalized:
+        return False
+    if any(normalized.startswith(prefix) for prefix in _DOC_ONLY_PREFIXES):
+        return True
+    parts = normalized.split("/")
+    basename = parts[-1]
+    if basename in _DOC_ONLY_BASENAMES:
+        return True
+    return False
+
+
+def is_non_confirmable_target(target: str | Path | None) -> bool:
+    """Return True if target path is non-confirmable (doc/memory/lessons or AGENTS.md).
+
+    Conservative target classification for steering-only annotations.
+    """
+    if not target:
+        return False
+    return is_doc_only_path(target)
+
+
+def classify_change_tier(files_changed: list[str] | None) -> str:
+    """Classify an integration's changed files as ``'doc-only'`` or ``'code-bearing'``.
+
+    Classification:
+      - ``'doc-only'`` iff every changed path is classified as doc-only (and list non-empty)
+      - ``'code-bearing'`` otherwise (mixed changes, code-only changes, and empty/None lists)
+    """
+    if not files_changed:
+        return "code-bearing"
+    cleaned = [f for f in files_changed if str(f).strip()]
+    if not cleaned:
+        return "code-bearing"
+    if all(is_doc_only_path(p) for p in cleaned):
+        return "doc-only"
+    return "code-bearing"
+
+
+def doc_only_budget_24h() -> int:
+    """Return the configured 24h budget for doc-only integrations (default 5)."""
+    raw = os.environ.get(_DOC_ONLY_BUDGET_ENV_VAR)
+    if raw is None:
+        return _DEFAULT_DOC_ONLY_24H_BUDGET
+    try:
+        val = int(raw.strip())
+        return max(0, val)
+    except Exception:
+        return _DEFAULT_DOC_ONLY_24H_BUDGET
+
+
+def count_doc_only_integrations_24h(state_dir: Path, now: datetime | None = None) -> int:
+    """Count terminal success outcomes in the last 24h classified as doc-only.
+
+    Reads only the current ``state_dir / 'ledger' / 'cycles.jsonl'`` (bounded,
+    no archive scans, with explicit byte cap). Fail-open to 0 on any filesystem/parse error.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=24)
+    ledger_file = state_dir / "ledger" / "cycles.jsonl"
+    if not ledger_file.is_file():
+        return 0
+
+    count = 0
+    try:
+        file_size = ledger_file.stat().st_size
+        with ledger_file.open("r", encoding="utf-8", errors="replace") as f:
+            if file_size > _MAX_LEDGER_BYTES_FOR_DOC_BUDGET:
+                f.seek(file_size - _MAX_LEDGER_BYTES_FOR_DOC_BUDGET)
+                f.readline()  # discard partial line
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if event.get("phase") != "outcome":
+                    continue
+                if event.get("outcome") != "success":
+                    continue
+                ts_str = event.get("ts")
+                if not ts_str:
+                    continue
+                try:
+                    event_ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    if event_ts.tzinfo is None:
+                        event_ts = event_ts.replace(tzinfo=timezone.utc)
+                except Exception:
+                    continue
+                if event_ts < cutoff:
+                    continue
+                tier = event.get("change_tier")
+                if tier is None:
+                    files_changed = event.get("files_changed", [])
+                    tier = classify_change_tier(files_changed)
+                if tier == "doc-only":
+                    count += 1
+    except Exception:
+        return 0
+    return count
+
+
 
 def demand_driven_enabled() -> bool:
     """#750-pattern kill switch: default ON; only the literal ``"0"`` disables."""
@@ -1909,10 +2036,14 @@ def _fold_completed(
             if success is None:
                 continue  # no terminal success for this cycle — not done
             files = success.get("files_changed")
+            tier = success.get("change_tier")
+            if tier is None:
+                tier = classify_change_tier(files if isinstance(files, list) else [])
             entries[demand_id] = {
                 "cycle_id": cycle_id,
                 "ts": str(success.get("ts") or ""),
                 "files_changed": files if isinstance(files, list) else [],
+                "change_tier": tier,
                 # #813: empty string when the proposed row carried no serves
                 # (or predates this field) — is_optimization_claim("") is
                 # False, so older/serves-less entries are unaffected.
@@ -2183,7 +2314,12 @@ def _reflection_items(
                 detail = str(recommendation.get("detail") or "").strip()
                 if detail:
                     evidence = str(recommendation.get("evidence") or "").strip()
-                    item = _make_item("reflection", detail, f"cycle {row['cycle_id']}: {evidence}")
+                    target_artifact = str(recommendation.get("target_artifact") or recommendation.get("target_path") or "").strip()
+                    if not target_artifact:
+                        m = _PATH_TOKEN_RE.search(detail)
+                        if m:
+                            target_artifact = m.group(0)
+                    item = _make_item("reflection", detail, f"cycle {row['cycle_id']}: {evidence}", affected_path=target_artifact)
                     try:
                         from nanobot.runtime import reflector
                         completed = _read_json(Path(state_dir) / "demand" / "completed.json", {})
@@ -2349,6 +2485,39 @@ def collect_demand(
                 kind_counts[k] = kind_counts.get(k, 0) + 1
             bounded_result.append(item)
         result = bounded_result
+
+        # #1090: Doc-only budget guard for presented reflection items.
+        # When terminal success integrations classified as doc-only in rolling 24h
+        # meet or exceed the budget (default 5, env EEEBOT_DOC_ONLY_24H_BUDGET),
+        # suppress presented reflection items that target doc-only paths.
+        # Non-doc reflection items and non-reflection lanes are completely unaffected.
+        doc_count_24h = count_doc_only_integrations_24h(state_dir, now=now)
+        doc_budget = doc_only_budget_24h()
+        doc_budget_exceeded = doc_count_24h >= doc_budget
+
+        post_doc_guard: list[dict[str, str]] = []
+        for item in result:
+            k = item.get("kind", "")
+            affected = item.get("affected_path", "")
+            if k == "reflection" and doc_budget_exceeded and is_doc_only_path(affected):
+                # Suppress doc-only reflection item under exceeded budget
+                continue
+            # When budget is exceeded, remaining reflection items get steering notice
+            if k == "reflection" and doc_budget_exceeded:
+                notice = (
+                    f"Doc-only daily budget ({doc_budget}) reached ({doc_count_24h} in 24h). "
+                    "Focus on code-bearing improvements (scripts/, runtime/, tests/)."
+                )
+                item["doc_budget_notice"] = notice
+                # Append steering notice to summary so it reaches LLM proposer prompt unconditionally
+                summary = item.get("summary", "")
+                if notice not in summary:
+                    item["summary"] = f"{summary} [STEERING NOTICE: {notice}]" if summary else notice
+            if k == "reflection" and is_non_confirmable_target(affected):
+                item["non_confirmable_target"] = "true"
+                item["steering_only"] = "true"
+            post_doc_guard.append(item)
+        result = post_doc_guard
 
         # #815: best-effort, operator-visible V1-vs-V2 split of what's
         # actually presented — never affects the returned list. Opt-in

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -306,13 +306,20 @@ def is_doc_only_path(path: str | Path) -> bool:
 
 
 def is_non_confirmable_target(target: str | Path | None) -> bool:
-    """Return True if target path is non-confirmable (doc/memory/lessons or AGENTS.md).
+    """Return True when a reflection target cannot produce usage evidence.
 
-    Conservative target classification for steering-only annotations.
+    A missing target is non-confirmable, as are targets outside the script
+    surfaces that the harness/usage layer can observe. This is steering-only:
+    it never blocks a demand or changes the gate.
     """
     if not target:
-        return False
-    return is_doc_only_path(target)
+        return True
+    normalized = str(target).replace("\\", "/").strip().lstrip("/")
+    if not normalized:
+        return True
+    if is_doc_only_path(normalized):
+        return True
+    return not bool(re.fullmatch(r"(?:scripts|surfaces)/[^/]+\.py", normalized))
 
 
 def classify_change_tier(files_changed: list[str] | None) -> str:
@@ -2516,6 +2523,12 @@ def collect_demand(
             if k == "reflection" and is_non_confirmable_target(affected):
                 item["non_confirmable_target"] = "true"
                 item["steering_only"] = "true"
+                steering_note = (
+                    "[STEERING ONLY: target cannot earn harness usage confirmation]"
+                )
+                summary = item.get("summary", "")
+                if steering_note not in summary:
+                    item["summary"] = f"{summary} {steering_note}".strip()
             post_doc_guard.append(item)
         result = post_doc_guard
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -895,10 +895,19 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
         owner_live_ratio_val = ol_res.get("ratio")
     except Exception:
         pass
+    # #1090: reporting-only counter of doc-only integrations in the rolling 24h window
+    doc_only_24h = 0
+    try:
+        from nanobot.runtime.demand import count_doc_only_integrations_24h
+        doc_only_24h = count_doc_only_integrations_24h(Path(state_dir), now=now)
+    except Exception:
+        pass
+
     return {
         "completed_declared": declared,
         "completed_confirmed": confirmed,
         "confirmed_ratio": _ratio(confirmed, declared),
+        "doc_only_integrations_24h": doc_only_24h,
         "owner_live_inventory": owner_live_inventory,
         "owner_live_active": owner_live_active,
         "owner_live_ratio": owner_live_ratio_val,

--- a/tests/test_bridge_release_root_coverage.py
+++ b/tests/test_bridge_release_root_coverage.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import json
 from pathlib import Path
 
 from nanobot.runtime import bridge, llm_proposer
 from nanobot.runtime.bridge import build_task
 from tests.test_cycle_ledger import _init_selfevo_repo, _seed_bridge_request
-
 
 CANONICAL_RELEASE_ROOT = "/opt/eeepc-agent/runtimes/self-evolving-agent/current"
 
@@ -41,6 +39,20 @@ def test_build_task_charter_pointer_only_when_in_system():
     assert "see system context" in pointer
     assert pointer.count("CHARTER_SENTINEL") == 1
     assert pointer.index("see system context") < pointer.index("CHARTER_SENTINEL")
+
+
+def test_build_task_renders_doc_budget_notice():
+    req = {
+        "task_title": "x",
+        "request_id": "r",
+        "cycle_id": "c",
+        "goal_id": "g",
+        "doc_budget_notice": "Doc-only daily budget (5) reached.",
+    }
+    rendered = build_task(req, "CHARTER", "", charter_in_system=False)
+    assert "## Value steering notice" in rendered
+    assert "Doc-only daily budget (5) reached." in rendered
+    assert "Prefer code-bearing improvements" in rendered
 
 
 class _ReleaseRootManager:

--- a/tests/test_cycle_ledger.py
+++ b/tests/test_cycle_ledger.py
@@ -109,6 +109,12 @@ class TestTypedHelpers:
         assert rows[0]["outcome"] == "success"
         assert rows[0]["files_changed"] == ["a.py"]
         assert rows[0]["branch"] == "selfevo/cycle-1"
+        assert rows[0]["change_tier"] == "code-bearing"
+
+    def test_record_cycle_outcome_doc_only_change_tier(self, tmp_path):
+        cycle_ledger.record_cycle_outcome(tmp_path, "c2", "success", None, ["docs/guide.md", "memory/facts/fact.json"], "selfevo/cycle-2")
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["change_tier"] == "doc-only"
 
     def test_record_cycle_outcome_invalid_enum_coerced_to_failed(self, tmp_path):
         """#720 test-plan contract: an invalid outcome value is coerced to
@@ -297,6 +303,7 @@ class TestBridgeIntegrationLedgerRows:
 
         outcome_rows = [r for r in rows if r["phase"] == "outcome"]
         assert outcome_rows[-1]["outcome"] == "success"
+        assert outcome_rows[-1]["change_tier"] == "code-bearing"
         assert "scripts/feature.py" in outcome_rows[-1]["files_changed"]
 
     def test_already_done_skip_writes_started_then_skipped(self, tmp_path, monkeypatch):

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -2785,6 +2785,126 @@ class TestIssue1038DemandLanesReproduction:
         assert len(artifacts) == 1
         assert artifacts[0]["id"] == item2["id"]
 
+class TestIssue1090DocGuard:
+    """Issue #1090: doc-only classification, daily budget, and steering."""
+
+    def test_classify_change_tier_doc_only(self):
+        assert demand.classify_change_tier(["docs/specs/foo.md"]) == "doc-only"
+        assert demand.classify_change_tier(["lessons/lessons.yaml", "memory/MEMORY.md"]) == "doc-only"
+        assert demand.classify_change_tier(["AGENTS.md", "docs/README.md"]) == "doc-only"
+
+    def test_classify_change_tier_code_bearing(self):
+        assert demand.classify_change_tier(["scripts/health_report.py"]) == "code-bearing"
+        assert demand.classify_change_tier(["nanobot/runtime/bridge.py"]) == "code-bearing"
+        assert demand.classify_change_tier(["tests/test_bridge.py"]) == "code-bearing"
+
+    def test_classify_change_tier_mixed(self):
+        assert demand.classify_change_tier(["docs/foo.md", "scripts/bar.py"]) == "code-bearing"
+        assert demand.classify_change_tier(["AGENTS.md", "nanobot/agent/subagent.py"]) == "code-bearing"
+        assert demand.classify_change_tier([]) == "code-bearing"
+
+    def test_count_doc_only_integrations_24h(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+
+        events = [
+            # Recent doc-only success
+            {"phase": "outcome", "outcome": "success", "files_changed": ["docs/a.md"], "ts": (now - timedelta(hours=2)).isoformat()},
+            # Recent code-bearing success
+            {"phase": "outcome", "outcome": "success", "files_changed": ["scripts/tool.py"], "ts": (now - timedelta(hours=3)).isoformat()},
+            # Recent doc-only success with explicit change_tier
+            {"phase": "outcome", "outcome": "success", "change_tier": "doc-only", "files_changed": ["lessons/error.yaml"], "ts": (now - timedelta(hours=4)).isoformat()},
+            # Old doc-only success (outside 24h)
+            {"phase": "outcome", "outcome": "success", "files_changed": ["docs/old.md"], "ts": (now - timedelta(hours=26)).isoformat()},
+            # Recent doc-only failure (not counted)
+            {"phase": "outcome", "outcome": "failed", "files_changed": ["docs/fail.md"], "ts": (now - timedelta(hours=1)).isoformat()},
+        ]
+        with open(ledger_dir / "cycles.jsonl", "w", encoding="utf-8") as f:
+            for ev in events:
+                f.write(json.dumps(ev) + "\n")
+
+        assert demand.count_doc_only_integrations_24h(state_dir, now=now) == 2
+
+    def test_reflection_doc_only_suppression_and_budget_notice(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        reflector_dir = state_dir / "reflector"
+        reflector_dir.mkdir(parents=True, exist_ok=True)
+        reflections = [
+            {"cycle_id": "c1", "created_at": _now_iso(5), "recommendations": [{"status": "active", "detail": "Improve docs/specs/a.md with more detail", "evidence": "good"}]},
+            {"cycle_id": "c2", "created_at": _now_iso(10), "recommendations": [{"status": "active", "detail": "Improve scripts/test_runner.py speed", "evidence": "slow"}]},
+        ]
+        (reflector_dir / "reflections.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in reflections) + "\n",
+            encoding="utf-8",
+        )
+
+        # Budget = 1, current doc count = 0 -> not suppressed, no notice
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda s, now=None: 0)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "1")
+        items = demand.collect_demand(state_dir, None)
+        refl_items = [i for i in items if i["kind"] == "reflection"]
+        assert len(refl_items) == 2
+        assert not any(i.get("doc_budget_notice") for i in refl_items)
+
+        # Budget = 1, current doc count = 1 -> doc-only reflection suppressed, code-bearing gets notice
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda s, now=None: 1)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "1")
+        items = demand.collect_demand(state_dir, None)
+        refl_items = [i for i in items if i["kind"] == "reflection"]
+        assert len(refl_items) == 1
+        assert "scripts/test_runner.py" in refl_items[0]["summary"]
+        assert "Doc-only daily budget (1) reached" in refl_items[0].get("doc_budget_notice", "")
+        assert "[STEERING NOTICE: Doc-only daily budget (1) reached" in refl_items[0]["summary"]
+
+    def test_completed_integrations_fold_preserves_change_tier(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+
+        events = [
+            {"phase": "proposed", "cycle_id": "c1", "demand_id": "d-doc", "ts": now.isoformat()},
+            {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "files_changed": ["docs/a.md"], "ts": now.isoformat()},
+            {"phase": "proposed", "cycle_id": "c2", "demand_id": "d-code", "ts": now.isoformat()},
+            {"phase": "outcome", "cycle_id": "c2", "outcome": "success", "files_changed": ["scripts/s.py"], "ts": now.isoformat()},
+        ]
+        with open(ledger_dir / "cycles.jsonl", "w", encoding="utf-8") as f:
+            for ev in events:
+                f.write(json.dumps(ev) + "\n")
+
+        demand._fold_completed(state_dir)
+        completed = json.loads((state_dir / "demand" / "completed.json").read_text(encoding="utf-8"))
+        assert completed["entries"]["d-doc"]["change_tier"] == "doc-only"
+        assert completed["entries"]["d-code"]["change_tier"] == "code-bearing"
+
+    def test_reflection_steering_only_for_non_confirmable_targets(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        reflector_dir = state_dir / "reflector"
+        reflector_dir.mkdir(parents=True, exist_ok=True)
+        reflections = [
+            {"cycle_id": "c1", "created_at": _now_iso(5), "recommendations": [{"status": "active", "detail": "Update AGENTS.md workflow guidelines", "evidence": "process"}]},
+            {"cycle_id": "c2", "created_at": _now_iso(10), "recommendations": [{"status": "active", "detail": "Improve scripts/test_runner.py speed", "evidence": "slow"}]},
+        ]
+        (reflector_dir / "reflections.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in reflections) + "\n",
+            encoding="utf-8",
+        )
+        items = demand.collect_demand(state_dir, None)
+        refl_items = {i["affected_path"]: i for i in items if i["kind"] == "reflection"}
+        assert refl_items["AGENTS.md"].get("steering_only") == "true"
+        assert refl_items["AGENTS.md"].get("non_confirmable_target") == "true"
+        assert "steering_only" not in refl_items["scripts/test_runner.py"]
+
+    def test_missing_or_malformed_ledger_fails_open(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        (ledger_dir / "cycles.jsonl").write_text("not json\n{bad\n", encoding="utf-8")
+        assert demand.count_doc_only_integrations_24h(state_dir) == 0
+
+
 class TestIssue1040DemandIODiet:
     """#1040: cycle I/O diet test suite."""
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -963,6 +963,7 @@ class TestGoalGaps:
         snap = scorecard.compute_scorecard(state_dir, None, force=True)
         assert snap["loop"]["confirmable_integrations"] == 2
         assert all(g["metric"] != "confirmed_integration_ratio" for g in snap["gaps"])
+        assert "doc_only_integrations_24h" in snap["value"]
 
     def test_confirmed_window_scores_higher_than_unconfirmed_window(self, tmp_path):
         """#814 acceptance: an (otherwise identical) window whose


### PR DESCRIPTION
## Summary
- classify terminal integrations as doc-only or code-bearing and preserve the class in completed demand evidence
- steer reflection demand away from doc-only work after a bounded rolling 24h budget (default 5)
- annotate non-confirmable reflection targets and report the doc-only count in scorecard value

## Scope and safety
- steering tier only; no gate, deny-set, fitness-target, or lesson-write policy changes
- current-ledger-only bounded read with 2 MiB cap; fail-open on malformed or unavailable state
- code-bearing demand remains unaffected
- `reflection_context.py` intentionally untouched (parallel #1089)

Closes #1090