### PR TITLE
feat: tri-state cycle verdict + frozen expected_outcome claim (#1118)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1344,6 +1344,9 @@ def build_task(req: dict, goal_text: str, report_source: str,
     backlog_instructions = artifact_data.get('next_bounded_candidate', {}).get('backlog_instructions', '')
     backlog_priority = artifact_data.get('next_bounded_candidate', {}).get('backlog_priority')
     recommended_action = artifact_data.get('recommended_next_action', '')
+    # #1118: the proposer's optional, FROZEN falsifiable claim (never rewritten
+    # after write_request wrote it) — informational only, never enforced here.
+    expected_outcome = artifact_data.get('expected_outcome') if isinstance(artifact_data.get('expected_outcome'), dict) else None
 
     # Build lessons context block from coordinator-injected cards
     lessons_context = req.get('lessons_context') or {}
@@ -1480,6 +1483,16 @@ def build_task(req: dict, goal_text: str, report_source: str,
             curriculum_note,
             '',
             backlog_instructions,
+            '',
+        ]
+    # #1118: surface the frozen claim (informational, never enforced) right
+    # after the concrete task — same place regardless of which branch above
+    # populated the task, since expected_outcome is orthogonal to backlog vs.
+    # recommended_action framing.
+    if expected_outcome and expected_outcome.get('claim'):
+        lines += [
+            '## Expected outcome (frozen claim from the proposal — informational)',
+            str(expected_outcome['claim'])[:300],
             '',
         ]
     elif recommended_action and 'Materialize one' not in recommended_action:
@@ -1979,8 +1992,10 @@ async def _main_impl_body():
                         'auto_committed': False,
                     },
                 )
+                _v, _vr = _derive_cycle_verdict('failed', 'head_on_main_precondition_failed')
                 record_cycle_outcome(
                     STATE_DIR, _cycle_id, 'failed', 'head_on_main_precondition_failed', [], None,
+                    verdict=_v, verdict_reason=_vr,
                 )
                 # #721: no cycle branch exists yet on this path — tag at current HEAD.
                 _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'failed')
@@ -2082,7 +2097,11 @@ async def _main_impl_body():
                 ],
             )
             record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_duplicate', f'tag:{_cycle_success_tag}')
-            record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done_tag', [], None)
+            _v, _vr = _derive_cycle_verdict('skipped-duplicate', 'already_done_tag')
+            record_cycle_outcome(
+                STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done_tag', [], None,
+                verdict=_v, verdict_reason=_vr,
+            )
             _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
             # #733: bulk-skip — bookkeeping done for this duplicate; move on to
             # the next pending request in the same run (bounded by MAX_SKIPS_PER_RUN).
@@ -2204,7 +2223,11 @@ async def _main_impl_body():
                 ],
             )
             record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_duplicate', _found_commit)
-            record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done', [], None)
+            _v, _vr = _derive_cycle_verdict('skipped-duplicate', 'already_done')
+            record_cycle_outcome(
+                STATE_DIR, _cycle_id, 'skipped-duplicate', 'already_done', [], None,
+                verdict=_v, verdict_reason=_vr,
+            )
             # #721: no cycle branch on this path — tag at current HEAD.
             _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
             # #733: bulk-skip — bookkeeping done for this duplicate; move on to
@@ -2263,7 +2286,11 @@ async def _main_impl_body():
             # #757: record the matched HISTORICAL title, not the proposal's
             # own title — matched_against must say what it actually matched.
             record_dedup_decision(STATE_DIR, _cycle_id, 'skipped_recent_failure', _recent_failure_title)
-            record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'recent_duplicate_failure', [], None)
+            _v, _vr = _derive_cycle_verdict('skipped-duplicate', 'recent_duplicate_failure')
+            record_cycle_outcome(
+                STATE_DIR, _cycle_id, 'skipped-duplicate', 'recent_duplicate_failure', [], None,
+                verdict=_v, verdict_reason=_vr,
+            )
             # #721: no cycle branch on this path — tag at current HEAD.
             _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
             # #733: bulk-skip — bookkeeping done for this duplicate; move on to
@@ -2319,7 +2346,11 @@ async def _main_impl_body():
             record_dedup_decision(
                 STATE_DIR, _cycle_id, 'skipped_duplicate', f'existence-index:{_existence_match}',
             )
-            record_cycle_outcome(STATE_DIR, _cycle_id, 'skipped-duplicate', 'existence_index_duplicate', [], None)
+            _v, _vr = _derive_cycle_verdict('skipped-duplicate', 'existence_index_duplicate')
+            record_cycle_outcome(
+                STATE_DIR, _cycle_id, 'skipped-duplicate', 'existence_index_duplicate', [], None,
+                verdict=_v, verdict_reason=_vr,
+            )
             # #721: no cycle branch on this path — tag at current HEAD.
             _tag_cycle_post(_selfevo_repo_check, _cycle_id, 'skipped-duplicate')
             # #733: bulk-skip — bookkeeping done for this duplicate; move on to
@@ -2409,8 +2440,10 @@ async def _main_impl_body():
                 'reason': _cycle_setup['reason'],
             },
         )
