### PR TITLE
fix(runtime): bounded curator evidence fallback

### DIFF
--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -55,6 +55,8 @@ _STAGED_DIR = "staged"
 _LEDGER_TAIL_LINES = 200  # bounded ledger tail read for cycle-id resolution
 _MAX_EVIDENCE_SOURCE_BYTES = 32_000  # cap on evidence-source text read for overlap check
 _MAX_LEDGER_TAIL_BYTES = 256_000
+_ACTION_INDEX_SEGMENTS = 7  # fixed file-open budget for the durable fallback
+_MAX_ACTION_INDEX_BYTES = 256_000
 _ISSUE_REF_RE = re.compile(
     r"^(?:#\d+|https://github\.com/[^/\s]+/[^/\s#]+/issues/\d+)$",
     re.IGNORECASE,
@@ -345,21 +347,64 @@ def _evidence_refs(evidence: Any) -> list[str]:
     return []
 
 
+def _read_action_index_cycle_text(state_dir: Path, cycle_id: str) -> str | None:
+    """Resolve a cycle from a bounded set of newest action-index segments.
+
+    The action index is the durable per-cycle source built by #1005.  Select
+    files before opening any of them so archive growth cannot turn this into an
+    archive-wide scan.  A malformed or oversized segment is simply skipped.
+    """
+    index_dir = Path(state_dir) / "action_index"
+    try:
+        paths = sorted(
+            {*index_dir.glob("*.jsonl"), *index_dir.glob("*.jsonl.gz")},
+            key=lambda path: path.name,
+            reverse=True,
+        )[:_ACTION_INDEX_SEGMENTS]
+    except OSError:
+        return None
+    for path in paths:
+        try:
+            if path.stat().st_size > _MAX_ACTION_INDEX_BYTES:
+                continue
+            opener = gzip.open if path.name.endswith(".gz") else open
+            with opener(path, "rt", encoding="utf-8") as fh:  # type: ignore[call-arg]
+                for line in fh:
+                    try:
+                        row = json.loads(line)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        continue
+                    if not isinstance(row, dict) or str(row.get("cycle_id") or "") != cycle_id:
+                        continue
+                    parts = []
+                    for field in ("outcome", "task_title", "actions"):
+                        value = row.get(field)
+                        if value:
+                            parts.append(json.dumps(value, ensure_ascii=False) if isinstance(value, list) else str(value))
+                    return " ".join(parts)[:_MAX_EVIDENCE_SOURCE_BYTES]
+        except (OSError, EOFError, gzip.BadGzipFile):
+            continue
+    return None
+
+
 def _resolve_evidence_ref(
     ref: str,
     workspace: Path,
     cycle_ids: set[str],
-) -> str | None:
+    state_dir: Path,
+) -> tuple[str | None, str | None]:
     """Check one evidence ref; unknown or dangling references fail closed."""
     ref = ref.strip()
     if not ref:
-        return "empty evidence ref"
+        return "empty evidence ref", None
     if _ISSUE_REF_RE.fullmatch(ref):
-        return None
+        return None, "issue"
     if _CYCLE_ID_RE.fullmatch(ref):
-        if ref not in cycle_ids:
-            return f"cycle_id not in ledger tail: {ref[:60]}"
-        return None
+        if ref in cycle_ids:
+            return None, "ledger_tail"
+        if _read_action_index_cycle_text(state_dir, ref) is not None:
+            return None, "action_index"
+        return f"cycle_id not in ledger tail: {ref[:60]}", None
     normalized = ref.replace("\\", "/").strip()
     path = Path(normalized)
     if (
@@ -369,33 +414,31 @@ def _resolve_evidence_ref(
         or PureWindowsPath(normalized).is_absolute()
         or ".." in path.parts
     ):
-        return f"unsafe evidence path: {ref[:120]}"
+        return f"unsafe evidence path: {ref[:120]}", None
     if not (workspace / path).is_file():
-        return f"file not found: {ref[:120]}"
-    return None
+        return f"file not found: {ref[:120]}", None
+    return None, "file"
 
 
 def _check_evidence_refs(
     evidence: Any,
     workspace: Path,
     state_dir: Path,
-) -> str | None:
-    """Return a failure reason if evidence is absent/dangling, else None.
-
-    Fail-closed: missing evidence list rejects the item.  Dangling refs also
-    reject.  Fail-open only for ledger read errors (cycle_ids will be empty).
-    """
+) -> tuple[str | None, str | None]:
+    """Return a failure reason and resolving source, preserving fail-closed."""
     if not evidence:
-        return "no evidence refs provided"
+        return "no evidence refs provided", None
     refs = _evidence_refs(evidence)
     if not refs:
-        return "no evidence refs provided"
+        return "no evidence refs provided", None
     cycle_ids = _read_ledger_cycle_ids(state_dir)
     for ref in refs:
-        reason = _resolve_evidence_ref(ref, workspace, cycle_ids)
+        reason, source = _resolve_evidence_ref(ref, workspace, cycle_ids, state_dir)
         if reason:
-            return reason
-    return None
+            return reason, None
+    return None, source
+
+
 
 
 # ---------------------------------------------------------------------------
