### PR TITLE
fix(runtime): consume escalation at proposal time (#1121)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2417,13 +2417,12 @@ async def _main_impl_body():
         pass
 
     bridge_model = resolve_model('executor', config_fallback=config.tools.subagent.model)
-    escalation_model = resolve_model('escalation')
-    if escalation_model and _request_serves_demand(req):
+    if _request_serves_demand(req):
         demand_id = req.get('task', '').split('Serves: demand ', 1)[-1].splitlines()[0].strip()
-        if demand.should_escalate(STATE_DIR, demand_id):
-            cycle_id = str(req.get('cycle_id') or request_id)
-            if demand.record_escalation(STATE_DIR, demand_id, cycle_id, escalation_model):
-                bridge_model = escalation_model
+        cycle_id = str(req.get('cycle_id') or request_id)
+        marker = demand._escalation_marker(STATE_DIR, demand_id)
+        if marker and marker.get('cycle_id') == cycle_id:
+            bridge_model = str(marker.get('model') or bridge_model)
     config.agents.defaults.model = bridge_model
     provider = _make_provider(config)
     bus = MessageBus()

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2602,7 +2602,11 @@ def write_request(
     if demand_id:
         proposed_event["demand_id"] = demand_id
         if demand.should_escalate(state_dir, demand_id):
-            proposed_event["escalated_model"] = demand.escalation_model()
+            escalation_model = demand.escalation_model()
+            if escalation_model and demand.record_escalation(
+                state_dir, demand_id, cycle_id, escalation_model
+            ):
+                proposed_event["escalated_model"] = escalation_model
     # #1118: carry the frozen claim's TEXT (not the full check dict) into the
     # ledger row — the reflector reads 'proposed' rows as ledger context
     # (nanobot.runtime.reflector._messages), so this is how the claim reaches

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -952,6 +952,23 @@ class TestExhaustion:
         monkeypatch.setattr(demand.Path, "write_text", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")))
         assert not demand.record_escalation(state_dir, "priority-marker", "cycle-marker", "an/frontier-model")
 
+    def test_escalated_proposal_consumes_before_dedup(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])
+        monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+        target = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "priority"][0]
+        for cycle_id in ("c-escalate-1", "c-escalate-2"):
+            _append_proposed(state_dir, cycle_id, target["id"], ts=_now_iso(5))
+            _append_outcome(state_dir, cycle_id, "completed_no_commit", ts=_now_iso(2))
+        assert demand.should_escalate(state_dir, target["id"])
+        assert demand.record_escalation(
+            state_dir, target["id"], "c-escalate-3", "an/frontier-model", _now_iso()
+        )
+        _append_proposed(state_dir, "c-escalate-3", target["id"], ts=_now_iso(1))
+        _append_outcome(state_dir, "c-escalate-3", "skipped-duplicate", ts=_now_iso())
+        assert not demand.should_escalate(state_dir, target["id"])
+        assert not any(i["id"] == target["id"] for i in demand.collect_demand(state_dir, None))
+
     def test_escalation_marker_is_durable_and_single_shot(self, tmp_path, monkeypatch):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -1653,6 +1653,30 @@ class TestWriteRequestSchemaEquality:
         proposed_rows = [r for r in rows if r.get("phase") == "proposed"]
         assert proposed_rows[0]["serves"] == ""
 
+    def test_escalated_proposal_records_marker_and_telemetry(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setenv("SELFEVO_ESCALATION_MODEL", "an/frontier-model")
+        demand_id = "priority-escalate123"
+        for cycle_id in ("c-old-1", "c-old-2"):
+            cycle_ledger.append_event(state_dir, {
+                "phase": "proposed", "cycle_id": cycle_id, "demand_id": demand_id,
+            })
+            cycle_ledger.append_event(state_dir, {
+                "phase": "outcome", "cycle_id": cycle_id, "outcome": "completed_no_commit",
+            })
+        proposal = {
+            "task_title": "Escalate this demand",
+            "rationale": "repeated no-op",
+            "target_path": "scripts/escalate.py",
+            "serves": f"demand {demand_id}",
+        }
+        llm_proposer.write_request(state_dir, proposal)
+        rows = [json.loads(line) for line in (state_dir / "ledger" / "cycles.jsonl").read_text().splitlines()]
+        row = [r for r in rows if r.get("phase") == "proposed" and r.get("request_id", "").startswith("llm-proposer-")][-1]
+        assert row["escalated_model"] == "an/frontier-model"
+        marker = demand._escalation_marker(state_dir, demand_id)
+        assert marker and marker["cycle_id"] == row["cycle_id"]
+
 
 # ─── #1118: optional, frozen expected_outcome claim ────────────────────────
 


### PR DESCRIPTION
## Summary\n- bind escalation consumption to the escalated proposal, before bridge execution/dedup gates\n- make bridge routing depend only on a durable marker matching the request cycle\n- add regression coverage for dedup-killed escalated proposals and proposal telemetry\n\nFixes the live #1121 defect documented in issue comment 5482847197.\n\n## Verification\n- escalation demand tests: 5 passed\n- escalated proposer test: 1 passed\n- model registry + bridge branch tests: 154 passed\n- full suite to be run against this worktree per central-module delivery gate