### PR TITLE
fix(heldout): support data-dependent reporter exits

### DIFF
--- a/nanobot/runtime/heldout/checkers.py
+++ b/nanobot/runtime/heldout/checkers.py
@@ -40,6 +40,20 @@ PASS = "pass"
 FAIL = "fail"
 SKIP = "skip"
 
+MODE_EXIT_ZERO = "exit_zero"
+MODE_EXECUTES = "executes"
+
+# Registry for per-script execution mode: exit_zero (default) vs executes (#1109).
+SCRIPT_MODES: dict[str, str] = {
+    "scripts/loop_health_report.py": MODE_EXECUTES,
+}
+
+
+def get_script_mode(artifact: str) -> str:
+    """Return the execution mode for an artifact ('exit_zero' by default)."""
+    return SCRIPT_MODES.get(artifact, MODE_EXIT_ZERO)
+
+
 _STDERR_TAIL = 160  # bounded evidence excerpt
 
 
@@ -101,6 +115,60 @@ def _run(ctx: CheckContext, args: tuple[str, ...] = ()) -> subprocess.CompletedP
 def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
     text = (proc.stderr or proc.stdout or "").strip()
     return text[-_STDERR_TAIL:].replace("\n", " ")
+
+
+def _has_traceback_or_exception(proc: subprocess.CompletedProcess) -> bool:
+    """Detect an uncaught Python failure without treating report text as one."""
+    stderr = (proc.stderr or "").lower()
+    stdout = (proc.stdout or "").lower()
+    if "traceback (most recent call last):" in stderr or "traceback (most recent call last):" in stdout:
+        return True
+    # Unhandled Python exceptions are written to stderr as ``TypeError: ...``.
+    return any(
+        line.strip().startswith(prefix)
+        for line in stderr.splitlines()
+        for prefix in (
+            "syntaxerror:", "nameerror:", "typeerror:", "valueerror:",
+            "attributeerror:", "importerror:", "modulenotfounderror:",
+            "keyerror:", "indexerror:", "zerodivisionerror:",
+            "filenotfounderror:", "runtimeerror:", "exception:",
+            "unboundlocalerror:", "indentationerror:", "taberror:",
+            "assertionerror:", "permissionerror:", "oserror:", "ioerror:",
+        )
+    )
+
+
+def validate_execution(
+    proc: subprocess.CompletedProcess,
+    *,
+    mode: str = MODE_EXIT_ZERO,
+    required_keywords: tuple[str, ...] = (),
+    empty_error: str = "empty stdout",
+    keyword_error: str = "stdout does not mention required keywords",
+    success_msg: str = "runs to exit 0 and outputs expected keywords",
+) -> tuple[str, str]:
+    """Validate a CompletedProcess against mode ('exit_zero' or 'executes') and stdout contract."""
+    if mode == MODE_EXECUTES:
+        if _has_traceback_or_exception(proc):
+            return FAIL, f"crashed with traceback/exception: {_stderr_tail(proc)}"
+        stdout = (proc.stdout or "").strip()
+        if not stdout:
+            return FAIL, empty_error
+        if required_keywords and not any(k in stdout.lower() for k in required_keywords):
+            return FAIL, keyword_error
+        if proc.returncode != 0:
+            return PASS, f"runs to completion with valid report output (exit {proc.returncode})"
+        return PASS, success_msg
+
+    # Default mode: MODE_EXIT_ZERO
+    if proc.returncode != 0:
+        return FAIL, f"exited {proc.returncode}: {_stderr_tail(proc)}"
+    stdout = (proc.stdout or "").strip()
+    if not stdout:
+        return FAIL, empty_error
+    if required_keywords and not any(k in stdout.lower() for k in required_keywords):
+        return FAIL, keyword_error
+    return PASS, success_msg
 
 
 def _write_fixture_ledger(ctx: CheckContext) -> Path:
@@ -170,19 +238,20 @@ def check_generate_system_map(ctx: CheckContext) -> tuple[str, str]:
 
 
 def check_loop_health_report(ctx: CheckContext) -> tuple[str, str]:
-    """Contract: prints loop health summary from state. STRICT core: runs to
-    exit 0 on fixture state and emits loop health keywords in stdout."""
+    """Contract: prints loop health summary from state. STRICT core: executes
+    on fixture state (mode='executes': accepts exit 0 or non-zero data-dependent
+    status if completed with nonempty valid report output and no traceback/exception)
+    and emits loop health keywords in stdout."""
     _write_fixture_ledger(ctx)
     proc = _run(ctx)
-    if proc.returncode != 0:
-        return FAIL, f"exited {proc.returncode}: {_stderr_tail(proc)}"
-    stdout = (proc.stdout or "").strip()
-    if not stdout:
-        return FAIL, "empty stdout from loop_health_report"
-    # Must produce expected health/cycle report terms
-    if not any(k in stdout.lower() for k in ("health", "cycle", "cycles", "ledger", "status", "ok")):
-        return FAIL, "stdout does not mention health or cycle status"
-    return PASS, "runs to exit 0 and outputs health status keywords"
+    return validate_execution(
+        proc,
+        mode=get_script_mode("scripts/loop_health_report.py"),
+        required_keywords=("health", "cycle", "cycles", "ledger", "status", "ok"),
+        empty_error="empty stdout from loop_health_report",
+        keyword_error="stdout does not mention health or cycle status",
+        success_msg="runs to exit 0 and outputs health status keywords",
+    )
 
 
 # ─── scripts/prune_failed_backlog.py ────────────────────────────────────────
@@ -204,14 +273,14 @@ def check_prune_failed_backlog(ctx: CheckContext) -> tuple[str, str]:
         "# Memory\n\n## Active backlog — pick one each session\n", encoding="utf-8"
     )
     proc = _run(ctx)
-    if proc.returncode != 0:
-        return FAIL, f"exited {proc.returncode}: {_stderr_tail(proc)}"
-    stdout = (proc.stdout or "").strip()
-    if not stdout:
-        return FAIL, "empty stdout from prune_failed_backlog"
-    if not any(k in stdout.lower() for k in ("prun", "backlog", "entries", "0", "done", "status")):
-        return FAIL, "stdout does not mention backlog pruning status"
-    return PASS, "runs to exit 0 and outputs backlog status keywords"
+    return validate_execution(
+        proc,
+        mode=get_script_mode("scripts/prune_failed_backlog.py"),
+        required_keywords=("prun", "backlog", "entries", "0", "done", "status"),
+        empty_error="empty stdout from prune_failed_backlog",
+        keyword_error="stdout does not mention backlog pruning status",
+        success_msg="runs to exit 0 and outputs backlog status keywords",
+    )
 
 
 # ─── registry ───────────────────────────────────────────────────────────────

--- a/nanobot/runtime/heldout/checkers.py
+++ b/nanobot/runtime/heldout/checkers.py
@@ -118,10 +118,10 @@ def _stderr_tail(proc: subprocess.CompletedProcess) -> str:
 
 
 def _has_traceback_or_exception(proc: subprocess.CompletedProcess) -> bool:
-    """Detect an uncaught Python failure without treating report text as one."""
+    """Detect traceback or an uncaught Python exception in process output."""
     stderr = (proc.stderr or "").lower()
     stdout = (proc.stdout or "").lower()
