### PR TITLE
fix(bridge): hotfix three runtime NameErrors shipped in #1142 explore mode

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3317,10 +3317,12 @@ async def _main_impl_body():
             _explore_n = 1
         else:
             try:
-                from nanobot.runtime.cycle_ledger import read_ledger_events, record_explore_started
+                from nanobot.runtime.cycle_ledger import read_events, record_explore_started
                 _today = __import__('datetime').datetime.now(__import__('datetime').timezone.utc).strftime('%Y-%m-%d')
-                _events = read_ledger_events(STATE_DIR) or {}
-                _daily_explores = sum(1 for e in _events.get('events',[]) if e.get('type') == 'explore_started' and e.get('timestamp','').startswith(_today))
+                _daily_explores = sum(
+                    1 for e in read_events(STATE_DIR)
+                    if e.get('phase') == 'explore_started' and str(e.get('ts', '')).startswith(_today)
+                )
                 if _daily_explores >= 1:
                     _explore_n = 1
                 else:
@@ -4962,10 +4964,6 @@ def cli_main() -> int:
     return asyncio.run(main())
 
 
-if __name__ == '__main__':
-    raise SystemExit(cli_main())
-
-
 def _parse_explore_mode(req: dict) -> tuple[int, str]:
     task = req.get('task') or req.get('task_title') or ""
     try:
@@ -4974,10 +4972,20 @@ def _parse_explore_mode(req: dict) -> tuple[int, str]:
         if m:
             n = int(m.group(1))
             n = max(1, min(n, 3))
-            
+
             meas_m = re.search(r'(?i)^\s*measurement:\s*([a-zA-Z0-9_\-]+)', task, flags=re.MULTILINE)
             metric = meas_m.group(1) if meas_m else ""
             return n, metric
         return 1, ""
     except Exception:
         return 1, ""
+
+
+# NOTE: keep this guard the LAST statement in the module. Under
+# ``python -m nanobot.runtime.bridge`` the module body executes top-to-bottom
+# with ``__name__ == '__main__'``, so any def placed below this block does not
+# exist yet when cli_main() starts the loop — the live bridge then dies with a
+# NameError that module-importing tests can never catch (incident 2026-09-01:
+# _parse_explore_mode defined below this guard killed every cycle for 8 hours).
+if __name__ == '__main__':
+    raise SystemExit(cli_main())

--- a/nanobot/runtime/cycle_ledger.py
+++ b/nanobot/runtime/cycle_ledger.py
@@ -286,19 +286,46 @@ def record_cycle_outcome(
         row,
     )
 
