### PR TITLE
fix(runtime): scan archived no-op results

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -162,6 +162,7 @@ _DEFECT_WINDOW_HOURS = 48
 _MAX_RESULT_FILES = 50  # bounded read, same discipline as existence_index._MAX_LEDGER_RESULTS
 _MAX_RESULT_FILE_DEFECTS = 10  # #1038: capped defect output from result files
 _MAX_RESULT_NOOP_FILES = 50  # #1114: bounded no-op exhaustion scan
+_RESULT_DIRS = ("results", "archive")  # handled results move to archive
 _MAX_LEDGER_DEFECTS = 10
 _MAX_COMPILE_DEFECTS = 10
 _MAX_HELDOUT_DEFECTS = 5  # #780: bounded held-out failure demand
@@ -2274,10 +2275,13 @@ def _completed_no_commit_ts_by_demand_id(
     """
     out: dict[str, list[datetime]] = {}
     try:
-        results_dir = Path(state_dir) / "subagents" / "results"
-        if not results_dir.is_dir():
+        paths: list[Path] = []
+        for dirname in _RESULT_DIRS:
+            results_dir = Path(state_dir) / "subagents" / dirname
+            if results_dir.is_dir():
+                paths.extend(p for p in results_dir.glob("*.json") if p.is_file())
+        if not paths:
             return out
-        paths = [p for p in results_dir.glob("*.json") if p.is_file()]
         try:
             paths.sort(key=lambda p: p.stat().st_mtime, reverse=True)
         except Exception:
@@ -2432,8 +2436,14 @@ def _fold_already_delivered_priorities(
         entries = completed["entries"]
         changed = False
         folded: set[str] = set()
-        results_dir = Path(state_dir) / "subagents" / "results"
-        candidates = sorted(results_dir.glob("*.json")) if results_dir.is_dir() else []
+        result_dirs = [Path(state_dir) / "subagents" / dirname for dirname in _RESULT_DIRS]
+        candidates = [
+            path
+            for result_dir in result_dirs
+            if result_dir.is_dir()
+            for path in result_dir.glob("*.json")
+            if path.is_file()
+        ]
         terminal_outcomes = {
             str(row.get("cycle_id") or "").strip(): row
             for row in rows

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1227,6 +1227,36 @@ class TestCompletedSidecar:
         completed = json.loads(completed_path.read_text(encoding="utf-8")) if completed_path.exists() else {}
         assert target_item["id"] not in completed.get("entries", {})
 
+    def test_archived_already_delivered_result_folds(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        repo = _git_repo(tmp_path)
+        subprocess.run(["git", "branch", "-M", "main"], cwd=repo, check=True)
+        target_path = "scripts/archived_delivery.py"
+        target = repo / target_path
+        target.parent.mkdir(parents=True)
+        target.write_text("print('done')\n", encoding="utf-8")
+        _commit_all(repo, "deliver archived target")
+
+        target_item = [i for i in demand.collect_demand(state_dir, repo) if i["kind"] == "priority"][0]
+        _append_proposed(state_dir, "c-archived", target_item["id"], ts=_now_iso(10))
+        archive_dir = state_dir / "subagents" / "archive"
+        archive_dir.mkdir(parents=True)
+        (archive_dir / "result-c-archived.json").write_text(
+            json.dumps({
+                "cycle_id": "c-archived",
+                "result_status": "completed",
+                "learning_classification": "completed_no_commit",
+                "target_path": target_path,
+            }),
+            encoding="utf-8",
+        )
+        _append_outcome(state_dir, "c-archived", "partial", ts=_now_iso(5))
+
+        remaining = demand.collect_demand(state_dir, repo)
+        assert not any(i["id"] == target_item["id"] for i in remaining)
+        assert _completed_sidecar(state_dir)["entries"][target_item["id"]]["evidence"]["target_path"] == target_path
+
     def test_already_delivered_fold_requires_main_branch(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])


### PR DESCRIPTION
## Rework for #1114 / #1115

The original implementation only inspected `state/subagents/results/`, but the bridge archives handled results before the next demand collection. This rework scans both `results/` and `archive/`, bounded by the existing newest-by-mtime result limit and preserving per-file malformed-record handling.

It also preserves strict evidence checks: ledger-linked cycle, terminal partial/no-commit outcome, result-linked target, current checkout on `main`, `git ls-tree HEAD`, and filesystem presence.

Changed files:
- `nanobot/runtime/demand.py`
- `tests/test_demand.py`

The first regression test intentionally failed against the pre-fix implementation with an archived result, then passed after the fix.
