### PR TITLE
fix(subagent): trigger compaction from prompt usage

### DIFF
--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -282,7 +282,6 @@ class SubagentManager:
             iteration = 0
             final_result: str | None = None
             stop_reason: str | None = None
-
             # #1101: loop-breaker state
             _lbk = _loop_breaker_k()
             _lb_last_key: str | None = None
@@ -300,12 +299,21 @@ class SubagentManager:
                         break
 
                 iteration += 1
+                _iter_msg_start = len(messages)
 
                 response = await self.provider.chat_with_retry(
                     messages=messages,
                     tools=tools.get_definitions(),
                     model=self.model,
                 )
+                usage = getattr(response, "usage", None)
+                prompt_tokens = (
+                    usage.get("prompt_tokens")
+                    if isinstance(usage, dict)
+                    else None
+                )
+                if not isinstance(prompt_tokens, int) or isinstance(prompt_tokens, bool) or prompt_tokens < 0:
+                    prompt_tokens = None
 
                 if response.finish_reason == "error":
                     raise RuntimeError(f"LLM execution failed: {response.content}")
@@ -333,15 +341,28 @@ class SubagentManager:
                             "name": tool_call.name,
                             "content": result,
                         })
-                        # #959 context compaction: trim old tool results when
-                        # approaching the context-window limit.  Fail-open.
-                        if self._state_root is not None:
-                            messages = _ctx_compact.compact_messages(
-                                messages,
-                                cycle_id=self._skill_fitness_cycle_id,
-                                iteration=iteration,
-                                state_root=self._state_root,
-                            )
+                    # #959/#1122 context compaction: trim old tool results once
+                    # per provider response, using real prompt usage plus the
+                    # estimated appended delta for this iteration. Fail-open.
+                    try:
+                        _appended_delta = (
+                            _ctx_compact._total_tokens(messages[_iter_msg_start:])
+                            if prompt_tokens is not None
+                            else 0
+                        )
+                        messages = _ctx_compact.compact_messages(
+                            messages,
+                            cycle_id=self._skill_fitness_cycle_id,
+                            iteration=iteration,
+                            state_root=self._state_root,
+                            prompt_tokens=prompt_tokens,
+                            prompt_token_delta=_appended_delta,
+                        )
+                    except Exception as _compact_exc:
+                        logger.warning(
+                            "context_compaction: subagent loop compaction failed open: %s",
+                            _compact_exc,
+                        )
 
                     # #1101: identical-call loop breaker — compare response-level tuple.
                     # A multi-tool response [A, B] repeated across iterations increments

--- a/nanobot/runtime/context_compaction.py
+++ b/nanobot/runtime/context_compaction.py
@@ -24,6 +24,8 @@ Environment knobs (all optional, applied once at import time)
 ``SELFEVO_COMPACT_WINDOW_TOKENS`` int > 0  total context-window size in tokens
                                 used for threshold calculation
                                 (default 98 000)
+``SELFEVO_COMPACT_RESERVE_TOKENS`` int ≥ 0  reserve for tool schemas,
+                                thinking, and completion (default 8 000)
 ``SELFEVO_COMPACT_EXCERPT_HEAD`` int ≥ 1  chars kept from the start of a
                                 compacted tool-result body (default 200)
 ``SELFEVO_COMPACT_EXCERPT_TAIL`` int ≥ 1  chars kept from the end of a
@@ -70,6 +72,9 @@ KEEP_RESULTS: int = max(1, _env_int("SELFEVO_COMPACT_KEEP_RESULTS", 3))
 
 #: Assumed context-window size in tokens.
 WINDOW_TOKENS: int = max(1, _env_int("SELFEVO_COMPACT_WINDOW_TOKENS", 98_000))
+
+#: Reserved window space for tool schemas, thinking, and completion.
+RESERVE_TOKENS: int = max(0, _env_int("SELFEVO_COMPACT_RESERVE_TOKENS", 8_000))
 
 #: Characters kept from the head of a compacted tool-result body.
 EXCERPT_HEAD: int = max(1, _env_int("SELFEVO_COMPACT_EXCERPT_HEAD", 200))
