### PR TITLE
fix(runtime): mint lessons from real reflector solutions

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -76,6 +76,7 @@ from nanobot.runtime.lesson_v2 import (
 )
 from nanobot.runtime.lesson_v2 import (
     validate_lesson as _validate_lesson_v2,
+    validate_lesson_for_mint as _validate_lesson_for_mint,
 )
 from nanobot.runtime.model_registry import resolve_max_tool_iterations, resolve_model  # noqa: E402
 from nanobot.runtime.schemas import CONTROLLED_LESSON_TAGS  # noqa: E402
@@ -3874,6 +3875,23 @@ def _has_meaningful_lesson(artifact_data: dict | None) -> bool:
     return _extract_meaningful_insight(artifact_data) is not None
 
 
+def _extract_reflector_solution(artifact_data: dict | None) -> str | None:
+    """Return concrete reflector advice, preferring it over generic insight text."""
+    if not isinstance(artifact_data, dict):
+        return None
+    containers: list[dict] = [artifact_data]
+    for key in ("lesson", "structured_lesson", "reflector_finding", "reflector"):
+        value = artifact_data.get(key)
+        if isinstance(value, dict):
+            containers.append(value)
+    for container in containers:
+        for key in ("reflector_recommendation", "recommendation", "recommendation_detail", "detail"):
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()[:500]
+    return None
+
+
 def _has_delta_evidence(
     artifact_data: dict | None,
     *,
@@ -3966,7 +3984,8 @@ def _write_structured_lesson(
         or f'Implementing "{backlog_title}" improves operator value.'
     )
     problem = str(artifact_data.get('problem') or hypothesis).strip()
-    solution = str(artifact_data.get('solution') or insight).strip()
+    reflector_solution = _extract_reflector_solution(artifact_data)
+    solution = str(reflector_solution or artifact_data.get('solution') or insight).strip()
     raw_tags = artifact_data.get('tags') or ['runtime']
     tags = [str(tag).lower() for tag in raw_tags] if isinstance(raw_tags, list) else []
     if not problem or not solution or not tags or any(tag not in CONTROLLED_LESSON_TAGS for tag in tags):
@@ -4002,7 +4021,7 @@ def _write_structured_lesson(
         'reusable_insight': insight,
         'files_changed': files_changed[:10],
     }
-    if not _validate_lesson_v2(lesson):
+    if not _validate_lesson_for_mint(lesson):
         return False
     duplicate = _find_lesson_duplicate(problem, existing['lessons'])
     if duplicate is not None:

--- a/nanobot/runtime/lesson_v2.py
+++ b/nanobot/runtime/lesson_v2.py
@@ -31,6 +31,23 @@ _MAX_FILE_BYTES = 2 * 1024 * 1024
 _MAX_FILE_AGE_DAYS = 90
 _MAX_ENTRIES = 200
 _WORD_RE = re.compile(r"[a-z]{3,}")
+_MIN_SOLUTION_MEANINGFUL_CHARS = 20
+_FILLER_SOLUTIONS = frozenset({
+    "apply the reflected approach hint.",
+    "apply the reflected approach hint",
+    "apply the reflected error pattern.",
+    "apply the reflected error pattern",
+    "fixed",
+    "fixed it",
+    "done",
+    "n/a",
+    "na",
+    "none",
+    "null",
+    "ok",
+    "pass",
+    "todo",
+})
 
 # Lateral-links constants (#1095).
 _RELATED_CAP = 3  # max slugs per entry
@@ -39,8 +56,22 @@ _RELATED_SLUG_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,119}")
 _INLINE_RELATED_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
+def solution_is_meaningful(problem: Any, solution: Any) -> bool:
+    """Reject filler and problem-shaped solutions before a v2 lesson is stored."""
+    if not isinstance(solution, str) or not solution.strip():
+        return False
+    normalized = " ".join(solution.casefold().split())
+    if normalized in _FILLER_SOLUTIONS or normalized.startswith("apply the reflected "):
+        return False
+    meaningful_chars = len(re.sub(r"[^\w]+", "", solution, flags=re.UNICODE))
+    if meaningful_chars < _MIN_SOLUTION_MEANINGFUL_CHARS:
+        return False
+    # The solution must teach an action/answer, not repeat the problem.
+    return keyword_jaccard(problem, solution) < 0.8
+
+
 def validate_lesson(card: Any) -> bool:
-    """Validate required v2 fields, controlled tags, severity, and evidence."""
+    """Validate the compatible v2 schema, controlled tags, severity, and evidence."""
     if not isinstance(card, dict):
         return False
     if not isinstance(card.get("problem"), str) or not card["problem"].strip():
@@ -61,6 +92,11 @@ def validate_lesson(card: Any) -> bool:
         and len(related) <= _RELATED_CAP
         and all(isinstance(slug, str) and _RELATED_SLUG_RE.fullmatch(slug.strip()) for slug in related)
     )
+
+
+def validate_lesson_for_mint(card: Any) -> bool:
+    """Apply stricter content checks to a newly minted lesson."""
+    return validate_lesson(card) and solution_is_meaningful(card.get("problem"), card.get("solution"))
 
 
 def normalize_problem(text: Any) -> str:

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -129,3 +129,147 @@ def test_prompt_includes_lesson_citation_instruction() -> None:
         "goal", "report",
     )
     assert "[Lesson LESS-1]" in task
