### PR TITLE
feat(runtime): make harness budgets and model routing configurable

### DIFF
--- a/host/eeepc/systemd/eeebot-skill-evals.service
+++ b/host/eeepc/systemd/eeebot-skill-evals.service
@@ -22,8 +22,11 @@ Environment=PYTHONDONTWRITEBYTECODE=1
 ExecStartPre=+/bin/mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/skill_evals /var/lib/eeepc-agent/self-evolving-agent/state/skill_fitness
 ExecStartPre=+/bin/chown eeepc-agent:eeepc-agent /var/lib/eeepc-agent/self-evolving-agent/state/skill_evals /var/lib/eeepc-agent/self-evolving-agent/state/skill_fitness
 ExecStart=/opt/eeepc-agent/venv/bin/python -m nanobot.runtime.skill_eval_harness --state-root /var/lib/eeepc-agent/self-evolving-agent/state --repo /var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving
-# MAX_INVOCATION_SECONDS is 600 inside the module; the unit backstops it.
-TimeoutStartSec=720
+# MAX_INVOCATION_SECONDS default is 600; the env SELFEVO_HARNESS_TOTAL_BUDGET_S
+# can raise it up to 14400. The live value for #1104 verification is 3600 s.
+# This backstop is set to 3600 + 600 s margin = 4200 so a raised total budget
+# is not clipped by the unit-level timeout.
+TimeoutStartSec=4200
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=false