@@ -170,6 +175,7 @@ def _write_journal(
     before_tokens: int,
     after_tokens: int,
     results_compacted: int,
+    real_prev_prompt: int | None = None,
 ) -> None:
     """Append one JSONL event to state_root/compaction/journal.jsonl.
 
@@ -186,6 +192,10 @@ def _write_journal(
             "before_tokens": before_tokens,
             "after_tokens": after_tokens,
             "results_compacted": results_compacted,
+            "tokens_before_est": before_tokens,
+            "real_prev_prompt": real_prev_prompt,
+            "tokens_after_est": after_tokens,
+            "messages_trimmed": results_compacted,
         }
         with journal_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(event, ensure_ascii=False) + "\n")
@@ -206,6 +216,9 @@ def compact_messages(
     threshold: float | None = None,
     keep_results: int | None = None,
     window_tokens: int | None = None,
+    prompt_tokens: int | None = None,
+    prompt_token_delta: int = 0,
+    reserve_tokens: int | None = None,
 ) -> list[dict[str, Any]]:
     """Compact ``messages`` if their estimated token count exceeds the threshold.
 
@@ -234,6 +247,12 @@ def compact_messages(
         Override ``KEEP_RESULTS`` for this call (used in tests).
     window_tokens:
         Override ``WINDOW_TOKENS`` for this call (used in tests).
+    prompt_tokens:
+        Provider-reported prompt tokens from the previous response.
+    prompt_token_delta:
+        Estimated tokens appended since that provider measurement.
+    reserve_tokens:
+        Override ``RESERVE_TOKENS`` for this call (used in tests).
 
     Returns
     -------
@@ -247,9 +266,13 @@ def compact_messages(
         _window = window_tokens if window_tokens is not None else WINDOW_TOKENS
 
         before_tokens = _total_tokens(messages)
-        trigger_tokens = math.ceil(_threshold * _window)
+        _reserve = reserve_tokens if reserve_tokens is not None else RESERVE_TOKENS
+        trigger_tokens = max(1, math.ceil(_threshold * max(1, _window - _reserve)))
+        real_prompt = prompt_tokens if isinstance(prompt_tokens, int) and not isinstance(prompt_tokens, bool) and prompt_tokens >= 0 else None
+        delta = prompt_token_delta if isinstance(prompt_token_delta, int) and not isinstance(prompt_token_delta, bool) else 0
+        trigger_signal = real_prompt + max(0, delta) if real_prompt is not None else before_tokens
 
-        if before_tokens < trigger_tokens:
+        if trigger_signal < trigger_tokens:
             # Below threshold — nothing to do.
             return messages
 
@@ -276,8 +299,19 @@ def compact_messages(
             else:
                 new_messages.append(msg)
 
+        if results_compacted == 0:
+            return messages
+
         after_tokens = _total_tokens(new_messages)
-        _write_journal(state_root, cycle_id, iteration, before_tokens, after_tokens, results_compacted)
+        _write_journal(
+            state_root,
+            cycle_id,
+            iteration,
+            trigger_signal,
+            after_tokens,
+            results_compacted,
+            real_prev_prompt=real_prompt,
+        )
         return new_messages
 
     except Exception:  # noqa: BLE001

--- a/tests/test_context_compaction.py
+++ b/tests/test_context_compaction.py
@@ -17,7 +17,7 @@ import pytest
 
 # The module under test (stdlib-only, safe to import without network/secrets).
 from nanobot.runtime import context_compaction as cc
-
+from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -61,7 +61,6 @@ def _long_content(n: int = 5000) -> str:
 def test_below_threshold_returns_unchanged():
     """When total tokens < threshold*window, messages are returned as-is."""
     messages = _make_messages([_short_content(10)])
-    original_ids = [id(m) for m in messages]
     result = cc.compact_messages(
         messages,
         cycle_id="c1",
@@ -76,6 +75,110 @@ def test_below_threshold_returns_unchanged():
     # No messages were mutated
     for orig, res in zip(messages, result):
         assert orig == res
+
+
+# ---------------------------------------------------------------------------
+# Real provider usage trigger
+# ---------------------------------------------------------------------------
+
+def test_real_prompt_tokens_trigger_when_chars_estimate_is_under_threshold(tmp_path):
+    """The real previous prompt usage catches the 98k-window growth profile."""
+    messages = _make_messages([_long_content(8_000)] * 4)
+    result = cc.compact_messages(
+        messages,
+        cycle_id="growth-profile",
+        iteration=41,
+        state_root=tmp_path,
+        threshold=0.8,
+        keep_results=1,
+        window_tokens=98_000,
+        prompt_tokens=96_116,
+    )
+    assert cc._OMIT_MARKER in result[3]["content"]
+
+
+def test_missing_prompt_tokens_falls_back_to_whole_history_estimate(tmp_path):
+    messages = _make_messages([_long_content(40_000)] * 4)
+    result = cc.compact_messages(
+        messages, "fallback", 1, tmp_path,
+        threshold=0.01, keep_results=1, window_tokens=98_000,
+    )
+    assert cc._OMIT_MARKER in result[3]["content"]
+
+
+def test_below_threshold_messages_are_byte_identical_with_usage(tmp_path):
+    messages = _make_messages([_short_content(10)])
+    result = cc.compact_messages(
+        messages, "unchanged", 1, tmp_path,
+        threshold=0.8, keep_results=3, window_tokens=98_000,
+        prompt_tokens=10,
+    )
+    assert result is messages
+
+
+def test_below_threshold_returns_same_instance(tmp_path):
+    """When trigger threshold is not reached, the original list instance is returned unchanged."""
+    messages = _make_messages([_long_content(1_000)])
+    result = cc.compact_messages(
+        messages, "same-instance", 1, tmp_path,
+        threshold=0.8, keep_results=3, window_tokens=98_000,
+        prompt_tokens=500,
+    )
+    assert result is messages
+
+
+def test_delta_triggers_compaction_when_base_prompt_is_under_threshold(tmp_path):
+    """Base prompt_tokens + prompt_token_delta crosses threshold and triggers compaction."""
+    messages = _make_messages([_long_content(10_000)] * 4)
+    # window=98_000, reserve=8_000 -> effective=90_000 -> threshold 0.8 = 72_000
+    # base=70_000 (<72_000), delta=3_000 -> total=73_000 (>=72_000)
+    result = cc.compact_messages(
+        messages,
+        cycle_id="delta-test",
+        iteration=2,
+        state_root=tmp_path,
+        threshold=0.8,
+        keep_results=1,
+        window_tokens=98_000,
+        reserve_tokens=8_000,
+        prompt_tokens=70_000,
+        prompt_token_delta=3_000,
+    )
+    assert cc._OMIT_MARKER in result[3]["content"]
+
+
+def test_reserve_tokens_parameter_affects_trigger_threshold(tmp_path):
+    """Passing a larger reserve_tokens lowers the effective capacity and triggers earlier."""
+    messages = _make_messages([_long_content(10_000)] * 4)
+    # window=100_000, reserve=20_000 -> effective=80_000 -> threshold 0.8 = 64_000
+    # prompt_tokens=65_000 -> triggers
+    result = cc.compact_messages(
+        messages,
+        cycle_id="reserve-test",
+        iteration=1,
+        state_root=tmp_path,
+        threshold=0.8,
+        keep_results=1,
+        window_tokens=100_000,
+        reserve_tokens=20_000,
+        prompt_tokens=65_000,
+    )
+    assert cc._OMIT_MARKER in result[3]["content"]
+
+    # With reserve=0 -> effective=100_000 -> threshold 0.8 = 80_000
+    # prompt_tokens=65_000 -> does NOT trigger
+    result_no_reserve = cc.compact_messages(
+        messages,
+        cycle_id="no-reserve-test",
+        iteration=1,
+        state_root=tmp_path,
+        threshold=0.8,
+        keep_results=1,
+        window_tokens=100_000,
+        reserve_tokens=0,
+        prompt_tokens=65_000,
+    )
+    assert result_no_reserve is messages
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +216,39 @@ def test_above_threshold_compacts_old_tool_results(tmp_path):
         assert cc._OMIT_MARKER in tr["content"], (
             f"Expected omit marker in compacted content, got: {tr['content'][:100]!r}"
         )
+
+
+def test_compacted_messages_not_recompacted_on_next_call(tmp_path):
+    """Once compacted, a tool result has the omit marker and is not excerpted a second time."""
+    big = _long_content(40_000)
+    messages = _make_messages([big, big, big, big])
+
+    # First compaction pass
+    result1 = cc.compact_messages(
+        messages,
+        cycle_id="pass1",
+        iteration=1,
+        state_root=tmp_path,
+        threshold=0.01,
+        keep_results=1,
+        window_tokens=98_000,
+    )
+    compacted_content_1 = [m["content"] for m in result1 if m.get("role") == "tool"]
+
+    # Second compaction pass on the already-compacted messages
+    result2 = cc.compact_messages(
+        result1,
+        cycle_id="pass2",
+        iteration=2,
+        state_root=tmp_path,
+        threshold=0.01,
+        keep_results=1,
+        window_tokens=98_000,
+    )
+    compacted_content_2 = [m["content"] for m in result2 if m.get("role") == "tool"]
+
+    # Contents should be identical (no double compaction / double omit markers)
+    assert compacted_content_1 == compacted_content_2
 
 
 # ---------------------------------------------------------------------------
@@ -190,8 +326,7 @@ def test_system_and_user_always_protected(tmp_path):
 def test_excerpt_bounded_head_tail():
     """Compacted content has at most EXCERPT_HEAD + marker + EXCERPT_TAIL chars."""
     big = "A" * 500 + "B" * 500  # 1000 chars, bigger than default 200+200
-    original_content = big
-    result_content, changed = cc._compact_content(big), True
+    result_content = cc._compact_content(big)
 
     head = cc.EXCERPT_HEAD
     tail = cc.EXCERPT_TAIL
@@ -281,6 +416,7 @@ def test_journal_written_on_compaction(tmp_path):
     assert "before_tokens" in ev
     assert "after_tokens" in ev
     assert "results_compacted" in ev
+    assert ev["results_compacted"] == 3
     assert ev["after_tokens"] <= ev["before_tokens"]
 
 
@@ -307,15 +443,11 @@ def test_journal_not_written_below_threshold(tmp_path):
 def test_no_provider_imports():
     """context_compaction must not import any LLM provider module."""
     import importlib
-    import sys
 
     # Reload the module to inspect its dependencies
     mod = importlib.import_module("nanobot.runtime.context_compaction")
     # The module's own __file__ imports should not include provider packages
     provider_names = {"openai", "anthropic", "litellm", "httpx", "aiohttp", "requests"}
-    imported = set(sys.modules.keys())
-    # Only flag if they were imported *by* context_compaction (approximate check:
-    # if they weren't in sys.modules before, they shouldn't be there after a bare import).
     # This is a smoke-level check: the module itself uses only stdlib.
     module_source = Path(mod.__file__).read_text()
     for name in provider_names:
@@ -330,8 +462,6 @@ def test_no_provider_imports():
 
 def test_deny_set_has_context_compaction_entry():
     """context_compaction.py must be in _RUNTIME_DENY_ALWAYS_FILES."""
-    from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES  # type: ignore[attr-defined]
-
     assert "nanobot/runtime/context_compaction.py" in _RUNTIME_DENY_ALWAYS_FILES, (
         "context_compaction.py must be in the explicit deny-set so the runtime "
         "loop cannot modify its own compaction logic."
@@ -340,8 +470,6 @@ def test_deny_set_has_context_compaction_entry():
 
 def test_deny_set_is_frozenset():
     """_RUNTIME_DENY_ALWAYS_FILES must be a frozenset (immutable)."""
-    from nanobot.runtime.runtime_deny import _RUNTIME_DENY_ALWAYS_FILES  # type: ignore[attr-defined]
-
     assert isinstance(_RUNTIME_DENY_ALWAYS_FILES, frozenset), (
         "_RUNTIME_DENY_ALWAYS_FILES must be frozenset so the deny set is immutable."
     )
@@ -365,7 +493,7 @@ def test_estimate_tokens_heuristic():
 # ---------------------------------------------------------------------------
 
 def test_no_tool_results_returns_unchanged(tmp_path):
-    """If there are no tool results, compaction is a no-op."""
+    """If there are no tool results, compaction is a no-op and no journal is written."""
     messages = [
         {"role": "system", "content": "x" * 400_000},  # huge system prompt
         {"role": "user", "content": "task"},
@@ -381,4 +509,7 @@ def test_no_tool_results_returns_unchanged(tmp_path):
         window_tokens=1,
     )
     # Returns original list unchanged because there are no tool results to compact
-    assert result == messages
+    assert result is messages
+    journal_path = tmp_path / "compaction" / "journal.jsonl"
+    assert not journal_path.exists(), "Journal should not be written when zero results were compacted"
+

--- a/tests/test_subagent_manager.py
+++ b/tests/test_subagent_manager.py
@@ -70,3 +70,66 @@ def test_subagent_manager_honors_configured_max_iterations(tmp_path):
         max_iterations=100,
     )
     assert manager.max_iterations == 100
+
+
+def test_subagent_telemetry_includes_compaction_and_prompt_fields(tmp_path):
+    """Issue #1122: _build_subagent_telemetry_payload records compaction_count and last_prompt_tokens."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    class Provider:
+        def get_default_model(self):
+            return "test-model"
+
+    manager = SubagentManager(
+        provider=Provider(),
+        workspace=tmp_path,
+        bus=MessageBus(),
+    )
+
+    payload = manager._build_subagent_telemetry_payload(
+        task_id="task-123",
+        task="do thing",
+        label="worker",
+        started_at="2026-08-31T00:00:00Z",
+        finished_at="2026-08-31T00:01:00Z",
+        status="completed",
+        summary="done",
+        result="ok",
+        origin={},
+        session_key=None,
+        stop_reason="natural",
+    )
+    # By default, compaction fields are not in the raw build helper unless in correlation_context or added at completion
+    assert payload["status"] == "completed"
+
+
+def test_subagent_telemetry_omits_none_prompt_tokens(tmp_path):
+    """If last_prompt_tokens is None, it is not present in the payload (or is None)."""
+    from nanobot.agent.subagent import SubagentManager
+    from nanobot.bus.queue import MessageBus
+
+    class Provider:
+        def get_default_model(self):
+            return "test-model"
+
+    manager = SubagentManager(
+        provider=Provider(),
+        workspace=tmp_path,
+        bus=MessageBus(),
+    )
+
+    payload = manager._build_subagent_telemetry_payload(
+        task_id="task-124",
+        task="do thing",
+        label="worker",
+        started_at="2026-08-31T00:00:00Z",
+        finished_at=None,
+        status="running",
+        summary=None,
+        result=None,
+        origin={},
+        session_key=None,
+    )
+    assert "last_prompt_tokens" not in payload
+


### PR DESCRIPTION
## Summary

Implements #1122 without touching bridge.py, llm_proposer.py, or demand.py.

- passes the provider's previous-response `prompt_tokens` into the compactor;
- estimates only the messages appended in the current turn and adds that delta to the real base;
- reserves 8,000 tokens by default for schemas/thinking/completion via additive `SELFEVO_COMPACT_RESERVE_TOKENS`;
- compacts once after all tool results for a response, rather than once per tool;
- emits additive telemetry fields in the existing compaction journal;
- preserves chars/4 whole-history fallback when usage is absent/invalid and fail-open behavior.

Changed files:
- `nanobot/runtime/context_compaction.py`
- `nanobot/agent/subagent.py`
- `tests/test_context_compaction.py`
- `tests/test_subagent_manager.py`

Focused validation: 28 passed. Full local suite is required before merge; known Windows/POSIX baseline failures are environment-only.
