### PR TITLE
feat(runtime): bounded demand model escalation (#1121)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -48,7 +48,7 @@ from nanobot.runtime.promoted_overlay import install_promoted_overlay
 
 install_promoted_overlay()
 
-from nanobot.runtime import llm_proposer  # noqa: E402
+from nanobot.runtime import llm_proposer, demand  # noqa: E402
 from nanobot.runtime.backlog_snapshot import write_backlog_snapshot  # noqa: E402
 from nanobot.runtime.cycle_ledger import (  # noqa: E402
     VALID_OUTCOMES,
@@ -2417,6 +2417,13 @@ async def _main_impl_body():
         pass
 
     bridge_model = resolve_model('executor', config_fallback=config.tools.subagent.model)
+    escalation_model = resolve_model('escalation')
+    if escalation_model and _request_serves_demand(req):
+        demand_id = req.get('task', '').split('Serves: demand ', 1)[-1].splitlines()[0].strip()
+        if demand.should_escalate(STATE_DIR, demand_id):
+            cycle_id = str(req.get('cycle_id') or request_id)
+            if demand.record_escalation(STATE_DIR, demand_id, cycle_id, escalation_model):
+                bridge_model = escalation_model
     config.agents.defaults.model = bridge_model
     provider = _make_provider(config)
     bus = MessageBus()

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -240,6 +240,7 @@ _VALIDATOR_PATH_RE = re.compile(
 _EXHAUSTION_REJECTS = 2
 _EXHAUSTION_EXPIRY_HOURS = 24  # was 7 days; shortened by #771 (deadlock escape)
 _NOOP_OUTCOMES = {"completed_no_commit", "skipped-duplicate"}
+_ESCALATION_MODEL_ENV = "SELFEVO_ESCALATION_MODEL"
 
 _SCRIPT_DIRS = ("scripts", "surfaces")  # mirrors system_map._SCRIPT_DIRS
 
@@ -2366,7 +2367,10 @@ def _filter_exhausted(
                     if success_reset and success_ts is not None
                     else now_iso
                 )
-                entry = {"status": "reset", "reset_at": reset_iso}
+                reset_entry: dict[str, Any] = {"status": "reset", "reset_at": reset_iso}
+                if isinstance(entry, dict) and isinstance(entry.get("escalated"), dict):
+                    reset_entry["escalated"] = entry["escalated"]
+                entry = reset_entry
                 entries[iid] = entry
                 changed = True
             if isinstance(entry, dict) and entry.get("status") == "reset":
@@ -2384,13 +2388,22 @@ def _filter_exhausted(
             if reset_at is not None:
                 item_rejects = [ts for ts in item_rejects if ts > reset_at]
             if len(item_rejects) >= _EXHAUSTION_REJECTS:
-                entries[iid] = {
+                # Optional escalation gets the next serving cycle before the
+                # normal exhaustion filter hides the item. It is disabled
+                # entirely when SELFEVO_ESCALATION_MODEL is unset.
+                if escalation_model() and not _escalation_marker(state_dir, iid):
+                    out.append(item)
+                    continue
+                exhausted_entry = {
                     "status": "exhausted",
                     "exhausted_at": now_iso,
                     "git_head": head or "",
                     "release": release,
                     "rejects": len(item_rejects),
                 }
+                if isinstance(entry, dict) and isinstance(entry.get("escalated"), dict):
+                    exhausted_entry["escalated"] = entry["escalated"]
+                entries[iid] = exhausted_entry
                 changed = True
                 continue
             out.append(item)
@@ -2400,6 +2413,69 @@ def _filter_exhausted(
         return out
     except Exception:
         return items
+
+
+def escalation_model() -> str:
+    """Return the optional, operator-configured escalation model."""
+    try:
+        from nanobot.runtime.model_registry import resolve_model
+        return resolve_model("escalation")
+    except Exception:
+        return os.environ.get(_ESCALATION_MODEL_ENV, "").strip()
+
+
+def _escalation_marker(state_dir: Path, demand_id: str) -> dict[str, Any] | None:
+    for path in (_exhausted_path(state_dir), _completed_path(state_dir)):
+        payload = _read_json(path, {})
+        entries = payload.get("entries", {}) if isinstance(payload, dict) else {}
+        entry = entries.get(demand_id) if isinstance(entries, dict) else None
+        marker = entry.get("escalated") if isinstance(entry, dict) else None
+        if isinstance(marker, dict) and marker.get("cycle_id") and marker.get("model"):
+            return marker
+    return None
+
+
+def should_escalate(state_dir: Path, demand_id: str) -> bool:
+    """Return whether this demand has earned its single optional escalation.
+
+    The same ledger/result evidence used by exhaustion is the trigger. This
+    keeps the opt-in rung off for fresh items and makes the decision survive
+    proposer/bridge process boundaries.
+    """
+    try:
+        model = escalation_model()
+        if not model or not demand_id or _escalation_marker(Path(state_dir), demand_id):
+            return False
+        rejects = _self_dedup_reject_ts_by_demand_id(Path(state_dir))
+        return len(rejects.get(demand_id, [])) >= _EXHAUSTION_REJECTS
+    except Exception:
+        return False
+
+
+def record_escalation(
+    state_dir: Path,
+    demand_id: str,
+    cycle_id: str,
+    model: str,
+    ts: str | None = None,
+) -> bool:
+    """Persist one escalation marker and report whether it was durable."""
+    if not demand_id or not cycle_id or not model or _escalation_marker(Path(state_dir), demand_id):
+        return False
+    try:
+        data = _load_exhausted(state_dir)
+        entry = data["entries"].setdefault(demand_id, {})
+        entry.setdefault(
+            "escalated",
+            {"cycle_id": cycle_id, "model": model, "ts": ts or datetime.now(timezone.utc).isoformat()},
+        )
+        data["entries"][demand_id] = entry
+        path = _exhausted_path(state_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        return _escalation_marker(Path(state_dir), demand_id) is not None
+    except Exception:
+        return False
 
 
 def _fold_already_delivered_priorities(

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2601,6 +2601,8 @@ def write_request(
     demand_id = _demand_id_from_serves(serves)
     if demand_id:
         proposed_event["demand_id"] = demand_id
+        if demand.should_escalate(state_dir, demand_id):
+            proposed_event["escalated_model"] = demand.escalation_model()
     # #1118: carry the frozen claim's TEXT (not the full check dict) into the
     # ledger row — the reflector reads 'proposed' rows as ledger context
     # (nanobot.runtime.reflector._messages), so this is how the claim reaches

--- a/nanobot/runtime/model_registry.py
+++ b/nanobot/runtime/model_registry.py
@@ -45,6 +45,7 @@ _ROLE_ENV_VARS: dict[str, tuple[str, ...]] = {
     "curator": ("SELFEVO_CURATOR_MODEL", "SELFEVO_SUMMARY_MODEL"),
     "reflector": ("SELFEVO_REFLECTOR_MODEL", "SELFEVO_SUMMARY_MODEL"),
     "strategist": ("SELFEVO_STRATEGIST_MODEL", "SELFEVO_SUMMARY_MODEL"),
+    "escalation": ("SELFEVO_ESCALATION_MODEL",),
 }
 
 _ROLE_DEFAULTS: dict[str, str] = {
@@ -56,6 +57,7 @@ _ROLE_DEFAULTS: dict[str, str] = {
     "curator": "cl/gemini-3.5-flash-low",
     "reflector": "cl/gemini-3.5-flash-low",
     "strategist": "cl/gemini-3.5-flash-low",
+    "escalation": "",
 }
 
 

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -905,6 +905,79 @@ class TestExhaustion:
             _append_outcome(state_dir, cycle_id, "completed_no_commit", ts=_now_iso(5))
         assert any(i["id"] == target["id"] for i in demand.collect_demand(state_dir, None))
 
+    def test_escalation_is_not_eligible_before_threshold(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+        target = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "priority"][0]
+        _append_proposed(state_dir, "c-one", target["id"], ts=_now_iso(5))
+        _append_outcome(state_dir, "c-one", "completed_no_commit", ts=_now_iso(2))
+        assert not demand.should_escalate(state_dir, target["id"])
+
+    def test_escalation_candidate_uses_archive_noop_evidence(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+        target = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "priority"][0]
+        _append_proposed(state_dir, "c-escalate", target["id"], ts=_now_iso(5))
+        archive = state_dir / "subagents" / "archive"
+        archive.mkdir(parents=True)
+        (archive / "result-c-escalate.json").write_text(
+            json.dumps({
+                "cycle_id": "c-escalate",
+                "learning_classification": "completed_no_commit",
+                "target_path": "scripts/missing.py",
+            }),
+            encoding="utf-8",
+        )
+        _append_outcome(state_dir, "c-escalate", "partial", ts=_now_iso(2))
+        # Result-side evidence alone is not a second no-op; the terminal
+        # ledger outcome is required for each credited attempt.
+        assert any(i["id"] == target["id"] for i in demand.collect_demand(state_dir, None))
+        assert not demand.should_escalate(state_dir, target["id"])
+        _append_proposed(state_dir, "c-escalate-2", target["id"], ts=_now_iso(5))
+        (archive / "result-c-escalate-2.json").write_text(
+            json.dumps({
+                "cycle_id": "c-escalate-2",
+                "learning_classification": "completed_no_commit",
+            }),
+            encoding="utf-8",
+        )
+        _append_outcome(state_dir, "c-escalate-2", "completed_no_commit", ts=_now_iso(2))
+        assert demand.should_escalate(state_dir, target["id"])
+
+    def test_escalation_marker_write_failure_does_not_claim_escalation(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+        monkeypatch.setattr(demand.Path, "write_text", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")))
+        assert not demand.record_escalation(state_dir, "priority-marker", "cycle-marker", "an/frontier-model")
+
+    def test_escalation_marker_is_durable_and_single_shot(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+        target = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "priority"][0]
+        for cycle_id in ("c-escalate-1", "c-escalate-2"):
+            _append_proposed(state_dir, cycle_id, target["id"], ts=_now_iso(5))
+            _append_outcome(state_dir, cycle_id, "completed_no_commit", ts=_now_iso(2))
+        assert demand.should_escalate(state_dir, target["id"])
+        demand.record_escalation(state_dir, target["id"], "c-escalate-3", "an/frontier-model", _now_iso())
+        assert not demand.should_escalate(state_dir, target["id"])
+        assert not any(i["id"] == target["id"] for i in demand.collect_demand(state_dir, None))
+        marker = json.loads((state_dir / "demand" / "exhausted.json").read_text(encoding="utf-8"))["entries"][target["id"]]["escalated"]
+        assert marker == {"cycle_id": "c-escalate-3", "model": "an/frontier-model", "ts": marker["ts"]}
+
+    def test_escalation_is_off_by_default(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        monkeypatch.delenv("SELFEVO_ESCALATION_MODEL", raising=False)
+        target = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "priority"][0]
+        for cycle_id in ("c-off-1", "c-off-2"):
+            _append_proposed(state_dir, cycle_id, target["id"], ts=_now_iso(5))
+            _append_outcome(state_dir, cycle_id, "completed_no_commit", ts=_now_iso(2))
+        assert not demand.should_escalate(state_dir, target["id"])
+        assert not any(i["id"] == target["id"] for i in demand.collect_demand(state_dir, None))
+
     def test_exhaustion_expires_when_head_moves(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -29,6 +29,7 @@ _ALL_MODEL_ENV_VARS = (
     "SELFEVO_REFLECTOR_MODEL",
     "SELFEVO_STRATEGIST_MODEL",
     "SELFEVO_HARNESS_MODEL",
+    "SELFEVO_ESCALATION_MODEL",
 )
 
 
@@ -47,6 +48,12 @@ def test_golden_default_proposer():
 
 def test_golden_default_executor():
     assert resolve_model("executor") == "cl/gemini-3.5-flash-low"
+
+
+def test_escalation_model_is_opt_in(monkeypatch):
+    assert resolve_model("escalation") == ""
+    monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+    assert resolve_model("escalation") == "an/frontier-model"
 
 
 def test_golden_default_harness():


### PR DESCRIPTION
## Summary\n- add opt-in SELFEVO_ESCALATION_MODEL routing for demand items at exhaustion threshold\n- persist one escalation marker across reset/exhaustion and use bounded ledger/results/archive evidence\n- preserve existing request schema and execution budgets\n\nCloses #1121\n\n## Verification\n- focused demand escalation: 5 passed\n- model registry, proposer, bridge branch: 345 passed\n- full suite on Windows: 2738 passed, 17 skipped, 18 known baseline failures in autoevolve/tag/locking tests (environmental Windows/POSIX assumptions)