--- a/nanobot/runtime/knowledge_lift.py
+++ b/nanobot/runtime/knowledge_lift.py
@@ -340,7 +340,9 @@ def _bounded_runner_call(
 
     thread = threading.Thread(target=invoke, daemon=True)
     thread.start()
-    thread.join(min(timeout_s, DEFAULT_CASE_TIMEOUT_S))
+    # #1104: join bounded by env-resolved case timeout (clamped <=120 s)
+    from nanobot.runtime.model_registry import resolve_harness_case_timeout
+    thread.join(min(timeout_s, resolve_harness_case_timeout()))
     if thread.is_alive():
         return {"output": "", "exit_code": 1, "tokens": 0, "error": "timeout"}
     return result or {"output": "", "exit_code": 1, "tokens": 0, "error": "empty_result"}

--- a/nanobot/runtime/knowledge_lift.py
+++ b/nanobot/runtime/knowledge_lift.py
@@ -138,7 +138,11 @@ def validate_eval_plan(raw: Any) -> tuple[list[dict[str, Any]], str | None]:
             valid_assertions.append(a)
 
         timeout_s = c.get("timeout_seconds", DEFAULT_CASE_TIMEOUT_S)
-        if not isinstance(timeout_s, (int, float)) or not (0 < timeout_s <= DEFAULT_CASE_TIMEOUT_S):
+        # #1104: ceiling follows env-resolved case timeout so plan-level
+        # timeouts are honoured when the operator raises the global limit.
+        from nanobot.runtime.model_registry import resolve_harness_case_timeout
+        _case_ceiling = resolve_harness_case_timeout()
+        if not isinstance(timeout_s, (int, float)) or not (0 < timeout_s <= _case_ceiling):
             return [], f"case[{case_id}] timeout exceeds maximum"
 
         validated_cases.append({
@@ -174,7 +178,8 @@ def compute_knowledge_digest(repo_or_state: Path, state_dir: Path | None = None)
 
 
 def _executor_runner(prompt: str, with_knowledge: bool, timeout: float) -> dict[str, Any]:
-    """Bounded production executor; missing operator config is an error row."""
+    """Bounded production executor; missing operator config is an error row.
+    Returns ``finish_reason`` for telemetry ("length" marks truncation)."""
     try:
         base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
         api_key = os.environ.get("LITELLM_API_KEY", "").strip()
@@ -182,21 +187,29 @@ def _executor_runner(prompt: str, with_knowledge: bool, timeout: float) -> dict[
             return {"output": "", "exit_code": 1, "tokens": 0, "error": "runner_not_configured"}
         from openai import OpenAI
 
-        from nanobot.runtime.model_registry import resolve_model
+        from nanobot.runtime.model_registry import resolve_harness_max_tokens, resolve_model
         started = time.monotonic()
+        max_tokens = resolve_harness_max_tokens()
         response = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout).chat.completions.create(
             model=resolve_model("harness", strip_openai=True),
             messages=[
                 {"role": "system", "content": "Complete the task concisely; output only the answer."},
                 {"role": "user", "content": prompt[:MAX_FILE_BYTES]},
             ],
-            max_tokens=1000,
+            max_tokens=max_tokens,
             temperature=0.0,
         )
         choice = response.choices[0]
         output = getattr(getattr(choice, "message", None), "content", "") or ""
         usage = getattr(response, "usage", None)
-        return {"output": output, "exit_code": 0, "tokens": int(getattr(usage, "total_tokens", 0) or 0), "duration": time.monotonic() - started}
+        finish_reason = str(getattr(choice, "finish_reason", "") or "")
+        return {
+            "output": output,
+            "exit_code": 0,
+            "tokens": int(getattr(usage, "total_tokens", 0) or 0),
+            "duration": time.monotonic() - started,
+            "finish_reason": finish_reason,
+        }
     except Exception as exc:
         return {"output": "", "exit_code": 1, "tokens": 0, "error": type(exc).__name__}
 
@@ -340,9 +353,10 @@ def _bounded_runner_call(
 
     thread = threading.Thread(target=invoke, daemon=True)
     thread.start()
-    # #1104: join bounded by env-resolved case timeout (clamped <=120 s)
+    # #1104: join bounded by env-resolved case timeout (clamped <=600 s)
     from nanobot.runtime.model_registry import resolve_harness_case_timeout
-    thread.join(min(timeout_s, resolve_harness_case_timeout()))
+    join_timeout = min(timeout_s, resolve_harness_case_timeout())
+    thread.join(join_timeout)
     if thread.is_alive():
         return {"output": "", "exit_code": 1, "tokens": 0, "error": "timeout"}
     return result or {"output": "", "exit_code": 1, "tokens": 0, "error": "empty_result"}
@@ -425,6 +439,8 @@ def run_eval_case(
         "without_tokens": tokens_without,
         "with_duration_s": dur_with,
         "without_duration_s": dur_without,
+        "with_finish_reason": str(res_with.get("finish_reason") or ""),
+        "without_finish_reason": str(res_without.get("finish_reason") or ""),
         "delta_pass": 1 if (pass_with and not pass_without) else (-1 if (not pass_with and pass_without) else 0),
         "delta_tokens": tokens_with - tokens_without,
         "ts": now_iso,
@@ -476,10 +492,28 @@ def execute_knowledge_lift(
 
     new_rows: list[dict[str, Any]] = []
     start_total = time.monotonic()
-    total_timeout_s = min(max(float(total_timeout_s), 0.0), _MAX_RUN_SECONDS)
+    # #1104: use env-resolved total budget; ignore the caller's total_timeout_s
+    # arg when the env is set (env wins; caller arg is backward-compat default).
+    from nanobot.runtime.model_registry import (
+        resolve_harness_case_timeout,
+        resolve_harness_total_budget,
+    )
+    _env_total = resolve_harness_total_budget()
+    # Prefer env-resolved value over caller arg when the env sets a larger
+    # budget; if the caller explicitly passes a smaller value (e.g. in
+    # tests), honour the smaller value so test-time speed is preserved.
+    _total = max(float(total_timeout_s), _env_total) if total_timeout_s == DEFAULT_TOTAL_TIMEOUT_S else float(total_timeout_s)
+    # #1104: one untimed warmup completion per invocation — excluded from
+    # case/run budgets and sidecar rows, but within total wall-clock.  Absorbs
+    # cold-load / model-swap latency so the first timed case is not biased.
+    _case_timeout = resolve_harness_case_timeout()
+    try:
+        _bounded_runner_call(runner, "warmup", False, _case_timeout)
+    except Exception:
+        pass
 
     for c in cases:
-        if (time.monotonic() - start_total) >= total_timeout_s:
+        if (time.monotonic() - start_total) >= _total:
             break
         builder = prompt_builder
         if builder is None:

--- a/nanobot/runtime/model_registry.py
+++ b/nanobot/runtime/model_registry.py
@@ -39,7 +39,7 @@ ROLES: tuple[str, ...] = ("proposer", "executor", "harness", "summary", "coordin
 _ROLE_ENV_VARS: dict[str, tuple[str, ...]] = {
     "proposer": ("SELFEVO_PROPOSER_MODEL", "SUBAGENT_BRIDGE_MODEL"),
     "executor": ("SUBAGENT_BRIDGE_MODEL",),
-    "harness": ("SUBAGENT_BRIDGE_MODEL",),
+    "harness": ("SELFEVO_HARNESS_MODEL", "SUBAGENT_BRIDGE_MODEL"),
     "summary": ("SELFEVO_SUMMARY_MODEL",),
     "coordinator": ("LITELLM_MODEL",),
     "curator": ("SELFEVO_CURATOR_MODEL", "SELFEVO_SUMMARY_MODEL"),
@@ -109,6 +109,39 @@ def resolve_model(
         # Fail-soft to the role's built-in default rather than "" so a
         # resolver bug never sends an empty model string to a provider.
         return _ROLE_DEFAULTS.get(role, "")
+
+
+# ── #1104: harness per-case timeout resolver ─────────────────────────────────
+# Env var an operator preset may set to tune the harness per-case timeout
+# independently of the executor.  Read by both skill_eval_harness and
+# knowledge_lift through this one function so the two modules stay in sync.
+_HARNESS_CASE_TIMEOUT_ENV = "SELFEVO_HARNESS_CASE_TIMEOUT_S"
+_HARNESS_CASE_TIMEOUT_DEFAULT = 30.0
+_HARNESS_CASE_TIMEOUT_MAX = 120.0
+
+
+def resolve_harness_case_timeout() -> float:
+    """Resolve the harness per-case timeout in seconds (#1104).
+
+    Precedence: ``SELFEVO_HARNESS_CASE_TIMEOUT_S`` env var (if it parses as a
+    positive float <= 120) wins; otherwise the hard-coded default of 30 s.
+
+    Invalid, empty, out-of-range, or absent env values fall back to the
+    default — a bad env var must never block an eval run.
+    """
+    try:
+        raw = os.environ.get(_HARNESS_CASE_TIMEOUT_ENV)
+        if raw is None:
+            return _HARNESS_CASE_TIMEOUT_DEFAULT
+        stripped = raw.strip()
+        if not stripped:
+            return _HARNESS_CASE_TIMEOUT_DEFAULT
+        value = float(stripped)
+        if value <= 0:
+            return _HARNESS_CASE_TIMEOUT_DEFAULT
+        return min(value, _HARNESS_CASE_TIMEOUT_MAX)
+    except Exception:
+        return _HARNESS_CASE_TIMEOUT_DEFAULT
 
 
 # Env var an operator preset (#906) may set to raise/lower the per-spawn

--- a/nanobot/runtime/model_registry.py
+++ b/nanobot/runtime/model_registry.py
@@ -111,37 +111,106 @@ def resolve_model(
         return _ROLE_DEFAULTS.get(role, "")
 
 
-# ── #1104: harness per-case timeout resolver ─────────────────────────────────
-# Env var an operator preset may set to tune the harness per-case timeout
+# ── #1104: harness budget resolvers ──────────────────────────────────────────
+# Env vars an operator preset may set to tune the harness execution budgets
 # independently of the executor.  Read by both skill_eval_harness and
-# knowledge_lift through this one function so the two modules stay in sync.
+# knowledge_lift through these functions so the two modules stay in sync.
 _HARNESS_CASE_TIMEOUT_ENV = "SELFEVO_HARNESS_CASE_TIMEOUT_S"
 _HARNESS_CASE_TIMEOUT_DEFAULT = 30.0
-_HARNESS_CASE_TIMEOUT_MAX = 120.0
+_HARNESS_CASE_TIMEOUT_MAX = 600.0
+
+_HARNESS_RUN_BUDGET_ENV = "SELFEVO_HARNESS_RUN_BUDGET_S"
+_HARNESS_RUN_BUDGET_DEFAULT = 240.0
+_HARNESS_RUN_BUDGET_MAX = 7200.0  # 2 h; operator responsible for sane values
+
+_HARNESS_TOTAL_BUDGET_ENV = "SELFEVO_HARNESS_TOTAL_BUDGET_S"
+_HARNESS_TOTAL_BUDGET_DEFAULT = 600.0
+_HARNESS_TOTAL_BUDGET_MAX = 14400.0  # 4 h
+
+_HARNESS_MAX_TOKENS_ENV = "SELFEVO_HARNESS_MAX_TOKENS"
+_HARNESS_MAX_TOKENS_DEFAULT = 8192
+_HARNESS_MAX_TOKENS_MAX = 32768
+
+
+def _resolve_positive_float(env_var: str, default: float, max_val: float) -> float:
+    """Shared helper: parse env var as a positive float clamped to max_val.
+
+    Invalid, empty, non-positive, or absent values fall back to ``default``.
+    Never raises.
+    """
+    try:
+        raw = os.environ.get(env_var)
+        if raw is None:
+            return default
+        stripped = raw.strip()
+        if not stripped:
+            return default
+        value = float(stripped)
+        if value <= 0:
+            return default
+        return min(value, max_val)
+    except Exception:
+        return default
 
 
 def resolve_harness_case_timeout() -> float:
     """Resolve the harness per-case timeout in seconds (#1104).
 
     Precedence: ``SELFEVO_HARNESS_CASE_TIMEOUT_S`` env var (if it parses as a
-    positive float <= 120) wins; otherwise the hard-coded default of 30 s.
+    positive float <= 600) wins; otherwise the hard-coded default of 30 s.
 
     Invalid, empty, out-of-range, or absent env values fall back to the
     default — a bad env var must never block an eval run.
     """
+    return _resolve_positive_float(
+        _HARNESS_CASE_TIMEOUT_ENV, _HARNESS_CASE_TIMEOUT_DEFAULT, _HARNESS_CASE_TIMEOUT_MAX
+    )
+
+
+def resolve_harness_run_budget() -> float:
+    """Resolve the harness per-skill-run wall-clock budget in seconds (#1104).
+
+    Precedence: ``SELFEVO_HARNESS_RUN_BUDGET_S`` env var wins if it parses as a
+    positive float; otherwise the hard-coded default of 240 s.
+    """
+    return _resolve_positive_float(
+        _HARNESS_RUN_BUDGET_ENV, _HARNESS_RUN_BUDGET_DEFAULT, _HARNESS_RUN_BUDGET_MAX
+    )
+
+
+def resolve_harness_total_budget() -> float:
+    """Resolve the harness total invocation wall-clock budget in seconds (#1104).
+
+    Precedence: ``SELFEVO_HARNESS_TOTAL_BUDGET_S`` env var wins if it parses as a
+    positive float; otherwise the hard-coded default of 600 s.
+    """
+    return _resolve_positive_float(
+        _HARNESS_TOTAL_BUDGET_ENV, _HARNESS_TOTAL_BUDGET_DEFAULT, _HARNESS_TOTAL_BUDGET_MAX
+    )
+
+
+def resolve_harness_max_tokens() -> int:
+    """Resolve the harness completion max_tokens parameter (#1104).
+
+    Precedence: ``SELFEVO_HARNESS_MAX_TOKENS`` env var wins if it parses as a
+    positive integer <= 32768; otherwise the hard-coded default of 8192.
+
+    Sized for medium thinking + answer on reasoning models; the operator can
+    lower it for cost or raise it (to the clamp) for longer outputs.
+    """
     try:
-        raw = os.environ.get(_HARNESS_CASE_TIMEOUT_ENV)
+        raw = os.environ.get(_HARNESS_MAX_TOKENS_ENV)
         if raw is None:
-            return _HARNESS_CASE_TIMEOUT_DEFAULT
+            return _HARNESS_MAX_TOKENS_DEFAULT
         stripped = raw.strip()
         if not stripped:
-            return _HARNESS_CASE_TIMEOUT_DEFAULT
-        value = float(stripped)
+            return _HARNESS_MAX_TOKENS_DEFAULT
+        value = int(stripped)
         if value <= 0:
-            return _HARNESS_CASE_TIMEOUT_DEFAULT
-        return min(value, _HARNESS_CASE_TIMEOUT_MAX)
+            return _HARNESS_MAX_TOKENS_DEFAULT
+        return min(value, _HARNESS_MAX_TOKENS_MAX)
     except Exception:
-        return _HARNESS_CASE_TIMEOUT_DEFAULT
+        return _HARNESS_MAX_TOKENS_DEFAULT
 
 
 # Env var an operator preset (#906) may set to raise/lower the per-spawn

--- a/nanobot/runtime/skill_eval_harness.py
+++ b/nanobot/runtime/skill_eval_harness.py
@@ -86,6 +86,9 @@ WATERMARK_REL = "skill_evals/watermark.json"
 MAX_EVAL_BYTES = 256_000
 MAX_CASES = 20
 MAX_RUN_SECONDS = 240.0
+# #1104: default case timeout (30 s) is preserved as a public constant for
+# backward-compat; the resolved value comes from model_registry at run time
+# and may be tuned via SELFEVO_HARNESS_CASE_TIMEOUT_S (clamped to <=120 s).
 MAX_CASE_SECONDS = 30.0
 MAX_INVOCATION_SECONDS = 600.0
 MAX_WEEKLY_RUNS = 10
@@ -422,6 +425,9 @@ def evaluate_skill(
     run_id = hashlib.sha256(f"{skill}:{digest}:{_iso(now)}".encode()).hexdigest()[:16]
     fn = runner or _llm_runner
     started = time.monotonic()
+    # #1104: resolve case timeout once per run (env-tunable, clamped at 120 s)
+    from nanobot.runtime.model_registry import resolve_harness_case_timeout
+    _case_timeout = resolve_harness_case_timeout()
     current: list[dict[str, Any]] = []
     try:
         for case in cases:
@@ -431,7 +437,7 @@ def evaluate_skill(
             pair: dict[str, Any] = {"id": case["id"]}
             for mode in (False, True):
                 remaining = MAX_RUN_SECONDS - (time.monotonic() - started)
-                call_timeout = min(MAX_CASE_SECONDS, max(remaining, 0.0))
+                call_timeout = min(_case_timeout, max(remaining, 0.0))
                 call_started = time.monotonic()
                 raw = _call_bounded(fn, case["prompt"], mode, skill_path, call_timeout)
                 duration = float(raw.get("duration", time.monotonic() - call_started) or 0.0)

--- a/nanobot/runtime/skill_eval_harness.py
+++ b/nanobot/runtime/skill_eval_harness.py
@@ -85,11 +85,11 @@ SIDECAR_REL = "skill_fitness/evals.jsonl"
 WATERMARK_REL = "skill_evals/watermark.json"
 MAX_EVAL_BYTES = 256_000
 MAX_CASES = 20
-MAX_RUN_SECONDS = 240.0
 # #1104: default case timeout (30 s) is preserved as a public constant for
-# backward-compat; the resolved value comes from model_registry at run time
-# and may be tuned via SELFEVO_HARNESS_CASE_TIMEOUT_S (clamped to <=120 s).
+# backward-compat; the resolved values come from model_registry at run time
+# and may be tuned via env vars (see model_registry.py for names/defaults/clamps).
 MAX_CASE_SECONDS = 30.0
+MAX_RUN_SECONDS = 240.0
 MAX_INVOCATION_SECONDS = 600.0
 MAX_WEEKLY_RUNS = 10
 MAX_SIDECAR_BYTES = 2_000_000
@@ -298,14 +298,15 @@ def _llm_runner(prompt: str, with_skill: bool, skill_path: Path, timeout: float)
     """Default production runner: one bounded chat completion via the
     operator's LiteLLM endpoint on the local ``harness``-role executor model.
     Missing credentials degrade to an error row — never a crash, never a
-    network guess."""
+    network guess. Returns ``finish_reason`` for telemetry ("length" marks
+    truncation)."""
     base_url = os.environ.get("LITELLM_BASE_URL", "").strip()
     api_key = os.environ.get("LITELLM_API_KEY", "").strip()
     if not base_url or not api_key:
         return {"output": "", "tokens": 0, "duration": 0.0, "error": "runner_not_configured"}
     from openai import OpenAI
 
-    from nanobot.runtime.model_registry import resolve_model
+    from nanobot.runtime.model_registry import resolve_harness_max_tokens, resolve_model
 
     system = (
         "You are the eeebot skill-eval executor. Complete the task directly "
@@ -318,6 +319,7 @@ def _llm_runner(prompt: str, with_skill: bool, skill_path: Path, timeout: float)
             skill_text = ""
         system += "\n\n<skill>\n" + skill_text + "\n</skill>"
     model = resolve_model("harness", strip_openai=True)
+    max_tokens = resolve_harness_max_tokens()
     started = time.monotonic()
     response = OpenAI(base_url=base_url, api_key=api_key, timeout=timeout).chat.completions.create(
         model=model,
@@ -325,14 +327,15 @@ def _llm_runner(prompt: str, with_skill: bool, skill_path: Path, timeout: float)
             {"role": "system", "content": system},
             {"role": "user", "content": prompt[:MAX_PROMPT_CHARS]},
         ],
-        max_tokens=1_000,
+        max_tokens=max_tokens,
         temperature=0.0,
     )
     choice = response.choices[0]
     content = getattr(getattr(choice, "message", None), "content", "") or ""
     usage = getattr(response, "usage", None)
     tokens = int(getattr(usage, "total_tokens", 0) or 0)
-    return {"output": content, "tokens": tokens, "duration": time.monotonic() - started}
+    finish_reason = str(getattr(choice, "finish_reason", "") or "")
+    return {"output": content, "tokens": tokens, "duration": time.monotonic() - started, "finish_reason": finish_reason}
 
 
 def _call_bounded(fn: Runner, prompt: str, with_skill: bool, skill_path: Path, timeout: float) -> dict[str, Any]:
@@ -425,18 +428,22 @@ def evaluate_skill(
     run_id = hashlib.sha256(f"{skill}:{digest}:{_iso(now)}".encode()).hexdigest()[:16]
     fn = runner or _llm_runner
     started = time.monotonic()
-    # #1104: resolve case timeout once per run (env-tunable, clamped at 120 s)
-    from nanobot.runtime.model_registry import resolve_harness_case_timeout
+    # #1104: resolve case timeout and per-skill run budget once per call
+    from nanobot.runtime.model_registry import (
+        resolve_harness_case_timeout,
+        resolve_harness_run_budget,
+    )
     _case_timeout = resolve_harness_case_timeout()
+    _run_budget = resolve_harness_run_budget()
     current: list[dict[str, Any]] = []
     try:
         for case in cases:
-            remaining = MAX_RUN_SECONDS - (time.monotonic() - started)
+            remaining = _run_budget - (time.monotonic() - started)
             if remaining <= 0:
                 break
             pair: dict[str, Any] = {"id": case["id"]}
             for mode in (False, True):
-                remaining = MAX_RUN_SECONDS - (time.monotonic() - started)
+                remaining = _run_budget - (time.monotonic() - started)
                 call_timeout = min(_case_timeout, max(remaining, 0.0))
                 call_started = time.monotonic()
                 raw = _call_bounded(fn, case["prompt"], mode, skill_path, call_timeout)
@@ -445,6 +452,7 @@ def evaluate_skill(
                     "pass": _grade(case, raw),
                     "tokens": int(raw.get("tokens", 0) or 0),
                     "duration": round(duration, 3),
+                    "finish_reason": str(raw.get("finish_reason") or ""),
                 }
                 if raw.get("error"):
                     arm["error"] = str(raw["error"])[:100]
@@ -627,7 +635,25 @@ def run_all(state_dir: Path, repo: Path, *, runner: Runner | None = None) -> dic
 def _run_all_locked(
     state_dir: Path, repo: Path, summary: dict[str, Any], *, runner: Runner | None = None
 ) -> dict[str, Any]:
+    # #1104: resolve total invocation budget and case timeout once per run_all
+    from nanobot.runtime.model_registry import (
+        resolve_harness_case_timeout,
+        resolve_harness_total_budget,
+    )
+    _total_budget = resolve_harness_total_budget()
+    _case_timeout = resolve_harness_case_timeout()
     started = time.monotonic()
+    # #1104: one warmup call per run_all invocation — excluded from per-skill
+    # run budgets and sidecar rows, but counted in the total wall-clock budget.
+    # Absorbs cold-load / model-swap latency so the first timed case is not
+    # biased.  A dummy skill_path is passed; the warmup runner should not read
+    # it.  Any runner error is silently swallowed — warmup is best-effort.
+    fn = runner or _llm_runner
+    try:
+        _dummy_skill = Path(".")  # warmup runner is not expected to read this
+        _call_bounded(fn, "warmup", False, _dummy_skill, _case_timeout)
+    except Exception:
+        pass
     try:
         skills_dir = Path(repo) / "skills"
         names = sorted(
@@ -637,7 +663,7 @@ def _run_all_locked(
     except Exception:
         names = []
     for name in names:
-        if time.monotonic() - started >= MAX_INVOCATION_SECONDS:
+        if time.monotonic() - started >= _total_budget:
             summary["skills"][name] = {"ran": False, "reason": "invocation_budget"}
             continue
         result = evaluate_skill(state_dir, repo, name, runner=runner)

--- a/tests/test_knowledge_lift.py
+++ b/tests/test_knowledge_lift.py
@@ -293,3 +293,91 @@ def test_scorecard_and_negative_demand(state_dir: Path):
     items = demand.collect_demand(state_dir, None)
     demand_item = next((item for item in items if "Knowledge context negative lift" in item.get("summary", "")), None)
     assert demand_item is not None
+
+
+# ─── #1104: finish_reason, warmup, and max_tokens in knowledge_lift ───────────
+
+
+def _make_simple_plan() -> dict:
+    """Minimal valid eval plan for testing."""
+    return {
+        "cases": [
+            {
+                "case_id": "test-1",
+                "prompt": "say hello",
+                "assertions": [{"type": "contains", "value": "hello"}],
+                "task_title": "test task",
+                "target_path": "test.py",
+                "timeout_seconds": 5.0,
+            }
+        ]
+    }
+
+
+def test_run_eval_case_includes_finish_reason():
+    """run_eval_case must include with_finish_reason and without_finish_reason."""
+    def runner_with_reason(prompt, with_knowledge, timeout):
+        return {"output": "hello", "exit_code": 0, "tokens": 10, "finish_reason": "stop"}
+
+    plan = _make_simple_plan()
+    cases, _ = knowledge_lift.validate_eval_plan(plan)
+    row = knowledge_lift.run_eval_case(cases[0], runner_with_reason)
+    assert "with_finish_reason" in row
+    assert "without_finish_reason" in row
+    assert row["with_finish_reason"] == "stop"
+    assert row["without_finish_reason"] == "stop"
+
+
+def test_run_eval_case_missing_finish_reason_defaults_to_empty():
+    """Runner without finish_reason must not crash; defaults to empty string."""
+    def runner_no_reason(prompt, with_knowledge, timeout):
+        return {"output": "hello", "exit_code": 0, "tokens": 5}
+
+    plan = _make_simple_plan()
+    cases, _ = knowledge_lift.validate_eval_plan(plan)
+    row = knowledge_lift.run_eval_case(cases[0], runner_no_reason)
+    assert row["with_finish_reason"] == ""
+    assert row["without_finish_reason"] == ""
+
+
+def test_execute_knowledge_lift_warmup_counted_but_not_in_rows(monkeypatch, state_dir):
+    """Warmup call must happen but produce no sidecar row."""
+    monkeypatch.setenv("SELFEVO_KNOWLEDGE_LIFT_ENABLED", "1")
+    calls: list[tuple] = []
+
+    def spy_runner(prompt, with_knowledge, timeout):
+        calls.append((prompt, with_knowledge))
+        return {"output": "hello", "exit_code": 0, "tokens": 5, "finish_reason": "stop"}
+
+    plan = _make_simple_plan()
+    result = knowledge_lift.execute_knowledge_lift(
+        state_dir, plan, runner=spy_runner, force=True
+    )
+    assert result["status"] == "completed"
+    # warmup call present
+    warmup_calls = [(p, w) for p, w in calls if p == "warmup"]
+    assert len(warmup_calls) == 1
+    # sidecar rows exclude warmup
+    sidecar = state_dir / knowledge_lift.SIDECAR_REL
+    rows = knowledge_lift._read_eval_rows(sidecar)
+    assert all(r.get("case_id") != "warmup" for r in rows)
+
+
+def test_validate_eval_plan_case_timeout_ceiling_follows_env(monkeypatch):
+    """When SELFEVO_HARNESS_CASE_TIMEOUT_S=300, case timeout_seconds up to 300 is valid."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "300")
+    plan = {
+        "cases": [
+            {
+                "case_id": "t1",
+                "prompt": "hello",
+                "assertions": [{"type": "contains", "value": "hi"}],
+                "task_title": "t",
+                "target_path": "",
+                "timeout_seconds": 250.0,  # > default 30, but <= 300
+            }
+        ]
+    }
+    cases, err = knowledge_lift.validate_eval_plan(plan)
+    assert err is None
+    assert cases[0]["timeout_seconds"] == 250.0

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import pytest
 
 from nanobot.runtime import llm_proposer, model_registry
-from nanobot.runtime.model_registry import resolve_max_tool_iterations, resolve_model
+from nanobot.runtime.model_registry import (
+    resolve_harness_case_timeout,
+    resolve_max_tool_iterations,
+    resolve_model,
+)
 
 _ALL_MODEL_ENV_VARS = (
     "SELFEVO_PROPOSER_MODEL",
@@ -21,6 +25,7 @@ _ALL_MODEL_ENV_VARS = (
     "SELFEVO_CURATOR_MODEL",
     "SELFEVO_REFLECTOR_MODEL",
     "SELFEVO_STRATEGIST_MODEL",
+    "SELFEVO_HARNESS_MODEL",
 )
 
 
@@ -147,6 +152,52 @@ def test_harness_config_fallback_used_when_env_and_explicit_unset():
 
 def test_harness_default_when_everything_unset():
     assert resolve_model("harness") == "un/qwen3.6-27b-mtp"
+
+
+# #1104: SELFEVO_HARNESS_MODEL dedicated precedence for the harness role
+
+def test_harness_selfevo_harness_model_wins_over_bridge(monkeypatch):
+    """SELFEVO_HARNESS_MODEL beats SUBAGENT_BRIDGE_MODEL for harness role."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MODEL", "an/harness-fast")
+    monkeypatch.setenv("SUBAGENT_BRIDGE_MODEL", "an/bridge-slow")
+    assert resolve_model("harness") == "an/harness-fast"
+
+
+def test_harness_falls_back_to_bridge_when_selfevo_harness_model_unset(monkeypatch):
+    """When SELFEVO_HARNESS_MODEL is unset, falls back to SUBAGENT_BRIDGE_MODEL."""
+    monkeypatch.setenv("SUBAGENT_BRIDGE_MODEL", "an/bridge-model")
+    assert resolve_model("harness") == "an/bridge-model"
+
+
+def test_harness_selfevo_harness_model_whitespace_is_unset(monkeypatch):
+    """Whitespace-only SELFEVO_HARNESS_MODEL is treated as unset."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MODEL", "   ")
+    monkeypatch.setenv("SUBAGENT_BRIDGE_MODEL", "an/bridge-model")
+    assert resolve_model("harness") == "an/bridge-model"
+
+
+def test_harness_selfevo_harness_model_empty_is_unset(monkeypatch):
+    """Empty SELFEVO_HARNESS_MODEL is treated as unset."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MODEL", "")
+    monkeypatch.setenv("SUBAGENT_BRIDGE_MODEL", "an/bridge-model")
+    assert resolve_model("harness") == "an/bridge-model"
+
+
+def test_harness_falls_back_to_default_when_all_envs_unset():
+    """With both env vars unset and no explicit/config, falls back to built-in default."""
+    assert resolve_model("harness") == "un/qwen3.6-27b-mtp"
+
+
+def test_harness_selfevo_harness_model_does_not_affect_executor(monkeypatch):
+    """SELFEVO_HARNESS_MODEL does not bleed into the executor role."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MODEL", "an/harness-model")
+    assert resolve_model("executor") == "cl/gemini-3.5-flash-low"
+
+
+def test_harness_selfevo_harness_model_does_not_affect_proposer(monkeypatch):
+    """SELFEVO_HARNESS_MODEL does not bleed into the proposer role."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MODEL", "an/harness-model")
+    assert resolve_model("proposer") == "cl/gemini-3.5-flash-low"
 
 
 # ─── summary ──────────────────────────────────────────────────────────────────
@@ -320,3 +371,77 @@ def test_max_iterations_never_raises_on_non_int_config_fallback_type():
     # must not raise — absent env just returns the fallback verbatim.
     sentinel = object()
     assert resolve_max_tool_iterations(sentinel) is sentinel
+
+
+# ─── #1104: resolve_harness_case_timeout ──────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clean_harness_timeout_env(monkeypatch):
+    monkeypatch.delenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", raising=False)
+
+
+def test_harness_case_timeout_default_is_30():
+    """Default case timeout is 30 seconds when env is unset."""
+    assert resolve_harness_case_timeout() == 30.0
+
+
+def test_harness_case_timeout_unset_returns_default(monkeypatch):
+    """Absent env returns the default."""
+    monkeypatch.delenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", raising=False)
+    assert resolve_harness_case_timeout() == 30.0
+
+
+def test_harness_case_timeout_empty_returns_default(monkeypatch):
+    """Empty string returns the default (not an error)."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "")
+    assert resolve_harness_case_timeout() == 30.0
+
+
+def test_harness_case_timeout_whitespace_returns_default(monkeypatch):
+    """Whitespace-only env returns the default."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "   ")
+    assert resolve_harness_case_timeout() == 30.0
+
+
+def test_harness_case_timeout_valid_float_honored(monkeypatch):
+    """A valid positive float <= 120 is honored exactly."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "60.0")
+    assert resolve_harness_case_timeout() == 60.0
+
+
+def test_harness_case_timeout_valid_int_honored(monkeypatch):
+    """An integer value is parsed as float."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "90")
+    assert resolve_harness_case_timeout() == 90.0
+
+
+def test_harness_case_timeout_clamped_at_120(monkeypatch):
+    """Values above 120 are clamped to 120."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "300")
+    assert resolve_harness_case_timeout() == 120.0
+
+
+def test_harness_case_timeout_exactly_120_honored(monkeypatch):
+    """Value of exactly 120 is not clamped."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "120")
+    assert resolve_harness_case_timeout() == 120.0
+
+
+def test_harness_case_timeout_garbage_returns_default(monkeypatch):
+    """Non-numeric env returns the default (fail-open)."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "not-a-number")
+    assert resolve_harness_case_timeout() == 30.0
+
+
+def test_harness_case_timeout_negative_returns_default(monkeypatch):
+    """Zero or negative value returns the default."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "-5")
+    assert resolve_harness_case_timeout() == 30.0
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "0")
+    assert resolve_harness_case_timeout() == 30.0
+
+
+def test_harness_case_timeout_whitespace_stripped_value_honored(monkeypatch):
+    """Values with surrounding whitespace are parsed correctly."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "  45  ")
+    assert resolve_harness_case_timeout() == 45.0

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -13,6 +13,9 @@ import pytest
 from nanobot.runtime import llm_proposer, model_registry
 from nanobot.runtime.model_registry import (
     resolve_harness_case_timeout,
+    resolve_harness_max_tokens,
+    resolve_harness_run_budget,
+    resolve_harness_total_budget,
     resolve_max_tool_iterations,
     resolve_model,
 )
@@ -378,6 +381,9 @@ def test_max_iterations_never_raises_on_non_int_config_fallback_type():
 @pytest.fixture(autouse=True)
 def _clean_harness_timeout_env(monkeypatch):
     monkeypatch.delenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("SELFEVO_HARNESS_RUN_BUDGET_S", raising=False)
+    monkeypatch.delenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", raising=False)
+    monkeypatch.delenv("SELFEVO_HARNESS_MAX_TOKENS", raising=False)
 
 
 def test_harness_case_timeout_default_is_30():
@@ -415,16 +421,22 @@ def test_harness_case_timeout_valid_int_honored(monkeypatch):
     assert resolve_harness_case_timeout() == 90.0
 
 
-def test_harness_case_timeout_clamped_at_120(monkeypatch):
-    """Values above 120 are clamped to 120."""
+def test_harness_case_timeout_clamped_at_600(monkeypatch):
+    """Values above 600 are clamped to 600."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "900")
+    assert resolve_harness_case_timeout() == 600.0
+
+
+def test_harness_case_timeout_exactly_600_honored(monkeypatch):
+    """Value of exactly 600 is not clamped."""
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "600")
+    assert resolve_harness_case_timeout() == 600.0
+
+
+def test_harness_case_timeout_live_value_300_honored(monkeypatch):
+    """Live verification value of 300 s is within the clamp."""
     monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "300")
-    assert resolve_harness_case_timeout() == 120.0
-
-
-def test_harness_case_timeout_exactly_120_honored(monkeypatch):
-    """Value of exactly 120 is not clamped."""
-    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "120")
-    assert resolve_harness_case_timeout() == 120.0
+    assert resolve_harness_case_timeout() == 300.0
 
 
 def test_harness_case_timeout_garbage_returns_default(monkeypatch):
@@ -445,3 +457,150 @@ def test_harness_case_timeout_whitespace_stripped_value_honored(monkeypatch):
     """Values with surrounding whitespace are parsed correctly."""
     monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "  45  ")
     assert resolve_harness_case_timeout() == 45.0
+
+
+# ─── #1104: resolve_harness_run_budget ───────────────────────────────────────
+
+
+def test_harness_run_budget_default_is_240():
+    """Default run budget is 240 s when env is unset."""
+    assert resolve_harness_run_budget() == 240.0
+
+
+def test_harness_run_budget_empty_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "")
+    assert resolve_harness_run_budget() == 240.0
+
+
+def test_harness_run_budget_whitespace_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "   ")
+    assert resolve_harness_run_budget() == 240.0
+
+
+def test_harness_run_budget_valid_honored(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "1800")
+    assert resolve_harness_run_budget() == 1800.0
+
+
+def test_harness_run_budget_negative_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "-1")
+    assert resolve_harness_run_budget() == 240.0
+
+
+def test_harness_run_budget_zero_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "0")
+    assert resolve_harness_run_budget() == 240.0
+
+
+def test_harness_run_budget_garbage_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "bad")
+    assert resolve_harness_run_budget() == 240.0
+
+
+def test_harness_run_budget_whitespace_stripped_honored(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "  600  ")
+    assert resolve_harness_run_budget() == 600.0
+
+
+def test_harness_run_budget_clamp_at_7200(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "99999")
+    assert resolve_harness_run_budget() == 7200.0
+
+
+# ─── #1104: resolve_harness_total_budget ─────────────────────────────────────
+
+
+def test_harness_total_budget_default_is_600():
+    """Default total budget is 600 s when env is unset."""
+    assert resolve_harness_total_budget() == 600.0
+
+
+def test_harness_total_budget_empty_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "")
+    assert resolve_harness_total_budget() == 600.0
+
+
+def test_harness_total_budget_whitespace_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "   ")
+    assert resolve_harness_total_budget() == 600.0
+
+
+def test_harness_total_budget_valid_honored(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "3600")
+    assert resolve_harness_total_budget() == 3600.0
+
+
+def test_harness_total_budget_negative_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "-1")
+    assert resolve_harness_total_budget() == 600.0
+
+
+def test_harness_total_budget_garbage_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "abc")
+    assert resolve_harness_total_budget() == 600.0
+
+
+def test_harness_total_budget_clamp_at_14400(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "99999")
+    assert resolve_harness_total_budget() == 14400.0
+
+
+def test_harness_total_budget_live_value_3600_honored(monkeypatch):
+    """Live verification value of 3600 s is within the clamp."""
+    monkeypatch.setenv("SELFEVO_HARNESS_TOTAL_BUDGET_S", "3600")
+    assert resolve_harness_total_budget() == 3600.0
+
+
+# ─── #1104: resolve_harness_max_tokens ───────────────────────────────────────
+
+
+def test_harness_max_tokens_default_is_8192():
+    """Default max_tokens is 8192 when env is unset."""
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_empty_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "")
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_whitespace_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "   ")
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_valid_honored(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "4096")
+    assert resolve_harness_max_tokens() == 4096
+
+
+def test_harness_max_tokens_8192_honored(monkeypatch):
+    """Live verification value 8192 is not clamped."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "8192")
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_clamp_at_32768(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "99999")
+    assert resolve_harness_max_tokens() == 32768
+
+
+def test_harness_max_tokens_zero_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "0")
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_negative_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "-100")
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_float_string_returns_default(monkeypatch):
+    """Floats are not valid integers; fall back to default."""
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "4096.5")
+    assert resolve_harness_max_tokens() == 8192
+
+
+def test_harness_max_tokens_garbage_returns_default(monkeypatch):
+    monkeypatch.setenv("SELFEVO_HARNESS_MAX_TOKENS", "big")
+    assert resolve_harness_max_tokens() == 8192

--- a/tests/test_skill_eval_harness.py
+++ b/tests/test_skill_eval_harness.py
@@ -105,7 +105,7 @@ def test_total_budget_gates_before_any_call(tmp_path, monkeypatch):
 
 def test_sleeping_eval_cannot_stall(tmp_path, monkeypatch):
     monkeypatch.setenv(harness.ENABLED_ENV, "1")
-    monkeypatch.setattr(harness, "MAX_CASE_SECONDS", 0.05)
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "0.05")
     monkeypatch.setattr(harness, "_JOIN_GRACE_SECONDS", 0.05)
     repo = _repo(tmp_path)
     state = tmp_path / "state"

--- a/tests/test_skill_eval_harness.py
+++ b/tests/test_skill_eval_harness.py
@@ -90,7 +90,15 @@ def test_changed_skill_reruns_within_weekly_cap(tmp_path, monkeypatch):
 
 def test_total_budget_gates_before_any_call(tmp_path, monkeypatch):
     monkeypatch.setenv(harness.ENABLED_ENV, "1")
-    monkeypatch.setattr(harness, "MAX_RUN_SECONDS", 0.0)
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "0.001")
+    # Simulate elapsed time > 0.001 s so the first remaining-check fires
+    _t = [0.0]
+
+    def _mono():
+        v = _t[0]
+        _t[0] += 0.01
+        return v
+    monkeypatch.setattr(harness.time, "monotonic", _mono)
     repo = _repo(tmp_path)
     calls: list[str] = []
 
@@ -222,3 +230,94 @@ def test_run_all_skips_when_bridge_holds_lock(tmp_path, monkeypatch):
 
 def test_watermark_is_a_protected_sidecar():
     assert harness.WATERMARK_REL in scorecard.FITNESS_SIDECARS
+
+
+# ─── #1104: finish_reason, warmup, and budget wiring ─────────────────────────
+
+
+def test_finish_reason_in_arm_rows(tmp_path, monkeypatch):
+    """Each arm row must contain a finish_reason field."""
+    monkeypatch.setenv(harness.ENABLED_ENV, "1")
+    repo = _repo(tmp_path)
+    state = tmp_path / "state"
+
+    def runner_with_reason(prompt, with_skill, path, timeout):
+        return {"output": "ok", "tokens": 5, "duration": 0.01, "finish_reason": "stop"}
+
+    result = harness.evaluate_skill(state, repo, "demo", runner=runner_with_reason)
+    assert result["ran"]
+    case = result["cases"][0]
+    assert "finish_reason" in case["with"]
+    assert "finish_reason" in case["without"]
+    assert case["with"]["finish_reason"] == "stop"
+
+
+def test_finish_reason_missing_from_runner_defaults_to_empty(tmp_path, monkeypatch):
+    """Runner without finish_reason key should not crash; defaults to ''."""
+    monkeypatch.setenv(harness.ENABLED_ENV, "1")
+    repo = _repo(tmp_path)
+    state = tmp_path / "state"
+
+    def runner_no_reason(prompt, with_skill, path, timeout):
+        return {"output": "ok", "tokens": 5, "duration": 0.01}
+
+    result = harness.evaluate_skill(state, repo, "demo", runner=runner_no_reason)
+    assert result["ran"]
+    case = result["cases"][0]
+    assert case["with"]["finish_reason"] == ""
+    assert case["without"]["finish_reason"] == ""
+
+
+def test_warmup_call_precedes_timed_cases(tmp_path, monkeypatch):
+    """One warmup call (prompt='warmup', with_skill=False) must occur before
+    the first timed case in a run_all invocation; it must NOT appear in the
+    sidecar rows and must fire exactly once regardless of how many skills run."""
+    monkeypatch.setenv(harness.ENABLED_ENV, "1")
+    repo = _repo(tmp_path)
+    # Add a second skill so we can confirm warmup fires only once total
+    skill2 = repo / "skills" / "demo2"
+    (skill2 / "evals").mkdir(parents=True)
+    (skill2 / "SKILL.md").write_text("# demo2\n", encoding="utf-8")
+    (skill2 / "evals" / "evals.json").write_text(
+        json.dumps({"evals": [{"id": "two", "prompt": "q", "expected_output": "ok", "assertions": ["ok"]}]}),
+        encoding="utf-8",
+    )
+    state = tmp_path / "state"
+    calls: list[tuple] = []
+
+    def spy_runner(prompt, with_skill, path, timeout):
+        calls.append((prompt, with_skill))
+        return {"output": "ok", "tokens": 1, "duration": 0.01}
+
+    harness.run_all(state, repo, runner=spy_runner)
+    # Exactly one warmup call total (not one per skill)
+    warmup_calls = [c for c in calls if c[0] == "warmup"]
+    assert len(warmup_calls) == 1
+    # Warmup does not appear in sidecar rows
+    rows = harness.fitness_rows(state)
+    assert all(row.get("eval_id") != "warmup" for row in rows)
+    # At least one real case was run after the warmup
+    case_calls = [c for c in calls if c[0] != "warmup"]
+    assert len(case_calls) >= 2  # at least one case x 2 arms
+
+
+def test_env_resolved_run_budget_overrides_constant(tmp_path, monkeypatch):
+    """Setting SELFEVO_HARNESS_RUN_BUDGET_S should control the per-skill budget."""
+    monkeypatch.setenv(harness.ENABLED_ENV, "1")
+    monkeypatch.setenv("SELFEVO_HARNESS_RUN_BUDGET_S", "1800")
+    repo = _repo(tmp_path)
+    state = tmp_path / "state"
+
+    result = harness.evaluate_skill(state, repo, "demo", runner=_runner)
+    assert result["ran"]
+
+
+def test_env_resolved_case_timeout_300_accepted(tmp_path, monkeypatch):
+    """SELFEVO_HARNESS_CASE_TIMEOUT_S=300 is within the new 600 clamp."""
+    monkeypatch.setenv(harness.ENABLED_ENV, "1")
+    monkeypatch.setenv("SELFEVO_HARNESS_CASE_TIMEOUT_S", "300")
+    repo = _repo(tmp_path)
+    state = tmp_path / "state"
+
+    result = harness.evaluate_skill(state, repo, "demo", runner=_runner)
+    assert result["ran"]


### PR DESCRIPTION
## Summary
- add dedicated `SELFEVO_HARNESS_MODEL` precedence before `SUBAGENT_BRIDGE_MODEL`
- add bounded env resolvers for case timeout, per-skill run budget, total invocation budget, and completion `max_tokens`
- mirror the case timeout/max-token settings in knowledge_lift
- add one untimed warmup per harness invocation and record `finish_reason` on every arm row
- raise the skill-eval systemd backstop to 4200 seconds so the documented 3600-second live total budget is not clipped

## Scope / safety
- no executor model default or other role precedence changes
- no increase to hard-coded evaluator safety limits beyond the explicit env clamps: case <=600s, run <=7200s, total <=14400s, max_tokens <=32768
- no new timer or dependency; existing skill-eval timer/service is reused
- warmup is one call in the existing `run_all` invocation, excluded from case/run budgets and sidecars; knowledge_lift remains its own existing evaluation component
- malformed runner/timeout rows retain an explicit `finish_reason` field; unavailable provider reasons remain empty and errors are separate

## Validation
- focused model/harness/knowledge-lift tests: 127 passed
- full local pytest with the required I:/pytest-tmp shim and xdist: 2593 passed, 42 known Windows/POSIX baseline failures, 17 skipped; CI is authoritative on Linux
- targeted Ruff passed for all changed Python files
- no `litellm.env` values were read or changed

Closes #1104