+        _v, _vr = _derive_cycle_verdict('failed', _cycle_setup['reason'])
         record_cycle_outcome(
             STATE_DIR, _cycle_id, 'failed', _cycle_setup['reason'], [], cycle_branch,
+            verdict=_v, verdict_reason=_vr,
         )
         # #721: cycle branch setup itself failed — tag at main_sha_before
         # (may be '' if even the pre-checkout rev-parse failed; _tag_cycle_post
@@ -2546,6 +2579,12 @@ async def _main_impl_body():
             escalate_on_budget=True,
         )
         print(msg)
+        # #1118: capture the fresh task_id NOW, while it is still a live key
+        # in mgr._running_tasks (spawn's own done-callback pops it the moment
+        # the background task finishes) — this is the only handle bridge.py
+        # has back to the telemetry file the subagent will write its raw
+        # final answer into (see _executor_reported_outcome below).
+        _subagent_task_id = next(iter(mgr._running_tasks), None)
         if mgr._running_tasks:
             try:
                 # Limit subagent execution time to 3000s (50 minutes).
@@ -3214,8 +3253,20 @@ async def _main_impl_body():
         _cycle_outcome = 'partial'
     else:
         _cycle_outcome = 'failed'
+    # #1118: 'partial'/'failed' rows are the only ambiguous case (see
+    # _derive_cycle_verdict's docstring) — attempt to resolve them further by
+    # reading the executor's OWN structured final answer for this cycle's
+    # subagent (best-effort, fail-open, no new LLM call). A confirmed
+    # ``outcome: skipped`` self-report upgrades the verdict reason so a
+    # verified already-done skip records 'reject', not 'inconclusive'.
+    _verdict_reason_hint = _rollback_reason
+    if _cycle_outcome in ('partial', 'failed') and not _rollback_reason:
+        if _executor_reported_skipped(STATE_DIR, _subagent_task_id):
+            _verdict_reason_hint = 'executor_reported_skipped'
+    _verdict, _verdict_reason = _derive_cycle_verdict(_cycle_outcome, _verdict_reason_hint)
     record_cycle_outcome(
         STATE_DIR, _cycle_id, _cycle_outcome, _rollback_reason, files_changed, cycle_branch,
+        verdict=_verdict, verdict_reason=_verdict_reason,
     )
     # #721: post-cycle tag at the terminal HEAD, same outcome value as the
     # ledger row above. Integrated -> main_sha_after (shared checkout stayed on
@@ -3605,6 +3656,119 @@ def _request_serves_demand(req: dict) -> bool:
         return bool(m) and m.group(1).strip().lower().startswith('demand ')
     except Exception:
         return False
