### PR TITLE
test: freeze wall-clock in skill_candidate_mining tests to fix 30-day time bomb (#1131)

### DIFF
--- a/tests/test_skill_candidate_mining.py
+++ b/tests/test_skill_candidate_mining.py
@@ -2,17 +2,38 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
-from nanobot.runtime import demand
+from nanobot.runtime import demand, skill_candidate_mining
 from nanobot.runtime.skill_candidate_mining import (
     _has_legacy_var,
     _is_meaningful,
     mine,
     write_sidecar,
 )
+
+
+# #1131: every fixture in this file hardcodes cycle-row dates in the
+# 2026-08-01..2026-08-10 window. mine()'s own _iter_rows() reads the REAL
+# wall-clock date via datetime.now(timezone.utc) to compute a 30-day
+# retention cutoff — a calendar time bomb, since the fixture dates fall
+# further outside that rolling window every day this suite exists (and can
+# already clip the 2026-08-01 fixture row once "now" passes noon UTC on
+# 2026-08-31). Freeze "now" to a fixed instant inside the fixtures' own
+# window so the cutoff math is stable regardless of when the test actually
+# runs, without changing any production behavior.
+class _FrozenDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 8, 15, 12, 0, 0, tzinfo=tz or timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _frozen_calendar(monkeypatch):
+    monkeypatch.setattr(skill_candidate_mining, "datetime", _FrozenDatetime)
 
 
 def _write_rows(state: Path, rows: list[dict]) -> None:


### PR DESCRIPTION
Closes #1131

## Problem

`tests/test_skill_candidate_mining.py::test_f1_sidecar_ranked_by_cycles_times_days` hardcodes fixture cycle timestamps on `2026-08-01`..`2026-08-10`. `mine()`'s `_iter_rows()` computes a real-wall-clock 30-day retention cutoff. On/after 2026-08-31 the cutoff crosses into the fixture's own date range and silently drops day-1 rows, undercounting sequence B below `MIN_CYCLES=8` and failing the `>= 2` candidates assertion. Discovered live during PR #1130 (#1119) CI.

## Fix

Same pattern and fix shape as #1124: monkeypatch `skill_candidate_mining.datetime` to a frozen subclass whose `now()` always returns a fixed instant inside the fixtures' own window. No production code changed.

## Tests

`test_skill_candidate_mining.py`: 16 passed, 1 skipped. Full suite (`-n 4`): 2708 passed, 19 failed, 17 skipped — all 19 confirmed pre-existing via `git stash` baseline against unmodified `origin/main` (18 known Windows-only flakes + one mtime-resolution timing flake in `test_commands.py` that also reproduces on main). Zero regressions.