### PR TITLE
fix(agent): break repeated tool-call loops (#1101)

### DIFF
--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -19,7 +19,7 @@ from nanobot.agent.memory import MemoryConsolidator
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
 from nanobot.agent.subagent import (
     SubagentManager,
-    _canonical_tool_key,
+    _canonical_response_key,
     _loop_breaker_k,
     _subagent_wall_deadline,
 )
@@ -257,38 +257,42 @@ class AgentLoop:
                         messages, tool_call.id, tool_call.name, result
                     )
 
-                    # #1101: identical-call loop breaker
-                    _key = _canonical_tool_key(tool_call.name, tool_call.arguments)
-                    if _key == _lb_last_key:
-                        _lb_count += 1
-                    else:
-                        _lb_last_key = _key
-                        _lb_count = 1
+                # #1101: identical-call loop breaker — compare response-level tuple.
+                # A multi-tool response [A, B] repeated across iterations increments
+                # the counter; a different tuple (or single-call change) resets it.
+                _resp_key = _canonical_response_key(response.tool_calls)
+                if _resp_key == _lb_last_key:
+                    _lb_count += 1
+                else:
+                    _lb_last_key = _resp_key
+                    _lb_count = 1
 
-                    if _lb_count >= 2 * _lbk:
-                        logger.warning(
-                            "Agent loop abort: {} identical '{}' calls (2K={})",
-                            _lb_count, tool_call.name, 2 * _lbk,
-                        )
-                        _lb_aborted = True
-                        break
-                    elif _lb_count == _lbk:
-                        logger.info(
-                            "Agent loop warning: {} identical '{}' calls",
-                            _lb_count, tool_call.name,
-                        )
-                        # Inject warning as a synthetic tool result
-                        messages = self.context.add_tool_result(
-                            messages,
-                            tool_call.id + "-lb",
-                            "loop_breaker",
-                            (
-                                f"Safety stop: this tool call ('{tool_call.name}') has been "
-                                f"repeated {_lb_count} consecutive times with no change in "
-                                f"arguments. Change approach, try a different strategy, or "
-                                f"provide the final answer now."
-                            ),
-                        )
+                if _lb_count >= 2 * _lbk:
+                    _names = ", ".join(tc.name for tc in response.tool_calls)
+                    logger.warning(
+                        "Agent loop abort: {} identical response tuples (2K={})",
+                        _lb_count, 2 * _lbk,
+                    )
+                    _lb_aborted = True
+                elif _lb_count == _lbk:
+                    _last_tc = response.tool_calls[-1]
+                    _names = ", ".join(tc.name for tc in response.tool_calls)
+                    logger.info(
+                        "Agent loop warning: {} identical response tuples",
+                        _lb_count,
+                    )
+                    # Inject warning as a synthetic tool result
+                    messages = self.context.add_tool_result(
+                        messages,
+                        _last_tc.id + "-lb",
+                        "loop_breaker",
+                        (
+                            f"Safety stop: this response (tools: [{_names}]) has been "
+                            f"repeated {_lb_count} consecutive times with no change. "
+                            f"Change approach, try a different strategy, or "
+                            f"provide the final answer now."
+                        ),
+                    )
 
                 if _lb_aborted:
                     break

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sys
+import time
 from contextlib import AsyncExitStack
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
@@ -15,9 +16,14 @@ from loguru import logger
 
 from nanobot.agent.context import ContextBuilder
 from nanobot.agent.memory import MemoryConsolidator
-from nanobot.agent.subagent import SubagentManager
-from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.skills import BUILTIN_SKILLS_DIR
+from nanobot.agent.subagent import (
+    SubagentManager,
+    _canonical_tool_key,
+    _loop_breaker_k,
+    _subagent_wall_deadline,
+)
+from nanobot.agent.tools.cron import CronTool
 from nanobot.agent.tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from nanobot.agent.tools.message import MessageTool
 from nanobot.agent.tools.registry import ToolRegistry
@@ -195,7 +201,24 @@ class AgentLoop:
         final_content = None
         tools_used: list[str] = []
 
+        # #1101: identical-call loop breaker state
+        _lbk = _loop_breaker_k()
+        _lb_last_key: str | None = None
+        _lb_count: int = 0
+        _lb_aborted = False
+        # #1101: wall-clock soft deadline
+        _wall_deadline = _subagent_wall_deadline()
+
         while iteration < self.max_iterations:
+            # #1101: wall-clock deadline check
+            if _wall_deadline is not None and time.monotonic() >= _wall_deadline:
+                logger.warning("Agent loop wall-clock deadline reached")
+                final_content = (
+                    "I reached the wall-clock time limit before completing the task. "
+                    "You can try breaking the task into smaller steps."
+                )
+                break
+
             iteration += 1
 
             tool_defs = self.tools.get_definitions()
@@ -233,6 +256,42 @@ class AgentLoop:
                     messages = self.context.add_tool_result(
                         messages, tool_call.id, tool_call.name, result
                     )