+
+
+def test_write_structured_lesson_persists_concrete_reflector_recommendation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    artifact = {
+        "problem": "Parser crashed on malformed nested tokens",
+        "tags": ["runtime"],
+        "severity": "medium",
+        "evidence": ["cycle-resolved"],
+        "reusable_insight": "Streaming JSON parser chunks prevents OOM crash",
+        "reflector_recommendation": "Use chunked generator streaming instead of reading entire file into memory",
+        "reflector_delta": True,
+    }
+    # When artifact contains concrete reflector recommendation, solution must persist that real recommendation, not template
+    assert _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-reflector-detail",
+        backlog_title="Memory issue",
+        files_changed=["parser.py"],
+        commits_pushed=1,
+        artifact_data=artifact,
+    )
+    data = yaml.safe_load((repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    lesson = data["lessons"][0]
+    assert lesson["solution"] == "Use chunked generator streaming instead of reading entire file into memory"
+
+
+def test_write_structured_lesson_rejects_filler_or_empty_or_trivial_solution(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Empty solution
+    artifact_empty = {
+        "problem": "Connection timeout on remote service call",
+        "solution": "",
+        "tags": ["runtime"],
+        "severity": "medium",
+        "evidence": ["cycle-resolved"],
+        "reusable_insight": "",
+        "delta_evidence": "errors-to-integrated-resolution",
+    }
+    assert not _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-empty",
+        backlog_title="Fix timeout",
+        files_changed=["client.py"],
+        commits_pushed=1,
+        artifact_data=artifact_empty,
+    )
+
+    # Filler solution like "fixed it", "done", "n/a", etc.
+    for filler in ("fixed it", "done", "fixed", "n/a", "ok", "pass", "N/A", "todo"):
+        artifact = {
+            "problem": "Connection timeout on remote service call",
+            "solution": filler,
+            "tags": ["runtime"],
+            "severity": "medium",
+            "evidence": ["cycle-resolved"],
+            "reusable_insight": filler,
+            "delta_evidence": "errors-to-integrated-resolution",
+        }
+        written = _write_structured_lesson(
+            repo_root=repo,
+            cycle_id=f"cycle-filler-{filler.replace('/', '_')}",
+            backlog_title="Fix timeout",
+            files_changed=["client.py"],
+            commits_pushed=1,
+            artifact_data=artifact,
+        )
+        assert not written, f"Expected filler '{filler}' to be rejected"
+    assert not (repo / "lessons" / "lessons.yaml").exists()
+
+
+def test_write_structured_lesson_rejects_problem_equal_or_near_duplicate_solution(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # (a) Exact match problem == solution
+    artifact_exact = {
+        "problem": "Timeout connecting to remote database in /var/log/db.py line 50",
+        "solution": "Timeout connecting to remote database in /var/log/db.py line 50",
+        "tags": ["runtime"],
+        "severity": "medium",
+        "evidence": ["cycle-resolved"],
+        "reusable_insight": "Timeout connecting to remote database",
+        "delta_evidence": "errors-to-integrated-resolution",
+    }
+    written_exact = _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-exact-same",
+        backlog_title="DB timeout",
+        files_changed=["db.py"],
+        commits_pushed=1,
+        artifact_data=artifact_exact,
+    )
+    assert not written_exact
+
+    # (b) Near-duplicate problem and solution (e.g. minor whitespace / case / punctuation differences)
+    artifact_near = {
+        "problem": "Error connecting to Redis backend at redis://localhost:6379",
+        "solution": "Error connecting to Redis backend at redis://localhost:6379!",
+        "tags": ["runtime"],
+        "severity": "medium",
+        "evidence": ["cycle-resolved"],
+        "reusable_insight": "Error connecting to Redis backend",
+        "delta_evidence": "errors-to-integrated-resolution",
+    }
+    written_near = _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-near-same",
+        backlog_title="Redis connection",
+        files_changed=["redis.py"],
+        commits_pushed=1,
+        artifact_data=artifact_near,
+    )
+    assert not written_near
+    assert not (repo / "lessons" / "lessons.yaml").exists()
+
+
+def test_write_structured_lesson_valid_v2_lesson_remains_accepted(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    artifact = _base_artifact(
+        problem="Database connection pool exhausts under heavy concurrency",
+        solution="Increase max pool size and configure aggressive idle connection timeout",
+        tags=["runtime"],
+        severity="high",
+        reusable_insight="Aggressive idle cleanup prevents connection leaks in pool",
+        delta_evidence="errors-to-integrated-resolution",
+    )
+    written = _write_structured_lesson(
+        repo_root=repo,
+        cycle_id="cycle-valid-v2",
+        backlog_title="Tune DB pool",
+        files_changed=["pool.py"],
+        commits_pushed=1,
+        artifact_data=artifact,
+    )
+    assert written
+    data = yaml.safe_load((repo / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    assert len(data["lessons"]) == 1
+    lesson = data["lessons"][0]
+    assert validate_lesson(lesson)
+    assert lesson["problem"] == "Database connection pool exhausts under heavy concurrency"
+    assert lesson["solution"] == "Increase max pool size and configure aggressive idle connection timeout"


### PR DESCRIPTION
## Summary
- persist concrete reflector recommendation text in v2 lesson solutions, bounded to 500 characters
- reject filler, trivial, and problem-shaped solutions at the mint boundary
- add tests-first regressions for real recommendations and fail-closed rejection

Closes #1106

## Verification
- `python -m pytest tests/test_lesson_v2.py tests/test_lateral_links.py tests/test_lessons_context.py -q` (68 passed)
- `python -m pytest tests/test_import_hygiene.py tests/test_config_schema.py tests/test_config_paths.py -q` (11 passed)
- Full Windows suite: 2620 passed, 19 pre-existing platform failures (POSIX/default-branch/tag/lock assumptions); no new failures attributed to this change.

`conftest.py` was copied into the local worktree only and is not committed.