@@ -436,7 +479,10 @@ def _read_evidence_source_text(workspace: Path, ref: str, state_dir: Path | None
                                 matched.append(val)
                 except Exception:
                     continue
-            return " ".join(matched)[:_MAX_EVIDENCE_SOURCE_BYTES]
+            if matched:
+                return " ".join(matched)[:_MAX_EVIDENCE_SOURCE_BYTES]
+            indexed = _read_action_index_cycle_text(Path(state_dir), ref)
+            return indexed or ""
         except Exception:
             return ""
     # Issue refs have no local body; the support claim is the bounded quoted line.
@@ -772,7 +818,7 @@ def _collect_stage_items(
                     evidence = src_ev
                 elif src_cycle:
                     evidence = [src_cycle]
-        ev_fail: str | None = _check_evidence_refs(evidence, workspace, state_dir)
+        ev_fail, ev_source = _check_evidence_refs(evidence, workspace, state_dir)
         if ev_fail is not None:
             _write_decision(
                 state_dir, lesson_id, "rejected",
@@ -834,7 +880,10 @@ def _collect_stage_items(
         })
         writes += 1
         decision_label = "promoted_unsupported" if overlap_flag else "promoted"
-        _write_decision(state_dir, lesson_id, decision_label, reason, rel_str)
+        decision_reason = reason
+        if ev_source and ev_source not in {"ledger_tail", "file", "issue"}:
+            decision_reason = f"{reason} (evidence source: {ev_source})"
+        _write_decision(state_dir, lesson_id, decision_label, decision_reason, rel_str)
 
     # Build a bounded in-memory graph for the facts staged in this pass. This
     # is deliberately mechanical: no LLM call, no archive scan, and unknown

--- a/tests/test_knowledge_curator.py
+++ b/tests/test_knowledge_curator.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 from nanobot.runtime.knowledge_curator import (
+    _ACTION_INDEX_SEGMENTS,
     _fact_path,
     clear_staged_manifest,
     lessons_after,
@@ -37,6 +38,89 @@ def _llm(decisions):
             enriched.append(item)
         return json.dumps(enriched)
     return call
+
+
+def test_tail_expired_cycle_resolves_from_action_index_and_records_source(tmp_path):
+    """#1107: durable action index resolves a cycle absent from the ledger tail."""
+    _journal(tmp_path, ["L1"])
+    state = tmp_path / "state"
+    ledger = state / "ledger" / "cycles.jsonl"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(
+        "\n".join(json.dumps({"cycle_id": f"cycle-tail-{i}"}) for i in range(200)) + "\n",
+        encoding="utf-8",
+    )
+    index = state / "action_index" / "2026-08-29.jsonl"
+    index.parent.mkdir(parents=True)
+    index.write_text(json.dumps({
+        "cycle_id": "cycle-expired",
+        "outcome": "success",
+        "actions": ["exec:pytest"],
+    }) + "\n", encoding="utf-8")
+
+    result = run_curation(tmp_path, state, llm=_llm([
+        {
+            "action": "create", "path": "memory/facts/pytest.md",
+            "content": "pytest evidence is durable", "lesson_id": "L1",
+            "reason": "record test evidence", "evidence": ["cycle-expired"],
+            "support_claim": "pytest evidence",
+        },
+    ]))
+
+    assert result["ok"] and result["writes"] == 1
+    row = json.loads((state / "curator/decisions.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert row["decision"] == "promoted"
+    assert "evidence source: action_index" in row["reason"]
+
+
+def test_nonexistent_cycle_still_rejected_with_ledger_tail_reason(tmp_path):
+    """#1107: fallback lookup remains fail-closed when no source contains the cycle."""
+    _journal(tmp_path, ["L1"])
+    state = tmp_path / "state"
+    result = run_curation(tmp_path, state, llm=_llm([
+        {
+            "action": "create", "path": "memory/facts/missing.md",
+            "content": "missing cycle must not promote", "lesson_id": "L1",
+            "reason": "test rejection", "evidence": ["cycle-does-not-exist"],
+            "support_claim": "missing cycle",
+        },
+    ]))
+
+    assert result["ok"] and result["writes"] == 0
+    row = json.loads((state / "curator/decisions.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert row["decision"] == "rejected"
+    assert row["reason"] == "evidence ref rejected: cycle_id not in ledger tail: cycle-does-not-exist"
+
+
+def test_action_index_fallback_opens_only_bounded_newest_segments(tmp_path, monkeypatch):
+    """#1107: a large index/archive cannot cause an unbounded fallback scan."""
+    import builtins
+    import gzip
+    from nanobot.runtime.knowledge_curator import _read_action_index_cycle_text
+
+    index_dir = tmp_path / "action_index"
+    index_dir.mkdir(parents=True)
+    for day in range(100):
+        (index_dir / f"2026-01-{day + 1:02d}.jsonl").write_text(
+            json.dumps({"cycle_id": f"cycle-{day}"}) + "\n", encoding="utf-8"
+        )
+
+    opened: list[str] = []
+    real_open = builtins.open
+    real_gzip_open = gzip.open
+
+    def tracking_open(file, *args, **kwargs):
+        opened.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    def tracking_gzip_open(file, *args, **kwargs):
+        opened.append(str(file))
+        return real_gzip_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", tracking_open)
+    monkeypatch.setattr(gzip, "open", tracking_gzip_open)
+    assert _read_action_index_cycle_text(tmp_path, "cycle-0") is None
+    assert len(opened) <= _ACTION_INDEX_SEGMENTS
 
 
 def test_curator_stages_promotions_not_workspace(tmp_path):


### PR DESCRIPTION
## Summary\n- resolve tail-expired cycle evidence from bounded durable action-index segments\n- preserve fail-closed rejection and record fallback source on promoted decisions\n- add fallback, rejection, and bounded-open regression tests\n\n## Validation\n- focused curator tests: 13 passed\n- full pytest: 2617 passed, 18 pre-existing Windows/platform failures\n- ruff check passed\n\nCloses #1107