### PR TITLE
fix(doctor): keep long executor cycles fresh

### DIFF
--- a/nanobot/runtime/doctor.py
+++ b/nanobot/runtime/doctor.py
@@ -23,6 +23,7 @@ DEFAULT_REPO_DIR = Path("/var/lib/eeepc-agent/self-evolving-agent/eeebot-self-ev
 DEFAULT_WATERMARK_AGE = timedelta(hours=48)
 MAX_SCAN_FILES = 200
 MAX_LEDGER_LINES = 2000
+MID_CYCLE_FRESHNESS = timedelta(minutes=60)  # 3000s executor budget plus margin
 
 
 @dataclass(frozen=True)
@@ -217,23 +218,29 @@ def _check_repository(repo_dir: Path, runner: CommandRunner, state_dir: Path | N
     branch = branch_result.stdout.strip()
     if branch_result.returncode != 0 or branch != "main":
         if branch.startswith("selfevo/cycle-") and state_dir is not None and now is not None:
+            latest = None
             try:
                 rows = (state_dir / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines()[-MAX_LEDGER_LINES:]
-                fresh = False
-                for line in rows:
-                    try:
-                        data = json.loads(line)
-                        ts = data.get("ts")
-                        if data.get("phase") in {"started", "outcome"} and ts:
-                            if now - datetime.fromisoformat(ts.replace("Z", "+00:00")) <= timedelta(minutes=15):
-                                fresh = True
-                                break
-                    except Exception:
-                        pass
-                if fresh:
-                    return Check("repository", "PASS", f"mid-cycle branch {branch}")
-            except Exception:
+            except (OSError, UnicodeError):
+                rows = []
+            for line in rows:
+                try:
+                    data = json.loads(line)
+                    ts = data.get("ts")
+                    if data.get("phase") in {"started", "outcome"} and ts:
+                        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                        latest = parsed if latest is None or parsed > latest else latest
+                except Exception:
+                    pass
+            calls_path = state_dir / "llm_calls" / f"{now:%Y-%m-%d}.jsonl"
+            try:
+                heartbeat = datetime.fromtimestamp(calls_path.stat().st_mtime, timezone.utc)
+                latest = heartbeat if latest is None or heartbeat > latest else latest
+            except OSError:
                 pass
+            fresh = latest is not None and now - latest <= MID_CYCLE_FRESHNESS
+            if fresh:
+                return Check("repository", "PASS", f"mid-cycle branch {branch}")
         return Check("repository", "FAIL", f"checkout is {branch or 'unavailable'}")
     status = _run(runner, ["git", "-C", str(repo_dir), "status", "--porcelain"])
     if status.returncode != 0:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -244,6 +244,30 @@ def test_mid_cycle_branch_with_fresh_bridge_activity_passes(tmp_path: Path) -> N
     assert repository.reason == "mid-cycle branch selfevo/cycle-cycle-abc"
 
 
+def test_live_executor_heartbeat_keeps_long_cycle_fresh(tmp_path: Path) -> None:
+    paths = _fixture(tmp_path)
+    now = doctor.datetime.fromisoformat("2026-08-31T12:00:00+00:00")
+    (paths["state"] / "ledger" / "cycles.jsonl").unlink()
+    calls = paths["state"] / "llm_calls" / "2026-08-31.jsonl"
+    calls.parent.mkdir(parents=True)
+    calls.write_text("heartbeat\n", encoding="utf-8")
+    import os
+    os.utime(calls, (now.timestamp() - 60, now.timestamp() - 60))
+
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "branch --show-current" in " ".join(command):
+            return subprocess.CompletedProcess(command, 0, "selfevo/cycle-cycle-live\n", "")
+        return _runner(command, **kwargs)
+
+    result = doctor.run_doctor(
+        state_dir=paths["state"], repo_dir=paths["repo"], release_link=paths["current"],
+        command_runner=runner, now=now, environment={"SUBAGENT_BRIDGE_MODEL": "x"},
+    )
+    repository = next(check for check in result.checks if check.name == "repository")
+    assert repository.status == "PASS"
+    assert repository.reason == "mid-cycle branch selfevo/cycle-cycle-live"
+
+
 def test_stale_mid_cycle_branch_fails(tmp_path: Path) -> None:
     paths = _fixture(tmp_path)
     now = doctor.datetime.fromisoformat("2026-08-31T12:00:00+00:00")


### PR DESCRIPTION
## REWORK-2 for #1129

Use the latest of:
- ledger `started`/`outcome` timestamp; and
- today's `state/llm_calls/YYYY-MM-DD.jsonl` mtime heartbeat.

The freshness window is 60 minutes, covering the 3000-second executor budget plus margin. Ledger and heartbeat reads are independently fail-open, and malformed ledger rows are skipped. The failing long-cycle heartbeat regression first failed against the previous implementation and now passes.

Changed files:
- `nanobot/runtime/doctor.py`
- `tests/test_doctor.py`

Focused doctor tests: 14 passed.