+
+                    # #1101: identical-call loop breaker
+                    _key = _canonical_tool_key(tool_call.name, tool_call.arguments)
+                    if _key == _lb_last_key:
+                        _lb_count += 1
+                    else:
+                        _lb_last_key = _key
+                        _lb_count = 1
+
+                    if _lb_count >= 2 * _lbk:
+                        logger.warning(
+                            "Agent loop abort: {} identical '{}' calls (2K={})",
+                            _lb_count, tool_call.name, 2 * _lbk,
+                        )
+                        _lb_aborted = True
+                        break
+                    elif _lb_count == _lbk:
+                        logger.info(
+                            "Agent loop warning: {} identical '{}' calls",
+                            _lb_count, tool_call.name,
+                        )
+                        # Inject warning as a synthetic tool result
+                        messages = self.context.add_tool_result(
+                            messages,
+                            tool_call.id + "-lb",
+                            "loop_breaker",
+                            (
+                                f"Safety stop: this tool call ('{tool_call.name}') has been "
+                                f"repeated {_lb_count} consecutive times with no change in "
+                                f"arguments. Change approach, try a different strategy, or "
+                                f"provide the final answer now."
+                            ),
+                        )
+
+                if _lb_aborted:
+                    break
             else:
                 clean = self._strip_think(response.content)
                 # Don't persist error responses to session history — they can
@@ -248,7 +307,12 @@ class AgentLoop:
                 final_content = clean
                 break
 
-        if final_content is None and iteration >= self.max_iterations:
+        if _lb_aborted:
+            final_content = (
+                f"Task aborted: agent repeated the same tool call "
+                f"{_lb_count} consecutive times (stop_reason=identical_call_loop)."
+            )
+        elif final_content is None and iteration >= self.max_iterations:
             logger.warning("Max iterations ({}) reached", self.max_iterations)
             final_content = (
                 f"I reached the maximum number of tool call iterations ({self.max_iterations}) "

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import os
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,8 +20,67 @@ from nanobot.bus.events import InboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.config.schema import ExecToolConfig
 from nanobot.providers.base import LLMProvider
-from nanobot.utils.helpers import build_assistant_message
 from nanobot.runtime import context_compaction as _ctx_compact
+from nanobot.utils.helpers import build_assistant_message
+
+# ── #1101: identical-tool-call loop breaker ───────────────────────────────────
+# Number of consecutive identical (tool_name, canonical_args) calls before the
+# warning message is injected.  2×K triggers abort.  Env-tunable; default 3.
+_LOOP_BREAKER_K_DEFAULT = 3
+
+
+def _loop_breaker_k() -> int:
+    """Return K from NANOBOT_LOOP_BREAKER_K env (positive int, default 3)."""
+    raw = os.environ.get("NANOBOT_LOOP_BREAKER_K", "").strip()
+    try:
+        v = int(raw)
+        if v > 0:
+            return v
+    except (ValueError, TypeError):
+        pass
+    return _LOOP_BREAKER_K_DEFAULT
+
+
+def _canonical_tool_key(name: str, arguments: Any) -> str:
+    """Stable string key for a tool call ignoring call ID.
+
+    Sorts dict keys for canonical ordering; falls back gracefully for
+    non-dict arguments so unusual invocations never crash the guard.
+    """
+    try:
+        if isinstance(arguments, dict):
+            return json.dumps({"n": name, "a": arguments}, sort_keys=True, ensure_ascii=False,
+                               separators=(",", ":"))
+        return json.dumps({"n": name, "a": str(arguments)}, sort_keys=True, ensure_ascii=False,
+                           separators=(",", ":"))
+    except Exception:
+        return f"{name}:?"
+
+
+def _subagent_wall_deadline(
+    _now: "float | None" = None,
+    _monotonic: "Any | None" = None,
+) -> "float | None":
+    """Return monotonic deadline for the subagent wall-clock guard.
+
+    Reads NANOBOT_SUBAGENT_WALL_SECS (positive float, default 3000 seconds
+    = 50 minutes, safely below TimeoutStartSec=55min).  Returns None when
+    env is unset/invalid so the guard is skipped.  Injectable clock for tests.
+    """
+    raw = os.environ.get("NANOBOT_SUBAGENT_WALL_SECS", "").strip()
+    if not raw:
+        # Default: 3000 s (50 min) soft deadline, active by default
+        secs: float = 3000.0
+    else:
+        try:
+            secs = float(raw)
+            if secs <= 0:
+                return None
+        except (ValueError, TypeError):
+            return None
+    clock = _monotonic or time.monotonic
+    start = _now if _now is not None else clock()
+    return start + secs
 
 
 class SubagentManager:
@@ -206,8 +267,24 @@ class SubagentManager:
             max_iterations = self.max_iterations
             iteration = 0
             final_result: str | None = None
+            stop_reason: str | None = None
+
+            # #1101: loop-breaker state
+            _lbk = _loop_breaker_k()
+            _lb_last_key: str | None = None
+            _lb_count: int = 0
+            # #1101: wall-clock soft deadline (injectable for tests)
+            _wall_deadline = _subagent_wall_deadline(_monotonic=getattr(self, '_monotonic', None))
 
             while iteration < max_iterations:
+                # #1101: wall-clock deadline check (same graceful path as max_iterations)
+                if _wall_deadline is not None:
+                    _clock = getattr(self, '_monotonic', None) or time.monotonic
+                    if _clock() >= _wall_deadline:
+                        logger.warning("Subagent [{}] wall-clock deadline reached", task_id)
+                        stop_reason = "wall_clock_deadline"
+                        break
+
                 iteration += 1
 
                 response = await self.provider.chat_with_retry(
@@ -251,14 +328,62 @@ class SubagentManager:
                                 iteration=iteration,
                                 state_root=self._state_root,
                             )
+
+                        # #1101: identical-call loop breaker — check each executed call.
+                        _key = _canonical_tool_key(tool_call.name, tool_call.arguments)
+                        if _key == _lb_last_key:
+                            _lb_count += 1
+                        else:
+                            _lb_last_key = _key
+                            _lb_count = 1
+
+                        if _lb_count >= 2 * _lbk:
+                            # Hard abort: 2K identical calls, record distinct stop reason.
+                            logger.warning(
+                                "Subagent [{}] abort: {} identical '{}' calls (2K={})",
+                                task_id, _lb_count, tool_call.name, 2 * _lbk,
+                            )
+                            stop_reason = "identical_call_loop"
+                            break
+                        elif _lb_count == _lbk:
+                            # Warning injection at exactly K: add synthetic tool result message.
+                            logger.info(
+                                "Subagent [{}] loop-breaker warning: {} identical '{}' calls",
+                                task_id, _lb_count, tool_call.name,
+                            )
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": tool_call.id + "-lb",
+                                "name": "loop_breaker",
+                                "content": (
+                                    f"Safety stop: this tool call ('{tool_call.name}') has been "
+                                    f"repeated {_lb_count} consecutive times with no change in "
+                                    f"arguments. Change approach, try a different strategy, or "
+                                    f"provide the final answer now."
+                                ),
+                            })
+
+                    if stop_reason == "identical_call_loop":
+                        break
                 else:
                     final_result = response.content
                     break
 
