### PR TITLE
fix(runtime): normalize non-secret sidecar modes

### DIFF
--- a/nanobot/runtime/_io.py
+++ b/nanobot/runtime/_io.py
@@ -69,11 +69,23 @@ def write_json_atomic(path: Path, payload: Any, *, indent: int = 2) -> None:
 
     Creates parent directories if needed. Writes to a sibling temporary file
     and replaces *path* via ``os.replace`` so readers never see partial content.
+
+    The resulting file is always mode 0644 regardless of the process umask
+    (issue #1096: mkstemp creates 0600 files; non-agent readers like the
+    dashboard publisher would otherwise be locked out after every rewrite).
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(f"{path.suffix}.tmp.{os.getpid()}")
-    tmp_path.write_text(json.dumps(payload, indent=indent, ensure_ascii=False), encoding="utf-8")
-    os.replace(tmp_path, path)
+    try:
+        tmp_path.write_text(json.dumps(payload, indent=indent, ensure_ascii=False), encoding="utf-8")
+        if os.name != "nt":
+            os.chmod(tmp_path, 0o644)
+        os.replace(tmp_path, path)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def read_json_strict(path: Path) -> dict[str, Any]:

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -730,6 +730,8 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
                 fh.write("\n")
                 fh.flush()
                 os.fsync(fh.fileno())
+            if os.name != "nt":
+                os.chmod(tmp, 0o644)  # mkstemp creates 0600; normalize for non-agent readers (#1096)
             os.replace(tmp, backlog_path)
         finally:
             try:

--- a/nanobot/runtime/skill_candidate_mining.py
+++ b/nanobot/runtime/skill_candidate_mining.py
@@ -234,6 +234,8 @@ def write_sidecar(state_dir: Path, selfevo_repo: Path | None = None) -> dict[str
             fh.write(payload)
             fh.flush()
             os.fsync(fh.fileno())
+        if os.name != "nt":
+            os.chmod(temporary, 0o644)  # NamedTemporaryFile creates 0600; normalize for non-agent readers (#1096)
         os.replace(temporary, path)
         temporary = None
     except OSError:

--- a/nanobot/runtime/strategist.py
+++ b/nanobot/runtime/strategist.py
@@ -57,6 +57,8 @@ def _atomic_json(path: Path, value: Any) -> None:
             fh.write("\n")
             fh.flush()
             os.fsync(fh.fileno())
+        if os.name != "nt":
+            os.chmod(temporary, 0o644)  # mkstemp creates 0600; normalize for non-agent readers (#1096)
         os.replace(temporary, path)
     finally:
         try:

--- a/tests/test_runtime_io.py
+++ b/tests/test_runtime_io.py
@@ -95,3 +95,23 @@ def test_utc_helpers() -> None:
     assert isinstance(iso_str, str)
     assert "T" in iso_str
     assert iso_str.endswith("Z") or "+00:00" not in iso_str
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits only")
+def test_write_json_atomic_mode_0644_under_restrictive_umask(tmp_path: Path) -> None:
+    """#1096: write_json_atomic must produce a 0644 file even when umask is 0077.
+
+    The dashboard publisher runs as a different user than the agent; mkstemp
+    creates 0600 temp files which os.replace preserves, locking out any
+    non-agent reader after every atomic rewrite.  This test verifies the fix.
+    """
+    target = tmp_path / "state.json"
+    old_umask = os.umask(0o077)
+    try:
+        write_json_atomic(target, {"key": "value"})
+    finally:
+        os.umask(old_umask)
+    assert target.exists()
+    assert target.stat().st_mode & 0o777 == 0o644, (
+        f"Expected 0644, got {oct(target.stat().st_mode & 0o777)}"
+    )

--- a/tests/test_skill_candidate_mining.py
+++ b/tests/test_skill_candidate_mining.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+
+import pytest
 
 from nanobot.runtime import demand
 from nanobot.runtime.skill_candidate_mining import (
@@ -336,3 +339,22 @@ def test_f4_force_regen_rebuilds_existing_day_files(tmp_path):
     rebuilt = [json.loads(line) for line in index_file.read_text(encoding="utf-8").splitlines() if line.strip()]
     # stale-extra should be gone
     assert not any(r.get("cycle_id") == "stale-extra" for r in rebuilt)
+
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits only")
+def test_write_sidecar_mode_0644_under_restrictive_umask(tmp_path, monkeypatch):
+    """#1096: skill_candidates.json must be 0644 even under umask 0077."""
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_CYCLES", "1")
+    monkeypatch.setenv("SELFEVO_SKILL_CANDIDATE_MIN_DAYS", "1")
+    _write_rows(tmp_path, _rows(5))
+    old_umask = os.umask(0o077)
+    try:
+        write_sidecar(tmp_path, None)
+    finally:
+        os.umask(old_umask)
+    sidecar = tmp_path / "demand" / "skill_candidates.json"
+    assert sidecar.exists()
+    assert sidecar.stat().st_mode & 0o777 == 0o644, (
+        f"Expected 0644, got {oct(sidecar.stat().st_mode & 0o777)}"
+    )

--- a/tests/test_strategist.py
+++ b/tests/test_strategist.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -273,3 +274,47 @@ def test_run_strategist_end_to_end(mock_state_and_repo, monkeypatch):
     hyp_data = json.loads((state_root / "hypotheses" / "durable.json").read_text(encoding="utf-8"))
     assert len(hyp_data["entries"]) == 1
     assert hyp_data["entries"][0]["title"] == "Subagent isolation"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits only")
+def test_strategist_atomic_json_mode_0644_under_restrictive_umask(tmp_path: Path) -> None:
+    """#1096: _atomic_json must produce 0644 files even with umask 0077.
+
+    Covers save_watermark (watermark.json) — the strategist's primary
+    mkstemp-based writer.
+    """
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    old_umask = os.umask(0o077)
+    try:
+        save_watermark(state_root, {"total_runs": 1})
+    finally:
+        os.umask(old_umask)
+    wm_path = state_root / "strategist" / "watermark.json"
+    assert wm_path.exists()
+    assert wm_path.stat().st_mode & 0o777 == 0o644, (
+        f"Expected 0644, got {oct(wm_path.stat().st_mode & 0o777)}"
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits only")
+def test_hypothesis_backlog_durable_json_mode_0644_under_restrictive_umask(tmp_path: Path) -> None:
+    """#1096: append_hypotheses must produce durable.json at 0644 under umask 0077."""
+    from nanobot.runtime.hypothesis_backlog import append_hypotheses
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    old_umask = os.umask(0o077)
+    try:
+        append_hypotheses(
+            state_dir,
+            [{"title": "Test hypothesis", "hypothesis": "testing", "action": "do",
+              "data_to_collect": "metrics", "insight_criterion": "x improves", "priority": "low"}],
+        )
+    finally:
+        os.umask(old_umask)
+    durable = state_dir / "hypotheses" / "durable.json"
+    assert durable.exists()
+    assert durable.stat().st_mode & 0o777 == 0o644, (
+        f"Expected 0644, got {oct(durable.stat().st_mode & 0o777)}"
+    )


### PR DESCRIPTION
## Summary

Closes #1096 by pinning non-secret atomic state sidecars to mode `0644`, independent of process umask, while preserving atomic replacement and cleanup.

### Writers changed

- `nanobot/runtime/_io.py:write_json_atomic`: explicitly chmods the temporary JSON to `0644` before `os.replace`; cleans up the temporary path on serialization/replace failure.
- `nanobot/runtime/strategist.py:_atomic_json`: normalizes its NamedTemporaryFile output to `0644` before replacement (watermark and advisories).
- `nanobot/runtime/hypothesis_backlog.py:append_hypotheses`: normalizes `hypotheses/durable.json` to `0644` before replacement.
- `nanobot/runtime/skill_candidate_mining.py:write_sidecar`: normalizes `demand/skill_candidates.json` to `0644` before replacement.

### Atomic-writer audit (`nanobot/runtime`)

`0644` after this change: `_io.write_json_atomic`; `strategist._atomic_json`; `hypothesis_backlog.append_hypotheses`; `skill_candidate_mining.write_sidecar`; `lessons_rotation._write_atomic` / `_write_archive_once` (already preserves existing mode or defaults 0644); `knowledge_curator._atomic_write_json` and `_write_proposals` (not changed here; retain 0600 and require separate classification/decision); `lesson_v2._save_citations` / `record_citations` (not changed; retain 0600); `usage_evidence._write_json` (not changed; retain 0600); `promotions_rotation.rotate_promotions_directory` (not changed; retain 0600). Path.write_text + replace writers (`llm_proposer`, `validator_harness`, `backlog_snapshot`, `skill_fitness`, `goal_gap_futility`) remain umask-dependent, typically 0644, and are not mkstemp-created.

No secret-like files were widened. `gate/deny-set`, `goals.md`, `skill_eval_harness.py`, and `scorecard.py` are untouched. The intentionally retained 0600 writers above should be reviewed separately before any widening.

### Verification

- Focused tests: `32 passed, 4 skipped` on Windows (POSIX mode tests skip by platform); targeted suite includes restrictive `umask 0077` assertions for `_io`, strategist, durable hypotheses, and skill candidates.
- Ruff: passed.
- `py_compile`: passed.
- `git diff --check`: passed.
- Full pytest: `2495 passed, 17 skipped, 18 failed` due to known Windows/POSIX baseline failures (temporary git push setup, fcntl locking, POSIX permissions). No failures were in the changed focused tests; full output available in PR context.
