### PR TITLE
feat(runtime): measure knowledge context lift

### DIFF
--- a/docs/TRUST_KERNEL.md
+++ b/docs/TRUST_KERNEL.md
@@ -37,6 +37,7 @@ nanobot/runtime/hypothesis_verdict.py
 nanobot/runtime/tech_tree.py
 nanobot/runtime/skill_fitness.py
 nanobot/runtime/skill_eval_harness.py
+nanobot/runtime/knowledge_lift.py
 nanobot/runtime/model_registry.py
 nanobot/runtime/knowledge_curator.py
 nanobot/runtime/context_compaction.py

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -166,6 +166,7 @@ _MAX_COMPILE_DEFECTS = 10
 _MAX_HELDOUT_DEFECTS = 5  # #780: bounded held-out failure demand
 _MAX_VALIDATOR_DEFECTS = 5  # #925: bounded validator-harness failure/findings demand
 _MAX_SKILL_EVAL_DEFECTS = 3  # #941: bounded skill-eval negative-delta demand
+_MAX_KNOWLEDGE_LIFT_DEFECTS = 1  # #1093: bounded knowledge-lift negative-delta demand
 # (#928 round 4) There was a _MAX_VALIDATOR_RUN_LINES = 500 here, used to
 # slice the sidecar's tail before filtering. It is gone rather than unused:
 # a few hundred forged rows with an unparseable path evicted every genuine
@@ -1104,6 +1105,28 @@ def _validator_defect_items(
                         affected_path=rel,
                     )
                 )
+        return items if limit is None else items[:limit]
+    except Exception:
+        return items
+
+
+def _knowledge_lift_defect_items(
+    state_dir: Path, *, limit: int | None = _MAX_KNOWLEDGE_LIFT_DEFECTS
+) -> list[dict[str, str]]:
+    """Harness-measured knowledge lift negative delta as defect demand (#1093)."""
+    items: list[dict[str, str]] = []
+    try:
+        from nanobot.runtime import knowledge_lift
+
+        for raw in knowledge_lift.negative_delta_demand(Path(state_dir), limit=limit):
+            items.append(
+                _make_item(
+                    "defect",
+                    raw.get("summary", ""),
+                    raw.get("evidence", ""),
+                    affected_path=raw.get("affected_path", ""),
+                )
+            )
         return items if limit is None else items[:limit]
     except Exception:
         return items
@@ -2405,6 +2428,7 @@ def collect_demand(
             _uncapped(_heldout_defect_items, state_dir),
             _uncapped(_validator_defect_items, state_dir),
             _uncapped(_skill_eval_defect_items, state_dir),
+            _uncapped(_knowledge_lift_defect_items, state_dir),
             _uncapped(_tamper_defect_items, state_dir, selfevo_repo),
             _uncapped(_repair_unused_items, state_dir, selfevo_repo, now, ledger_rows=ledger_rows),
             _uncapped(_goal_gap_items, state_dir, selfevo_repo, ledger_rows=ledger_rows),

--- a/nanobot/runtime/knowledge_lift.py
+++ b/nanobot/runtime/knowledge_lift.py
@@ -29,6 +29,7 @@ WATERMARK_REL = "knowledge_lift/watermark.json"
 
 # Operational constraints & sizing
 MAX_FILE_BYTES = 50_000
+MAX_PLAN_BYTES = 256_000
 MAX_CASES_PER_SET = 20
 MAX_ASSERTIONS_PER_CASE = 10
 MAX_WEEKLY_RUNS = 20
@@ -42,6 +43,8 @@ _RESERVED_KEYS = {
     "prompt",
     "assertions",
     "timeout_seconds",
+    "task_title",
+    "target_path",
 }
 
 _ALLOWED_ASSERTIONS = {
@@ -55,6 +58,22 @@ def is_enabled() -> bool:
     """Return True only if SELFEVO_KNOWLEDGE_LIFT_ENABLED is set to truthy."""
     val = os.environ.get(ENV_ENABLED, "").strip().lower()
     return val in ("1", "true", "yes", "on")
+
+
+def load_eval_plan(repo: Path) -> dict[str, Any] | None:
+    """Load the operator-authored fixed plan from the instance repo.
+
+    A missing plan is an honest no-op; plans are steering input and are
+    validated completely before any executor call.
+    """
+    try:
+        path = Path(repo) / "knowledge_lift" / "evals.json"
+        if not path.is_file() or path.stat().st_size > MAX_PLAN_BYTES:
+            return None
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else None
+    except Exception:
+        return None
 
 
 def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
@@ -92,8 +111,12 @@ def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
         seen_ids.add(case_id)
 
         prompt = c.get("prompt")
-        if not isinstance(prompt, str) or not prompt.strip():
-            return [], f"case[{case_id}] missing valid 'prompt'"
+        if not isinstance(prompt, str) or not prompt.strip() or len(prompt) > MAX_FILE_BYTES:
+            return [], f"case[{case_id}] missing or oversized 'prompt'"
+        task_title = c.get("task_title", case_id)
+        target_path = c.get("target_path", "")
+        if not isinstance(task_title, str) or not isinstance(target_path, str):
+            return [], f"case[{case_id}] task metadata has wrong type"
 
         assertions = c.get("assertions")
         if not isinstance(assertions, list) or len(assertions) == 0:
@@ -123,18 +146,20 @@ def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
             "prompt": prompt,
             "assertions": valid_assertions,
             "timeout_seconds": float(timeout_s),
+            "task_title": task_title[:200],
+            "target_path": target_path[:200],
         })
 
     return validated_cases, None
 
 
-def compute_knowledge_digest(repo_or_state: Path) -> str:
+def compute_knowledge_digest(repo_or_state: Path, state_dir: Path | None = None) -> str:
     """Digest only the bounded files that feed production knowledge context."""
     hasher = hashlib.sha256()
     try:
         root = Path(repo_or_state)
         paths = [root / "lessons" / "lessons.yaml", root / "lessons" / "errors.yaml"]
-        paths.append(root / "reflector" / "reflections.jsonl")
+        paths.append((Path(state_dir) if state_dir else root) / "reflector" / "reflections.jsonl")
         for path in paths:
             try:
                 if not path.is_file() or path.stat().st_size > MAX_FILE_BYTES:
@@ -146,6 +171,34 @@ def compute_knowledge_digest(repo_or_state: Path) -> str:
     except Exception:
         pass
     return hasher.hexdigest()