+
+
+# #1118: outcome -> (verdict, reason) mapping, keyed on the SAME string
+# already recorded as this row's own ``outcome`` — no new signal, no new
+# LLM call, just a deterministic read of a value the ledger already writes.
+# ``outcome`` itself is completely untouched by this table (byte-identical
+# values/semantics preserved for every existing consumer).
+_OUTCOME_TO_VERDICT: dict[str, str] = {
+    'success': 'accept',
+    'promotion_candidate': 'accept',
+    # A duplicate/already-done/recently-rejected skip is a HEALTHY negative
+    # result — the loop correctly declined to redo settled work. This is
+    # exactly the issue's "reject = verified already-done" case.
+    'skipped-duplicate': 'reject',
+    # 'partial' (the bridge's catch-all for "no commits landed, no dedup
+    # match either") and 'failed' are both ambiguous on their own — could be
+    # a genuine gate/infra failure (inconclusive) or a deliberate, honest
+    # skip the executor reported in its structured final answer (reject).
+    # Resolved by ``reason`` below when available; a bare/unknown reason
+    # falls through to inconclusive (fail-closed toward the least confident
+    # verdict, never a false accept/reject).
+}
+
+# Rollback/dedup reasons that represent a CLEAN, deterministic negative
+# result (the loop correctly declined already-settled or already-rejected
+# work) rather than an operational failure — these upgrade an otherwise
+# ambiguous 'partial'/'failed' outcome to verdict 'reject'.
+_REJECT_REASONS = frozenset({
+    'already_done_tag', 'already_done', 'recent_duplicate_failure',
+    'existence_index_duplicate', 'executor_reported_skipped',
+})
+
+# Rollback/reason codes that represent infra/harness trouble or an ambiguous
+# result — always 'inconclusive', never upgraded to accept/reject even when
+# they co-occur with an otherwise-terminal outcome.
+_INCONCLUSIVE_REASONS = frozenset({
+    'gate_failed', 'mutation_surface_violation', 'blocked_file_present',
+    'out_of_band_main_detected', 'switch_base_gate_error',
+    'switch_base_gate_blocked', 'head_on_main_precondition_failed',
+    'no_commit', 'internal_error',
+})
+
+
+def _executor_reported_skipped(state_dir: Path, task_id: 'str | None') -> bool:
+    """#1118: best-effort read of the executor's OWN structured final answer
+    (the JSON contract in ``build_task()``'s prompt: ``{"outcome": "completed"
+    | "skipped" | "blocked", ...}``) to tell "executor verified already-done,
+    honestly reported skipped" apart from "ran out of budget / crashed" for a
+    zero-commit cycle — both currently collapse into the same ``outcome:
+    partial``/``failed`` ledger value (#1118's problem statement).
+
+    Reads the subagent telemetry file the SAME cycle's spawn already wrote
+    (``nanobot.agent.subagent``'s ``_write_subagent_telemetry`` —
+    ``state_root/subagents/{task_id}.json``, fields ``summary``/``result``
+    carry the raw LLM reply text) — no new LLM call, purely a local read of
+    data this cycle's own spawn already produced.
+
+    Fail-open to False on ANY problem (missing task_id, missing/unreadable
+    file, unparseable JSON, wrong shape) — this only ever UPGRADES an
+    otherwise-ambiguous verdict to 'reject'; a miss here just leaves the
+    existing fail-closed 'inconclusive' default in place, never a false
+    'accept'/'reject'.
+    """
+    if not task_id:
+        return False
+    try:
+        telemetry_path = Path(state_dir) / 'subagents' / f'{task_id}.json'
+        if not telemetry_path.exists():
+            return False
+        payload = json.loads(telemetry_path.read_text(encoding='utf-8'))
+        raw_reply = payload.get('result') or payload.get('summary') or ''
+        if not isinstance(raw_reply, str) or not raw_reply.strip():
+            return False
+        from nanobot.runtime.llm_proposer import _extract_json_object
+        parsed = _extract_json_object(raw_reply)
+        if not isinstance(parsed, dict):
+            return False
+        return str(parsed.get('outcome') or '').strip().lower() == 'skipped'
+    except Exception:
+        return False
+
+
+def _derive_cycle_verdict(outcome: str, reason: 'str | None') -> tuple[str, 'str | None']:
+    """#1118: deterministically derive the tri-state ``verdict`` from the
+    SAME ``outcome``/``reason`` values already computed and about to be
+    written to the terminal ledger row — no new LLM call, no new parsing of
+    the executor's raw reply text (bridge.py has no such parser today, and
+    adding one purely to re-derive a signal the ledger already carries in
+    ``outcome``/``reason`` would be needless duplication).
+
+    Returns ``(verdict, verdict_reason)``. ``verdict_reason`` mirrors
+    ``reason`` when it drove the decision, else is ``None`` (the bare
+    ``outcome`` value was enough, e.g. plain ``success``).
+    Fail-closed: any unrecognized combination lands on ``'inconclusive'``
+    with no reason, never a false ``accept``/``reject``.
+    """
+    outcome = (outcome or '').strip()
+    reason = (reason or '').strip() or None
+
+    if reason in _REJECT_REASONS:
+        return 'reject', reason
+    if reason in _INCONCLUSIVE_REASONS:
+        return 'inconclusive', reason
+
+    mapped = _OUTCOME_TO_VERDICT.get(outcome)
+    if mapped:
+        return mapped, None
+
+    # 'partial' / 'failed' / anything else with no recognized reason: the
+    # ledger cannot tell "executor honestly reported skipped" from "ran out
+    # of budget"/"crashed" without a signal this module does not have
+    # (see docstring) — inconclusive is the honest, fail-closed answer.
+    return 'inconclusive', None
 
 
 def _extract_target_path(req: dict) -> 'str | None':

--- a/nanobot/runtime/cycle_ledger.py
+++ b/nanobot/runtime/cycle_ledger.py
@@ -55,6 +55,20 @@ VALID_OUTCOMES = frozenset({
 })
 VALID_DEDUP_DECISIONS = frozenset({"proceeded", "skipped_duplicate", "skipped_recent_failure"})
 
+# #1118: a NEW, purely additive tri-state field on the terminal row —
+# ``outcome`` above is untouched (byte-identical values/semantics for every
+# existing consumer). ``verdict`` answers a narrower question ``outcome``
+# cannot: was this cycle's own work a healthy result?
+#   accept       — integrated (and, when a claim exists, it held).
+#   reject       — a clean negative: verified already-done/not-applicable,
+#                  or the work measurably failed (e.g. a policy/gate
+#                  violation) — a HEALTHY, deterministic cycle.
+#   inconclusive — blocked or ambiguous: infra/harness trouble, a timeout,
+#                  or no signal either way.
+# Derivation lives in nanobot.runtime.bridge (deterministic, code-only —
+# never a new LLM call); this module only validates and stores the result.
+VALID_VERDICTS = frozenset({"accept", "reject", "inconclusive"})
+
 
 def _ledger_dir(state_dir: Path) -> Path:
     return Path(state_dir) / _LEDGER_SUBDIR