-            if final_result is None:
+            if stop_reason == "identical_call_loop":
+                final_result = (
+                    f"Task aborted: subagent repeated the same tool call "
+                    f"{_lb_count} consecutive times (stop_reason=identical_call_loop)."
+                )
+            elif stop_reason == "wall_clock_deadline":
+                final_result = (
+                    "I reached the wall-clock time limit before completing the task. "
+                    "You can try breaking the task into smaller steps."
+                )
+            elif final_result is None:
                 final_result = "Task completed but no final response was generated."
 
             finished_at = self._utc_now()
+            _telem_status = "bounded_stop" if stop_reason else "ok"
             self._write_subagent_telemetry(
                 task_id,
                 self._build_subagent_telemetry_payload(
@@ -267,12 +392,13 @@ class SubagentManager:
                     label=label,
                     started_at=self._read_subagent_started_at(task_id) or finished_at,
                     finished_at=finished_at,
-                    status="ok",
+                    status=_telem_status,
                     summary=final_result,
                     result=final_result,
                     origin=origin,
                     session_key=session_key,
                     correlation_context=correlation_context,
+                    stop_reason=stop_reason,
                 ),
             )
             logger.info("Subagent [{}] completed successfully", task_id)
@@ -353,7 +479,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
 
         await self.bus.publish_inbound(msg)
         logger.debug("Subagent [{}] announced result to {}:{}", task_id, origin['channel'], origin['chat_id'])
-    
+
     def _build_subagent_correlation_context(self) -> dict[str, Any]:
         """Return best-effort runtime correlation data for durable telemetry."""
         try:
@@ -402,6 +528,7 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         origin: dict[str, str],
         session_key: str | None,
         correlation_context: dict[str, Any] | None = None,
+        stop_reason: str | None = None,
     ) -> dict[str, Any]:
         payload = {
             "subagent_id": task_id,
@@ -418,6 +545,8 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
             "runtime_state_root": str(self._state_root),
             "runtime_state_source": self._runtime_state_source,
         }
+        if stop_reason:
+            payload["stop_reason"] = stop_reason
         if correlation_context:
             payload.update(correlation_context)
         return payload

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -57,6 +57,20 @@ def _canonical_tool_key(name: str, arguments: Any) -> str:
         return f"{name}:?"
 
 
+def _canonical_response_key(tool_calls: "list[Any]") -> str:
+    """Stable string key for an entire response's tool-call tuple.
+
+    Compares the ordered sequence of (name, canonical_args) across all calls
+    in the response, ignoring call IDs.  A multi-tool response [A, B] repeated
+    twice increments the counter; [A, B, A, B] alternating resets it.
+    """
+    parts = [_canonical_tool_key(tc.name, tc.arguments) for tc in tool_calls]
+    try:
+        return json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
+    except Exception:
+        return str(parts)
+
+
 def _subagent_wall_deadline(
     _now: "float | None" = None,
     _monotonic: "Any | None" = None,
@@ -329,42 +343,44 @@ class SubagentManager:
                                 state_root=self._state_root,
                             )
 