-def record_explore_started(state_dir: 'Path', cycle_id: str, candidates_count: int, declared_measurement: str) -> None:
-    _append_event(state_dir, cycle_id, 'explore_started', {
+def read_events(state_dir: Path) -> list[dict]:
+    """Read all rows from the ACTIVE ledger file. Best-effort — never raises.
+
+    Returns the parsed JSON rows of the current (unrotated) ledger file,
+    oldest first; an unreadable file yields an empty list and malformed
+    lines are skipped. Rotated files are intentionally not read: callers
+    using this for same-day checks (the explore daily cap) only need
+    today's rows, and the active file always contains today.
+    """
+    rows: list[dict] = []
+    with contextlib.suppress(Exception):
+        active_path = _ledger_dir(state_dir) / _LEDGER_FILENAME
+        with open(active_path, encoding="utf-8") as fh:
+            for line in fh:
+                with contextlib.suppress(Exception):
+                    row = json.loads(line)
+                    if isinstance(row, dict):
+                        rows.append(row)
+    return rows
+
+
+def record_explore_started(state_dir: Path, cycle_id: str, candidates_count: int, declared_measurement: str) -> None:
+    append_event(state_dir, {
+        'phase': 'explore_started',
+        'cycle_id': cycle_id,
         'candidates_count': candidates_count,
-        'declared_measurement': declared_measurement
+        'declared_measurement': declared_measurement,
     })
 
-def record_explore_candidate(state_dir: 'Path', cycle_id: str, cand_cycle_id: str, score: float) -> None:
-    _append_event(state_dir, cycle_id, 'explore_candidate', {
+def record_explore_candidate(state_dir: Path, cycle_id: str, cand_cycle_id: str, score: float) -> None:
+    append_event(state_dir, {
+        'phase': 'explore_candidate',
+        'cycle_id': cycle_id,
         'cand_cycle_id': cand_cycle_id,
-        'score': score
+        'score': score,
     })
 
-def record_explore_selected(state_dir: 'Path', cycle_id: str, winner_branch: str) -> None:
-    _append_event(state_dir, cycle_id, 'explore_selected', {
-        'winner_branch': winner_branch
+def record_explore_selected(state_dir: Path, cycle_id: str, winner_branch: str) -> None:
+    append_event(state_dir, {
+        'phase': 'explore_selected',
+        'cycle_id': cycle_id,
+        'winner_branch': winner_branch,
     })

--- a/tests/test_bridge_main_guard_last.py
+++ b/tests/test_bridge_main_guard_last.py
@@ -1,0 +1,50 @@
+"""Regression guard for the def-after-__main__ incident (2026-09-01).
+
+``python -m nanobot.runtime.bridge`` executes the module body top-to-bottom
+with ``__name__ == '__main__'``: the guard block starts the whole bridge loop
+the moment it is reached, so any top-level ``def``/``class``/assignment placed
+BELOW the guard does not exist in module scope while the loop runs. Tests
+import the module (all defs load), so CI stays green while every live cycle
+dies with a NameError — exactly what happened when ``_parse_explore_mode``
+was appended below the guard: the loop crashed on every timer fire for 8
+hours (release 20260901T041403Z-canonical-fe03357c).
+
+This test statically asserts the ``if __name__ == '__main__'`` guard is the
+LAST top-level statement in bridge.py, so nothing can hide below it.
+"""
+
+import ast
+from pathlib import Path
+
+BRIDGE_PATH = Path(__file__).resolve().parents[1] / "nanobot" / "runtime" / "bridge.py"
+
+
+def _is_main_guard(node: ast.stmt) -> bool:
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and len(test.comparators) == 1
+        and isinstance(test.comparators[0], ast.Constant)
+        and test.comparators[0].value == "__main__"
+    )
+
+
+def test_main_guard_is_last_top_level_statement() -> None:
+    tree = ast.parse(BRIDGE_PATH.read_text(encoding="utf-8"))
+    guards = [i for i, node in enumerate(tree.body) if _is_main_guard(node)]
+    assert guards, "bridge.py must contain an if __name__ == '__main__' guard"
+    last_guard = guards[-1]
+    trailing = tree.body[last_guard + 1 :]
+    offenders = [
+        f"line {node.lineno}: {type(node).__name__}"
+        for node in trailing
+    ]
+    assert not offenders, (
+        "top-level statements found AFTER the __main__ guard in bridge.py — "
+        "they do not exist in module scope while the live loop runs "
+        "(def-after-guard incident class): " + "; ".join(offenders)
+    )

--- a/tests/test_explore_ledger_recorders.py
+++ b/tests/test_explore_ledger_recorders.py
@@ -1,0 +1,60 @@
+"""Regression tests for the explore ledger recorders (2026-09-01 incident).
+
+Release fe03357c shipped three explore recorders calling a nonexistent
+``_append_event`` (NameError, silently swallowed by callers' try/except —
+explore events could never be written) and a bridge daily-cap check importing
+a nonexistent ``read_ledger_events``. These tests fail on that code.
+"""
+
+import ast
+import json
+from pathlib import Path
+
+from nanobot.runtime import cycle_ledger as cl
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_record_explore_started_writes_phase_row(tmp_path) -> None:
+    cl.record_explore_started(tmp_path, "cycle-x", 2, "latency")
+    rows = cl.read_events(tmp_path)
+    assert [r for r in rows if r.get("phase") == "explore_started"], rows
+    row = rows[-1]
+    assert row["cycle_id"] == "cycle-x"
+    assert row["candidates_count"] == 2
+    assert row["declared_measurement"] == "latency"
+    assert row.get("ts"), "append_event must stamp ts"
+
+
+def test_record_candidate_and_selected_write_rows(tmp_path) -> None:
+    cl.record_explore_candidate(tmp_path, "cycle-x", "cycle-x-1", 0.5)
+    cl.record_explore_selected(tmp_path, "cycle-x", "selfevo/cycle-x-1")
+    phases = [r.get("phase") for r in cl.read_events(tmp_path)]
+    assert "explore_candidate" in phases
+    assert "explore_selected" in phases
+
+
+def test_read_events_missing_file_and_malformed_lines(tmp_path) -> None:
+    assert cl.read_events(tmp_path) == []
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir(parents=True)
+    (ledger_dir / "cycles.jsonl").write_text(
+        'not json\n{"phase": "outcome", "cycle_id": "c1"}\n[1,2]\n', encoding="utf-8"
+    )
+    rows = cl.read_events(tmp_path)
+    assert rows == [{"phase": "outcome", "cycle_id": "c1"}]
+
+
+def test_bridge_ledger_imports_resolve() -> None:
+    """Every ``from nanobot.runtime.cycle_ledger import X`` in bridge.py must
+    name a real attribute — the incident import (`read_ledger_events`) was
+    hidden inside try/except and only failed at runtime."""
+    source = (REPO_ROOT / "nanobot" / "runtime" / "bridge.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    missing = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "nanobot.runtime.cycle_ledger":
+            for alias in node.names:
+                if not hasattr(cl, alias.name):
+                    missing.append(f"line {node.lineno}: {alias.name}")
+    assert not missing, f"bridge.py imports nonexistent cycle_ledger names: {missing}"


### PR DESCRIPTION
Emergency hotfix — release fe03357c killed every live bridge cycle for 8 hours (NameError: _parse_explore_mode; def placed after the __main__ guard, invisible to import-based tests). Also fixes two dormant mines in the same feature: explore recorders calling nonexistent _append_event, and the daily-cap block importing nonexistent read_ledger_events (both silently swallowed). Four regression tests, all red on fe03357c. Details in the commit message. Reopens the #1000 verification question: live evidence must be re-collected after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)