### PR TITLE
fix(runtime): suppress doc-only demand across lanes

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -341,6 +341,28 @@ def classify_change_tier(files_changed: list[str] | None) -> str:
     return "code-bearing"
 
 
+def predict_item_change_tier(item: dict[str, Any] | None) -> str:
+    """Predict an item's output tier using the integration classifier.
+
+    Demand items carry an explicit affected path when their producer knows one;
+    priority and goal-gap items may only mention paths in their bounded text.
+    Missing or ambiguous paths fail open as code-bearing, preserving demand.
+    """
+    if not isinstance(item, dict):
+        return "code-bearing"
+    paths: list[str] = []
+    affected = str(item.get("affected_path") or "").strip()
+    if affected:
+        paths.append(affected)
+    else:
+        for field in ("summary", "evidence"):
+            for match in _PATH_TOKEN_RE.findall(str(item.get(field) or ""))[:20]:
+                path = match.strip(".,;:()[]{}")
+                if path and path not in paths:
+                    paths.append(path)
+    return classify_change_tier(paths)
+
+
 def doc_only_budget_24h() -> int:
     """Return the configured 24h budget for doc-only integrations (default 5)."""
     raw = os.environ.get(_DOC_ONLY_BUDGET_ENV_VAR)
@@ -2550,30 +2572,28 @@ def collect_demand(
             bounded_result.append(item)
         result = bounded_result
 
-        # #1090: Doc-only budget guard for presented reflection items.
-        # When terminal success integrations classified as doc-only in rolling 24h
-        # meet or exceed the budget (default 5, env EEEBOT_DOC_ONLY_24H_BUDGET),
-        # suppress presented reflection items that target doc-only paths.
-        # Non-doc reflection items and non-reflection lanes are completely unaffected.
+        # #1090/#1108: suppress predicted doc-only items once the rolling
+        # budget is reached.  Prediction calls the same classifier used for
+        # integration-time counting, so the two decisions cannot drift.
         doc_count_24h = count_doc_only_integrations_24h(state_dir, now=now)
         doc_budget = doc_only_budget_24h()
         doc_budget_exceeded = doc_count_24h >= doc_budget
+        notice = (
+            f"Doc-only daily budget ({doc_budget}) reached ({doc_count_24h} in 24h). "
+            "Focus on code-bearing improvements (scripts/, runtime/, tests/)."
+        )
 
         post_doc_guard: list[dict[str, str]] = []
         for item in result:
             k = item.get("kind", "")
             affected = item.get("affected_path", "")
-            if k == "reflection" and doc_budget_exceeded and is_doc_only_path(affected):
-                # Suppress doc-only reflection item under exceeded budget
+            if doc_budget_exceeded and predict_item_change_tier(item) == "doc-only":
+                # Deferral only: leave completion/exhaustion state untouched.
                 continue
-            # When budget is exceeded, remaining reflection items get steering notice
-            if k == "reflection" and doc_budget_exceeded:
-                notice = (
-                    f"Doc-only daily budget ({doc_budget}) reached ({doc_count_24h} in 24h). "
-                    "Focus on code-bearing improvements (scripts/, runtime/, tests/)."
-                )
+            # Preserve #1090's reflection steering and extend the same bounded
+            # notice to every surviving lane under the reached budget.
+            if doc_budget_exceeded:
                 item["doc_budget_notice"] = notice
-                # Append steering notice to summary so it reaches LLM proposer prompt unconditionally
                 summary = item.get("summary", "")
                 if notice not in summary:
                     item["summary"] = f"{summary} [STEERING NOTICE: {notice}]" if summary else notice

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -2904,6 +2904,90 @@ class TestIssue1090DocGuard:
         (ledger_dir / "cycles.jsonl").write_text("not json\n{bad\n", encoding="utf-8")
         assert demand.count_doc_only_integrations_24h(state_dir) == 0
 
+    def test_over_budget_suppresses_doc_only_items_across_lanes(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_priority = demand._make_item(
+            "priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md"
+        )
+        code_priority = demand._make_item(
+            "priority", "Priority 2 — scripts/worker.py", "Improve scripts/worker.py"
+        )
+        doc_gap = demand._make_item(
+            "goal-gap", "goal gap: docs_coverage", "Improve docs/coverage.md"
+        )
+        code_gap = demand._make_item(
+            "goal-gap", "goal gap: runtime_health", "Improve nanobot/runtime/health.py"
+        )
+        doc_decay = demand._make_item(
+            "decay", "Propose archiving docs/old.md", "archive", affected_path="docs/old.md"
+        )
+        code_decay = demand._make_item(
+            "decay", "Propose archiving scripts/old.py", "archive", affected_path="scripts/old.py"
+        )
+        monkeypatch.setattr(demand, "_priority_items", lambda *args, **kwargs: [doc_priority, code_priority])
+        monkeypatch.setattr(demand, "_goal_gap_items", lambda *args, **kwargs: [doc_gap, code_gap])
+        monkeypatch.setattr(demand, "_decay_items", lambda *args, **kwargs: [doc_decay, code_decay])
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: 5)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+
+        items = demand.collect_demand(state_dir, None)
+        ids = {item["id"] for item in items}
+        assert doc_priority["id"] not in ids
+        assert doc_gap["id"] not in ids
+        assert doc_decay["id"] not in ids
+        assert {code_priority["id"], code_gap["id"], code_decay["id"]} <= ids
+        assert all("Doc-only daily budget (5) reached" in item["summary"] for item in items)
+
+    def test_doc_only_selection_is_byte_identical_below_budget(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_item = demand._make_item("priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md")
+        code_item = demand._make_item("priority", "Priority 2 — scripts/worker.py", "Improve scripts/worker.py")
+        monkeypatch.setattr(demand, "_priority_items", lambda *args, **kwargs: [doc_item, code_item])
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: 0)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+
+        baseline = demand.collect_demand(state_dir, None)
+        again = demand.collect_demand(state_dir, None)
+        assert again == baseline
+        assert doc_item in again and code_item in again
+
+    def test_doc_only_deferral_does_not_change_lifecycle_or_counters(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_item = demand._make_item("priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md")
+        monkeypatch.setattr(demand, "_priority_items", lambda *args, **kwargs: [doc_item])
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: 5)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+        exhausted = state_dir / "demand" / "exhausted.json"
+        exhausted.parent.mkdir(parents=True, exist_ok=True)
+        before = {
+            "schema_version": "demand-exhausted-v1",
+            "entries": {doc_item["id"]: {"status": "active", "rejects": 1}},
+        }
+        exhausted.write_text(json.dumps(before), encoding="utf-8")
+
+        assert demand.collect_demand(state_dir, None) == []
+        assert json.loads(exhausted.read_text(encoding="utf-8")) == before
+
+    def test_doc_budget_count_and_prediction_use_shared_classifier(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        (ledger_dir / "cycles.jsonl").write_text(json.dumps({
+            "phase": "outcome", "outcome": "success", "files_changed": ["docs/a.md"],
+            "ts": _now_iso(1),
+        }) + "\n", encoding="utf-8")
+        calls = []
+        original = demand.classify_change_tier
+        def tracking(files):
+            calls.append(tuple(files or []))
+            return original(files)
+        monkeypatch.setattr(demand, "classify_change_tier", tracking)
+        assert demand.count_doc_only_integrations_24h(state_dir) == 1
+        assert demand.predict_item_change_tier(
+            demand._make_item("priority", "Priority 1 — docs/a.md", "Update docs/a.md")
+        ) == "doc-only"
+        assert len(calls) >= 2
+
 
 class TestIssue1040DemandIODiet:
     """#1040: cycle I/O diet test suite."""


### PR DESCRIPTION
## Summary
- extend the #1090 rolling doc-only budget guard from reflection items to all demand lanes
- predict item output tier through the same `classify_change_tier` function used for integration counting
- defer predicted doc-only items without touching lifecycle, completion, deduplication, or exhaustion state
- preserve below-budget selection and existing reflection steering behavior

Closes #1108

## Verification
- `python -m pytest tests/test_demand.py -q` — 155 passed
- full local Windows suite — 2627 passed, 19 known pre-existing POSIX/default-branch/tag/lock failures
- `nanobot/runtime/heldout/` was not modified

Classifier sharing proof: `count_doc_only_integrations_24h()` calls `classify_change_tier()` for integration rows; `predict_item_change_tier()` delegates to the same function for demand prediction; `collect_demand()` uses `predict_item_change_tier()` for selection suppression.

`conftest.py` is a local untracked pytest shim and is not committed.