-                        # #1101: identical-call loop breaker — check each executed call.
-                        _key = _canonical_tool_key(tool_call.name, tool_call.arguments)
-                        if _key == _lb_last_key:
-                            _lb_count += 1
-                        else:
-                            _lb_last_key = _key
-                            _lb_count = 1
+                    # #1101: identical-call loop breaker — compare response-level tuple.
+                    # A multi-tool response [A, B] repeated across iterations increments
+                    # the counter; a different tuple (or single-call change) resets it.
+                    _resp_key = _canonical_response_key(response.tool_calls)
+                    if _resp_key == _lb_last_key:
+                        _lb_count += 1
+                    else:
+                        _lb_last_key = _resp_key
+                        _lb_count = 1
 
-                        if _lb_count >= 2 * _lbk:
-                            # Hard abort: 2K identical calls, record distinct stop reason.
-                            logger.warning(
-                                "Subagent [{}] abort: {} identical '{}' calls (2K={})",
-                                task_id, _lb_count, tool_call.name, 2 * _lbk,
-                            )
-                            stop_reason = "identical_call_loop"
-                            break
-                        elif _lb_count == _lbk:
-                            # Warning injection at exactly K: add synthetic tool result message.
-                            logger.info(
-                                "Subagent [{}] loop-breaker warning: {} identical '{}' calls",
-                                task_id, _lb_count, tool_call.name,
-                            )
-                            messages.append({
-                                "role": "tool",
-                                "tool_call_id": tool_call.id + "-lb",
-                                "name": "loop_breaker",
-                                "content": (
-                                    f"Safety stop: this tool call ('{tool_call.name}') has been "
-                                    f"repeated {_lb_count} consecutive times with no change in "
-                                    f"arguments. Change approach, try a different strategy, or "
-                                    f"provide the final answer now."
-                                ),
-                            })
-
-                    if stop_reason == "identical_call_loop":
+                    if _lb_count >= 2 * _lbk:
+                        # Hard abort: 2K identical response tuples.
+                        _names = ", ".join(tc.name for tc in response.tool_calls)
+                        logger.warning(
+                            "Subagent [{}] abort: {} identical response tuples (2K={})",
+                            task_id, _lb_count, 2 * _lbk,
+                        )
+                        stop_reason = "identical_call_loop"
                         break