-    if "traceback (most recent call last):" in stderr or "traceback (most recent call last):" in stdout:
+    if "traceback" in stderr or "traceback" in stdout:
         return True
     # Unhandled Python exceptions are written to stderr as ``TypeError: ...``.
     return any(

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -399,6 +399,159 @@ class TestRunner:
         assert second["regressions"] == []
 
 
+# ─── execution mode tests (#1109) ───────────────────────────────────────────
+
+
+class TestScriptExecutionModes:
+    def test_script_modes_registry_and_defaults(self):
+        assert checkers.get_script_mode("scripts/loop_health_report.py") == checkers.MODE_EXECUTES
+        assert checkers.get_script_mode("scripts/prune_failed_backlog.py") == checkers.MODE_EXIT_ZERO
+        assert checkers.get_script_mode("scripts/eeebot_dashboard.py") == checkers.MODE_EXIT_ZERO
+        assert checkers.get_script_mode("scripts/unknown.py") == checkers.MODE_EXIT_ZERO
+
+    def test_executes_mode_accepts_nonzero_exit_with_valid_output(self):
+        # Valid report output but nonzero returncode (e.g. exit code 1 because loop is unhealthy/critical)
+        proc = subprocess.CompletedProcess(
+            args=["dummy"],
+            returncode=1,
+            stdout="Loop health: 0 outcomes recorded. Cycles status: degraded.\n",
+            stderr="",
+        )
+        status, evidence = checkers.validate_execution(
+            proc,
+            mode=checkers.MODE_EXECUTES,
+            required_keywords=("health", "cycle", "cycles", "ledger", "status", "ok"),
+            empty_error="empty stdout",
+            keyword_error="missing keywords",
+        )
+        assert status == checkers.PASS
+        assert "exit 1" in evidence
+
+    def test_executes_mode_rejects_traceback_on_nonzero_exit(self):
+        proc = subprocess.CompletedProcess(
+            args=["dummy"],
+            returncode=1,
+            stdout="Loop health: starting...\n",
+            stderr="Traceback (most recent call last):\n  File 'x.py', line 1\nZeroDivisionError: division by zero\n",
+        )
+        status, evidence = checkers.validate_execution(
+            proc,
+            mode=checkers.MODE_EXECUTES,
+            required_keywords=("health",),
+        )
+        assert status == checkers.FAIL
+        assert "traceback/exception" in evidence
+
+    def test_executes_mode_rejects_traceback_on_zero_exit(self):
+        # Even if exit code is 0, uncaught traceback in output must fail
+        proc = subprocess.CompletedProcess(
+            args=["dummy"],
+            returncode=0,
+            stdout="Loop health: ok\nTraceback in output\n",
+            stderr="",
+        )
+        status, evidence = checkers.validate_execution(
+            proc,
+            mode=checkers.MODE_EXECUTES,
+            required_keywords=("health",),
+        )
+        assert status == checkers.FAIL
+        assert "traceback/exception" in evidence
+
+    def test_executes_mode_rejects_empty_output(self):
+        proc = subprocess.CompletedProcess(
+            args=["dummy"],
+            returncode=1,
+            stdout="   \n",
+            stderr="",
+        )
+        status, evidence = checkers.validate_execution(
+            proc,
+            mode=checkers.MODE_EXECUTES,
+            required_keywords=("health",),
+            empty_error="empty stdout from loop_health_report",
+        )
+        assert status == checkers.FAIL
+        assert evidence == "empty stdout from loop_health_report"
+
+    def test_executes_mode_rejects_missing_required_keywords(self):
+        proc = subprocess.CompletedProcess(
+            args=["dummy"],
+            returncode=1,
+            stdout="hello random text\n",
+            stderr="",
+        )
+        status, evidence = checkers.validate_execution(
+            proc,
+            mode=checkers.MODE_EXECUTES,
+            required_keywords=("health", "cycle"),
+            keyword_error="stdout does not mention health or cycle status",
+        )
+        assert status == checkers.FAIL
+        assert evidence == "stdout does not mention health or cycle status"
+
+    def test_exit_zero_mode_rejects_nonzero_exit_even_with_valid_output(self):
+        proc = subprocess.CompletedProcess(
+            args=["dummy"],
+            returncode=1,
+            stdout="backlog pruning: 0 items pruned, ok\n",
+            stderr="",
+        )
+        status, evidence = checkers.validate_execution(
+            proc,
+            mode=checkers.MODE_EXIT_ZERO,
+            required_keywords=("prun", "backlog"),
+        )
+        assert status == checkers.FAIL
+        assert "exited 1" in evidence
+
+    def test_loop_health_report_heldout_check_with_exit_1_valid_output(self, tmp_path):
+        # A script that analyzes ledger and exits 1 because ledger has 0 cycles,
+        # but produces valid health report output without exceptions.
+        script_source = '''\
+"""Loop health report."""
+from pathlib import Path
+ledger = Path("state/ledger/cycles.jsonl")
+if ledger.is_file():
+    print("Loop health status: ok (1 cycle found)")
+    raise SystemExit(1)
+'''
+        repo = _make_repo(tmp_path, {"loop_health_report.py": script_source})
+        state_dir = tmp_path / "state"
+        data = heldout.run_heldout(state_dir, repo, force=True)
+        entry = data["results"]["scripts/loop_health_report.py"]
+        assert entry["status"] == checkers.PASS
+        assert "exit 1" in entry["evidence"]
+
+    def test_loop_health_report_heldout_check_with_traceback_fails(self, tmp_path):
+        # A script that crashes with traceback
+        script_source = '''\
+"""Loop health report."""
+print("Loop health status: starting")
+raise RuntimeError("database unreachable")
+'''
+        repo = _make_repo(tmp_path, {"loop_health_report.py": script_source})
+        state_dir = tmp_path / "state"
+        data = heldout.run_heldout(state_dir, repo, force=True)
+        entry = data["results"]["scripts/loop_health_report.py"]
+        assert entry["status"] == checkers.FAIL
+        assert "traceback/exception" in entry["evidence"]
+
+    def test_loop_health_report_heldout_check_with_empty_output_fails(self, tmp_path):
+        # A script that exits 1 with empty stdout
+        script_source = '''\
+"""Loop health report."""
+import sys
+sys.exit(1)
+'''
+        repo = _make_repo(tmp_path, {"loop_health_report.py": script_source})
+        state_dir = tmp_path / "state"
+        data = heldout.run_heldout(state_dir, repo, force=True)
+        entry = data["results"]["scripts/loop_health_report.py"]
+        assert entry["status"] == checkers.FAIL
+        assert "empty stdout" in entry["evidence"]
+
+
 # ─── flaky detection (#842: non-deterministic verdict exclusion) ───────────
 
 


### PR DESCRIPTION
## Summary

- Add per-script heldout execution modes with `exit_zero` as the unchanged default.
- Mark `scripts/loop_health_report.py` as `executes`, accepting a completed nonzero report while rejecting traceback/exception/empty output.
- Add regression coverage for mode semantics while preserving #842 flaky confirmation unchanged.

## Heldout set audit

| Script | Mode | Justification |
|---|---|---|
| `scripts/eeebot_dashboard.py` | `exit_zero` | Dashboard smoke check requires successful process completion. |
| `scripts/generate_system_map.py` | `exit_zero` | Generator must complete successfully to produce the system map. |
| `scripts/prune_failed_backlog.py` | `exit_zero` | Maintenance utility must complete successfully; its report is not a health status signal. |
| `scripts/loop_health_report.py` | `executes` | Exit status intentionally reflects data-dependent loop health; valid report output proves execution. |

## Validation

- `python -m pytest -q tests/test_heldout.py`: 37 passed
- `ruff check nanobot/runtime/heldout tests/test_heldout.py`: passed
- Full local pytest baseline: 2623 passed, 17 skipped, 19 known Windows/platform baseline failures (POSIX `fcntl`, synthetic git default-branch fixtures, etc.); the CI correction for traceback text is included in the latest commit.
- `nanobot/runtime/demand.py` untouched.
- `nanobot/runtime/heldout/__init__.py` untouched; #842 flaky rerun logic unchanged.

Closes #1109