+
+
+def _executor_runner(prompt: str, with_knowledge: bool, timeout: float) -> dict[str, Any]:
+    """Bounded production executor; missing operator config is an error row."""
+    try:
+        base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
+        api_key = os.environ.get("LITELLM_API_KEY", "").strip()
+        if not base_url or not api_key:
+            return {"output": "", "exit_code": 1, "tokens": 0, "error": "runner_not_configured"}
+        from openai import OpenAI
+
+        from nanobot.runtime.model_registry import resolve_model
+        started = time.monotonic()
+        response = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout).chat.completions.create(
+            model=resolve_model("harness", strip_openai=True),
+            messages=[
+                {"role": "system", "content": "Complete the task concisely; output only the answer."},
+                {"role": "user", "content": prompt[:MAX_FILE_BYTES]},
+            ],
+            max_tokens=1000,
+            temperature=0.0,
+        )
+        choice = response.choices[0]
+        output = getattr(getattr(choice, "message", None), "content", "") or ""
+        usage = getattr(response, "usage", None)
+        return {"output": output, "exit_code": 0, "tokens": int(getattr(usage, "total_tokens", 0) or 0), "duration": time.monotonic() - started}
+    except Exception as exc:
+        return {"output": "", "exit_code": 1, "tokens": 0, "error": type(exc).__name__}
 
 
 def _read_json(path: Path, default: Any = None) -> Any:
@@ -179,9 +232,13 @@ def _atomic_write_json(path: Path, data: Any) -> None:
         raise
 
 
