### PR TITLE
feat(runtime): lateral [[links]] for lessons v2 and KB facts (#1095)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1355,8 +1355,11 @@ def build_task(req: dict, goal_text: str, report_source: str,
             f"ID: {err.get('id')}  Title: {err.get('title')}",
             f"Root cause: {err.get('root_cause', '')}",
             f"Prevention: {err.get('prevention', '')}",
-            '',
         ]
+        # Add compact related hint if present (#1095); absent when empty → byte-identical.
+        if err.get('related'):
+            lessons_lines.append(f"Related: {err['related']}")
+        lessons_lines.append('')
     if lessons_context.get('relevant_lesson'):
         less = lessons_context['relevant_lesson']
         less_id = less.get('id') or '<unknown>'
@@ -1366,8 +1369,11 @@ def build_task(req: dict, goal_text: str, report_source: str,
             f"Problem: {less.get('problem') or less.get('approach', '')}",
             f"Solution: {less.get('solution') or less.get('reusable_insight', '')}",
             f"If you apply this lesson, cite [Lesson {less_id}] in your proposal/response.",
-            '',
         ]
+        # Add compact related hint if present (#1095); absent when empty → byte-identical.
+        if less.get('related'):
+            lessons_lines.append(f"Related: {less['related']}")
+        lessons_lines.append('')
     if reflection_hints:
         lessons_lines += [
             '## Recent reflections (how past cycles worked — steering hints)',
@@ -4004,6 +4010,14 @@ def _write_structured_lesson(
         duplicate['last_seen'] = date_str
     else:
         existing['lessons'].insert(0, lesson)  # newest-first
+
+    # Fill lateral related links mechanically before writing (#1095).
+    # Fail-open: any error in fill_related_links must never block the write.
+    try:
+        from nanobot.runtime.lesson_v2 import fill_related_links as _fill_related
+        existing['lessons'], _ = _fill_related(existing['lessons'])
+    except Exception:
+        pass
 
     try:
         try:

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -879,6 +879,9 @@ def promote_reflector_recommendations_to_v2(
                 existing.insert(0, card)
             count += 1
     if count:
+        # Fill lateral related links mechanically before writing (#1095).
+        from nanobot.runtime.lesson_v2 import fill_related_links
+        existing, _unknown = fill_related_links(existing)
         atomic_write_yaml(target, {"lessons": existing})
     return count
 

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -34,6 +34,7 @@ from nanobot.observability.llm_telemetry import call_context, record_llm_call, r
 from nanobot.runtime.lesson_v2 import (
     atomic_write_yaml,
     bounded_load_yaml,
+    fill_related_links,
     find_duplicate,
     inline_related_slugs,
     related_hint,
@@ -613,6 +614,7 @@ def _stage_promotions(
             "payload_file": slug,
             "index_line": index_line,
             "related": related_hint(item),
+            "unknown_related": list(item.get("unknown_related") or []),
             "index_rel": str(item.get("index_rel") or ""),
             # #1094: evidence verification fields (advisory)
             "evidence": item.get("evidence", []),
@@ -818,7 +820,10 @@ def _collect_stage_items(
             "action": action,
             "content": content,
             "index_line": index_line,
-            "related": related,
+            "related": raw_related if isinstance(raw_related, list) else ([raw_related] if raw_related else []),
+            "unknown_related": [],
+            "tags": d.get("tags") or d.get("glossary_tags") or [],
+            "demand_lineage": d.get("demand_lineage") or d.get("demand_id") or d.get("delta_evidence") or "",
             "index_rel": index_rel if action == "create" else "",
             "lesson_id": lesson_id,
             "reason": reason,
@@ -830,6 +835,18 @@ def _collect_stage_items(
         writes += 1
         decision_label = "promoted_unsupported" if overlap_flag else "promoted"
         _write_decision(state_dir, lesson_id, decision_label, reason, rel_str)
+
+    # Build a bounded in-memory graph for the facts staged in this pass. This
+    # is deliberately mechanical: no LLM call, no archive scan, and unknown
+    # inline/explicit targets are retained and reported in the manifest.
+    if items:
+        linked, unknown = fill_related_links(items)
+        for item in linked:
+            item["unknown_related"] = sorted(unknown)
+            hint = related_hint(item)
+            if hint and item.get("index_line") and "related:" not in str(item["index_line"]):
+                item["index_line"] = f'{item["index_line"].rstrip()} — {hint}'
+        items = linked
     return items, writes
 
 

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -31,7 +31,13 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable, Iterable
 
 from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
-from nanobot.runtime.lesson_v2 import atomic_write_yaml, bounded_load_yaml, find_duplicate
+from nanobot.runtime.lesson_v2 import (
+    atomic_write_yaml,
+    bounded_load_yaml,
+    find_duplicate,
+    inline_related_slugs,
+    related_hint,
+)
 from nanobot.runtime.model_registry import resolve_model
 
 MAX_WRITES_DEFAULT = 3
@@ -606,6 +612,7 @@ def _stage_promotions(
             "action": action,
             "payload_file": slug,
             "index_line": index_line,
+            "related": related_hint(item),
             "index_rel": str(item.get("index_rel") or ""),
             # #1094: evidence verification fields (advisory)
             "evidence": item.get("evidence", []),
@@ -796,15 +803,22 @@ def _collect_stage_items(
 
         rel_str = str(rel).replace("\\", "/")
         index_rel = "memory/index.md" if rel.parts[0] == "memory" else "docs/index.md"
+        raw_related = d.get("related") or inline_related_slugs(content)
+        related = ", ".join(
+            s for s in (raw_related if isinstance(raw_related, list) else [raw_related])
+            if isinstance(s, str) and s.strip()
+        )[:500]
         index_line = str(
             d.get("index_line")
             or f"- [{d.get('title') or rel.stem}]({rel.as_posix()})"
+            + (f" — related: {related}" if related else "")
         ) if action == "create" else ""
         items.append({
             "path": rel_str,
             "action": action,
             "content": content,
             "index_line": index_line,
+            "related": related,
             "index_rel": index_rel if action == "create" else "",
             "lesson_id": lesson_id,
             "reason": reason,

--- a/nanobot/runtime/lesson_v2.py
+++ b/nanobot/runtime/lesson_v2.py
@@ -242,20 +242,35 @@ def fill_related_links(
             b_lineage = _lineage(b)
             shared_lineage = bool(a_lineage and a_lineage == b_lineage)
 
-            if len(shared_tags) >= _RELATED_MIN_SHARED_TAGS or shared_lineage:
+            if (
+                (len(shared_tags) >= _RELATED_MIN_SHARED_TAGS or shared_lineage)
+                and len(related_map[a_slug]) < _RELATED_CAP
+                and len(related_map[b_slug]) < _RELATED_CAP
+            ):
                 related_map[a_slug].add(b_slug)
                 related_map[b_slug].add(a_slug)
 
-    # Collect unknown slugs from EXISTING related lists.
+    # Collect unknown slugs from explicit and inline links. They are retained
+    # and reported, never treated as schema failures.
     unknown: set[str] = set()
     for entry in entries:
-        for existing_slug in (entry.get("related") or []):
-            if isinstance(existing_slug, str) and existing_slug.strip():
-                if existing_slug.strip() not in by_slug:
-                    unknown.add(existing_slug.strip())
+        for existing_slug in _related_values(entry.get("related")) + inline_related_slugs(
+            entry.get("problem"), entry.get("solution"), entry.get("content"),
+            entry.get("title"), entry.get("description"),
+        ):
+            if existing_slug not in by_slug:
+                unknown.add(existing_slug)
+
+    # Mirror known explicit/inline links where the target still has capacity.
+    # Unknown targets remain retained on their source entry and are only
+    # reported; they never cause validation or writing to fail.
+    for left in slugs:
+        for right in list(related_map[left]):
+            if left not in related_map[right] and len(related_map[right]) < _RELATED_CAP:
+                related_map[right].add(left)
 
     # Build updated entries: shallow-copy each, merge existing + new related,
-    # cap at _RELATED_CAP, sorted for determinism.
+    # cap at _RELATED_CAP, deterministic ordering.
     updated: list[dict[str, Any]] = []
     for entry in entries:
         slug = _entry_slug(entry)
@@ -299,10 +314,7 @@ def related_hint(entry: dict[str, Any], *, cap: int = _RELATED_CAP) -> str:
     Returns empty string when ``related`` is absent or empty (byte-identical
     prompt for entries without lateral links).
     """
-    slugs = [
-        s for s in (entry.get("related") or [])
-        if isinstance(s, str) and s.strip()
-    ][:cap]
+    slugs = _related_values(entry.get("related"))[:max(0, cap)]
     if not slugs:
         return ""
     return "related: " + ", ".join(slugs)

--- a/nanobot/runtime/lesson_v2.py
+++ b/nanobot/runtime/lesson_v2.py
@@ -3,6 +3,15 @@
 A v2 lesson is a problem-to-solution record. The module is intentionally
 stdlib-first and contains no LLM or timer behavior; callers decide which
 validated delta is allowed to mint a lesson.
+
+Lateral links (#1095):
+- ``fill_related_links(entries)`` fills ``related`` mechanically:
+  entries sharing ≥2 controlled glossary tags, OR sharing a non-empty
+  demand-lineage key (``delta_evidence`` or ``cycle_id``), are linked
+  symmetrically up to a cap of 3 slugs per entry.
+- Unknown slug targets are allowed (future entries); they are reported via
+  the returned ``unknown`` set, never rejected.
+- No LLM is used; the function is deterministic and bounded.
 """
 from __future__ import annotations
 
@@ -22,6 +31,10 @@ _MAX_FILE_BYTES = 2 * 1024 * 1024
 _MAX_FILE_AGE_DAYS = 90
 _MAX_ENTRIES = 200
 _WORD_RE = re.compile(r"[a-z]{3,}")
+
+# Lateral-links constants (#1095).
+_RELATED_CAP = 3  # max slugs per entry
+_RELATED_MIN_SHARED_TAGS = 2  # minimum shared controlled glossary tags to auto-link
 
 
 def validate_lesson(card: Any) -> bool:
@@ -114,6 +127,133 @@ def atomic_write_yaml(path: Path, value: Any) -> None:
             os.unlink(name)
         except FileNotFoundError:
             pass
+
+
+def _entry_slug(entry: dict[str, Any]) -> str:
+    """Return the slug (id) for an entry, or empty string."""
+    return str(entry.get("id") or "").strip()
+
+
+def fill_related_links(
+    entries: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], set[str]]:
+    """Fill ``related`` lists mechanically for v2 lesson entries (#1095).
+
+    Two entries are related if they share ≥2 controlled glossary tags OR
+    share the same non-empty demand-lineage key (``delta_evidence`` or
+    ``cycle_id`` field on the entry).  Links are symmetric; each entry's
+    ``related`` list is capped at ``_RELATED_CAP`` slugs.
+
+    Entries without a slug (no ``id`` field) are skipped.
+    Unknown slug targets (slugs in existing ``related`` lists that do not
+    correspond to any entry in the input) are reported via the returned
+    ``unknown`` set — never rejected.
+
+    Returns ``(updated_entries, unknown_slugs)``.
+    The input list is NOT mutated; a shallow-copy list is returned.
+    No LLM calls; deterministic and stdlib-only.
+    """
+    # Index entries by slug.
+    by_slug: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        slug = _entry_slug(entry)
+        if slug:
+            by_slug[slug] = entry
+
+    # For each pair, decide if they are related.
+    slugs = list(by_slug.keys())
+    # Accumulate new related sets (symmetric).
+    related_map: dict[str, set[str]] = {slug: set() for slug in slugs}
+
+    for i in range(len(slugs)):
+        for j in range(i + 1, len(slugs)):
+            a_slug, b_slug = slugs[i], slugs[j]
+            a, b = by_slug[a_slug], by_slug[b_slug]
+
+            # Criterion 1: ≥2 shared controlled glossary tags.
+            a_tags = frozenset(
+                t for t in (a.get("tags") or []) if t in CONTROLLED_LESSON_TAGS
+            )
+            b_tags = frozenset(
+                t for t in (b.get("tags") or []) if t in CONTROLLED_LESSON_TAGS
+            )
+            shared_tags = a_tags & b_tags
+
+            # Criterion 2: shared non-empty demand-lineage key.
+            def _lineage(e: dict[str, Any]) -> str:
+                for field in ("delta_evidence", "cycle_id"):
+                    val = str(e.get(field) or "").strip()
+                    if val:
+                        return val
+                return ""
+
+            a_lineage = _lineage(a)
+            b_lineage = _lineage(b)
+            shared_lineage = bool(a_lineage and a_lineage == b_lineage)
+
+            if len(shared_tags) >= _RELATED_MIN_SHARED_TAGS or shared_lineage:
+                related_map[a_slug].add(b_slug)
+                related_map[b_slug].add(a_slug)
+
+    # Collect unknown slugs from EXISTING related lists.
+    unknown: set[str] = set()
+    for entry in entries:
+        for existing_slug in (entry.get("related") or []):
+            if isinstance(existing_slug, str) and existing_slug.strip():
+                if existing_slug.strip() not in by_slug:
+                    unknown.add(existing_slug.strip())
+
+    # Build updated entries: shallow-copy each, merge existing + new related,
+    # cap at _RELATED_CAP, sorted for determinism.
+    updated: list[dict[str, Any]] = []
+    for entry in entries:
+        slug = _entry_slug(entry)
+        copy = dict(entry)
+        if slug and slug in related_map:
+            # Merge: start from existing related (preserving existing ones first),
+            # add newly computed ones, deduplicate, cap.
+            existing_related: list[str] = [
+                s for s in (copy.get("related") or [])
+                if isinstance(s, str) and s.strip() and s.strip() != slug
+            ]
+            new_related = sorted(related_map[slug])
+            merged: list[str] = []
+            seen: set[str] = set()
+            for s in existing_related + new_related:
+                if s not in seen:
+                    merged.append(s)
+                    seen.add(s)
+            merged = merged[:_RELATED_CAP]
+            if merged:
+                copy["related"] = merged
+            elif "related" in copy:
+                # Keep existing related even if not mechanically linked
+                # (they may be manually curated / future entries).
+                existing = [
+                    s for s in (copy.get("related") or [])
+                    if isinstance(s, str) and s.strip() and s.strip() != slug
+                ]
+                if existing:
+                    copy["related"] = existing[:_RELATED_CAP]
+                else:
+                    copy.pop("related", None)
+        updated.append(copy)
+    return updated, unknown
+
+
+def related_hint(entry: dict[str, Any], *, cap: int = _RELATED_CAP) -> str:
+    """Return a compact one-line related hint string for prompt cards/indexes.
+
+    Returns empty string when ``related`` is absent or empty (byte-identical
+    prompt for entries without lateral links).
+    """
+    slugs = [
+        s for s in (entry.get("related") or [])
+        if isinstance(s, str) and s.strip()
+    ][:cap]
+    if not slugs:
+        return ""
+    return "related: " + ", ".join(slugs)
 
 
 def record_citations(

--- a/nanobot/runtime/lesson_v2.py
+++ b/nanobot/runtime/lesson_v2.py
@@ -34,7 +34,9 @@ _WORD_RE = re.compile(r"[a-z]{3,}")
 
 # Lateral-links constants (#1095).
 _RELATED_CAP = 3  # max slugs per entry
-_RELATED_MIN_SHARED_TAGS = 2  # minimum shared controlled glossary tags to auto-link
+_RELATED_MIN_SHARED_TAGS = 2  # minimum shared glossary tags to auto-link
+_RELATED_SLUG_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,119}")
+_INLINE_RELATED_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
 def validate_lesson(card: Any) -> bool:
@@ -51,7 +53,14 @@ def validate_lesson(card: Any) -> bool:
     if card.get("severity", "medium") not in LESSON_SEVERITIES:
         return False
     evidence = card.get("evidence", [])
-    return isinstance(evidence, (list, dict))
+    if not isinstance(evidence, (list, dict)):
+        return False
+    related = card.get("related", [])
+    return (
+        isinstance(related, list)
+        and len(related) <= _RELATED_CAP
+        and all(isinstance(slug, str) and _RELATED_SLUG_RE.fullmatch(slug.strip()) for slug in related)
+    )
 
 
 def normalize_problem(text: Any) -> str:
@@ -130,8 +139,44 @@ def atomic_write_yaml(path: Path, value: Any) -> None:
 
 
 def _entry_slug(entry: dict[str, Any]) -> str:
-    """Return the slug (id) for an entry, or empty string."""
-    return str(entry.get("id") or "").strip()
+    """Return a stable entry slug from an id/slug/path, or empty string."""
+    value = str(entry.get("id") or entry.get("slug") or "").strip()
+    if value:
+        return value
+    path = str(entry.get("path") or "").replace("\\", "/").strip()
+    return path.rsplit("/", 1)[-1].rsplit(".", 1)[0] if path else ""
+
+
+def _related_values(value: Any) -> list[str]:
+    """Normalize related values without rejecting future/unknown slugs."""
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple)):
+        values = list(value)
+    else:
+        return []
+    result: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        slug = str(raw or "").strip()
+        if not slug or slug in seen or not _RELATED_SLUG_RE.fullmatch(slug):
+            continue
+        seen.add(slug)
+        result.append(slug)
+    return result
+
+
+def inline_related_slugs(*texts: Any) -> list[str]:
+    """Extract bounded ``[[slug]]`` references from text, deterministically."""
+    result: list[str] = []
+    seen: set[str] = set()
+    for text in texts:
+        for raw in _INLINE_RELATED_RE.findall(str(text or "")):
+            slug = raw.strip()
+            if slug and slug not in seen and _RELATED_SLUG_RE.fullmatch(slug):
+                seen.add(slug)
+                result.append(slug)
+    return result
 
 
 def fill_related_links(
@@ -170,18 +215,24 @@ def fill_related_links(
             a_slug, b_slug = slugs[i], slugs[j]
             a, b = by_slug[a_slug], by_slug[b_slug]
 
-            # Criterion 1: ≥2 shared controlled glossary tags.
-            a_tags = frozenset(
-                t for t in (a.get("tags") or []) if t in CONTROLLED_LESSON_TAGS
-            )
-            b_tags = frozenset(
-                t for t in (b.get("tags") or []) if t in CONTROLLED_LESSON_TAGS
-            )
-            shared_tags = a_tags & b_tags
+            # Criterion 1: ≥2 shared glossary tags. V2 entries use the
+            # controlled vocabulary; generic KB records may carry arbitrary
+            # bounded glossary tags.
+            def _tags(e: dict[str, Any]) -> frozenset[str]:
+                raw = e.get("tags") or e.get("glossary_tags") or []
+                return frozenset(
+                    str(tag).strip().lower() for tag in raw
+                    if str(tag).strip() and (
+                        e.get("schema_version") != 2 or tag in CONTROLLED_LESSON_TAGS
+                    )
+                )
 
-            # Criterion 2: shared non-empty demand-lineage key.
+            shared_tags = _tags(a) & _tags(b)
+
+            # Criterion 2: shared non-empty demand-lineage key. Keep the
+            # field list deliberately small and never infer lineage from prose.
             def _lineage(e: dict[str, Any]) -> str:
-                for field in ("delta_evidence", "cycle_id"):
+                for field in ("demand_lineage", "demand_id", "delta_evidence", "cycle_id"):
                     val = str(e.get(field) or "").strip()
                     if val:
                         return val
@@ -212,14 +263,18 @@ def fill_related_links(
         if slug and slug in related_map:
             # Merge: start from existing related (preserving existing ones first),
             # add newly computed ones, deduplicate, cap.
-            existing_related: list[str] = [
-                s for s in (copy.get("related") or [])
-                if isinstance(s, str) and s.strip() and s.strip() != slug
+            existing_related = [
+                s for s in _related_values(copy.get("related"))
+                if s != slug
             ]
+            inline_related = [s for s in inline_related_slugs(
+                copy.get("problem"), copy.get("solution"), copy.get("content"),
+                copy.get("title"), copy.get("description"),
+            ) if s != slug]
             new_related = sorted(related_map[slug])
             merged: list[str] = []
             seen: set[str] = set()
-            for s in existing_related + new_related:
+            for s in existing_related + inline_related + new_related:
                 if s not in seen:
                     merged.append(s)
                     seen.add(s)
@@ -229,10 +284,7 @@ def fill_related_links(
             elif "related" in copy:
                 # Keep existing related even if not mechanically linked
                 # (they may be manually curated / future entries).
-                existing = [
-                    s for s in (copy.get("related") or [])
-                    if isinstance(s, str) and s.strip() and s.strip() != slug
-                ]
+                existing = [s for s in _related_values(copy.get("related")) if s != slug]
                 if existing:
                     copy["related"] = existing[:_RELATED_CAP]
                 else:

--- a/nanobot/runtime/lessons_context.py
+++ b/nanobot/runtime/lessons_context.py
@@ -70,6 +70,8 @@ _MIN_SHARED_WORDS = 2
 
 _TITLE_CAP = 200
 _TEXT_CAP = 400
+# Related hint cap: at most this many slugs rendered in a card (#1095).
+_RELATED_HINT_CAP = 3
 
 _WORD_RE = re.compile(r"[A-Za-z]{4,}")
 
@@ -82,6 +84,15 @@ def _cap(text: Any, limit: int) -> str:
     return str(text or "")[:limit]
 
 
+def _related_hint_for(entry: dict[str, Any]) -> str:
+    """Return compact related string for a card (capped, empty when none). (#1095)"""
+    slugs = [
+        s for s in (entry.get("related") or [])
+        if isinstance(s, str) and s.strip()
+    ][:_RELATED_HINT_CAP]
+    if not slugs:
+        return ""
+    return ", ".join(slugs)
 _MAX_FILE_AGE_DAYS = 90
 
 
@@ -228,16 +239,21 @@ def build_lessons_context(
 
         err = _best_card(_capped_entries(lessons_dir / "errors.yaml"), task_words, "root_cause")
         if err:
-            result["relevant_error"] = {
+            err_card: dict[str, Any] = {
                 "id": err.get("id"),
                 "title": _cap(err.get("title"), _TITLE_CAP),
                 "root_cause": _cap(err.get("root_cause"), _TEXT_CAP),
                 "prevention": _cap(err.get("prevention"), _TEXT_CAP),
             }
+            # Add related hint if present (#1095): one compact line, absent when empty.
+            _err_related = _related_hint_for(err)
+            if _err_related:
+                err_card["related"] = _err_related
+            result["relevant_error"] = err_card
 
         less = _best_card(_capped_entries(lessons_dir / "lessons.yaml"), task_words, "approach")
         if less:
-            result["relevant_lesson"] = {
+            less_card: dict[str, Any] = {
                 "id": less.get("id"),
                 "title": _cap(less.get("title"), _TITLE_CAP),
                 "approach": _cap(less.get("approach"), _TEXT_CAP),
@@ -246,6 +262,11 @@ def build_lessons_context(
                     "solution": _cap(less.get("solution"), _TEXT_CAP)}
                    if less.get("problem") and less.get("solution") else {}),
             }
+            # Add related hint if present (#1095): one compact line, absent when empty.
+            _less_related = _related_hint_for(less)
+            if _less_related:
+                less_card["related"] = _less_related
+            result["relevant_lesson"] = less_card
 
         return result
     except Exception:

--- a/tests/test_lateral_links.py
+++ b/tests/test_lateral_links.py
@@ -381,3 +381,232 @@ def test_fill_related_links_no_file_io(monkeypatch: pytest.MonkeyPatch) -> None:
     fill_related_links(entries)
 
     assert not open_calls, f"fill_related_links opened files: {open_calls}"
+
+
+# ---------------------------------------------------------------------------
+# 7. Bridge _write_structured_lesson fills related links before writing
+# ---------------------------------------------------------------------------
+
+def test_write_structured_lesson_fills_related(tmp_path: Path) -> None:
+    """_write_structured_lesson calls fill_related_links before writing (#1095).
+
+    When two lessons share >=2 controlled tags, the written file must contain
+    'related' fields on both entries (symmetric linking).
+    """
+    import yaml
+
+    from nanobot.runtime.bridge import _write_structured_lesson
+
+    repo = tmp_path / "repo"
+    (repo / "lessons").mkdir(parents=True)
+
+    # Pre-populate with one lesson that shares tags with the one we'll write.
+    existing_lesson = {
+        "schema_version": 2,
+        "id": "LESS-EXISTING",
+        "title": "Existing runtime state lesson",
+        "problem": "Existing runtime state problem bounded read failure",
+        "solution": "Use bounded state reads to avoid unbounded loading",
+        "tags": ["runtime", "state"],
+        "severity": "medium",
+        "seen_count": 1,
+        "first_seen": "2026-01-01",
+        "last_seen": "2026-01-01",
+        "evidence": ["cycle-existing"],
+        "date": "2026-01-01",
+        "cycle_id": "cycle-existing",
+        "task_id": "existing-task",
+        "hypothesis": "Existing hypothesis",
+        "result": "Committed 1 commit(s)",
+        "approach": "Use bounded reads",
+        "generalized_insight": "Use bounded state reads to avoid unbounded loading",
+        "reusable_insight": "Use bounded state reads to avoid unbounded loading",
+        "files_changed": ["nanobot/runtime/state.py"],
+    }
+    (repo / "lessons" / "lessons.yaml").write_text(
+        yaml.safe_dump({"lessons": [existing_lesson]}, allow_unicode=True),
+        encoding="utf-8",
+    )
+    # Also write an errors.yaml with a matching entry to trigger delta evidence.
+    (repo / "lessons" / "errors.yaml").write_text(
+        yaml.safe_dump([{
+            "task_id": "runtime state bounded read",
+            "reason": "prior failure",
+        }]),
+        encoding="utf-8",
+    )
+
+    # Write a new lesson that shares >=2 tags with existing (runtime + state).
+    wrote = _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-abc123def456",
+        backlog_title="runtime state bounded read",
+        files_changed=["nanobot/runtime/state.py"],
+        commits_pushed=1,
+        artifact_data={
+            "hypothesis": "runtime state bounded read improves performance",
+            "reusable_insight": "Bounded state reads prevent memory spikes in runtime",
+            "problem": "Runtime state bounded read failure causes memory spikes",
+            "solution": "Bounded state reads prevent memory spikes in runtime",
+            "tags": ["runtime", "state"],
+            "severity": "medium",
+            "evidence": ["cycle-abc123def456"],
+            "delta_evidence": True,
+        },
+    )
+    assert wrote is True
+
+    loaded = yaml.safe_load(
+        (repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8")
+    )
+    lessons = loaded["lessons"]
+    by_id = {e["id"]: e for e in lessons}
+
+    # Both entries share runtime+state tags → should be symmetrically linked.
+    new_id = next(k for k in by_id if k != "LESS-EXISTING")
+    new_entry = by_id[new_id]
+    existing_entry = by_id["LESS-EXISTING"]
+
+    assert "LESS-EXISTING" in new_entry.get("related", []), (
+        f"New lesson missing related link to LESS-EXISTING; new_entry={new_entry}"
+    )
+    assert new_id in existing_entry.get("related", []), (
+        f"LESS-EXISTING missing related link to new lesson; existing_entry={existing_entry}"
+    )
+
+
+def test_write_structured_lesson_no_related_when_no_overlap(tmp_path: Path) -> None:
+    """fill_related_links in bridge writer: entries with <2 shared tags get no related."""
+    import yaml
+
+    from nanobot.runtime.bridge import _write_structured_lesson
+
+    repo = tmp_path / "repo"
+    (repo / "lessons").mkdir(parents=True)
+
+    existing_lesson = {
+        "schema_version": 2,
+        "id": "LESS-DISJOINT",
+        "title": "Disjoint tags lesson",
+        "problem": "Disjoint tags problem with reflector output parsing",
+        "solution": "Use separate paths for reflector output handling",
+        "tags": ["reflector"],
+        "severity": "medium",
+        "seen_count": 1,
+        "first_seen": "2026-01-01",
+        "last_seen": "2026-01-01",
+        "evidence": ["cycle-disjoint"],
+        "date": "2026-01-01",
+        "cycle_id": "cycle-disjoint",
+        "task_id": "disjoint-task",
+        "hypothesis": "Disjoint hypothesis",
+        "result": "Committed 1 commit(s)",
+        "approach": "Use separate reflector paths",
+        "generalized_insight": "Use separate paths for reflector output handling",
+        "reusable_insight": "Use separate paths for reflector output handling",
+        "files_changed": ["nanobot/runtime/reflector.py"],
+    }
+    (repo / "lessons" / "lessons.yaml").write_text(
+        yaml.safe_dump({"lessons": [existing_lesson]}, allow_unicode=True),
+        encoding="utf-8",
+    )
+    (repo / "lessons" / "errors.yaml").write_text(
+        yaml.safe_dump([{
+            "task_id": "runtime bounded read delta fix",
+            "reason": "prior failure",
+        }]),
+        encoding="utf-8",
+    )
+
+    wrote = _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-xyz789abc123",
+        backlog_title="runtime bounded read delta fix",
+        files_changed=["nanobot/runtime/lesson_v2.py"],
+        commits_pushed=1,
+        artifact_data={
+            "hypothesis": "runtime bounded read delta fix improves performance",
+            "reusable_insight": "Bounded reads prevent memory spikes in runtime modules",
+            "problem": "Runtime bounded read delta fix failure causes memory spikes",
+            "solution": "Bounded reads prevent memory spikes in runtime modules",
+            "tags": ["runtime"],
+            "severity": "medium",
+            "evidence": ["cycle-xyz789abc123"],
+            "delta_evidence": True,
+        },
+    )
+    assert wrote is True
+
+    loaded = yaml.safe_load(
+        (repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8")
+    )
+    lessons = loaded["lessons"]
+    by_id = {e["id"]: e for e in lessons}
+
+    # No shared tags >=2: "runtime" vs "reflector" → no cross-link on LESS-DISJOINT.
+    disjoint_entry = by_id["LESS-DISJOINT"]
+    new_id = next(k for k in by_id if k != "LESS-DISJOINT")
+    assert new_id not in disjoint_entry.get("related", [])
+    assert "LESS-DISJOINT" not in by_id[new_id].get("related", [])
+
+
+# ---------------------------------------------------------------------------
+# 8. Bridge build_task prompt rendering: related hint rendered / absent
+# ---------------------------------------------------------------------------
+
+def test_build_task_prompt_includes_related_hint(tmp_path: Path) -> None:
+    """build_task renders 'Related:' line in lesson section when related is set (#1095)."""
+    from nanobot.runtime.bridge import build_task
+
+    req = {
+        "task_title": "test task title",
+        "request_id": "req-001",
+        "cycle_id": "cycle-001",
+        "goal_id": "goal-001",
+        "lessons_context": {
+            "relevant_lesson": {
+                "id": "LESS-ABC",
+                "title": "Test lesson title",
+                "problem": "Test problem text",
+                "solution": "Test solution text",
+                "approach": "Test approach",
+                "reusable_insight": "Test insight",
+                "related": "LESS-DEF, LESS-GHI",
+            }
+        },
+    }
+
+    prompt = build_task(req, "test goal text", "")
+
+    assert "Related: LESS-DEF, LESS-GHI" in prompt, (
+        "Expected 'Related:' line in build_task prompt when related is set"
+    )
+
+
+def test_build_task_prompt_no_related_hint_when_absent(tmp_path: Path) -> None:
+    """build_task omits 'Related:' line when related is absent (byte-identical, #1095)."""
+    from nanobot.runtime.bridge import build_task
+
+    req = {
+        "task_title": "test task title",
+        "request_id": "req-001",
+        "cycle_id": "cycle-001",
+        "goal_id": "goal-001",
+        "lessons_context": {
+            "relevant_lesson": {
+                "id": "LESS-ABC",
+                "title": "Test lesson title",
+                "problem": "Test problem text",
+                "solution": "Test solution text",
+                "approach": "Test approach",
+                "reusable_insight": "Test insight",
+                # No 'related' field.
+            }
+        },
+    }
+
+    prompt = build_task(req, "test goal text", "")
+
+    assert "Related:" not in prompt, (
+        "Expected no 'Related:' line in build_task prompt when related is absent"
+    )

--- a/tests/test_lateral_links.py
+++ b/tests/test_lateral_links.py
@@ -1,0 +1,383 @@
+"""Focused acceptance tests for lateral [[links]] (#1095).
+
+Tests cover:
+1. Schema: related list accepted, capped, preserved; unknown slugs reported not rejected.
+2. Mechanical linking: shared-tag entries produce symmetric links within cap;
+   shared-lineage entries link; unrelated entries do not.
+3. Card rendering: related hint rendered in build_lessons_context cards; absent when empty.
+4. Byte-identity: absent related produces byte-identical prompt output.
+5. Rotation preserves related field through YAML rotation.
+6. Bounded open-count: fill_related_links uses no file I/O (open-count = 0).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from nanobot.runtime.lesson_v2 import (
+    atomic_write_yaml,
+    bounded_load_yaml,
+    fill_related_links,
+    related_hint,
+    validate_lesson,
+)
+from nanobot.runtime.lessons_context import build_lessons_context
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _base_card(lesson_id: str, tags: list[str], **extra: Any) -> dict:
+    card: dict = {
+        "schema_version": 2,
+        "id": lesson_id,
+        "problem": f"Problem for {lesson_id}",
+        "solution": f"Solution for {lesson_id}",
+        "tags": tags,
+        "severity": "medium",
+        "evidence": ["cycle-test"],
+    }
+    card.update(extra)
+    return card
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema: related list accepted, capped, preserved; unknown slugs reported
+# ---------------------------------------------------------------------------
+
+def test_related_accepted_by_validate_lesson() -> None:
+    """related is an optional field; validate_lesson still passes with it."""
+    card = _base_card("LESS-1", ["runtime"], related=["LESS-2", "LESS-3"])
+    assert validate_lesson(card)
+
+
+def test_related_absent_still_validates() -> None:
+    """Entries without related still validate correctly."""
+    card = _base_card("LESS-1", ["runtime"])
+    assert "related" not in card
+    assert validate_lesson(card)
+
+
+def test_fill_related_caps_at_three() -> None:
+    """fill_related_links must cap related at 3 slugs per entry."""
+    # Entry with 4 manually set related (existing) — must be capped to 3.
+    entry = _base_card("LESS-A", ["runtime"], related=["X1", "X2", "X3", "X4"])
+    updated, _unknown = fill_related_links([entry])
+    assert len(updated[0].get("related", [])) <= 3
+
+
+def test_fill_related_reports_unknown_slugs() -> None:
+    """Unknown slug targets are reported (returned in unknown set), never rejected."""
+    entry = _base_card("LESS-A", ["runtime"], related=["FUTURE-ENTRY"])
+    updated, unknown = fill_related_links([entry])
+    # The entry is NOT rejected; it's preserved.
+    assert len(updated) == 1
+    # FUTURE-ENTRY is not in the entries list → it's unknown.
+    assert "FUTURE-ENTRY" in unknown
+
+
+def test_fill_related_unknown_slug_preserves_entry() -> None:
+    """Entry with unknown related slug is preserved (not rejected or dropped)."""
+    entry = _base_card("LESS-A", ["runtime"], related=["DOES-NOT-EXIST"])
+    updated, unknown = fill_related_links([entry])
+    assert updated[0]["id"] == "LESS-A"
+    assert "DOES-NOT-EXIST" in unknown
+
+
+# ---------------------------------------------------------------------------
+# 2. Mechanical linking: tag-based and lineage-based, symmetric, unrelated stays
+# ---------------------------------------------------------------------------
+
+def test_shared_tags_produce_symmetric_links() -> None:
+    """Entries sharing >=2 controlled glossary tags get linked symmetrically."""
+    a = _base_card("LESS-A", ["runtime", "state"])
+    b = _base_card("LESS-B", ["runtime", "state"])
+    c = _base_card("LESS-C", ["lint"])  # only 1 tag shared with a/b if any
+
+    updated, unknown = fill_related_links([a, b, c])
+    by_id = {e["id"]: e for e in updated}
+
+    # A and B share 2 tags: they must be linked.
+    assert "LESS-B" in by_id["LESS-A"].get("related", [])
+    assert "LESS-A" in by_id["LESS-B"].get("related", [])
+
+    # C shares at most 0 tags with A/B → not linked.
+    assert "LESS-C" not in by_id["LESS-A"].get("related", [])
+    assert "LESS-C" not in by_id["LESS-B"].get("related", [])
+
+    # No unknown slugs: all ids are present.
+    assert not unknown
+
+
+def test_one_shared_tag_does_not_link() -> None:
+    """Entries sharing exactly 1 controlled tag must NOT be linked."""
+    a = _base_card("LESS-A", ["runtime", "lint"])
+    b = _base_card("LESS-B", ["runtime", "state"])  # shares only 'runtime'
+
+    updated, _unknown = fill_related_links([a, b])
+    by_id = {e["id"]: e for e in updated}
+
+    assert "LESS-B" not in by_id["LESS-A"].get("related", [])
+    assert "LESS-A" not in by_id["LESS-B"].get("related", [])
+
+
+def test_shared_lineage_produces_links() -> None:
+    """Entries with same non-empty delta_evidence value are linked."""
+    a = _base_card("LESS-A", ["lint"], delta_evidence="errors-to-integrated-resolution")
+    b = _base_card("LESS-B", ["state"], delta_evidence="errors-to-integrated-resolution")
+
+    updated, _unknown = fill_related_links([a, b])
+    by_id = {e["id"]: e for e in updated}
+
+    assert "LESS-B" in by_id["LESS-A"].get("related", [])
+    assert "LESS-A" in by_id["LESS-B"].get("related", [])
+
+
+def test_different_lineage_does_not_link() -> None:
+    """Entries with different delta_evidence are not linked by lineage."""
+    a = _base_card("LESS-A", ["lint"], delta_evidence="lineage-1")
+    b = _base_card("LESS-B", ["state"], delta_evidence="lineage-2")
+
+    updated, _unknown = fill_related_links([a, b])
+    by_id = {e["id"]: e for e in updated}
+
+    assert "LESS-B" not in by_id["LESS-A"].get("related", [])
+    assert "LESS-A" not in by_id["LESS-B"].get("related", [])
+
+
+def test_cap_at_three_with_many_related() -> None:
+    """Each entry's related list is capped at 3 even when many entries link it."""
+    # 5 entries all sharing 2 tags → each can have up to 4 links but cap is 3.
+    entries = [_base_card(f"LESS-{i}", ["runtime", "state"]) for i in range(5)]
+    updated, _unknown = fill_related_links(entries)
+    for entry in updated:
+        assert len(entry.get("related", [])) <= 3
+
+
+def test_entry_without_id_is_skipped_for_linking() -> None:
+    """Entries without id field are not used as link targets."""
+    a = _base_card("LESS-A", ["runtime", "state"])
+    no_id: dict = {
+        "problem": "no id", "solution": "sol", "tags": ["runtime", "state"],
+        "severity": "medium", "evidence": ["x"],
+    }
+    updated, unknown = fill_related_links([a, no_id])
+    # no_id is preserved in output even without id.
+    assert len(updated) == 2
+    # no_id is not in LESS-A's related (no slug to link).
+    assert updated[0].get("related", []) == [] or all(
+        s and s != "" for s in updated[0].get("related", [])
+    )
+
+
+def test_fill_related_does_not_mutate_input() -> None:
+    """fill_related_links must not mutate the original entry dicts."""
+    a = _base_card("LESS-A", ["runtime", "state"])
+    b = _base_card("LESS-B", ["runtime", "state"])
+    original_a_keys = set(a.keys())
+    fill_related_links([a, b])
+    assert set(a.keys()) == original_a_keys
+
+
+# ---------------------------------------------------------------------------
+# 3. Card rendering: related hint in build_lessons_context
+# ---------------------------------------------------------------------------
+
+def test_related_hint_in_lesson_card(tmp_path: Path) -> None:
+    """build_lessons_context includes 'related' in card when entries have related."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    lesson_with_related = {
+        "lessons": [
+            {
+                "id": "LESS-1",
+                "title": "parser incremental reads failure",
+                "problem": "parser fails when processing incremental reads",
+                "solution": "use incremental reads",
+                "tags": ["runtime"],
+                "approach": "Incremental parser reads avoid failure",
+                "reusable_insight": "Use bounded incremental reads everywhere",
+                "severity": "medium",
+                "evidence": ["cycle-test"],
+                "related": ["LESS-2", "LESS-3"],
+            }
+        ]
+    }
+    (lessons_dir / "lessons.yaml").write_text(
+        yaml.safe_dump(lesson_with_related, allow_unicode=True), encoding="utf-8"
+    )
+
+    ctx = build_lessons_context(tmp_path, "parser incremental reads failure")
+    assert "relevant_lesson" in ctx
+    rl = ctx["relevant_lesson"]
+    assert "related" in rl
+    assert "LESS-2" in rl["related"] or "LESS-3" in rl["related"]
+
+
+def test_related_hint_is_absent_when_not_set(tmp_path: Path) -> None:
+    """build_lessons_context omits 'related' key when entry has no related field."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    lesson_no_related = {
+        "lessons": [
+            {
+                "id": "LESS-1",
+                "title": "parser incremental reads failure",
+                "problem": "parser fails when processing incremental reads",
+                "solution": "use incremental reads",
+                "tags": ["runtime"],
+                "approach": "Incremental parser reads avoid failure",
+                "reusable_insight": "Use bounded incremental reads everywhere",
+                "severity": "medium",
+                "evidence": ["cycle-test"],
+                # No 'related' field.
+            }
+        ]
+    }
+    (lessons_dir / "lessons.yaml").write_text(
+        yaml.safe_dump(lesson_no_related, allow_unicode=True), encoding="utf-8"
+    )
+
+    ctx = build_lessons_context(tmp_path, "parser incremental reads failure")
+    assert "relevant_lesson" in ctx
+    rl = ctx["relevant_lesson"]
+    assert "related" not in rl
+
+
+# ---------------------------------------------------------------------------
+# 4. Byte-identity: absent related must not change existing output
+# ---------------------------------------------------------------------------
+
+def test_related_hint_empty_string() -> None:
+    """related_hint() returns '' for entries without related (byte-identical behavior)."""
+    entry = {"id": "LESS-1", "problem": "x", "solution": "y"}
+    assert related_hint(entry) == ""
+
+
+def test_related_hint_non_empty() -> None:
+    """related_hint() renders compact one-line hint when related is present."""
+    entry = {"id": "LESS-1", "related": ["LESS-2", "LESS-3"]}
+    hint = related_hint(entry)
+    assert hint == "related: LESS-2, LESS-3"
+
+
+def test_related_hint_capped() -> None:
+    """related_hint() caps at 3 slugs."""
+    entry = {"id": "LESS-1", "related": ["A", "B", "C", "D"]}
+    hint = related_hint(entry)
+    assert hint.count(",") == 2  # only 3 slugs → 2 commas
+
+
+def test_build_lessons_context_byte_identical_without_related(tmp_path: Path) -> None:
+    """When no entry has related, build_lessons_context output has no 'related' key at all."""
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir()
+    (lessons_dir / "lessons.yaml").write_text(
+        yaml.safe_dump({
+            "lessons": [{
+                "id": "LESS-1",
+                "title": "incremental parser bounded reads",
+                "problem": "incremental parser bounded reads fails",
+                "solution": "incremental bounded solution",
+                "tags": ["runtime"],
+                "approach": "Use incremental bounded streaming",
+                "reusable_insight": "Stream data incrementally",
+                "severity": "medium",
+                "evidence": ["cycle-x"],
+            }]
+        }),
+        encoding="utf-8",
+    )
+    ctx = build_lessons_context(tmp_path, "incremental parser bounded reads")
+    rl = ctx.get("relevant_lesson", {})
+    assert "related" not in rl
+
+
+# ---------------------------------------------------------------------------
+# 5. Rotation preserves related field
+# ---------------------------------------------------------------------------
+
+def test_rotation_preserves_related(tmp_path: Path) -> None:
+    """lessons_rotation preserves 'related' field through atomic YAML round-trip."""
+    lessons_path = tmp_path / "lessons.yaml"
+    # Write entry with related using atomic_write_yaml.
+    entries = [
+        _base_card("LESS-1", ["runtime", "state"], related=["LESS-2"]),
+        _base_card("LESS-2", ["runtime", "state"], related=["LESS-1"]),
+    ]
+    atomic_write_yaml(lessons_path, {"lessons": entries})
+
+    # Read back and verify related is preserved.
+    loaded = bounded_load_yaml(lessons_path)
+    by_id = {e["id"]: e for e in loaded}
+    assert "LESS-2" in by_id["LESS-1"]["related"]
+    assert "LESS-1" in by_id["LESS-2"]["related"]
+
+
+def test_rotation_module_preserves_related_bytes(tmp_path: Path) -> None:
+    """lessons_rotation.rotate_lessons_file round-trips related field via raw bytes."""
+    from nanobot.runtime.lessons_rotation import rotate_lessons_file
+
+    yaml_path = tmp_path / "lessons.yaml"
+    # Build 201 entries with id FIRST (the rotation parser splits on '- id:' boundaries).
+    # Use atomic_write_yaml via manual write — sort_keys=False and id-first dict ordering.
+    entries = []
+    for i in range(201):
+        # id must be first key so yaml.safe_dump(sort_keys=False) emits '- id:' as boundary.
+        e = {
+            "id": f"LESS-{i:03d}",
+            "problem": f"Problem for LESS-{i:03d}",
+            "solution": f"Solution for LESS-{i:03d}",
+            "tags": ["runtime", "state"],
+            "severity": "medium",
+            "evidence": ["cycle-test"],
+        }
+        if i < 5:
+            e["related"] = ["LESS-999"]
+        entries.append(e)
+    # sort_keys=False keeps id first so the rotation parser sees '- id:' entry boundaries.
+    yaml_path.write_text(
+        yaml.safe_dump({"lessons": entries}, allow_unicode=True, sort_keys=False), encoding="utf-8"
+    )
+
+    result = rotate_lessons_file(yaml_path)
+    # Rotation should have occurred (returns archive name): 201 entries > 200 cap.
+    assert result is not None
+
+    # Active window still parseable.
+    loaded_text = yaml_path.read_text(encoding="utf-8")
+    loaded = yaml.safe_load(loaded_text)
+    assert isinstance(loaded.get("lessons"), list)
+    # Entries 0..4 had 'related'; they are in the active window (first 200).
+    active_related = [
+        e for e in loaded["lessons"] if "related" in e
+    ]
+    assert active_related, "at least one entry with 'related' should survive rotation"
+
+
+# ---------------------------------------------------------------------------
+# 6. Bounded open-count: fill_related_links uses no file I/O
+# ---------------------------------------------------------------------------
+
+def test_fill_related_links_no_file_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fill_related_links must not open any files (pure in-memory operation)."""
+    open_calls: list[str] = []
+    original_open = open
+
+    def counting_open(*args: Any, **kwargs: Any) -> Any:
+        # Record any call to open.
+        open_calls.append(str(args[0]) if args else "unknown")
+        return original_open(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", counting_open)
+
+    entries = [
+        _base_card("LESS-A", ["runtime", "state"]),
+        _base_card("LESS-B", ["runtime", "state"]),
+    ]
+    fill_related_links(entries)
+
+    assert not open_calls, f"fill_related_links opened files: {open_calls}"

--- a/tests/test_lateral_links.py
+++ b/tests/test_lateral_links.py
@@ -61,6 +61,22 @@ def test_related_absent_still_validates() -> None:
     assert validate_lesson(card)
 
 
+def test_related_validation_is_bounded_but_unknown_is_allowed() -> None:
+    """Unknown targets remain valid, while malformed/over-cap links fail."""
+    card = _base_card("LESS-1", ["runtime"], related=["FUTURE-SLUG"])
+    assert validate_lesson(card)
+    assert not validate_lesson({**card, "related": ["A", "B", "C", "D"]})
+    assert not validate_lesson({**card, "related": ["bad slug"]})
+
+
+def test_inline_wikilinks_are_reported_and_preserved() -> None:
+    """Inline [[slug]] references are mechanical, bounded, and non-fatal."""
+    card = _base_card("LESS-1", ["runtime"], problem="See [[future-fact]] for context")
+    updated, unknown = fill_related_links([card])
+    assert updated[0]["problem"] == card["problem"]
+    assert "future-fact" in unknown
+
+
 def test_fill_related_caps_at_three() -> None:
     """fill_related_links must cap related at 3 slugs per entry."""
     # Entry with 4 manually set related (existing) — must be capped to 3.
@@ -269,6 +285,26 @@ def test_related_hint_capped() -> None:
     entry = {"id": "LESS-1", "related": ["A", "B", "C", "D"]}
     hint = related_hint(entry)
     assert hint.count(",") == 2  # only 3 slugs → 2 commas
+
+
+def test_curator_stage_items_add_related_to_index_line(tmp_path: Path) -> None:
+    """Curator's bounded staged fact index hint carries explicit related slugs."""
+    from nanobot.runtime.knowledge_curator import _collect_stage_items
+
+    state = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    (workspace / "memory" / "facts").mkdir(parents=True)
+    items, writes = _collect_stage_items(
+        workspace, state,
+        [{"action": "create", "path": "memory/facts/fact-a.md", "title": "Fact A",
+          "content": "Fact body [[fact-b]]", "lesson_id": "L1", "reason": "reason",
+          "evidence": ["#1095"], "support_claim": "Fact body"}],
+        3,
+        entries=[],
+    )
+    assert writes == 1
+    assert "related: fact-b" in items[0]["index_line"]
+    assert items[0]["related"] == ["fact-b"]
 
 
 def test_build_lessons_context_byte_identical_without_related(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements lateral related-edges for lesson v2 entries and curator KB facts (#1095).

### Changes

**`nanobot/runtime/lesson_v2.py`**
- `fill_related_links(entries)`: mechanical linking by shared ≥2 controlled glossary tags OR shared demand-lineage key (`delta_evidence`/`cycle_id`). Symmetric, cap 3, deterministic, no LLM. Unknown slug targets are reported (returned set), never rejected.
- `related_hint(entry)`: compact one-line renderer — empty string when no related (byte-identical behavior for unlinked entries).

**`nanobot/runtime/lessons_context.py`**
- `build_lessons_context`: renders `related` field in selected card output when present; omits key entirely when absent (byte-identical prompt for entries without lateral links).
- `_related_hint_for`: internal helper capped at 3 slugs.

**`nanobot/runtime/knowledge_curator.py`**
- `promote_reflector_recommendations_to_v2`: calls `fill_related_links()` after writing lessons.yaml so every curator write applies mechanical linking.

**`tests/test_lateral_links.py`** — 21 focused acceptance tests:
- Schema: `related` accepted, capped, preserved; unknown slugs reported not rejected
- Mechanical linking: shared-tag (≥2) → symmetric links; single-tag → no link; shared lineage → link; different lineage → no link; cap at 3 with many entries
- Entry without id skipped; input not mutated
- Card rendering: related rendered when present, absent when not set
- Byte identity: `related_hint()` returns `""` when absent; `build_lessons_context` omits key
- Rotation preserves related via `atomic_write_yaml` round-trip and raw-byte rotation
- Bounded open-count: `fill_related_links` opens zero files

### Design notes
- No LLM calls added anywhere in this change
- Rotation (`lessons_rotation.rotate_lessons_file`) preserves `related` via raw-byte pass-through (unchanged)
- #1094 two-tier evidence verification and fail-closed schema validation untouched
- `gate/deny-set/goals.md` not touched

Closes #1095