+                    elif _lb_count == _lbk:
+                        # Warning injection at exactly K: add synthetic tool result message.
+                        _last_tc = response.tool_calls[-1]
+                        _names = ", ".join(tc.name for tc in response.tool_calls)
+                        logger.info(
+                            "Subagent [{}] loop-breaker warning: {} identical response tuples",
+                            task_id, _lb_count,
+                        )
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": _last_tc.id + "-lb",
+                            "name": "loop_breaker",
+                            "content": (
+                                f"Safety stop: this response (tools: [{_names}]) has been "
+                                f"repeated {_lb_count} consecutive times with no change. "
+                                f"Change approach, try a different strategy, or "
+                                f"provide the final answer now."
+                            ),
+                        })
                 else:
                     final_result = response.content
                     break

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -15,6 +15,7 @@ import asyncio
 import pytest
 
 from nanobot.agent.subagent import (
+    _canonical_response_key,
     _canonical_tool_key,
     _loop_breaker_k,
     _subagent_wall_deadline,
@@ -350,3 +351,180 @@ class TestAgentLoopBreaker:
         # Content may be None (no iterations ran) or the deadline message
         # The key constraint is: no exception was raised
         assert content is None or isinstance(content, str)
+
+
+# ── _canonical_response_key unit tests ───────────────────────────────────────
+
+class TestCanonicalResponseKey:
+    def _make_tc(self, name: str, arguments: dict, call_id: str = "id1") -> ToolCallRequest:
+        return ToolCallRequest(id=call_id, name=name, arguments=arguments)
+
+    def test_same_single_call_equal(self):
+        a = self._make_tc("exec", {"cmd": "ls"}, "id-1")
+        b = self._make_tc("exec", {"cmd": "ls"}, "id-2")  # different ID
+        assert _canonical_response_key([a]) == _canonical_response_key([b])
+
+    def test_same_multi_call_equal(self):
+        r1 = [
+            self._make_tc("exec", {"cmd": "ls"}, "x"),
+            self._make_tc("read", {"path": "/tmp"}, "y"),
+        ]
+        r2 = [
+            self._make_tc("exec", {"cmd": "ls"}, "a"),  # different IDs
+            self._make_tc("read", {"path": "/tmp"}, "b"),
+        ]
+        assert _canonical_response_key(r1) == _canonical_response_key(r2)
+
+    def test_differing_order_not_equal(self):
+        """[A, B] vs [B, A] are NOT identical — order matters in a response."""
+        r1 = [self._make_tc("exec", {"cmd": "ls"}), self._make_tc("read", {"path": "/x"})]
+        r2 = [self._make_tc("read", {"path": "/x"}), self._make_tc("exec", {"cmd": "ls"})]
+        assert _canonical_response_key(r1) != _canonical_response_key(r2)
+
+    def test_differing_args_not_equal(self):
+        r1 = [self._make_tc("exec", {"cmd": "ls"})]
+        r2 = [self._make_tc("exec", {"cmd": "pwd"})]
+        assert _canonical_response_key(r1) != _canonical_response_key(r2)
+
+    def test_differing_length_not_equal(self):
+        r1 = [self._make_tc("exec", {"cmd": "ls"})]
+        r2 = [self._make_tc("exec", {"cmd": "ls"}), self._make_tc("exec", {"cmd": "ls"})]
+        assert _canonical_response_key(r1) != _canonical_response_key(r2)
+
+    def test_dict_key_order_ignored(self):
+        """arg key ordering within each call must not matter."""
+        r1 = [self._make_tc("exec", {"cmd": "ls", "dir": "."})]
+        r2 = [self._make_tc("exec", {"dir": ".", "cmd": "ls"})]
+        assert _canonical_response_key(r1) == _canonical_response_key(r2)
+
+
+# ── Multi-tool response regression tests ─────────────────────────────────────
+
+class TestMultiToolResponseBreaker:
+    """Regression: multi-tool response [A, B] repeated across iterations
+    must trigger the breaker; alternating [A, B], [C, D] must not."""
+
+    async def test_subagent_multi_tool_repeated_aborts(self, tmp_path, monkeypatch):
+        """SubagentManager: response [exec, read] repeated 2K times → abort."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+
+        class _MultiToolProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[
+                        ToolCallRequest(id=f"a-{self.calls}", name="exec", arguments={"cmd": "ls"}),
+                        ToolCallRequest(id=f"b-{self.calls}", name="exec", arguments={"cmd": "pwd"}),
+                    ],
+                )
+
+        provider = _MultiToolProvider()
+        telem = await _run_manager(tmp_path, provider, max_iterations=100)
+        assert telem.get("stop_reason") == "identical_call_loop"
+        assert telem["status"] == "bounded_stop"
+
+    async def test_subagent_alternating_multi_tool_no_abort(self, tmp_path, monkeypatch):
+        """SubagentManager: alternating [A, B] / [C, D] must NOT trigger the breaker."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+
+        class _AlternatingProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                if self.calls > 6:
+                    return LLMResponse(content="done", tool_calls=[])
+                if self.calls % 2 == 1:
+                    # odd: [exec(ls), exec(pwd)]
+                    tcs = [
+                        ToolCallRequest(id=f"a-{self.calls}", name="exec", arguments={"cmd": "ls"}),
+                        ToolCallRequest(id=f"b-{self.calls}", name="exec", arguments={"cmd": "pwd"}),
+                    ]
+                else:
+                    # even: [exec(ls), exec(date)]
+                    tcs = [
+                        ToolCallRequest(id=f"a-{self.calls}", name="exec", arguments={"cmd": "ls"}),
+                        ToolCallRequest(id=f"b-{self.calls}", name="exec", arguments={"cmd": "date"}),
+                    ]
+                return LLMResponse(content=None, tool_calls=tcs)
+
+        provider = _AlternatingProvider()
+        telem = await _run_manager(tmp_path, provider, max_iterations=20)
+        assert telem.get("stop_reason") != "identical_call_loop"
+        assert telem["status"] == "ok"
+
+    async def test_agent_loop_multi_tool_repeated_aborts(self, tmp_path, monkeypatch):
+        """AgentLoop: response [list_dir, list_dir] repeated 2K times → abort."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.agent.tools.filesystem import ListDirTool
+        from nanobot.bus.queue import MessageBus
+
+        class _MultiLoopProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[
+                        ToolCallRequest(id=f"a-{self.calls}", name="list_dir", arguments={"path": "."}),
+                        ToolCallRequest(id=f"b-{self.calls}", name="list_dir", arguments={"path": ".."}),
+                    ],
+                )
+
+        provider = _MultiLoopProvider()
+        bus = MessageBus()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, max_iterations=100)
+        loop.tools.register(ListDirTool(workspace=tmp_path))
+
+        initial = [{"role": "user", "content": "loop with multi tools"}]
+        content, tools_used, _ = await loop._run_agent_loop(initial)
+        assert "identical_call_loop" in (content or "")
+
+    async def test_agent_loop_alternating_multi_tool_no_abort(self, tmp_path, monkeypatch):
+        """AgentLoop: alternating [A, B] / [A, C] does NOT trigger breaker."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.agent.tools.filesystem import ListDirTool
+        from nanobot.bus.queue import MessageBus
+
+        class _AltLoopProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                if self.calls > 6:
+                    return LLMResponse(content="done", tool_calls=[])
+                if self.calls % 2 == 1:
+                    tcs = [
+                        ToolCallRequest(id=f"x-{self.calls}", name="list_dir", arguments={"path": "."}),
+                        ToolCallRequest(id=f"y-{self.calls}", name="list_dir", arguments={"path": ".."}),
+                    ]
+                else:
+                    tcs = [
+                        ToolCallRequest(id=f"x-{self.calls}", name="list_dir", arguments={"path": "."}),
+                        ToolCallRequest(id=f"y-{self.calls}", name="list_dir", arguments={"path": "./sub"}),
+                    ]
+                return LLMResponse(content=None, tool_calls=tcs)
+
+        provider = _AltLoopProvider()
+        bus = MessageBus()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, max_iterations=20)
+        loop.tools.register(ListDirTool(workspace=tmp_path))
+
+        initial = [{"role": "user", "content": "alternate multi tools"}]
+        content, tools_used, _ = await loop._run_agent_loop(initial)
+        assert "identical_call_loop" not in (content or "")
+        assert content == "done"

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -1,0 +1,352 @@
+"""Tests for #1101: identical-tool-call loop breaker and wall-clock alignment.
+
+Covers:
+- K consecutive identical calls inject a synthetic break message (counter resets on differing call)
+- 2K consecutive identical calls abort with stop_reason=identical_call_loop
+- Wall-clock soft deadline triggers graceful stop (fake clock)
+- Polling with changing arguments never triggers the guard
+- Env-tunable K with default 3
+- Both SubagentManager._run_subagent and AgentLoop._run_agent_loop
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nanobot.agent.subagent import (
+    _canonical_tool_key,
+    _loop_breaker_k,
+    _subagent_wall_deadline,
+)
+from nanobot.providers.base import LLMProvider, LLMResponse, ToolCallRequest
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+class _Provider(LLMProvider):
+    """Base test provider; subclass and override chat()."""
+
+    def get_default_model(self) -> str:
+        return "test-model"
+
+    async def chat(
+        self, messages=None, tools=None, model=None, max_tokens=4096,
+        temperature=0.7, reasoning_effort=None, tool_choice=None,
+    ) -> LLMResponse:
+        raise NotImplementedError
+
+
+# ── Unit tests for helper functions ──────────────────────────────────────────
+
+class TestCanonicalToolKey:
+    def test_same_name_same_args_equal(self):
+        a = _canonical_tool_key("exec", {"cmd": "ls", "dir": "."})
+        b = _canonical_tool_key("exec", {"dir": ".", "cmd": "ls"})
+        assert a == b, "dict key order must not matter"
+
+    def test_different_name_different(self):
+        a = _canonical_tool_key("exec", {"cmd": "ls"})
+        b = _canonical_tool_key("read_file", {"cmd": "ls"})
+        assert a != b
+
+    def test_different_args_different(self):
+        a = _canonical_tool_key("exec", {"cmd": "ls"})
+        b = _canonical_tool_key("exec", {"cmd": "ls -la"})
+        assert a != b
+
+    def test_non_dict_args_stable(self):
+        # Should not raise
+        a = _canonical_tool_key("exec", None)
+        b = _canonical_tool_key("exec", None)
+        assert a == b
+
+    def test_tool_id_not_included(self):
+        # Same name/args regardless of conceptual ID
+        a = _canonical_tool_key("read", {"path": "/tmp/x"})
+        b = _canonical_tool_key("read", {"path": "/tmp/x"})
+        assert a == b
+
+
+class TestLoopBreakerK:
+    def test_default_is_3(self, monkeypatch):
+        monkeypatch.delenv("NANOBOT_LOOP_BREAKER_K", raising=False)
+        assert _loop_breaker_k() == 3
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "5")
+        assert _loop_breaker_k() == 5
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "garbage")
+        assert _loop_breaker_k() == 3
+
+    def test_zero_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "0")
+        assert _loop_breaker_k() == 3
+
+    def test_negative_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "-1")
+        assert _loop_breaker_k() == 3
+
+
+class TestSubagentWallDeadline:
+    def test_default_active_at_3000s(self, monkeypatch):
+        monkeypatch.delenv("NANOBOT_SUBAGENT_WALL_SECS", raising=False)
+        # Fake monotonic start=0; deadline should be 0+3000
+        dl = _subagent_wall_deadline(_now=0.0, _monotonic=lambda: 0.0)
+        assert dl is not None
+        assert abs(dl - 3000.0) < 1.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_SUBAGENT_WALL_SECS", "100")
+        dl = _subagent_wall_deadline(_now=0.0, _monotonic=lambda: 0.0)
+        assert dl == pytest.approx(100.0)
+
+    def test_invalid_env_returns_none(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_SUBAGENT_WALL_SECS", "badval")
+        dl = _subagent_wall_deadline(_now=0.0, _monotonic=lambda: 0.0)
+        assert dl is None
+
+    def test_zero_env_returns_none(self, monkeypatch):
+        monkeypatch.setenv("NANOBOT_SUBAGENT_WALL_SECS", "0")
+        dl = _subagent_wall_deadline(_now=0.0, _monotonic=lambda: 0.0)
+        assert dl is None
+
+
+# ── SubagentManager integration tests ─────────────────────────────────────────
+
+class _RepeatProvider(_Provider):
+    """Returns the same exec tool call every time until depleted, then final answer."""
+
+    def __init__(self, *, repeat_count: int, final: str = "done", vary_after: int | None = None):
+        super().__init__()
+        self.calls = 0
+        self.repeat_count = repeat_count
+        self.final = final
+        self.vary_after = vary_after  # after this many calls, change args
+
+    async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+        self.calls += 1
+        if self.calls > self.repeat_count:
+            return LLMResponse(content=self.final, tool_calls=[])
+        args = {"cmd": "ls ."}
+        if self.vary_after is not None and self.calls > self.vary_after:
+            args = {"cmd": f"ls . #{self.calls}"}  # changing args after threshold
+        return LLMResponse(
+            content=None,
+            tool_calls=[ToolCallRequest(id=f"call-{self.calls}", name="exec", arguments=args)],
+        )
+
+
+async def _run_manager(tmp_path, provider, max_iterations=50, monkeypatch=None, wall_secs=None) -> dict:
+    """Spawn a task and wait for its telemetry JSON."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    if monkeypatch and wall_secs is not None:
+        monkeypatch.setenv("NANOBOT_SUBAGENT_WALL_SECS", str(wall_secs))
+
+    manager = SubagentManager(
+        provider=provider,
+        workspace=tmp_path,
+        bus=MessageBus(),
+        max_iterations=max_iterations,
+    )
+    await manager.spawn(task="test-task", label="lbtest")
+    await asyncio.gather(*list(manager._running_tasks.values()), return_exceptions=True)
+
+    # Read telemetry
+    import json
+    files = list((tmp_path / "state" / "subagents").glob("*.json"))
+    if not files:
+        # try alternate state path
+        files = list(tmp_path.rglob("subagents/*.json"))
+    assert files, "no telemetry file written"
+    return json.loads(files[0].read_text(encoding="utf-8"))
+
+
+class TestSubagentLoopBreaker:
+    async def test_k_identical_calls_inject_break_message(self, tmp_path, monkeypatch):
+        """After K identical calls a synthetic message is injected; the run continues."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        # 2 identical calls → warning injection, then final answer on call 3
+        provider = _RepeatProvider(repeat_count=2, final="finished")
+        telem = await _run_manager(tmp_path, provider, max_iterations=20)
+        # Run must complete without abort
+        assert telem["status"] == "ok"
+        assert telem.get("stop_reason") is None
+        # Provider was called 3 times (2 tool calls + 1 final answer)
+        assert provider.calls == 3
+
+    async def test_counter_resets_on_differing_call(self, tmp_path, monkeypatch):
+        """A different tool call after K-1 identical calls resets the counter."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "3")
+        # vary_after=1: first call identical, second changes args → resets counter
+        provider = _RepeatProvider(repeat_count=3, final="done", vary_after=1)
+        telem = await _run_manager(tmp_path, provider, max_iterations=20)
+        # Should NOT be an identical_call_loop abort since args changed
+        assert telem.get("stop_reason") != "identical_call_loop"
+
+    async def test_2k_identical_calls_abort_with_stop_reason(self, tmp_path, monkeypatch):
+        """2K consecutive identical calls abort with stop_reason=identical_call_loop."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        # 4+ identical calls → abort at 2K=4
+        provider = _RepeatProvider(repeat_count=100, final="should not reach")
+        telem = await _run_manager(tmp_path, provider, max_iterations=100)
+        assert telem.get("stop_reason") == "identical_call_loop"
+        assert telem["status"] == "bounded_stop"
+        assert "identical_call_loop" in telem["result"]
+
+    async def test_polling_with_changing_args_never_aborts(self, tmp_path, monkeypatch):
+        """Changing arguments (polling) reset the counter and must never abort."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        # Each call changes the cmd arg; after 6 calls gives final answer
+        class _PollingProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                if self.calls > 6:
+                    return LLMResponse(content="poll done", tool_calls=[])
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[ToolCallRequest(
+                        id=f"call-{self.calls}",
+                        name="exec",
+                        arguments={"cmd": f"check status #{self.calls}"},
+                    )],
+                )
+
+        provider = _PollingProvider()
+        telem = await _run_manager(tmp_path, provider, max_iterations=20)
+        assert telem.get("stop_reason") != "identical_call_loop"
+        assert telem["status"] == "ok"
+
+
+class TestSubagentWallClockDeadline:
+    async def test_wall_clock_deadline_triggers_graceful_stop(self, tmp_path, monkeypatch):
+        """Wall-clock deadline triggers graceful stop with honest message, no exception."""
+        # Set a very short wall-clock deadline
+        monkeypatch.setenv("NANOBOT_SUBAGENT_WALL_SECS", "0.001")
+
+        class _InfiniteProvider(_Provider):
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                import asyncio
+                await asyncio.sleep(0.01)  # small delay so deadline elapses
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[ToolCallRequest(id="call-1", name="exec", arguments={"cmd": "ls"})],
+                )
+
+        provider = _InfiniteProvider()
+        telem = await _run_manager(tmp_path, provider, max_iterations=100)
+        # Should have stopped with wall_clock_deadline or completed max_iterations
+        # The deadline is so short that either the deadline or max_iterations fires first
+        # We just need no exception and an honest result
+        assert telem["status"] in ("ok", "bounded_stop", "error")
+        # No crash (no status="error" with an actual exception stack trace)
+        if telem["status"] == "bounded_stop":
+            assert telem.get("stop_reason") in ("wall_clock_deadline", "identical_call_loop")
+
+
+# ── AgentLoop integration tests ───────────────────────────────────────────────
+
+class TestAgentLoopBreaker:
+    async def test_agent_loop_2k_identical_calls_abort(self, tmp_path, monkeypatch):
+        """AgentLoop._run_agent_loop aborts at 2K identical tool calls."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.bus.queue import MessageBus
+
+        class _LoopProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[ToolCallRequest(
+                        id=f"call-{self.calls}", name="list_dir", arguments={"path": "."},
+                    )],
+                )
+
+        provider = _LoopProvider()
+        bus = MessageBus()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, max_iterations=100)
+
+        from nanobot.agent.tools.filesystem import ListDirTool
+        loop.tools.register(ListDirTool(workspace=tmp_path))
+
+        initial = [{"role": "user", "content": "loop forever"}]
+        content, tools_used, _ = await loop._run_agent_loop(initial)
+
+        assert "identical_call_loop" in (content or "")
+
+    async def test_agent_loop_changing_args_no_abort(self, tmp_path, monkeypatch):
+        """AgentLoop: calls with changing args do not trigger breaker."""
+        monkeypatch.setenv("NANOBOT_LOOP_BREAKER_K", "2")
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.bus.queue import MessageBus
+
+        class _VaryProvider(_Provider):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                self.calls += 1
+                if self.calls > 5:
+                    return LLMResponse(content="all done", tool_calls=[])
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[ToolCallRequest(
+                        id=f"call-{self.calls}", name="list_dir",
+                        arguments={"path": f"./dir{self.calls}"},
+                    )],
+                )
+
+        provider = _VaryProvider()
+        bus = MessageBus()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, max_iterations=20)
+
+        from nanobot.agent.tools.filesystem import ListDirTool
+        loop.tools.register(ListDirTool(workspace=tmp_path))
+
+        initial = [{"role": "user", "content": "do many things"}]
+        content, tools_used, _ = await loop._run_agent_loop(initial)
+
+        assert "identical_call_loop" not in (content or "")
+        assert content == "all done"
+
+    async def test_agent_loop_wall_clock_deadline(self, tmp_path, monkeypatch):
+        """AgentLoop wall-clock deadline produces graceful result without exception."""
+        monkeypatch.setenv("NANOBOT_SUBAGENT_WALL_SECS", "0.001")
+        from nanobot.agent.loop import AgentLoop
+        from nanobot.bus.queue import MessageBus
+
+        class _SlowProvider(_Provider):
+            async def chat(self, messages=None, tools=None, model=None, **kwargs) -> LLMResponse:
+                import asyncio
+                await asyncio.sleep(0.05)
+                return LLMResponse(
+                    content=None,
+                    tool_calls=[ToolCallRequest(id="c1", name="list_dir", arguments={"path": "."})],
+                )
+
+        provider = _SlowProvider()
+        bus = MessageBus()
+        loop = AgentLoop(bus=bus, provider=provider, workspace=tmp_path, max_iterations=100)
+
+        from nanobot.agent.tools.filesystem import ListDirTool
+        loop.tools.register(ListDirTool(workspace=tmp_path))
+
+        initial = [{"role": "user", "content": "keep going"}]
+        # Should return without raising
+        content, tools_used, _ = await loop._run_agent_loop(initial)
+        # Content may be None (no iterations ran) or the deadline message
+        # The key constraint is: no exception was raised
+        assert content is None or isinstance(content, str)


### PR DESCRIPTION
## Summary
- add a default-on, env-tunable consecutive identical tool-response breaker (K=3, abort at 2K)
- canonicalize tool name + sorted compact args while ignoring tool-call IDs
- inject a deterministic break message at K and report `stop_reason=identical_call_loop` at 2K
- evaluate complete multi-tool response tuples so repeated `[A,B]` responses cannot evade the breaker
- add monotonic wall-clock soft deadline (default 50 minutes, safely below the 55-minute bridge unit timeout) with graceful wrap-up
- cover both `SubagentManager._run_subagent` and `AgentLoop._run_agent_loop`

## Scope
Only `nanobot/agent/subagent.py`, `nanobot/agent/loop.py`, and tests changed. No runtime/1095 files, demand, deny-set, or gate changes.

## No new LLM calls
Loop detection is local bookkeeping after existing tool execution. No provider call, retry, timer, or scheduler was added.

## Validation
Focused agent/loop suites pass; full local pytest was run with the required shim and reports only known Windows/POSIX baseline failures. CI is authoritative for Linux.

Closes #1101