+SCHEMA = "knowledge-lift-v1"
+
+
 def _row_well_formed(row: Any) -> bool:
     return (
         isinstance(row, dict)
+        and row.get("schema") == SCHEMA
         and isinstance(row.get("case_id"), str)
         and bool(row.get("case_id"))
         and isinstance(row.get("with_pass"), bool)
@@ -235,6 +292,22 @@ def _atomic_write_eval_rows(path: Path, rows: list[dict[str, Any]]) -> None:
         raise
 
 
+def render_knowledge_prompt(prompt: str, knowledge: dict[str, Any] | None, *, with_knowledge: bool) -> str:
+    """Render the production knowledge sections for the A arm only.
+
+    The caller supplies already-rendered lessons/reflection text from the
+    production path; the B arm receives the identical task without them.
+    """
+    if not with_knowledge or not isinstance(knowledge, dict):
+        return prompt
+    sections = []
+    for key in ("lessons_context", "reflection_hints"):
+        value = knowledge.get(key)
+        if isinstance(value, str) and value.strip():
+            sections.append(value[:MAX_FILE_BYTES])
+    return ("\n\n".join(sections) + "\n\n" + prompt)[:MAX_FILE_BYTES] if sections else prompt
+
+
 def _check_assertions(assertions: list[dict[str, Any]], result: dict[str, Any]) -> bool:
     output = str(result.get("output", ""))
     exit_code = result.get("exit_code", 0)
@@ -273,6 +346,39 @@ def _bounded_runner_call(
     return result or {"output": "", "exit_code": 1, "tokens": 0, "error": "empty_result"}
 
 
+def _production_knowledge(repo: Path, state_dir: Path, case: dict[str, Any]) -> dict[str, str]:
+    """Use the same lesson/reflection producers as the proposer, read-only."""
+    out: dict[str, str] = {}
+    try:
+        from nanobot.runtime.lessons_context import build_lessons_context
+        from nanobot.runtime.reflection_context import build_reflection_hints
+        context = build_lessons_context(repo, case["task_title"], case["target_path"])
+        error = context.get("relevant_error") if isinstance(context, dict) else None
+        lesson = context.get("relevant_lesson") if isinstance(context, dict) else None
+        parts: list[str] = []
+        if isinstance(error, dict):
+            parts.extend([
+                "## Known pitfall for this task (from lessons/errors.yaml)",
+                f"ID: {error.get('id')}", f"Title: {error.get('title')}",
+                f"Root cause: {error.get('root_cause', '')}",
+                f"Prevention: {error.get('prevention', '')}", "",
+            ])
+        if isinstance(lesson, dict):
+            parts.extend([
+                "## Proven approach for this task (from lessons/lessons.yaml)",
+                f"ID: {lesson.get('id')}", f"Title: {lesson.get('title')}",
+                f"Problem: {lesson.get('problem') or lesson.get('approach', '')}",
+                f"Solution: {lesson.get('solution') or lesson.get('reusable_insight', '')}", "",
+            ])
+        hints = build_reflection_hints(state_dir, case["task_title"], case["target_path"])
+        if hints:
+            parts.extend(["## Recent reflections (how past cycles worked — steering hints)", *[f"- {h[:200]}" for h in hints[:3]], ""])
+        out["context"] = "\n".join(parts)[:MAX_FILE_BYTES]
+    except Exception:
+        return {}
+    return out
+
+
 def run_eval_case(
     case: dict[str, Any],
     runner: Callable[[str, bool, float], dict[str, Any]],
@@ -309,6 +415,7 @@ def run_eval_case(
 
     now_iso = datetime.now(timezone.utc).isoformat()
     return {
+        "schema": SCHEMA,
         "case_id": case_id,
         "with_pass": pass_with,
         "without_pass": pass_without,
@@ -356,7 +463,7 @@ def execute_knowledge_lift(
         return {"status": "rate_limited", "reason": "weekly_cap_exceeded", "rows_written": 0}
 
     # Check knowledge corpus digest watermark
-    current_digest = compute_knowledge_digest(selfevo_repo or state_dir)
+    current_digest = compute_knowledge_digest(selfevo_repo or state_dir, state_dir=state_dir)
     last_digest = watermark.get("knowledge_digest")
     if last_digest == current_digest and not force:
         return {"status": "watermarked", "reason": "knowledge_unchanged", "rows_written": 0}
@@ -372,7 +479,14 @@ def execute_knowledge_lift(
     for c in cases:
         if (time.monotonic() - start_total) >= total_timeout_s:
             break
-        row = run_eval_case(c, runner, prompt_builder=prompt_builder)
+        builder = prompt_builder
+        if builder is None:
+            knowledge = _production_knowledge(Path(selfevo_repo), state_dir, c) if selfevo_repo else {}
+
+            def builder(prompt: str, with_knowledge: bool, k: dict[str, str] = knowledge) -> str:
+                return render_knowledge_prompt(prompt, k, with_knowledge=with_knowledge)
+
+        row = run_eval_case(c, runner, prompt_builder=builder)
         new_rows.append(row)
 
     if not new_rows:
@@ -425,6 +539,47 @@ def read_knowledge_lift_summary(state_dir: Path) -> dict[str, Any]:
         "net_benefit": net_benefit,
         "latest_ts": latest_ts,
     }
+
+
+def run_all(
+    state_dir: Path,
+    repo: Path,
+    *,
+    runner: Callable[[str, bool, float], dict[str, Any]] | None = None,
+    lock_held: bool = False,
+) -> dict[str, Any]:
+    """Run the fixed knowledge plan from the existing #941 harness invocation.
+
+    No new timer is required: ``skill_eval_harness.run_all`` calls this while
+    holding the bridge lock. A direct CLI call acquires the same lock.
+    """
+    summary: dict[str, Any] = {"enabled": is_enabled(), "status": "disabled"}
+    if not is_enabled():
+        return summary
+    plan = load_eval_plan(Path(repo))
+    if plan is None:
+        summary["status"] = "missing_plan"
+        return summary
+    lock = None
+    if not lock_held:
+        from nanobot.runtime.skill_eval_harness import _acquire_bridge_lock
+
+        lock = _acquire_bridge_lock(Path(state_dir))
+        if lock is None:
+            summary["status"] = "bridge_busy"
+            return summary
+    try:
+        summary.update(execute_knowledge_lift(
+            Path(state_dir), plan, runner=runner or _executor_runner,
+            selfevo_repo=Path(repo),
+        ))
+        return summary
+    finally:
+        if lock is not None and lock is not True:
+            try:
+                lock.close()
+            except Exception:
+                pass
 
 
 def negative_delta_demand(state_dir: Path, *, limit: int | None = 1) -> list[dict[str, str]]:

--- a/nanobot/runtime/knowledge_lift.py
+++ b/nanobot/runtime/knowledge_lift.py
@@ -1,0 +1,417 @@
+"""Knowledge-lift harness (#1093): measures the incremental value of knowledge context.
+
+Runs matched A/B evaluations of tasks with knowledge context (lessons card +
+reflection hints) vs stripped knowledge context against an executor runner.
+Results land in a parent-owned sidecar protected by FITNESS_SIDECARS.
+Protected against tampering via atomic rewrite-at-exit.
+Budget-gated by weekly cap, knowledge corpus digest watermark, per-run timeout,
+and global kill-switch env (SELFEVO_KNOWLEDGE_LIFT_ENABLED, default OFF).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+# Environment kill-switch (default OFF)
+ENV_ENABLED = "SELFEVO_KNOWLEDGE_LIFT_ENABLED"
+
+# Sidecar paths relative to state_dir
+SIDECAR_REL = "knowledge_lift/evals.jsonl"
+WATERMARK_REL = "knowledge_lift/watermark.json"
+
+# Operational constraints & sizing
+MAX_FILE_BYTES = 50_000
+MAX_CASES_PER_SET = 20
+MAX_ASSERTIONS_PER_CASE = 10
+MAX_WEEKLY_RUNS = 20
+DEFAULT_CASE_TIMEOUT_S = 30.0
+DEFAULT_TOTAL_TIMEOUT_S = 120.0
+_MAX_HISTORY_ROWS = 500
+
+_RESERVED_KEYS = {
+    "case_id",
+    "prompt",
+    "assertions",
+    "timeout_seconds",
+}
+
+_ALLOWED_ASSERTIONS = {
+    "contains",
+    "not_contains",
+    "exit_code_zero",
+}
+
+
+def is_enabled() -> bool:
+    """Return True only if SELFEVO_KNOWLEDGE_LIFT_ENABLED is set to truthy."""
+    val = os.environ.get(ENV_ENABLED, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
+    """Schema-validate a knowledge eval set.
+
+    Fails closed: returns ([], error_message) on any malformed or oversized
+    input.
+    """
+    if not isinstance(raw, dict):
+        return [], "eval plan must be a JSON object"
+
+    cases = raw.get("cases")
+    if not isinstance(cases, list):
+        return [], "eval plan must contain a 'cases' list"
+
+    if len(cases) == 0:
+        return [], "cases list is empty"
+
+    if len(cases) > MAX_CASES_PER_SET:
+        return [], f"cases list exceeds maximum of {MAX_CASES_PER_SET}"
+
+    validated_cases: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for idx, c in enumerate(cases):
+        if not isinstance(c, dict):
+            return [], f"case[{idx}] must be an object"
+
+        case_id = c.get("case_id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            return [], f"case[{idx}] missing valid 'case_id'"
+        case_id = case_id.strip()
+        if case_id in seen_ids:
+            return [], f"duplicate case_id: {case_id}"
+        seen_ids.add(case_id)
+
+        prompt = c.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return [], f"case[{case_id}] missing valid 'prompt'"
+
+        assertions = c.get("assertions")
+        if not isinstance(assertions, list) or len(assertions) == 0:
+            return [], f"case[{case_id}] must have non-empty 'assertions' list"
+        if len(assertions) > MAX_ASSERTIONS_PER_CASE:
+            return [], f"case[{case_id}] exceeds max assertions ({MAX_ASSERTIONS_PER_CASE})"
+
+        valid_assertions: list[dict[str, Any]] = []
+        for a_idx, a in enumerate(assertions):
+            if not isinstance(a, dict):
+                return [], f"case[{case_id}] assertion[{a_idx}] must be an object"
+            atype = a.get("type")
+            if atype not in _ALLOWED_ASSERTIONS:
+                return [], f"case[{case_id}] assertion[{a_idx}] unknown type: {atype}"
+            if atype in ("contains", "not_contains"):
+                val = a.get("value")
+                if not isinstance(val, str) or not val:
+                    return [], f"case[{case_id}] assertion[{a_idx}] missing 'value'"
+            valid_assertions.append(a)
+
+        timeout_s = c.get("timeout_seconds", DEFAULT_CASE_TIMEOUT_S)
+        if not isinstance(timeout_s, (int, float)) or timeout_s <= 0:
+            timeout_s = DEFAULT_CASE_TIMEOUT_S
+
+        validated_cases.append({
+            "case_id": case_id,
+            "prompt": prompt,
+            "assertions": valid_assertions,
+            "timeout_seconds": float(timeout_s),
+        })
+
+    return validated_cases, None
+
+
+def compute_knowledge_digest(repo_or_state: Path) -> str:
+    """Compute sha256 digest over knowledge corpus (lessons, hints, etc.)."""
+    hasher = hashlib.sha256()
+    try:
+        p = Path(repo_or_state)
+        # Scan lessons files if present
+        lessons_dir = p / "lessons"
+        if lessons_dir.is_dir():
+            for f in sorted(lessons_dir.glob("*.md")):
+                try:
+                    hasher.update(f.name.encode("utf-8"))
+                    hasher.update(f.read_bytes())
+                except Exception:
+                    pass
+        # Scan state_dir reflection / knowledge files if present
+        reflections_file = p / "reflections" / "latest.json"
+        if reflections_file.is_file():
+            try:
+                hasher.update(reflections_file.read_bytes())
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return hasher.hexdigest()
+
+
+def _read_json(path: Path, default: Any = None) -> Any:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return default
+
+
+def _atomic_write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        delete=False,
+    )
+    try:
+        json.dump(data, temp_file, indent=2, ensure_ascii=False)
+        temp_file.flush()
+        os.fsync(temp_file.fileno())
+        temp_file.close()
+        os.replace(temp_file.name, path)
+    except Exception:
+        if os.path.exists(temp_file.name):
+            try:
+                os.unlink(temp_file.name)
+            except Exception:
+                pass
+        raise
+
+
+def _read_eval_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.is_file():
+        return rows
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                    if isinstance(row, dict) and "case_id" in row:
+                        rows.append(row)
+                except Exception:
+                    continue
+    except Exception:
+        pass
+    return rows
+
+
+def _atomic_write_eval_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_file = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        delete=False,
+    )
+    try:
+        # Keep tail rows within limit
+        for row in rows[-_MAX_HISTORY_ROWS:]:
+            temp_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+        temp_file.flush()
+        os.fsync(temp_file.fileno())
+        temp_file.close()
+        os.replace(temp_file.name, path)
+    except Exception:
+        if os.path.exists(temp_file.name):
+            try:
+                os.unlink(temp_file.name)
+            except Exception:
+                pass
+        raise
+
+
+def _check_assertions(assertions: list[dict[str, Any]], result: dict[str, Any]) -> bool:
+    output = str(result.get("output", ""))
+    exit_code = result.get("exit_code", 0)
+    for a in assertions:
+        atype = a.get("type")
+        val = str(a.get("value", ""))
+        if atype == "contains" and val not in output:
+            return False
+        if atype == "not_contains" and val in output:
+            return False
+        if atype == "exit_code_zero" and exit_code != 0:
+            return False
+    return True
+
+
+def run_eval_case(
+    case: dict[str, Any],
+    runner: Callable[[str, bool, float], dict[str, Any]],
+) -> dict[str, Any]:
+    """Run a single test case under A (with knowledge) and B (without knowledge).
+
+    runner signature: (prompt, with_knowledge, timeout_s) -> {output: str, exit_code: int, tokens: int, error?: str}
+    """
+    case_id = case["case_id"]
+    prompt = case["prompt"]
+    assertions = case["assertions"]
+    timeout_s = case["timeout_seconds"]
+
+    # Run with knowledge
+    t0 = time.monotonic()
+    try:
+        res_with = runner(prompt, True, timeout_s)
+    except Exception as e:
+        res_with = {"output": "", "exit_code": 1, "tokens": 0, "error": str(e)}
+    dur_with = round(time.monotonic() - t0, 3)
+    pass_with = (res_with.get("error") is None) and _check_assertions(assertions, res_with)
+    tokens_with = int(res_with.get("tokens", 0) or 0)
+
+    # Run without knowledge
+    t0 = time.monotonic()
+    try:
+        res_without = runner(prompt, False, timeout_s)
+    except Exception as e:
+        res_without = {"output": "", "exit_code": 1, "tokens": 0, "error": str(e)}
+    dur_without = round(time.monotonic() - t0, 3)
+    pass_without = (res_without.get("error") is None) and _check_assertions(assertions, res_without)
+    tokens_without = int(res_without.get("tokens", 0) or 0)
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    return {
+        "case_id": case_id,
+        "with_pass": pass_with,
+        "without_pass": pass_without,
+        "with_tokens": tokens_with,
+        "without_tokens": tokens_without,
+        "with_duration_s": dur_with,
+        "without_duration_s": dur_without,
+        "delta_pass": 1 if (pass_with and not pass_without) else (-1 if (not pass_with and pass_without) else 0),
+        "delta_tokens": tokens_with - tokens_without,
+        "ts": now_iso,
+    }
+
+
+def execute_knowledge_lift(
+    state_dir: Path,
+    eval_plan_raw: dict[str, Any],
+    *,
+    runner: Callable[[str, bool, float], dict[str, Any]],
+    selfevo_repo: Path | None = None,
+    total_timeout_s: float = DEFAULT_TOTAL_TIMEOUT_S,
+    now: datetime | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Execute knowledge lift evaluation if enabled and within budget limits."""
+    if not is_enabled() and not force:
+        return {"status": "disabled", "rows_written": 0}
+
+    cases, err = validate_eval_plan(eval_plan_raw)
+    if err or not cases:
+        return {"status": "rejected", "error": err or "invalid plan", "rows_written": 0}
+
+    state_dir = Path(state_dir)
+    now = now or datetime.now(timezone.utc)
+    now_ts = now.timestamp()
+    one_week_ago_ts = (now - timedelta(days=7)).timestamp()
+
+    watermark_path = state_dir / WATERMARK_REL
+    watermark = _read_json(watermark_path, {}) or {}
+
+    # Check weekly cap
+    run_history = watermark.get("runs", [])
+    recent_runs = [t for t in run_history if isinstance(t, (int, float)) and t >= one_week_ago_ts]
+    if len(recent_runs) >= MAX_WEEKLY_RUNS and not force:
+        return {"status": "rate_limited", "reason": "weekly_cap_exceeded", "rows_written": 0}
+
+    # Check knowledge corpus digest watermark
+    current_digest = compute_knowledge_digest(selfevo_repo or state_dir)
+    last_digest = watermark.get("knowledge_digest")
+    if last_digest == current_digest and not force:
+        return {"status": "watermarked", "reason": "knowledge_unchanged", "rows_written": 0}
+
+    # Parent atomic load of existing sidecar rows
+    sidecar_path = state_dir / SIDECAR_REL
+    existing_rows = _read_eval_rows(sidecar_path)
+
+    new_rows: list[dict[str, Any]] = []
+    start_total = time.monotonic()
+
+    for c in cases:
+        if (time.monotonic() - start_total) >= total_timeout_s:
+            break
+        row = run_eval_case(c, runner)
+        new_rows.append(row)
+
+    if not new_rows:
+        return {"status": "timeout_before_runs", "rows_written": 0}
+
+    # Parent atomic rewrite of sidecar: existing + new rows
+    combined_rows = existing_rows + new_rows
+    _atomic_write_eval_rows(sidecar_path, combined_rows)
+
+    # Update watermark atomically
+    recent_runs.append(now_ts)
+    watermark["runs"] = recent_runs
+    watermark["knowledge_digest"] = current_digest
+    watermark["last_run_utc"] = now.isoformat()
+    _atomic_write_json(watermark_path, watermark)
+
+    return {
+        "status": "completed",
+        "rows_written": len(new_rows),
+        "total_rows": len(combined_rows),
+    }
+
+
+def read_knowledge_lift_summary(state_dir: Path) -> dict[str, Any]:
+    """Read knowledge lift summary metrics from sidecar (reporting-only)."""
+    sidecar_path = Path(state_dir) / SIDECAR_REL
+    rows = _read_eval_rows(sidecar_path)
+    if not rows:
+        return {
+            "total_evals": 0,
+            "pass_lift": 0,
+            "token_lift_avg": 0.0,
+            "net_benefit": True,
+            "latest_ts": None,
+        }
+
+    total = len(rows)
+    pass_lift = sum(r.get("delta_pass", 0) for r in rows)
+    token_diffs = [r.get("delta_tokens", 0) for r in rows]
+    avg_token_diff = round(sum(token_diffs) / total, 1) if total > 0 else 0.0
+    latest_ts = rows[-1].get("ts")
+
+    # Net benefit is negative if lift is strictly negative
+    net_benefit = pass_lift >= 0
+
+    return {
+        "total_evals": total,
+        "pass_lift": pass_lift,
+        "token_lift_avg": avg_token_diff,
+        "net_benefit": net_benefit,
+        "latest_ts": latest_ts,
+    }
+
+
+def negative_delta_demand(state_dir: Path, *, limit: int | None = 1) -> list[dict[str, str]]:
+    """Return negative lift findings as defect demand items if knowledge hurts."""
+    summary = read_knowledge_lift_summary(state_dir)
+    if summary.get("total_evals", 0) == 0 or summary.get("net_benefit", True):
+        return []
+
+    pass_lift = summary.get("pass_lift", 0)
+    token_avg = summary.get("token_lift_avg", 0.0)
+
+    evidence = (
+        f"Knowledge lift A/B evaluation shows negative impact: "
+        f"net pass delta {pass_lift} across {summary.get('total_evals')} cases, "
+        f"average token overhead {token_avg}. Knowledge context may be degrading execution."
+    )
+    item = {
+        "summary": "Knowledge context negative lift detected in A/B evaluations",
+        "evidence": evidence,
+        "affected_path": "nanobot/runtime/reflection_context.py",
+    }
+    return [item] if limit is None else [item][:limit]

--- a/nanobot/runtime/knowledge_lift.py
+++ b/nanobot/runtime/knowledge_lift.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import tempfile
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -34,6 +35,7 @@ MAX_WEEKLY_RUNS = 20
 DEFAULT_CASE_TIMEOUT_S = 30.0
 DEFAULT_TOTAL_TIMEOUT_S = 120.0
 _MAX_HISTORY_ROWS = 500
+_MAX_RUN_SECONDS = 120.0
 
 _RESERVED_KEYS = {
     "case_id",
@@ -113,8 +115,8 @@ def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
             valid_assertions.append(a)
 
         timeout_s = c.get("timeout_seconds", DEFAULT_CASE_TIMEOUT_S)
-        if not isinstance(timeout_s, (int, float)) or timeout_s <= 0:
-            timeout_s = DEFAULT_CASE_TIMEOUT_S
+        if not isinstance(timeout_s, (int, float)) or not (0 < timeout_s <= DEFAULT_CASE_TIMEOUT_S):
+            return [], f"case[{case_id}] timeout exceeds maximum"
 
         validated_cases.append({
             "case_id": case_id,
@@ -127,26 +129,20 @@ def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
 
 
 def compute_knowledge_digest(repo_or_state: Path) -> str:
-    """Compute sha256 digest over knowledge corpus (lessons, hints, etc.)."""
+    """Digest only the bounded files that feed production knowledge context."""
     hasher = hashlib.sha256()
     try:
-        p = Path(repo_or_state)
-        # Scan lessons files if present
-        lessons_dir = p / "lessons"
-        if lessons_dir.is_dir():
-            for f in sorted(lessons_dir.glob("*.md")):
-                try:
-                    hasher.update(f.name.encode("utf-8"))
-                    hasher.update(f.read_bytes())
-                except Exception:
-                    pass
-        # Scan state_dir reflection / knowledge files if present
-        reflections_file = p / "reflections" / "latest.json"
-        if reflections_file.is_file():
+        root = Path(repo_or_state)
+        paths = [root / "lessons" / "lessons.yaml", root / "lessons" / "errors.yaml"]
+        paths.append(root / "reflector" / "reflections.jsonl")
+        for path in paths:
             try:
-                hasher.update(reflections_file.read_bytes())
+                if not path.is_file() or path.stat().st_size > MAX_FILE_BYTES:
+                    continue
+                hasher.update(path.name.encode("utf-8"))
+                hasher.update(path.read_bytes())
             except Exception:
-                pass
+                continue
     except Exception:
         pass
     return hasher.hexdigest()
@@ -183,25 +179,35 @@ def _atomic_write_json(path: Path, data: Any) -> None:
         raise
 
 
+def _row_well_formed(row: Any) -> bool:
+    return (
+        isinstance(row, dict)
+        and isinstance(row.get("case_id"), str)
+        and bool(row.get("case_id"))
+        and isinstance(row.get("with_pass"), bool)
+        and isinstance(row.get("without_pass"), bool)
+        and isinstance(row.get("delta_pass"), int)
+        and isinstance(row.get("delta_tokens"), int)
+        and isinstance(row.get("ts"), str)
+    )
+
+
 def _read_eval_rows(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    if not path.is_file():
-        return rows
     try:
+        if not path.is_file() or path.stat().st_size > MAX_FILE_BYTES * 40:
+            return rows
         with open(path, "r", encoding="utf-8") as fh:
             for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
                 try:
                     row = json.loads(line)
-                    if isinstance(row, dict) and "case_id" in row:
-                        rows.append(row)
                 except Exception:
                     continue
+                if _row_well_formed(row):
+                    rows.append(row)
     except Exception:
         pass
-    return rows
+    return rows[-_MAX_HISTORY_ROWS:]
 
 
 def _atomic_write_eval_rows(path: Path, rows: list[dict[str, Any]]) -> None:
@@ -244,9 +250,33 @@ def _check_assertions(assertions: list[dict[str, Any]], result: dict[str, Any]) 
     return True
 
 
+def _bounded_runner_call(
+    runner: Callable[[str, bool, float], dict[str, Any]],
+    prompt: str,
+    with_knowledge: bool,
+    timeout_s: float,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+
+    def invoke() -> None:
+        try:
+            raw = runner(prompt, with_knowledge, timeout_s)
+            result.update(raw if isinstance(raw, dict) else {"output": str(raw)})
+        except Exception as exc:
+            result.update({"output": "", "exit_code": 1, "tokens": 0, "error": type(exc).__name__})
+
+    thread = threading.Thread(target=invoke, daemon=True)
+    thread.start()
+    thread.join(min(timeout_s, DEFAULT_CASE_TIMEOUT_S))
+    if thread.is_alive():
+        return {"output": "", "exit_code": 1, "tokens": 0, "error": "timeout"}
+    return result or {"output": "", "exit_code": 1, "tokens": 0, "error": "empty_result"}
+
+
 def run_eval_case(
     case: dict[str, Any],
     runner: Callable[[str, bool, float], dict[str, Any]],
+    prompt_builder: Callable[[str, bool], str] | None = None,
 ) -> dict[str, Any]:
     """Run a single test case under A (with knowledge) and B (without knowledge).
 
@@ -260,7 +290,7 @@ def run_eval_case(
     # Run with knowledge
     t0 = time.monotonic()
     try:
-        res_with = runner(prompt, True, timeout_s)
+        res_with = _bounded_runner_call(runner, prompt_builder(prompt, True) if prompt_builder else prompt, True, timeout_s)
     except Exception as e:
         res_with = {"output": "", "exit_code": 1, "tokens": 0, "error": str(e)}
     dur_with = round(time.monotonic() - t0, 3)
@@ -270,7 +300,7 @@ def run_eval_case(
     # Run without knowledge
     t0 = time.monotonic()
     try:
-        res_without = runner(prompt, False, timeout_s)
+        res_without = _bounded_runner_call(runner, prompt_builder(prompt, False) if prompt_builder else prompt, False, timeout_s)
     except Exception as e:
         res_without = {"output": "", "exit_code": 1, "tokens": 0, "error": str(e)}
     dur_without = round(time.monotonic() - t0, 3)
@@ -298,6 +328,7 @@ def execute_knowledge_lift(
     *,
     runner: Callable[[str, bool, float], dict[str, Any]],
     selfevo_repo: Path | None = None,
+    prompt_builder: Callable[[str, bool], str] | None = None,
     total_timeout_s: float = DEFAULT_TOTAL_TIMEOUT_S,
     now: datetime | None = None,
     force: bool = False,
@@ -336,11 +367,12 @@ def execute_knowledge_lift(
 
     new_rows: list[dict[str, Any]] = []
     start_total = time.monotonic()
+    total_timeout_s = min(max(float(total_timeout_s), 0.0), _MAX_RUN_SECONDS)
 
     for c in cases:
         if (time.monotonic() - start_total) >= total_timeout_s:
             break
-        row = run_eval_case(c, runner)
+        row = run_eval_case(c, runner, prompt_builder=prompt_builder)
         new_rows.append(row)
 
     if not new_rows:
@@ -378,8 +410,8 @@ def read_knowledge_lift_summary(state_dir: Path) -> dict[str, Any]:
         }
 
     total = len(rows)
-    pass_lift = sum(r.get("delta_pass", 0) for r in rows)
-    token_diffs = [r.get("delta_tokens", 0) for r in rows]
+    pass_lift = sum(int(r.get("delta_pass", 0) or 0) for r in rows)
+    token_diffs = [int(r.get("delta_tokens", 0) or 0) for r in rows]
     avg_token_diff = round(sum(token_diffs) / total, 1) if total > 0 else 0.0
     latest_ts = rows[-1].get("ts")
 

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -102,6 +102,8 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     # 'harness' are not in _RUNTIME_DENY_TOKENS, deliberately, so unrelated
     # future '*_eval*.py'/'*_harness.py' modules are not swept in by name).
     'nanobot/runtime/skill_eval_harness.py',
+    # #1093: knowledge-lift evaluation harness
+    'nanobot/runtime/knowledge_lift.py',
     # #899: the single resolver for runtime LLM model selection (operator
     # control-plane, same tier as bridge.py's own model knobs) — the loop
     # must never be able to rewrite which model each role runs on.

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -985,6 +985,9 @@ FITNESS_SIDECARS = (
     # (skill_eval_harness._acquire_bridge_lock), so a legitimate write can
     # never land inside a #789 spawn window and be misread as tampering.
     "skill_evals/watermark.json",
+    # #1093: knowledge lift sidecar & watermark
+    "knowledge_lift/evals.jsonl",
+    "knowledge_lift/watermark.json",
 )
 
 
@@ -1022,6 +1025,30 @@ _FEEDS: tuple[tuple[str, str, bool, str | None, int], ...] = (
         12 * 3600,
     ),
 )
+
+
+def _knowledge_lift_section(state_dir: Path | None) -> dict[str, Any]:
+    """#1093: Reporting-only summary of knowledge lift evaluations."""
+    if state_dir is None:
+        return {
+            "total_evals": 0,
+            "pass_lift": 0,
+            "token_lift_avg": 0.0,
+            "net_benefit": True,
+            "latest_ts": None,
+        }
+    try:
+        from nanobot.runtime import knowledge_lift
+
+        return knowledge_lift.read_knowledge_lift_summary(Path(state_dir))
+    except Exception:
+        return {
+            "total_evals": 0,
+            "pass_lift": 0,
+            "token_lift_avg": 0.0,
+            "net_benefit": True,
+            "latest_ts": None,
+        }
 
 
 def _feed_latest_timestamp(
@@ -1501,6 +1528,8 @@ def compute_scorecard(
             "heldout": _heldout_section(state_dir),
             "integrity": _integrity_section(rows),
             "feeds": _feeds_section(state_dir, now),
+            # #1093: reporting-only knowledge lift A/B summary (no fitness target)
+            "knowledge_lift": _knowledge_lift_section(state_dir),
             # #865: visibility-only snapshot of active operator flags — never
             # fed into fitness/targets/gaps below.
             "control_plane": _control_plane_snapshot(state_dir),
@@ -1580,6 +1609,7 @@ def compute_scorecard(
             "value": {},
             "heldout": {},
             "integrity": {},
+            "knowledge_lift": {},
             "gaps": [],
             "control_plane": _control_plane_snapshot(state_dir),
         }

--- a/nanobot/runtime/skill_eval_harness.py
+++ b/nanobot/runtime/skill_eval_harness.py
@@ -597,7 +597,19 @@ def run_all(state_dir: Path, repo: Path, *, runner: Runner | None = None) -> dic
         summary["skipped"] = "bridge_busy"
         return summary
     try:
-        return _run_all_locked(state_dir, repo, summary, runner=runner)
+        result = _run_all_locked(state_dir, repo, summary, runner=runner)
+        # #1093: reuse this existing parent-owned harness invocation and lock;
+        # knowledge lift is independently default-off and therefore inert
+        # unless its operator kill-switch is explicitly enabled.
+        try:
+            from nanobot.runtime import knowledge_lift
+
+            result["knowledge_lift"] = knowledge_lift.run_all(
+                Path(state_dir), Path(repo), lock_held=True,
+            )
+        except Exception:
+            pass
+        return result
     finally:
         if lock is not True:
             try:

--- a/tests/test_knowledge_lift.py
+++ b/tests/test_knowledge_lift.py
@@ -1,0 +1,294 @@
+"""Tests for knowledge lift harness (#1093)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import demand, knowledge_lift, runtime_deny, scorecard
+
+
+@pytest.fixture
+def state_dir(tmp_path: Path) -> Path:
+    s = tmp_path / "state"
+    s.mkdir()
+    return s
+
+
+def test_runtime_deny_and_scorecard_sidecars():
+    """Knowledge lift module is runtime-denied and sidecars are in FITNESS_SIDECARS."""
+    assert runtime_deny._is_runtime_deny("nanobot/runtime/knowledge_lift.py")
+    assert knowledge_lift.SIDECAR_REL in scorecard.FITNESS_SIDECARS
+    assert knowledge_lift.WATERMARK_REL in scorecard.FITNESS_SIDECARS
+
+
+def test_default_off(monkeypatch, state_dir: Path):
+    """When env is unset or false, knowledge lift is disabled and inert."""
+    monkeypatch.delenv("SELFEVO_KNOWLEDGE_LIFT_ENABLED", raising=False)
+    assert not knowledge_lift.is_enabled()
+
+    plan = {
+        "cases": [
+            {
+                "case_id": "test_1",
+                "prompt": "Say hello",
+                "assertions": [{"type": "contains", "value": "hello"}],
+            }
+        ]
+    }
+
+    def dummy_runner(prompt, with_knowledge, timeout):
+        return {"output": "hello", "exit_code": 0, "tokens": 10}
+
+    res = knowledge_lift.execute_knowledge_lift(state_dir, plan, runner=dummy_runner)
+    assert res["status"] == "disabled"
+    assert not (state_dir / knowledge_lift.SIDECAR_REL).exists()
+
+
+def test_schema_validation_and_rejection():
+    """Malformed or oversized plans fail closed without executing."""
+    # Not a dict
+    cases, err = knowledge_lift.validate_eval_plan(["not a dict"])
+    assert cases == []
+    assert err is not None
+
+    # Missing cases
+    cases, err = knowledge_lift.validate_eval_plan({})
+    assert cases == []
+    assert "cases" in err
+
+    # Empty cases
+    cases, err = knowledge_lift.validate_eval_plan({"cases": []})
+    assert cases == []
+    assert "empty" in err
+
+    # Too many cases
+    huge_cases = [
+        {"case_id": f"c_{i}", "prompt": "p", "assertions": [{"type": "exit_code_zero"}]}
+        for i in range(knowledge_lift.MAX_CASES_PER_SET + 1)
+    ]
+    cases, err = knowledge_lift.validate_eval_plan({"cases": huge_cases})
+    assert cases == []
+    assert "exceeds maximum" in err
+
+    # Duplicate case_id
+    dup_cases = [
+        {"case_id": "dup", "prompt": "p", "assertions": [{"type": "exit_code_zero"}]},
+        {"case_id": "dup", "prompt": "p2", "assertions": [{"type": "exit_code_zero"}]},
+    ]
+    cases, err = knowledge_lift.validate_eval_plan({"cases": dup_cases})
+    assert cases == []
+    assert "duplicate" in err
+
+    # Invalid assertion type
+    bad_assert = [
+        {"case_id": "c1", "prompt": "p", "assertions": [{"type": "unknown_assert"}]}
+    ]
+    cases, err = knowledge_lift.validate_eval_plan({"cases": bad_assert})
+    assert cases == []
+    assert "unknown type" in err
+
+
+def test_ab_execution_and_parent_atomic_rewrite(monkeypatch, state_dir: Path):
+    """A/B run writes protected sidecar and survives forged rows."""
+    monkeypatch.setenv("SELFEVO_KNOWLEDGE_LIFT_ENABLED", "1")
+
+    plan = {
+        "cases": [
+            {
+                "case_id": "lift_case",
+                "prompt": "fix error X",
+                "assertions": [
+                    {"type": "contains", "value": "solution"},
+                    {"type": "exit_code_zero"},
+                ],
+            }
+        ]
+    }
+
+    # Runner succeeds only WITH knowledge
+    def mock_runner(prompt, with_knowledge, timeout):
+        if with_knowledge:
+            return {"output": "solution applied", "exit_code": 0, "tokens": 150}
+        return {"output": "failed error", "exit_code": 1, "tokens": 100}
+
+    res = knowledge_lift.execute_knowledge_lift(state_dir, plan, runner=mock_runner)
+    assert res["status"] == "completed"
+    assert res["rows_written"] == 1
+
+    summary = knowledge_lift.read_knowledge_lift_summary(state_dir)
+    assert summary["total_evals"] == 1
+    assert summary["pass_lift"] == 1
+    assert summary["net_benefit"] is True
+
+    # Test forged row discarded / parent atomic rewrite
+    sidecar_path = state_dir / knowledge_lift.SIDECAR_REL
+    with open(sidecar_path, "a", encoding="utf-8") as f:
+        f.write("invalid json row\n")
+        f.write(json.dumps({"forged": "no case_id"}) + "\n")
+
+    summary2 = knowledge_lift.read_knowledge_lift_summary(state_dir)
+    assert summary2["total_evals"] == 1  # Forged rows ignored
+
+    # Run another plan with force=True, ensure rewrite produces clean rows
+    plan2 = {
+        "cases": [
+            {
+                "case_id": "case_2",
+                "prompt": "do something",
+                "assertions": [{"type": "contains", "value": "ok"}],
+            }
+        ]
+    }
+    res2 = knowledge_lift.execute_knowledge_lift(state_dir, plan2, runner=lambda p, k, t: {"output": "ok", "exit_code": 0, "tokens": 50}, force=True)
+    assert res2["status"] == "completed"
+    summary3 = knowledge_lift.read_knowledge_lift_summary(state_dir)
+    assert summary3["total_evals"] == 2
+
+
+def test_timeouts_and_hung_case(monkeypatch, state_dir: Path):
+    """Per-case errors/timeouts and total timeouts are handled gracefully."""
+    monkeypatch.setenv("SELFEVO_KNOWLEDGE_LIFT_ENABLED", "1")
+
+    plan = {
+        "cases": [
+            {
+                "case_id": "hang_case",
+                "prompt": "hang",
+                "timeout_seconds": 0.1,
+                "assertions": [{"type": "exit_code_zero"}],
+            },
+            {
+                "case_id": "fast_case",
+                "prompt": "fast",
+                "timeout_seconds": 1.0,
+                "assertions": [{"type": "contains", "value": "fast"}],
+            },
+        ]
+    }
+
+    def hung_runner(prompt, with_knowledge, timeout):
+        if prompt == "hang":
+            raise TimeoutError("Execution timed out")
+        return {"output": "fast result", "exit_code": 0, "tokens": 20}
+
+    res = knowledge_lift.execute_knowledge_lift(
+        state_dir,
+        plan,
+        runner=hung_runner,
+        total_timeout_s=5.0,
+    )
+    assert res["status"] == "completed"
+    assert res["rows_written"] == 2
+
+    rows = knowledge_lift._read_eval_rows(state_dir / knowledge_lift.SIDECAR_REL)
+    assert len(rows) == 2
+    hang_row = next(r for r in rows if r["case_id"] == "hang_case")
+    assert hang_row["with_pass"] is False
+    assert hang_row["without_pass"] is False
+
+
+def test_watermark_and_weekly_cap(monkeypatch, state_dir: Path, tmp_path: Path):
+    """Digest watermark and weekly cap prevent runaway execution."""
+    monkeypatch.setenv("SELFEVO_KNOWLEDGE_LIFT_ENABLED", "1")
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    lessons_dir = repo_dir / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "lesson_1.md").write_text("initial lesson content", encoding="utf-8")
+
+    plan = {
+        "cases": [
+            {
+                "case_id": "c1",
+                "prompt": "p",
+                "assertions": [{"type": "exit_code_zero"}],
+            }
+        ]
+    }
+
+    def runner(prompt, with_k, timeout):
+        return {"output": "", "exit_code": 0, "tokens": 10}
+
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    # First execution succeeds
+    res1 = knowledge_lift.execute_knowledge_lift(
+        state_dir, plan, runner=runner, selfevo_repo=repo_dir, now=now
+    )
+    assert res1["status"] == "completed"
+
+    # Second execution immediately after without change is watermarked
+    res2 = knowledge_lift.execute_knowledge_lift(
+        state_dir, plan, runner=runner, selfevo_repo=repo_dir, now=now + timedelta(minutes=10)
+    )
+    assert res2["status"] == "watermarked"
+    assert res2["reason"] == "knowledge_unchanged"
+
+    # Updating knowledge allows new run
+    (lessons_dir / "lesson_1.md").write_text("updated lesson content", encoding="utf-8")
+    res3 = knowledge_lift.execute_knowledge_lift(
+        state_dir, plan, runner=runner, selfevo_repo=repo_dir, now=now + timedelta(hours=1)
+    )
+    assert res3["status"] == "completed"
+
+    # Weekly cap check: fill runs up to MAX_WEEKLY_RUNS
+    watermark_path = state_dir / knowledge_lift.WATERMARK_REL
+    wm = json.loads(watermark_path.read_text(encoding="utf-8"))
+    base_ts = now.timestamp()
+    wm["runs"] = [base_ts + i * 3600 for i in range(knowledge_lift.MAX_WEEKLY_RUNS)]
+    watermark_path.write_text(json.dumps(wm), encoding="utf-8")
+
+    (lessons_dir / "lesson_1.md").write_text("brand new content", encoding="utf-8")
+    res_capped = knowledge_lift.execute_knowledge_lift(
+        state_dir, plan, runner=runner, selfevo_repo=repo_dir, now=now + timedelta(hours=2)
+    )
+    assert res_capped["status"] == "rate_limited"
+    assert res_capped["reason"] == "weekly_cap_exceeded"
+
+
+def test_scorecard_and_negative_demand(state_dir: Path):
+    """Scorecard reports knowledge_lift and negative lift mints defect demand."""
+    # Write negative lift rows directly via atomic helper
+    sidecar_path = state_dir / knowledge_lift.SIDECAR_REL
+    rows = [
+        {
+            "case_id": "neg_case_1",
+            "with_pass": False,
+            "without_pass": True,
+            "with_tokens": 500,
+            "without_tokens": 100,
+            "with_duration_s": 2.5,
+            "without_duration_s": 1.0,
+            "delta_pass": -1,
+            "delta_tokens": 400,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+    ]
+    knowledge_lift._atomic_write_eval_rows(sidecar_path, rows)
+
+    summary = knowledge_lift.read_knowledge_lift_summary(state_dir)
+    assert summary["total_evals"] == 1
+    assert summary["pass_lift"] == -1
+    assert summary["net_benefit"] is False
+
+    # Check scorecard includes knowledge_lift key
+    sc = scorecard.compute_scorecard(state_dir, None, force=True)
+    assert "knowledge_lift" in sc
+    assert sc["knowledge_lift"]["total_evals"] == 1
+    assert sc["knowledge_lift"]["pass_lift"] == -1
+    assert sc["knowledge_lift"]["net_benefit"] is False
+
+    # Check negative demand adapter
+    defects = demand._knowledge_lift_defect_items(state_dir)
+    assert len(defects) == 1
+    assert "negative lift detected" in defects[0]["summary"]
+    assert "reflection_context.py" in defects[0]["affected_path"]
+
+    # Check demand collection integrates it
+    items = demand.collect_demand(state_dir, None)
+    demand_item = next((item for item in items if "Knowledge context negative lift" in item.get("summary", "")), None)
+    assert demand_item is not None

--- a/tests/test_knowledge_lift.py
+++ b/tests/test_knowledge_lift.py
@@ -256,6 +256,7 @@ def test_scorecard_and_negative_demand(state_dir: Path):
     sidecar_path = state_dir / knowledge_lift.SIDECAR_REL
     rows = [
         {
+            "schema": knowledge_lift.SCHEMA,
             "case_id": "neg_case_1",
             "with_pass": False,
             "without_pass": True,

--- a/tests/test_knowledge_lift.py
+++ b/tests/test_knowledge_lift.py
@@ -199,7 +199,7 @@ def test_watermark_and_weekly_cap(monkeypatch, state_dir: Path, tmp_path: Path):
     repo_dir.mkdir()
     lessons_dir = repo_dir / "lessons"
     lessons_dir.mkdir()
-    (lessons_dir / "lesson_1.md").write_text("initial lesson content", encoding="utf-8")
+    (lessons_dir / "lessons.yaml").write_text("initial lesson content", encoding="utf-8")
 
     plan = {
         "cases": [
@@ -229,7 +229,7 @@ def test_watermark_and_weekly_cap(monkeypatch, state_dir: Path, tmp_path: Path):
     assert res2["reason"] == "knowledge_unchanged"
 
     # Updating knowledge allows new run
-    (lessons_dir / "lesson_1.md").write_text("updated lesson content", encoding="utf-8")
+    (lessons_dir / "lessons.yaml").write_text("updated lesson content", encoding="utf-8")
     res3 = knowledge_lift.execute_knowledge_lift(
         state_dir, plan, runner=runner, selfevo_repo=repo_dir, now=now + timedelta(hours=1)
     )
@@ -242,7 +242,7 @@ def test_watermark_and_weekly_cap(monkeypatch, state_dir: Path, tmp_path: Path):
     wm["runs"] = [base_ts + i * 3600 for i in range(knowledge_lift.MAX_WEEKLY_RUNS)]
     watermark_path.write_text(json.dumps(wm), encoding="utf-8")
 
-    (lessons_dir / "lesson_1.md").write_text("brand new content", encoding="utf-8")
+    (lessons_dir / "lessons.yaml").write_text("brand new content", encoding="utf-8")
     res_capped = knowledge_lift.execute_knowledge_lift(
         state_dir, plan, runner=runner, selfevo_repo=repo_dir, now=now + timedelta(hours=2)
     )


### PR DESCRIPTION
## Summary
- add a dedicated, default-off knowledge_lift harness for matched A/B executor evaluations
- use the production lessons/reflection context producers for the with-knowledge arm and the identical task without those sections for the control arm
- validate fixed plans before execution; mechanically grade assertions; bound plan/input/sidecar reads, weekly runs, per-case and total runtime
- parent-owned atomic rewrite of protected rows and watermark; forged rows are discarded on rewrite
- expose reporting-only `knowledge_lift` scorecard data and one bounded negative-lift defect demand

## Design
A dedicated sibling module is simpler than extending skill_eval_harness: it has a distinct plan schema, knowledge-corpus watermark, sidecar schema, and demand meaning, while reusing the existing bridge-lock invocation. `skill_eval_harness.run_all()` invokes it under the existing bridge lock; no new timer or LLM role was added. The module and sidecars are deny/protected.

## Safety
- default OFF (`SELFEVO_KNOWLEDGE_LIFT_ENABLED`)
- no fitness target or gate policy changes
- no changes to lesson/reflection renderers
- no secrets or fabricated usage evidence

Closes #1093