### PR TITLE
gate: deterministic test-weakening detector before the smoke gate (#1119)

### DIFF
--- a/docs/TRUST_KERNEL.md
+++ b/docs/TRUST_KERNEL.md
@@ -44,6 +44,7 @@ nanobot/runtime/context_compaction.py
 nanobot/runtime/goal_gap_futility.py
 nanobot/runtime/skill_candidate_mining.py
 nanobot/runtime/strategist.py
+nanobot/runtime/test_guard.py
 ```
 
 The basename token deny family is:
@@ -80,6 +81,7 @@ manifest and compares it to the code constant, preserving an exact-set check.
 | Demand served-defect priority forgery | Harness-served validator records are ordered before unserved records; instance-authored text cannot create the served signal | `nanobot/runtime/demand.py:_validator_defect_items` (served-map ordering) | demand validator-priority tests; #933/#1003 |
 | Repeat-failure metric laundering | Only `recent_duplicate_failure` skips and `self_dedup` rejects enter `repeat_failure_rate`; healthy skips and steering-only records do not | `nanobot/runtime/scorecard.py` module contract and `_loop_section` | `tests/test_scorecard.py`; #977/#980/#983 |
 | Context/identity steering confusion | Product and instance `AGENTS.md` are distinct; steering text is not trusted as fitness or gate evidence | `AGENTS.md`, `CONSTITUTION.md`, runtime prompt construction and harness trust boundaries | import/hygiene and harness tests; #619/#789 |
+| Test-weakening reward hack | Deterministic pre-smoke-gate diff scan blocks deleted/gutted/newly-skipped existing test files; runs on every gate re-run, recorded reason `test_weakening` | `nanobot/runtime/test_guard.py:evaluate`; `nanobot/runtime/bridge.py:_check_test_weakening` | `tests/test_test_guard.py`; #1119 |
 
 ## Deliberate reader asymmetry
 

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -97,6 +97,10 @@ from nanobot.runtime.scorecard import (  # noqa: E402
     fitness_sidecar_hashes as _fitness_sidecar_hashes,
 )
 from nanobot.runtime.stop_guards import REVISION_CAP_DEFAULT, revision_outcome  # noqa: E402
+# #1119: deterministic test-weakening detector — runs BEFORE the smoke gate
+# decides a cycle's fate, same placement discipline as
+# _validate_mutation_surfaces (#678 F1). Deny-set protected (runtime_deny.py).
+from nanobot.runtime.test_guard import evaluate as _evaluate_test_weakening  # noqa: E402
 
 STATE_DIR = Path(os.environ.get('STATE_DIR', '/var/lib/eeepc-agent/self-evolving-agent/state'))
 TARGET_WORKSPACE = Path(os.environ.get('TARGET_WORKSPACE', '/opt/eeepc-agent/runtimes/self-evolving-agent/current'))
@@ -464,6 +468,29 @@ def _changed_files_and_violations(repo_root: 'Path', base_sha: str) -> 'tuple[li
     # #812: two-tier classification (script vs operator-approved runtime slice).
     blocked, mutation, tier = _classify_mutation_surface(files_changed)
     return files_changed, blocked, mutation, tier
+
+
+def _check_test_weakening(repo_root: 'Path', base_sha: str) -> 'tuple[bool, list[str], list[str]]':
+    """#1119: run the deterministic test-weakening detector for ``base_sha..HEAD``.
+
+    Thin bridge-side wrapper around :func:`nanobot.runtime.test_guard.evaluate`
+    — same recompute discipline as :func:`_changed_files_and_violations`
+    (called at the same points: initial commit, every repair retry, and the
+    final pre-gate recompute), so a repair turn that itself weakens a test
+    (or CURES a previously-flagged weakening) is caught on the very next gate
+    re-run. Returns ``(blocked, hard_violations, soft_signals)``. Fail-open:
+    on any unexpected error returns ``(False, [], [])`` — a detector bug must
+    never block an otherwise-clean cycle.
+    """
+    try:
+        verdict = _evaluate_test_weakening(repo_root, base_sha, 'HEAD')
+        return (
+            bool(verdict.get('blocked')),
+            list(verdict.get('hard_violations') or []),
+            list(verdict.get('soft_signals') or []),
+        )
+    except Exception:
+        return False, [], []
 
 
 def _diff_against_remote_touches_only(repo_root: 'Path', remote_ref: str, allowed: 'set[str]') -> bool:
@@ -2533,6 +2560,12 @@ async def _main_impl_body():
     # files_changed is known, enforced as a hard block in the gate decision.
     _mutation_violations: 'list[str]' = []
     _blocked_pattern_violations: 'list[str]' = []
+    # #1119: deterministic test-weakening detector state — recomputed at the
+    # same points as the mutation-surface violations above (initial commit,
+    # every repair retry, final pre-gate recompute).
+    _test_weakening_blocked = False
+    _test_weakening_hard: 'list[str]' = []
+    _test_weakening_soft: 'list[str]' = []
     main_sha_after = main_sha_before
     _repair_attempts = 0
     _smoke_passed = True
@@ -2659,6 +2692,19 @@ async def _main_impl_body():
                 else:
                     print(f'mutation surfaces: clean ({len(files_changed)} file(s) changed)')
                 print(f'cycle-branch: {cycle_commit_count} new commit(s) on {cycle_branch}')
+                # #1119: test-weakening check, same recompute point as the
+                # mutation-surface classification above.
+                _test_weakening_blocked, _test_weakening_hard, _test_weakening_soft = (
+                    _check_test_weakening(_selfevo_repo, _pre_spawn_sha)
+                )
+                if _test_weakening_hard:
+                    print(f'test-weakening: {len(_test_weakening_hard)} hard signal(s):')
+                    for v in _test_weakening_hard:
+                        print(f'  ! {v}')
+                if _test_weakening_soft:
+                    print(f'test-weakening: {len(_test_weakening_soft)} soft signal(s) recorded (not blocking):')
+                    for v in _test_weakening_soft:
+                        print(f'  ~ {v}')
         else:
             print(f'cycle-branch: eeebot-self-evolving not found at {_selfevo_repo}')
 
@@ -2749,6 +2795,13 @@ async def _main_impl_body():
                         _rc_files, _rc_blocked, _rc_mut
                     )
                     _cycle_tier = _rc_tier  # #812: tier follows the repaired diff
+                # #1119: re-run the test-weakening detector on every repair
+                # retry too, against the CURRENT diff — a repair turn MAY fix
+                # (or introduce) a weakening; either way this reflects the
+                # latest state, same discipline as the mutation-surface recompute.
+                _test_weakening_blocked, _test_weakening_hard, _test_weakening_soft = (
+                    _check_test_weakening(_selfevo_repo, _pre_spawn_sha)
+                )
                 # Re-run smoke tests after repair. Re-applying the shrink guard
                 # on every retry (not just the first check) closes the path
                 # where a repair turn iteratively deletes/weakens tests to make
@@ -2772,6 +2825,23 @@ async def _main_impl_body():
             if _fc or _bpv or _mv:
                 files_changed, _blocked_pattern_violations, _mutation_violations = _fc, _bpv, _mv
                 _cycle_tier = _tier  # #812: tier reflects the full commit set at gate time
+            # #1119: final pre-gate recompute of the test-weakening verdict,
+            # against the full commit set (initial + every repair turn) —
+            # mirrors the mutation-surface final recompute directly above.
+            _test_weakening_blocked, _test_weakening_hard, _test_weakening_soft = (
+                _check_test_weakening(_selfevo_repo, _pre_spawn_sha)
+            )
+            if _test_weakening_soft:
+                # Soft signals never block (v1 policy, issue #1119 non-goals) —
+                # recorded as a ledger event only, for future tightening.
+                append_event(
+                    STATE_DIR,
+                    {
+                        'phase': 'test_weakening',
+                        'cycle_id': _cycle_id,
+                        'soft_signals': _test_weakening_soft,
+                    },
+                )
 
         # ── #789: spawn-boundary fitness-sidecar tamper detection ────────────
         # Re-hash AFTER the subagent (and any repair turns) finished, BEFORE
@@ -2847,6 +2917,23 @@ async def _main_impl_body():
                 )
                 record_gate_decision(
                     STATE_DIR, _cycle_id, False, _rollback_reason, _mutation_violations,
+                )
+            elif _test_weakening_blocked:
+                # #1119: a hard test-weakening signal (existing test file
+                # deleted alongside non-test changes, net loss of
+                # assert/pytest.raises in an existing test file, or a
+                # skip/xfail marker newly added to a previously-passing
+                # test) is a hard block — same placement/severity as the
+                # mutation-surface check directly above, and BEFORE the
+                # smoke gate is ever consulted (a weakened test could
+                # otherwise make smoke pass green).
+                _rollback_reason = 'test_weakening'
+                print(
+                    f'test-weakening: {len(_test_weakening_hard)} hard signal(s) — '
+                    f'{cycle_branch} kept for forensics, main left unchanged (#1119)'
+                )
+                record_gate_decision(
+                    STATE_DIR, _cycle_id, False, _rollback_reason, _test_weakening_hard,
                 )
             elif _cycle_tier == 'runtime':
                 # #812: runtime-slice cycle. Surface is clean and includes at least
@@ -3686,6 +3773,12 @@ _OUTCOME_TO_VERDICT: dict[str, str] = {
 _REJECT_REASONS = frozenset({
     'already_done_tag', 'already_done', 'recent_duplicate_failure',
     'existence_index_duplicate', 'executor_reported_skipped',
+    # #1119: a detected test-weakening attempt is a CONFIRMED, deterministic
+    # negative result (the gate correctly caught a reward-hack attempt
+    # before it could integrate) — not an ambiguous infra/gate failure, so
+    # it upgrades to 'reject' rather than 'inconclusive' like the plain
+    # mutation-surface/blocked-file violations below.
+    'test_weakening',
 })
 
 # Rollback/reason codes that represent infra/harness trouble or an ambiguous

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -130,6 +130,14 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     'nanobot/runtime/skill_candidate_mining.py',
     # #999: strategist periodic archive reviewer.
     'nanobot/runtime/strategist.py',
+    # #1119: deterministic test-weakening detector — the module itself must
+    # be immutable, otherwise the instance could simply neuter its own
+    # reward-hack check instead of restoring the weakened test it flags. No
+    # basename token match applies ('guard' alone is too broad a token to add
+    # to _RUNTIME_DENY_TOKENS, deliberately, and would also swallow the
+    # unrelated 'stop_guard' token's intent), so this explicit entry is the
+    # only protection.
+    'nanobot/runtime/test_guard.py',
 })
 # Fail-closed token match: any runtime file whose basename contains one of these
 # is also denied, so a future gate/safety/approval module is covered without

--- a/nanobot/runtime/test_guard.py
+++ b/nanobot/runtime/test_guard.py
@@ -1,0 +1,286 @@
+"""#1119: deterministic test-weakening detector ("never weaken a test").
+
+The gate stack had no defense against the classic reward-hack path: a
+candidate commit that makes the smoke gate pass by weakening the tests
+instead of fixing the code (pattern borrowed from dream-machine's
+adversarial "reward-hack check", https://github.com/ruvnet/dream-machine).
+This module runs BEFORE the smoke gate is allowed to decide a cycle's fate
+— same placement discipline as ``bridge._validate_mutation_surfaces`` (#678
+F1) — so a subagent under pressure to "make tests green" cannot delete a
+failing test, comment out an assertion, or narrow a parametrization and
+have the smoke gate happily pass.
+
+Pure and deterministic: :func:`evaluate` is exactly ``(repo_path, base_ref,
+head_ref) -> structured verdict``. No LLM calls. Driven entirely by ``git
+diff --find-renames --name-status`` restricted to test files (``tests/``,
+``test_*.py``, ``*_test.py``) plus stdlib :mod:`ast` parsing of the old/new
+blob contents at each ref — files are never executed or imported, only
+parsed as syntax trees via ``git show <ref>:<path>``. Bounded runtime: one
+``git diff`` + one ``git show`` per changed test file.
+
+Hard signals (block, ``blocked: True``):
+
+- an existing test file is deleted (status ``D`` — i.e. NOT collapsed into
+  a ``git`` rename pairing, see below) while the cycle ALSO touches
+  non-test files;
+- net loss of ``assert`` statements + ``pytest.raises(...)`` calls in a
+  test file that still exists at ``head_ref``. Any touched EXISTING test
+  file is, by construction, part of the bounded gate's own test selection
+  (``gate._select_gate_tests`` always adds a changed ``tests/test_*.py``
+  file to its own selection) — the issue's "file appears in the bounded
+  gate's selected tests" scoping is therefore automatically satisfied for
+  every file this function considers, with no extra plumbing needed;
+- a ``@pytest.mark.skip`` / ``skipif`` / ``xfail`` decorator added to a
+  test function that existed, unmarked, at ``base_ref``.
+
+Soft signals (recorded only, never block):
+
+- a statically-countable ``@pytest.mark.parametrize`` argument list that
+  shrank;
+- an assert/raises count drop in a file git ALSO reports as renamed
+  (``status R`` — a real content-similarity rename, most likely a
+  legitimate refactor that moved equivalent coverage elsewhere).
+
+New tests and brand-new test files (git status ``A``) are never penalized
+— only files present at BOTH refs (or a detected rename's old/new pair)
+are compared. A genuine test-file rename-with-equivalent-coverage is never
+treated as a deletion: when ``git`` (with ``--find-renames``) judges the
+old and new blobs similar enough, it reports a single ``R`` row, not a
+``D``+``A`` pair, so the deletion branch above is never reached for it.
+
+Fail-open throughout: any git failure, timeout, or syntax error degrades
+straight to an unblocked, empty-violations verdict — a detector bug must
+never block an otherwise-clean cycle. It can only ever ADD a rollback
+reason on a genuinely observed, structurally-detected weakening.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+_TEST_FILE_RE = re.compile(r'(^|/)(test_[^/]+\.py|[^/]+_test\.py)$')
+_SKIP_MARKS = frozenset({'skip', 'skipif', 'xfail'})
+
+_EMPTY_VERDICT: dict = {'blocked': False, 'hard_violations': [], 'soft_signals': []}
+
+
+def _is_test_path(path: str) -> bool:
+    p = path.replace('\\', '/')
+    return p.startswith('tests/') or bool(_TEST_FILE_RE.search(p))
+
+
+def _git(repo_path: Path, *args: str, timeout: int = 30) -> 'subprocess.CompletedProcess | None':
+    try:
+        return subprocess.run(
+            ['git', '-c', f'safe.directory={repo_path}', '-C', str(repo_path), *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except Exception:
+        return None
+
+
+def _blob_at(repo_path: Path, ref: str, path: str) -> 'str | None':
+    result = _git(repo_path, 'show', f'{ref}:{path}')
+    if result is None or result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _diff_status(repo_path: Path, base_ref: str, head_ref: str) -> 'list[tuple[str, str, str]]':
+    """Return ``(status_letter, old_path, new_path)`` rows for ``base_ref..head_ref``.
+
+    ``--find-renames`` makes a genuine, content-similar rename come back as
+    a single ``R<score>\told\tnew`` row rather than a ``D``+``A`` pair —
+    the caller relies on this to tell a real deletion apart from
+    equivalent-coverage-moved-elsewhere.
+    """
+    result = _git(repo_path, 'diff', '--find-renames', '--name-status', base_ref, head_ref)
+    if result is None or result.returncode != 0:
+        return []
+    rows: 'list[tuple[str, str, str]]' = []
+    for line in result.stdout.splitlines():
+        parts = line.split('\t')
+        if len(parts) < 2:
+            continue
+        status = parts[0][:1]
+        if status in ('R', 'C') and len(parts) >= 3:
+            rows.append((status, parts[1], parts[2]))
+        elif status not in ('R', 'C'):
+            rows.append((status, parts[1], parts[1]))
+    return rows
+
+
+class _FuncStats:
+    __slots__ = ('asserts', 'raises', 'skip_marks')
+
+    def __init__(self) -> None:
+        self.asserts = 0
+        self.raises = 0
+        self.skip_marks: 'set[str]' = set()
+
+
+def _decorator_mark_name(node: ast.expr) -> 'str | None':
+    """Return the mark name if *node* is a bare or called ``pytest.mark.<name>`` decorator."""
+    target = node.func if isinstance(node, ast.Call) else node
+    if isinstance(target, ast.Attribute) and target.attr in _SKIP_MARKS:
+        return target.attr
+    return None
+
+
+def _is_raises_call(node: ast.Call) -> bool:
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == 'raises':
+        return True
+    if isinstance(func, ast.Name) and func.id == 'raises':
+        return True
+    return False
+
+
+def _parametrize_len(node: ast.expr) -> 'int | None':
+    """Statically-countable arg-list length of a ``parametrize(...)`` decorator call, else ``None``."""
+    if not isinstance(node, ast.Call):
+        return None
+    target = node.func
+    if not (isinstance(target, ast.Attribute) and target.attr == 'parametrize'):
+        return None
+    if len(node.args) < 2:
+        return None
+    values = node.args[1]
+    if isinstance(values, (ast.List, ast.Tuple)):
+        return len(values.elts)
+    return None
+
+
+def _collect_test_functions(source: str) -> 'dict[str, _FuncStats] | None':
+    """Parse *source* and return per-test-function structural stats, or ``None`` on a syntax error."""
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+    stats: 'dict[str, _FuncStats]' = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith('test_'):
+            continue
+        fs = _FuncStats()
+        for dec in node.decorator_list:
+            mark = _decorator_mark_name(dec)
+            if mark:
+                fs.skip_marks.add(mark)
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Assert):
+                fs.asserts += 1
+            elif isinstance(inner, ast.Call) and _is_raises_call(inner):
+                fs.raises += 1
+        stats[node.name] = fs
+    return stats
+
+
+def _file_parametrize_total(source: str) -> 'int | None':
+    """Sum of statically-countable ``parametrize`` arg-list lengths across the whole file.
+
+    Returns ``None`` (unknown, never compared) when the file has zero
+    statically-countable ``parametrize`` decorators — a file may use only
+    dynamically-built parametrize values, which this can never see, so
+    "unknown" must never be conflated with "zero" (which would produce a
+    false shrink report on every such file).
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+    total = 0
+    seen = False
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        for dec in getattr(node, 'decorator_list', []):
+            length = _parametrize_len(dec)
+            if length is not None:
+                seen = True
+                total += length
+    return total if seen else None
+
+
+def evaluate(repo_path: 'str | Path', base_ref: str, head_ref: str) -> dict:
+    """Deterministically evaluate ``base_ref..head_ref`` for test-weakening signals.
+
+    Returns ``{"blocked": bool, "hard_violations": [str, ...], "soft_signals": [str, ...]}``.
+    Fail-open: any git/parse trouble yields the unblocked, empty-violations
+    result (never a false positive from a detector bug).
+    """
+    repo_path = Path(repo_path)
+    try:
+        rows = _diff_status(repo_path, base_ref, head_ref)
+        if not rows:
+            return dict(_EMPTY_VERDICT, hard_violations=[], soft_signals=[])
+
+        any_non_test_change = any(not _is_test_path(new) for _status, _old, new in rows)
+
+        hard: 'list[str]' = []
+        soft: 'list[str]' = []
+
+        for status, old_path, new_path in rows:
+            if status == 'D':
+                if _is_test_path(old_path) and any_non_test_change:
+                    hard.append(
+                        f'existing test file deleted alongside non-test changes: {old_path}'
+                    )
+                continue
+            if status == 'A':
+                continue  # brand-new files are never penalized
+            if not _is_test_path(new_path):
+                continue
+
+            # M, R, or C with a test path at head_ref: compare old vs new content.
+            old_source = _blob_at(repo_path, base_ref, old_path)
+            new_source = _blob_at(repo_path, head_ref, new_path)
+            if old_source is None or new_source is None:
+                continue
+            old_stats = _collect_test_functions(old_source)
+            new_stats = _collect_test_functions(new_source)
+            if old_stats is None or new_stats is None:
+                continue
+            is_renamed = status in ('R', 'C')
+
+            old_total = sum(s.asserts + s.raises for s in old_stats.values())
+            new_total = sum(s.asserts + s.raises for s in new_stats.values())
+            if new_total < old_total:
+                msg = (
+                    f'net loss of assert/pytest.raises in {new_path}: '
+                    f'{old_total} -> {new_total}'
+                )
+                if is_renamed:
+                    soft.append(msg + ' (file also renamed — recorded, not blocked)')
+                else:
+                    hard.append(msg)
+
+            for name, old_fs in old_stats.items():
+                new_fs = new_stats.get(name)
+                if new_fs is None:
+                    continue  # function removed entirely — covered by the total check above
+                added_marks = new_fs.skip_marks - old_fs.skip_marks
+                if added_marks:
+                    hard.append(
+                        f'skip/xfail marker added to previously-unmarked test '
+                        f'{new_path}::{name}: {sorted(added_marks)}'
+                    )
+
+            old_param_total = _file_parametrize_total(old_source)
+            new_param_total = _file_parametrize_total(new_source)
+            if (
+                old_param_total is not None
+                and new_param_total is not None
+                and new_param_total < old_param_total
+            ):
+                soft.append(
+                    f'parametrize argument list shrank in {new_path}: '
+                    f'{old_param_total} -> {new_param_total}'
+                )
+
+        return {'blocked': bool(hard), 'hard_violations': hard, 'soft_signals': soft}
+    except Exception:
+        return dict(_EMPTY_VERDICT, hard_violations=[], soft_signals=[])

--- a/tests/test_test_guard.py
+++ b/tests/test_test_guard.py
@@ -1,0 +1,427 @@
+"""Tests for #1119: deterministic test-weakening detector (nanobot.runtime.test_guard).
+
+Real git repos, mirroring the fixture style of tests/test_bounded_gate.py /
+tests/test_bridge_cycle_branch.py — no mocked subprocess for the git-diff
+plumbing itself.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from nanobot.runtime import test_guard
+
+
+def _git(repo: Path) -> list[str]:
+    return ["git", "-c", f"safe.directory={repo}", "-C", str(repo)]
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(_git(repo) + list(args), capture_output=True, text=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    work = tmp_path / "work"
+    work.mkdir()
+    _run(work, "init", "-q", "--initial-branch=main")
+    _run(work, "config", "user.email", "guard@test.local")
+    _run(work, "config", "user.name", "guard-test")
+    (work / "tests").mkdir()
+    (work / "tests" / "test_seed.py").write_text("def test_seed():\n    assert True\n")
+    _run(work, "add", "-A")
+    _run(work, "commit", "-q", "-m", "init")
+    return work
+
+
+def _write(repo: Path, rel: str, content: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _commit(repo: Path, message: str) -> None:
+    _run(repo, "add", "-A")
+    _run(repo, "commit", "-q", "-m", message)
+
+
+class TestNoChanges:
+    def test_empty_diff_is_clean(self, tmp_path):
+        work = _init_repo(tmp_path)
+        verdict = test_guard.evaluate(work, "HEAD", "HEAD")
+        assert verdict == {"blocked": False, "hard_violations": [], "soft_signals": []}
+
+    def test_new_test_file_never_penalized(self, tmp_path):
+        work = _init_repo(tmp_path)
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+        _write(work, "tests/test_new.py", "def test_new():\n    assert 1 == 1\n")
+        _commit(work, "add new test")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+        assert verdict["hard_violations"] == []
+
+    def test_new_assert_rich_file_never_flagged(self, tmp_path):
+        work = _init_repo(tmp_path)
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+        _write(
+            work,
+            "tests/test_rich.py",
+            "def test_rich():\n    assert True\n    assert True\n    assert True\n",
+        )
+        _commit(work, "rich new test file")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+
+
+class TestHardSignalDeletion:
+    def test_deleted_test_file_with_non_test_change_blocks(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(work, "tests/test_victim.py", "def test_victim():\n    assert True\n")
+        _write(work, "scripts/thing.py", "def thing():\n    return 1\n")
+        _commit(work, "seed victim + script")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        (work / "tests" / "test_victim.py").unlink()
+        _write(work, "scripts/thing.py", "def thing():\n    return 2\n")
+        _commit(work, "delete victim test, edit script")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is True
+        assert any("test_victim.py" in v for v in verdict["hard_violations"])
+
+    def test_deleted_test_file_pure_test_only_commit_still_blocks(self, tmp_path):
+        # Non-test-change scoping only exempts RENAMES (see below), not a
+        # bare test-only deletion with no equivalent coverage anywhere else —
+        # that is still a straightforward test-weakening deletion.
+        work = _init_repo(tmp_path)
+        _write(work, "tests/test_victim.py", "def test_victim():\n    assert True\n")
+        _commit(work, "seed victim")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        (work / "tests" / "test_victim.py").unlink()
+        _commit(work, "delete victim test only")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        # any_non_test_change is False here (only a test file touched), so
+        # per spec this is NOT flagged as the "deleted alongside non-test
+        # changes" hard signal — deliberately scoped narrowly per the issue.
+        assert verdict["blocked"] is False
+
+    def test_renamed_test_file_equivalent_coverage_not_blocked(self, tmp_path):
+        work = _init_repo(tmp_path)
+        body = (
+            "import pytest\n\n\n"
+            "def test_alpha():\n    assert 1 == 1\n\n\n"
+            "def test_beta():\n    assert 2 == 2\n\n\n"
+            "def test_gamma():\n    with pytest.raises(ValueError):\n        raise ValueError()\n"
+        )
+        _write(work, "tests/test_old_name.py", body)
+        _write(work, "scripts/thing.py", "def thing():\n    return 1\n")
+        _commit(work, "seed renamed-candidate + script")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        (work / "tests" / "test_old_name.py").unlink()
+        _write(work, "tests/test_new_name.py", body)
+        _write(work, "scripts/thing.py", "def thing():\n    return 2\n")
+        _commit(work, "rename test file, edit script")
+
+        status = test_guard._diff_status(work, base, "HEAD")
+        assert any(row[0] == "R" for row in status), f"expected git to detect a rename: {status}"
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+        assert verdict["hard_violations"] == []
+
+
+class TestHardSignalAssertLoss:
+    def test_removed_asserts_in_existing_file_blocks(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_math.py",
+            "def test_math():\n    assert 1 == 1\n    assert 2 == 2\n",
+        )
+        _commit(work, "seed math test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(work, "tests/test_math.py", "def test_math():\n    assert 1 == 1\n")
+        _commit(work, "weaken math test")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is True
+        assert any("test_math.py" in v for v in verdict["hard_violations"])
+
+    def test_removed_pytest_raises_blocks(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_err.py",
+            "import pytest\n\n\n"
+            "def test_err():\n    with pytest.raises(ValueError):\n        raise ValueError()\n",
+        )
+        _commit(work, "seed err test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_err.py",
+            "def test_err():\n    pass\n",
+        )
+        _commit(work, "remove raises check")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is True
+
+    def test_added_asserts_never_blocks(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(work, "tests/test_math.py", "def test_math():\n    assert 1 == 1\n")
+        _commit(work, "seed math test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_math.py",
+            "def test_math():\n    assert 1 == 1\n    assert 2 == 2\n",
+        )
+        _commit(work, "strengthen math test")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+
+    def test_new_test_function_added_alongside_unrelated_edit_not_blocked(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_multi.py",
+            "def test_one():\n    assert 1 == 1\n",
+        )
+        _commit(work, "seed multi test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_multi.py",
+            "def test_one():\n    assert 1 == 1\n\n\ndef test_two():\n    assert 2 == 2\n",
+        )
+        _commit(work, "add second test function")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+
+
+class TestHardSignalSkipMarker:
+    def test_added_skip_marker_on_previously_unmarked_test_blocks(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_flaky.py",
+            "def test_flaky():\n    assert True\n",
+        )
+        _commit(work, "seed flaky test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_flaky.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.skip(reason='flaky')\n"
+            "def test_flaky():\n    assert True\n",
+        )
+        _commit(work, "skip flaky test")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is True
+        assert any("test_flaky.py" in v and "test_flaky" in v for v in verdict["hard_violations"])
+
+    def test_added_xfail_marker_blocks(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(work, "tests/test_x.py", "def test_x():\n    assert True\n")
+        _commit(work, "seed x test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_x.py",
+            "import pytest\n\n\n@pytest.mark.xfail\ndef test_x():\n    assert True\n",
+        )
+        _commit(work, "xfail x test")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is True
+
+    def test_preexisting_skip_marker_untouched_not_reblocked(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_marked.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.skip(reason='known issue')\n"
+            "def test_marked():\n    assert True\n",
+        )
+        _commit(work, "seed already-skipped test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_marked.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.skip(reason='known issue, still true')\n"
+            "def test_marked():\n    assert True\n",
+        )
+        _commit(work, "edit skip reason text only")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+
+
+class TestSoftSignals:
+    def test_shrunk_parametrize_recorded_not_blocked(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_param.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.parametrize('n', [1, 2, 3, 4])\n"
+            "def test_param(n):\n    assert n > 0\n",
+        )
+        _commit(work, "seed parametrized test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_param.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.parametrize('n', [1, 2])\n"
+            "def test_param(n):\n    assert n > 0\n",
+        )
+        _commit(work, "shrink parametrize list")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+        assert any("parametrize" in s for s in verdict["soft_signals"])
+
+    def test_grown_parametrize_not_recorded_as_shrink(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(
+            work,
+            "tests/test_param.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.parametrize('n', [1, 2])\n"
+            "def test_param(n):\n    assert n > 0\n",
+        )
+        _commit(work, "seed parametrized test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(
+            work,
+            "tests/test_param.py",
+            "import pytest\n\n\n"
+            "@pytest.mark.parametrize('n', [1, 2, 3, 4])\n"
+            "def test_param(n):\n    assert n > 0\n",
+        )
+        _commit(work, "grow parametrize list")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["soft_signals"] == []
+
+    def test_assert_loss_on_renamed_file_is_soft_not_hard(self, tmp_path):
+        work = _init_repo(tmp_path)
+        body_old = (
+            "import pytest\n\n\n"
+            "def test_alpha():\n    assert 1 == 1\n\n\n"
+            "def test_beta():\n    assert 2 == 2\n\n\n"
+            "def test_gamma():\n    assert 3 == 3\n\n\n"
+            "def test_delta():\n    assert 4 == 4\n"
+        )
+        _write(work, "tests/test_old.py", body_old)
+        _write(work, "scripts/thing.py", "def thing():\n    return 1\n")
+        _commit(work, "seed renamed-candidate")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        # Rename + trim one function's body (still a majority-similar blob so
+        # git's similarity heuristic still calls it a rename), plus the
+        # unrelated script edit so any_non_test_change is True.
+        body_new = (
+            "import pytest\n\n\n"
+            "def test_alpha():\n    assert 1 == 1\n\n\n"
+            "def test_beta():\n    assert 2 == 2\n\n\n"
+            "def test_gamma():\n    assert 3 == 3\n\n\n"
+            "def test_delta():\n    pass\n"
+        )
+        (work / "tests" / "test_old.py").unlink()
+        _write(work, "tests/test_new.py", body_new)
+        _write(work, "scripts/thing.py", "def thing():\n    return 2\n")
+        _commit(work, "rename + trim one assert")
+
+        status = test_guard._diff_status(work, base, "HEAD")
+        assert any(row[0] == "R" for row in status), f"expected a detected rename: {status}"
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+        assert any("test_new.py" in s for s in verdict["soft_signals"])
+
+
+class TestFailOpen:
+    def test_bad_base_ref_fails_open(self, tmp_path):
+        work = _init_repo(tmp_path)
+        verdict = test_guard.evaluate(work, "not-a-real-ref", "HEAD")
+        assert verdict == {"blocked": False, "hard_violations": [], "soft_signals": []}
+
+    def test_nonexistent_repo_fails_open(self, tmp_path):
+        verdict = test_guard.evaluate(tmp_path / "does-not-exist", "HEAD", "HEAD")
+        assert verdict["blocked"] is False
+
+    def test_syntax_error_in_new_blob_fails_open_for_that_file(self, tmp_path):
+        work = _init_repo(tmp_path)
+        _write(work, "tests/test_broken.py", "def test_broken():\n    assert True\n")
+        _commit(work, "seed broken-candidate test")
+        base = _run(work, "rev-parse", "HEAD").stdout.strip()
+
+        _write(work, "tests/test_broken.py", "def test_broken(:\n    this is not python\n")
+        _commit(work, "introduce syntax error")
+
+        verdict = test_guard.evaluate(work, base, "HEAD")
+
+        assert verdict["blocked"] is False
+
+
+class TestHelpers:
+    def test_is_test_path_matches_conventions(self):
+        assert test_guard._is_test_path("tests/test_foo.py")
+        assert test_guard._is_test_path("tests/sub/test_bar.py")
+        assert test_guard._is_test_path("nanobot/thing_test.py")
+        assert not test_guard._is_test_path("nanobot/runtime/bridge.py")
+        assert not test_guard._is_test_path("scripts/foo.py")
+
+    def test_collect_test_functions_ignores_non_test_functions(self):
+        source = (
+            "def helper():\n    assert True\n\n\n"
+            "def test_real():\n    assert 1 == 1\n"
+        )
+        stats = test_guard._collect_test_functions(source)
+        assert stats is not None
+        assert "test_real" in stats
+        assert "helper" not in stats
+
+    def test_collect_test_functions_syntax_error_returns_none(self):
+        assert test_guard._collect_test_functions("def broken(:\n") is None
+
+    def test_file_parametrize_total_none_when_no_static_parametrize(self):
+        source = "def test_plain():\n    assert True\n"
+        assert test_guard._file_parametrize_total(source) is None


### PR DESCRIPTION
Closes #1119

## Problem

The gate stack had no defense against a candidate commit that makes the smoke gate pass by weakening the tests instead of fixing the code ("never weaken a test" — pattern borrowed from dream-machine's adversarial reward-hack check). Existing protections (filler-solution gate #1106, fitness integrity #789, mutation-surface gate) never inspected the test diff itself.

## Solution

New standalone module `nanobot/runtime/test_guard.py` (~300 LOC): a pure, deterministic `evaluate(repo_path, base_ref, head_ref) -> dict`. No LLM calls, bounded runtime (one `git diff` + one `git show` per changed test file). Driven by `git diff --find-renames --name-status` restricted to test files, plus stdlib `ast` parsing of old/new blob content (files are parsed, never imported/executed).

**Hard signals (block):**
- an existing test file deleted (status `D`, not a detected rename) while the cycle also touches non-test files;
- net loss of `assert` + `pytest.raises(...)` in an existing test file;
- `@pytest.mark.skip` / `skipif` / `xfail` newly added to a previously-unmarked test function.

**Soft signals (recorded, never block):**
- shrunk `@pytest.mark.parametrize` argument list;
- assert/raises loss in a file git also reports as a genuine content-similarity rename (`--find-renames` collapses equivalent-coverage-moved-elsewhere into one `R` row, not `D`+`A`, so the rename case never reaches the hard-deletion branch).

New tests / brand-new test files (status `A`) are never penalized. Fail-open throughout: any git/parse trouble degrades to an unblocked, empty-violations verdict.

## Wiring

`_check_test_weakening()` (bridge.py) wraps `test_guard.evaluate()` and runs at the same three recompute points as the existing mutation-surface check (#678 F1/F3 discipline): after the initial commit, after every repair-turn retry, and in the final pre-gate recompute. The gate decision gets a new `elif _test_weakening_blocked:` branch, placed immediately after the mutation-surface-violation branch and **before** the smoke-gate/runtime-tier/integrate branches — same severity and placement as `mutation_surface_violation` / `blocked_file_present`.

## #1118 tri-state verdict integration

`'test_weakening'` is added to `_REJECT_REASONS` — a detected weakening is a confirmed, deterministic negative result (the gate correctly caught a reward-hack attempt), so it maps to verdict `reject`, not the ambiguous `inconclusive` that plain gate/infra failures get. Purely additive; no other outcome/verdict semantics change.

## Deny-set

`nanobot/runtime/test_guard.py` added to `_RUNTIME_DENY_ALWAYS_FILES` in this same PR — the instance must never be able to neuter its own reward-hack detector. `docs/TRUST_KERNEL.md`'s fenced manifest + attack-class map updated to match (kept in sync by `tests/test_trust_kernel_manifest.py`).

## Scope

Confined per the concurrent-work fence: only `nanobot/runtime/test_guard.py` (new), `tests/test_test_guard.py` (new), a `bridge.py` wiring hunk, `nanobot/runtime/runtime_deny.py` deny-set addition, and `docs/TRUST_KERNEL.md` doc sync. No changes to `doctor.py`, `context_compaction.py`, `agent/subagent.py`, `llm_proposer.py`, or `demand.py`. Rebased cleanly onto `origin/main` after #1120/#1128 merged (no shared files, zero conflicts).

## Tests

`tests/test_test_guard.py` — 23 new tests: empty diff, new-file/new-function never penalized, hard deletion (with/without non-test changes), rename-with-equivalent-coverage NOT blocked (`git diff --find-renames` verified explicitly), assert/raises loss (blocks) vs gain (does not), skip/xfail newly added (blocks) vs pre-existing-untouched (does not), parametrize shrink (soft) vs growth (not recorded), assert loss on a genuine rename (soft, not hard), fail-open on bad ref / missing repo / syntax error, plus direct AST-helper unit coverage.

Full suite (`py -3.13 -m pytest -q -n 4`): **2723 passed**, 19 failed, 17 skipped. All 19 failures confirmed identical on unmodified `origin/main` via `git stash` baseline comparison — 18 pre-existing Windows-only fcntl/chmod/symlink flakes (`test_autoevolve*`, `test_bridge_locking`, `test_bridge_cycle_tags`, `test_selfevo_export_security`) plus one pre-existing date-window timing flake in `test_skill_candidate_mining` (unrelated to this change, hardcoded `2026-08-*` fixture dates similar in shape to the #1124 time-bomb but out of this issue's scope). Zero new regressions.

Ruff: clean on every new/changed line in `test_guard.py`, `test_test_guard.py`, `runtime_deny.py`. `bridge.py`'s 11 pre-existing lint findings confirmed byte-identical via `git stash` baseline — none introduced by this diff.

CI on Linux expected fully green (the Windows-only failures above don't reproduce there).