@@ -220,6 +234,9 @@ def record_cycle_outcome(
     reason: str | None,
     files_changed: list[str] | None,
     branch: str | None,
+    *,
+    verdict: str | None = None,
+    verdict_reason: str | None = None,
 ) -> None:
     """Write the terminal, exactly-once-per-cycle row with an enum ``outcome``.
 
@@ -228,6 +245,21 @@ def record_cycle_outcome(
     (KB warning this design is built to avoid). ``outcome`` not in
     :data:`VALID_OUTCOMES` is coerced to ``'failed'`` (fail-closed
     classification; the write itself still never raises).
+
+    #1118: ``verdict`` (keyword-only, appended LAST) is a NEW optional
+    sibling field — ``accept``/``reject``/``inconclusive``, see
+    :data:`VALID_VERDICTS`. It is purely additive: every existing positional
+    call site keeps working unchanged and omits it, in which case the row
+    carries no ``verdict``/``verdict_reason`` key at all (not even ``None``)
+    — identical to the pre-#1118 row shape, so no existing exact-dict-
+    equality assertion or key-count check anywhere can observe a change.
+    An unrecognized ``verdict`` value is dropped the same way (fail-closed
+    on the classification, fail-open on the write, mirroring ``outcome``'s
+    own coercion above — except here "coercion" means "omit" rather than a
+    forced fallback value, since an absent verdict is itself a valid,
+    honest state for any caller not yet updated for #1118).
+    ``verdict_reason`` (e.g. ``already_done``) is recorded only alongside a
+    valid ``verdict`` and is always optional/free-form.
     """
     if outcome not in VALID_OUTCOMES:
         outcome = "failed"
@@ -239,6 +271,10 @@ def record_cycle_outcome(
         "files_changed": list(files_changed or []),
         "branch": branch or None,
     }
+    if verdict in VALID_VERDICTS:
+        row["verdict"] = verdict
+        if verdict_reason:
+            row["verdict_reason"] = str(verdict_reason)[:200]
     if files_changed is not None:
         try:
             from nanobot.runtime.demand import classify_change_tier

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -252,7 +252,11 @@ _PROPOSER_SYSTEM_PROMPT = (
     "You are proposing exactly ONE small, bounded engineering improvement for a "
     "self-evolving codebase. Reply with ONLY a JSON object with keys "
     "task_title, rationale, target_path, serves — no prose, no markdown code "
-    "fences. task_title must be non-empty and at most 120 characters, "
+    "fences. Optionally also include expected_outcome: {\"claim\": \"<short "
+    "falsifiable statement of what this change should achieve>\", \"check\": "
+    "{\"kind\": \"script_exit_zero\"|\"test_count_increase\"|\"file_exists\"|"
+    "\"free_text\", ...}} — omit it entirely if you cannot state a falsifiable "
+    "claim; it is never required. task_title must be non-empty and at most 120 characters, "
     "describing a single behavior/bug (not a bundle). target_path must name "
     "exactly ONE path (file or directory) under one of these mutable "
     "surfaces: surfaces/, scripts/, memory/, lessons/, docs/, tests/, skills/ "
@@ -288,7 +292,11 @@ _DEMAND_PROPOSER_SYSTEM_PROMPT = (
     "of the context and proposing a small, bounded engineering task that "
     "addresses it. You MUST NOT invent work that no demand item calls for. "
     "Reply with ONLY a JSON object with keys task_title, rationale, "
-    "target_path, serves — no prose, no markdown code fences. task_title "
+    "target_path, serves — no prose, no markdown code fences. Optionally also "
+    "include expected_outcome: {\"claim\": \"<short falsifiable statement of "
+    "what this change should achieve>\", \"check\": {\"kind\": \"script_exit_zero\"|"
+    "\"test_count_increase\"|\"file_exists\"|\"free_text\", ...}} — omit it entirely "
+    "if you cannot state a falsifiable claim; it is never required. task_title "
     "must be non-empty and at most 120 characters, describing a single "
     "behavior/bug (not a bundle). target_path must name exactly ONE path "
     "(file or directory) under one of these mutable surfaces: surfaces/, "
@@ -1763,6 +1771,49 @@ def _validate_serves(proposal: dict[str, Any]) -> tuple[bool, str]:
     return True, ""
 
 
+_MAX_CLAIM_CHARS = 300
+_VALID_CHECK_KINDS = frozenset({
+    "script_exit_zero", "test_count_increase", "file_exists", "free_text",
+})
+
+
+def _sanitized_expected_outcome(proposal: dict[str, Any]) -> dict[str, Any] | None:
+    """#1118: extract and validate the OPTIONAL ``expected_outcome`` claim
+    from a raw proposal reply, returning a small sanitized dict ready to
+    freeze into the artifact, or ``None`` when absent/malformed. Never
+    rejects the whole proposal — an invalid ``expected_outcome`` is simply
+    dropped (fail-open), since B is optional and steering-only per the
+    issue's acceptance criteria ("artifacts without it remain valid").
+
+    Shape: ``{"claim": "<non-empty string, capped>", "check": {"kind": ...}}``
+    — ``check`` itself is optional; when present, only ``kind`` (one of
+    :data:`_VALID_CHECK_KINDS`) is required, any other keys the model added
+    (e.g. a path/threshold for its chosen kind) are carried through
+    verbatim but capped in total size so a malformed/huge reply can't bloat
+    the artifact.
+    """
+    raw = proposal.get("expected_outcome")
+    if not isinstance(raw, dict):
+        return None
+    claim = str(raw.get("claim") or "").strip()
+    if not claim:
+        return None
+    result: dict[str, Any] = {"claim": claim[:_MAX_CLAIM_CHARS]}
+    check = raw.get("check")
+    if isinstance(check, dict):
+        kind = str(check.get("kind") or "").strip()
+        if kind in _VALID_CHECK_KINDS:
+            try:
+                sanitized_check = json.loads(json.dumps(check, ensure_ascii=False)[:_MAX_CLAIM_CHARS * 2])
+            except Exception:
+                sanitized_check = {"kind": kind}
+            if isinstance(sanitized_check, dict) and sanitized_check.get("kind") == kind:
+                result["check"] = sanitized_check
+            else:
+                result["check"] = {"kind": kind}
+    return result
+
+
 def _demand_id_from_serves(serves: Any) -> str:
     """#760: extract the demand id from a ``serves`` value of the form
     ``demand <id>`` (case-insensitive); ``""`` for legacy forms or garbage."""
@@ -2484,6 +2535,16 @@ def write_request(
         },
         "recommended_next_action": f"Implement and commit: {task_title} (target: {target_path})",
     }
+    # #1118: an OPTIONAL, FROZEN falsifiable claim — written once, here, at
+    # proposal time, and NEVER rewritten afterwards (this is the only call
+    # site that ever creates this artifact file). Modeled on #878's
+    # hypothesis-lane claim shape: steering-only, never a hard gate.
+    # Absent entirely (no key at all) when the model didn't supply one —
+    # existing/older artifacts and this key's absence are equally valid, so
+    # no downstream reader needs a default/backward-compat branch.
+    _expected_outcome = _sanitized_expected_outcome(proposal)
+    if _expected_outcome:
+        artifact_payload["expected_outcome"] = _expected_outcome
     artifact_path.write_text(json.dumps(artifact_payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
     lessons_context = build_lessons_context(selfevo_repo, task_title, target_path)
@@ -2540,6 +2601,13 @@ def write_request(
     demand_id = _demand_id_from_serves(serves)
     if demand_id:
         proposed_event["demand_id"] = demand_id
+    # #1118: carry the frozen claim's TEXT (not the full check dict) into the
+    # ledger row — the reflector reads 'proposed' rows as ledger context
+    # (nanobot.runtime.reflector._messages), so this is how the claim reaches
+    # the reflector prompt without the reflector needing to re-read the
+    # artifact file from disk. Absent entirely when no claim was made.
+    if _expected_outcome and _expected_outcome.get("claim"):
+        proposed_event["expected_outcome_claim"] = str(_expected_outcome["claim"])[:300]
     # #912: telemetry for the lessons-context re-close — record WHICH cards
     # (if any) were injected into this request, so effectiveness is
     # auditable from the ledger alone. Absent entirely when nothing matched

--- a/tests/test_cycle_ledger.py
+++ b/tests/test_cycle_ledger.py
@@ -123,6 +123,64 @@ class TestTypedHelpers:
         rows = _read_ledger(tmp_path)
         assert rows[0]["outcome"] == "failed"
 
+    # ─── #1118: verdict is a NEW, purely additive, keyword-only field ─────
+
+    def test_record_cycle_outcome_without_verdict_omits_the_key_entirely(self, tmp_path):
+        """Every pre-#1118 positional call site keeps working byte-identically:
+        omitting ``verdict`` means the row carries no ``verdict``/
+        ``verdict_reason`` key at all — not even ``None`` — so the shape is
+        indistinguishable from before #1118."""
+        cycle_ledger.record_cycle_outcome(tmp_path, "c1", "success", None, ["a.py"], "selfevo/cycle-1")
+        rows = _read_ledger(tmp_path)
+        assert "verdict" not in rows[0]
+        assert "verdict_reason" not in rows[0]
+
+    def test_record_cycle_outcome_with_valid_verdict_and_reason(self, tmp_path):
+        cycle_ledger.record_cycle_outcome(
+            tmp_path, "c1", "skipped-duplicate", "already_done", [], None,
+            verdict="reject", verdict_reason="already_done",
+        )
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["outcome"] == "skipped-duplicate"  # untouched, byte-identical
+        assert rows[0]["verdict"] == "reject"
+        assert rows[0]["verdict_reason"] == "already_done"
+
+    def test_record_cycle_outcome_verdict_without_reason_omits_reason_key(self, tmp_path):
+        cycle_ledger.record_cycle_outcome(
+            tmp_path, "c1", "success", None, ["a.py"], None, verdict="accept",
+        )
+        rows = _read_ledger(tmp_path)
+        assert rows[0]["verdict"] == "accept"
+        assert "verdict_reason" not in rows[0]
+
+    def test_record_cycle_outcome_invalid_verdict_is_dropped_not_coerced(self, tmp_path):
+        """Unlike ``outcome`` (coerced to 'failed'), an unrecognized ``verdict``
+        is simply omitted — an absent verdict is itself a valid, honest state."""
+        cycle_ledger.record_cycle_outcome(
+            tmp_path, "c1", "success", None, [], None, verdict="maybe",
+        )
+        rows = _read_ledger(tmp_path)
+        assert "verdict" not in rows[0]
+
+    def test_record_cycle_outcome_exact_dict_shape_still_matches_pre_1118(self, tmp_path):
+        """Sibling of the exact-equality check on record_cycle_started's
+        output (see TestAppendEvent above): confirms the OMITTED-verdict row
+        shape is unchanged, exhaustively, not just on the keys this test file
+        happens to assert elsewhere."""
+        cycle_ledger.record_cycle_outcome(tmp_path, "c1", "success", None, ["a.py"], "selfevo/cycle-1")
+        rows = _read_ledger(tmp_path)
+        row = dict(rows[0])
+        row.pop("ts", None)
+        assert row == {
+            "phase": "outcome",
+            "cycle_id": "c1",
+            "outcome": "success",
+            "reason": None,
+            "files_changed": ["a.py"],
+            "branch": "selfevo/cycle-1",
+            "change_tier": "code-bearing",
+        }
+
     def test_one_terminal_row_per_cycle(self, tmp_path):
         """Exercising the full helper set for one cycle produces exactly one
         'outcome'-phase row (the others are 'started'/'dedup'/'gate')."""

--- a/tests/test_cycle_verdict.py
+++ b/tests/test_cycle_verdict.py
@@ -1,0 +1,216 @@
+"""Tests for issue #1118: tri-state cycle verdict (accept/reject/inconclusive).
+
+Covers ``nanobot.runtime.bridge._derive_cycle_verdict`` (pure, deterministic
+mapping table) and ``_executor_reported_skipped`` (best-effort telemetry
+read) as unit tests, plus one light bridge-integration test proving a real
+green cycle's terminal ledger row carries ``verdict: accept`` and an
+already-done dedup skip carries ``verdict: reject`` end to end.
+
+``outcome`` itself is never touched by any of this — see
+tests/test_cycle_ledger.py for the byte-identical-shape guarantee on an
+omitted verdict.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from nanobot.runtime import bridge
+from tests.test_cycle_ledger import (
+    _FakeSubagentManager,
+    _init_selfevo_repo,
+    _read_ledger,
+    _seed_bridge_request,
+)
+
+# ─── unit: _derive_cycle_verdict — the full mapping matrix ─────────────────
+
+
+class TestDeriveCycleVerdict:
+    def test_success_is_accept(self):
+        assert bridge._derive_cycle_verdict("success", None) == ("accept", None)
+
+    def test_promotion_candidate_is_accept(self):
+        assert bridge._derive_cycle_verdict("promotion_candidate", None) == ("accept", None)
+
+    @pytest.mark.parametrize(
+        "reason",
+        ["already_done_tag", "already_done", "recent_duplicate_failure", "existence_index_duplicate"],
+    )
+    def test_skipped_duplicate_reasons_are_reject(self, reason):
+        assert bridge._derive_cycle_verdict("skipped-duplicate", reason) == ("reject", reason)
+
+    def test_executor_reported_skipped_reason_is_reject(self):
+        """The issue's headline case: a zero-commit cycle whose executor
+        honestly reported outcome: skipped in its structured final answer
+        (i.e. verified already-done) must land on 'reject', not
+        'inconclusive' — a HEALTHY negative result, distinct from an
+        operational failure."""
+        assert bridge._derive_cycle_verdict("partial", "executor_reported_skipped") == (
+            "reject", "executor_reported_skipped",
+        )
+        assert bridge._derive_cycle_verdict("failed", "executor_reported_skipped") == (
+            "reject", "executor_reported_skipped",
+        )
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "gate_failed",
+            "mutation_surface_violation",
+            "blocked_file_present",
+            "out_of_band_main_detected",
+            "switch_base_gate_error",
+            "switch_base_gate_blocked",
+            "head_on_main_precondition_failed",
+            "no_commit",
+            "internal_error",
+        ],
+    )
+    def test_infra_and_gate_reasons_are_inconclusive(self, reason):
+        """Acceptance criterion: gate/infra failures (spawn timeout, checkout
+        failure, smoke-infra error) must record 'inconclusive', never
+        'reject' — they are not a verified negative result."""
+        verdict, verdict_reason = bridge._derive_cycle_verdict("failed", reason)
+        assert verdict == "inconclusive"
+        assert verdict_reason == reason
+
+    def test_bare_partial_with_no_reason_is_inconclusive(self):
+        """'explored but failed to implement' (no dedup match, no executor
+        self-report, no rollback reason) is genuinely ambiguous — must be
+        'inconclusive', never a false 'accept'/'reject'."""
+        assert bridge._derive_cycle_verdict("partial", None) == ("inconclusive", None)
+
+    def test_bare_failed_with_no_reason_is_inconclusive(self):
+        assert bridge._derive_cycle_verdict("failed", None) == ("inconclusive", None)
+
+    def test_unrecognized_outcome_is_inconclusive_fail_closed(self):
+        assert bridge._derive_cycle_verdict("not-a-real-outcome", None) == ("inconclusive", None)
+
+    def test_unrecognized_reason_with_known_outcome_falls_through_to_outcome_mapping(self):
+        """An outcome the table maps directly (success/promotion_candidate)
+        is not derailed by a stray/unknown reason string."""
+        assert bridge._derive_cycle_verdict("success", "some_future_reason_code") == ("accept", None)
+
+    def test_empty_string_reason_behaves_like_none(self):
+        assert bridge._derive_cycle_verdict("partial", "") == ("inconclusive", None)
+
+
+# ─── unit: _executor_reported_skipped — telemetry read, fail-open ─────────
+
+
+class TestExecutorReportedSkipped:
+    def test_none_task_id_returns_false(self, tmp_path):
+        assert bridge._executor_reported_skipped(tmp_path, None) is False
+
+    def test_missing_telemetry_file_returns_false(self, tmp_path):
+        assert bridge._executor_reported_skipped(tmp_path, "nonexistent-task-id") is False
+
+    def test_true_when_final_answer_declares_skipped(self, tmp_path):
+        subagents_dir = tmp_path / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "abc123.json").write_text(
+            json.dumps({
+                "result": json.dumps({
+                    "action_taken": "verified the feature already exists",
+                    "files_changed": [],
+                    "outcome": "skipped",
+                    "concrete_next_action": "n/a",
+                    "findings": ["already implemented in mod.py"],
+                }),
+            }),
+            encoding="utf-8",
+        )
+        assert bridge._executor_reported_skipped(tmp_path, "abc123") is True
+
+    def test_false_when_final_answer_declares_completed(self, tmp_path):
+        subagents_dir = tmp_path / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "abc123.json").write_text(
+            json.dumps({"result": json.dumps({"outcome": "completed"})}),
+            encoding="utf-8",
+        )
+        assert bridge._executor_reported_skipped(tmp_path, "abc123") is False
+
+    def test_false_when_result_is_not_json(self, tmp_path):
+        subagents_dir = tmp_path / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "abc123.json").write_text(
+            json.dumps({"result": "I looked around and didn't do anything structured."}),
+            encoding="utf-8",
+        )
+        assert bridge._executor_reported_skipped(tmp_path, "abc123") is False
+
+    def test_falls_back_to_summary_when_result_absent(self, tmp_path):
+        subagents_dir = tmp_path / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "abc123.json").write_text(
+            json.dumps({"summary": json.dumps({"outcome": "skipped"})}),
+            encoding="utf-8",
+        )
+        assert bridge._executor_reported_skipped(tmp_path, "abc123") is True
+
+    def test_malformed_telemetry_file_fails_open(self, tmp_path):
+        subagents_dir = tmp_path / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "abc123.json").write_text("not even json", encoding="utf-8")
+        assert bridge._executor_reported_skipped(tmp_path, "abc123") is False
+
+
+# ─── light bridge integration: verdict lands on the real terminal row ─────
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
+
+
+class TestBridgeIntegrationVerdict:
+    def test_full_green_cycle_records_verdict_accept(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+        _init_selfevo_repo(base)
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "SubagentManager", _FakeSubagentManager)
+        monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+
+        _seed_bridge_request(state_dir, "req-green-verdict", "cycle-green-verdict")
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r["phase"] == "outcome"]
+        assert outcome_rows[-1]["outcome"] == "success"  # untouched, byte-identical
+        assert outcome_rows[-1]["verdict"] == "accept"
+        assert "verdict_reason" not in outcome_rows[-1]
+
+    def test_already_done_skip_records_verdict_reject(self, tmp_path, monkeypatch):
+        base = tmp_path
+        state_dir = base / "state"
+        state_dir.mkdir()
+
+        monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+        monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+        monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+        monkeypatch.setattr(bridge, "_task_already_done", lambda *_a, **_k: True)
+
+        _seed_bridge_request(
+            state_dir, "req-dup-verdict", "cycle-dup-verdict",
+            task_title="implement thing xyz already done",
+        )
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        rows = _read_ledger(state_dir)
+        outcome_rows = [r for r in rows if r["phase"] == "outcome"]
+        assert outcome_rows[-1]["outcome"] == "skipped-duplicate"  # untouched, byte-identical
+        assert outcome_rows[-1]["verdict"] == "reject"
+        assert outcome_rows[-1]["verdict_reason"] == "already_done"

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1654,6 +1654,179 @@ class TestWriteRequestSchemaEquality:
         assert proposed_rows[0]["serves"] == ""
 
 
+# ─── #1118: optional, frozen expected_outcome claim ────────────────────────
+
+
+class TestExpectedOutcomeClaim:
+    """Optional, write-once claim on the proposer artifact (issue #1118,
+    Part B) — modeled on #878's hypothesis-lane claim shape. Never required;
+    an artifact without it remains valid (backward compatible)."""
+
+    def _artifact_payload(self, state_dir, path):
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+        artifact_path = written["source_artifact"]
+        return json.loads(Path(artifact_path).read_text(encoding="utf-8"))
+
+    def test_absent_when_proposal_has_no_expected_outcome(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert "expected_outcome" not in artifact
+
+    def test_claim_and_check_recorded_verbatim_when_valid(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {
+                "claim": "running the new script exits 0",
+                "check": {"kind": "script_exit_zero", "path": "scripts/helper.py"},
+            },
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert artifact["expected_outcome"] == {
+            "claim": "running the new script exits 0",
+            "check": {"kind": "script_exit_zero", "path": "scripts/helper.py"},
+        }
+
+    def test_free_text_check_kind_is_accepted(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "onboarding docs read more clearly", "check": {"kind": "free_text"}},
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert artifact["expected_outcome"]["claim"] == "onboarding docs read more clearly"
+        assert artifact["expected_outcome"]["check"]["kind"] == "free_text"
+
+    def test_claim_without_check_is_accepted(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "the doc exists and is non-empty"},
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert artifact["expected_outcome"] == {"claim": "the doc exists and is non-empty"}
+
+    def test_empty_claim_is_dropped_entirely(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "   "},
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert "expected_outcome" not in artifact
+
+    def test_malformed_expected_outcome_is_dropped_not_fatal(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": "not a dict",
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert "expected_outcome" not in artifact
+
+    def test_invalid_check_kind_is_dropped_but_claim_kept(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "something falsifiable", "check": {"kind": "not_a_real_kind"}},
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert artifact["expected_outcome"] == {"claim": "something falsifiable"}
+
+    def test_claim_is_capped_in_length(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "x" * 5000},
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        artifact = self._artifact_payload(state_dir, path)
+        assert len(artifact["expected_outcome"]["claim"]) <= 300
+
+    def test_ledger_proposed_row_carries_claim_text(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "the new doc exists on disk"},
+        }
+        llm_proposer.write_request(state_dir, proposal)
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert proposed_rows[0]["expected_outcome_claim"] == "the new doc exists on disk"
+
+    def test_ledger_proposed_row_omits_claim_key_when_absent(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+        }
+        llm_proposer.write_request(state_dir, proposal)
+
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        rows = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
+        assert "expected_outcome_claim" not in proposed_rows[0]
+
+    def test_canonical_request_keys_unaffected(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        proposal = {
+            "task_title": "Add a helper doc",
+            "rationale": "helps operators",
+            "target_path": "docs/helper.md",
+            "serves": "priority 1",
+            "expected_outcome": {"claim": "the new doc exists on disk"},
+        }
+        path = llm_proposer.write_request(state_dir, proposal)
+        written = json.loads(Path(path).read_text(encoding="utf-8"))
+        assert "expected_outcome" not in written
+
+    def test_proposer_prompts_mention_expected_outcome_as_optional(self):
+        for prompt in (llm_proposer._PROPOSER_SYSTEM_PROMPT, llm_proposer._DEMAND_PROPOSER_SYSTEM_PROMPT):
+            assert "expected_outcome" in prompt
+            assert "Optionally" in prompt or "optional" in prompt.lower()
+
+
 # ─── write_request — #912 lessons_context wiring ───────────────────────────
 
 


### PR DESCRIPTION
Closes #1118

## Summary

**A. Tri-state `verdict` on the terminal ledger row.** `record_cycle_outcome` gains two new keyword-only params, `verdict` (`accept`/`reject`/`inconclusive`) and `verdict_reason`, additive on top of the existing `outcome` field (values/semantics untouched — byte-identical for every existing consumer: `demand.py`, `loop_metrics_report.py`, `scorecard.py`, heldout checkers). Derivation (`bridge._derive_cycle_verdict`) is deterministic, code-only — no new LLM call — built from signals bridge.py already computes for the same row (`_cycle_outcome`, `_rollback_reason`), plus a new best-effort local read of the executor's own structured final-answer JSON (`outcome: "skipped"`) from the subagent telemetry file the cycle's own spawn already wrote.

Mapping:
| outcome / reason | verdict |
|---|---|
| `success`, `promotion_candidate` | `accept` |
| `skipped-duplicate` (any `already_done*` reason) | `reject` |
| executor self-reported `outcome: skipped` | `reject` (`verdict_reason: executor_reported_skipped`) |
| gate/infra failure reasons (`gate_failed`, `mutation_surface_violation`, timeouts, setup failures, ...) | `inconclusive` |
| anything else / no reason | `inconclusive` (fail-closed) |

**B. Optional frozen `expected_outcome` claim in proposer artifacts.** `llm_proposer.write_request`'s `llm-proposed-improvement-v1` artifact gains an optional `expected_outcome: {"claim": "...", "check": {"kind": "script_exit_zero"|"test_count_increase"|"file_exists"|"free_text", ...}}`, modeled on #878's hypothesis-lane claim shape. Frozen at write time (never rewritten afterward), steering-only, never enforced — artifacts without it remain fully valid. Both proposer system prompts ask for it as optional. Following the #751 `serves` precedent, the claim is **not** added to the request payload (`_CANONICAL_REQUEST_KEYS` unaffected) — only to the artifact file and, as claim text, the ledger `proposed` row (`expected_outcome_claim`) so the existing reflector can read it as context. `bridge.build_task()` surfaces the claim to the executor prompt (informational only).

## Tests
- `tests/test_cycle_ledger.py`: additive-shape tests for `verdict`/`verdict_reason` (omitted-key byte-identical row, valid/invalid verdict, exact-dict-shape regression).
- `tests/test_cycle_verdict.py` (new): full `_derive_cycle_verdict` matrix, `_executor_reported_skipped` fail-open unit tests, two bridge-integration tests (green cycle → `accept`; already-done dedup skip → `reject`).
- `tests/test_llm_proposer.py`: `TestExpectedOutcomeClaim` — absence/presence, sanitization, ledger propagation, request-schema non-interference.

Full suite: 2690 passed, 20 pre-existing Windows-only platform failures (fcntl/chmod/mtime — confirmed identical on unmodified `main`), 17 skipped. CI runs on Linux, so these should be fully green there.

## Non-goals (per issue)
- No existing `outcome` values changed or removed.
- No new LLM calls anywhere in verdict derivation.
- No enforcement that claims be machine-checkable (`free_text` accepted).
