### PR TITLE
fix(bridge): thread cycle_tier and subagent_task_id through the explore candidate boundary

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3307,6 +3307,8 @@ async def _main_impl_body():
             'rollback_reason': locals().get('_rollback_reason', ''),
             'integrated': locals().get('_integrated', False),
             'score': locals().get('cand_score', float('-inf')),
+            'cycle_tier': locals().get('_cycle_tier', 'script'),
+            'subagent_task_id': locals().get('_subagent_task_id', None),
             'origin_main_observed': locals().get('_origin_main_observed', locals().get('main_sha_before', ''))
         }
 
@@ -3404,7 +3406,10 @@ async def _main_impl_body():
     _integrity_changed = _res['integrity_changed']
     _rollback_reason = _res['rollback_reason']
     _integrated = _res['integrated']
+    _cycle_tier = _res.get('cycle_tier', 'script')
+    _subagent_task_id = _res.get('subagent_task_id')
     commits_pushed = cycle_commit_count if _integrated else 0
+    import subprocess as _sp
 
     # Write a real completed result to state/subagents/results/ so the coordinator
     # can see that the subagent actually ran (not just a blocked stub).

--- a/tests/test_bridge_no_undefined_globals.py
+++ b/tests/test_bridge_no_undefined_globals.py
@@ -1,0 +1,62 @@
+"""Generalized guard for the undefined-name-at-runtime class (2026-09-01).
+
+PR #1142 split the bridge cycle body into ``_evaluate_candidate`` while
+leaving code in ``_main_impl_body`` that referenced names now assigned only
+inside the new function's scope (``_cycle_tier``, ``_sp``). Python compiles
+such references as LOAD_GLOBAL; module-importing tests stay green, and the
+live loop dies with NameError only when the code path runs.
+
+This test disassembles every code object reachable from the bridge module
+and asserts every LOAD_GLOBAL target exists in the module namespace or in
+builtins. It is red on the pre-fix code and catches the whole defect class,
+not just the two known names.
+"""
+
+import builtins
+import dis
+import types
+
+from nanobot.runtime import bridge
+
+# Names legitimately absent at import time: created at runtime before use.
+_ALLOWED_RUNTIME_NAMES: set[str] = {
+    "__debug__",
+    # `del`-then-rebind or conditional plugin-style globals would go here.
+}
+
+
+def _iter_code_objects(code: types.CodeType):
+    yield code
+    for const in code.co_consts:
+        if isinstance(const, types.CodeType):
+            yield from _iter_code_objects(const)
+
+
+def test_every_load_global_in_bridge_resolves() -> None:
+    module_names = set(vars(bridge))
+    builtin_names = set(vars(builtins))
+    offenders: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    for func in list(vars(bridge).values()):
+        code = getattr(func, "__code__", None)
+        if code is None or getattr(func, "__module__", None) != bridge.__name__:
+            continue
+        for co in _iter_code_objects(code):
+            for ins in dis.get_instructions(co):
+                if ins.opname != "LOAD_GLOBAL":
+                    continue
+                name = ins.argval
+                if (
+                    name in module_names
+                    or name in builtin_names
+                    or name in _ALLOWED_RUNTIME_NAMES
+                ):
+                    continue
+                key = (co.co_name, name)
+                if key not in seen:
+                    seen.add(key)
+                    offenders.append(f"{co.co_name}:{co.co_firstlineno} loads undefined global '{name}'")
+    assert not offenders, (
+        "bridge.py references names that exist in no scope at runtime "
+        "(import-green, runtime-dead class): " + "; ".join(sorted(offenders))
+    )


### PR DESCRIPTION
Second hotfix for the #1142 scope split: after #1144, live cycles progressed to outcome classification and died on NameError: _cycle_tier (bridge.py:3470); _subagent_task_id and the _sp alias had the same latent break. Result dict + unpack fix, plus a generalized dis-based guard test asserting every LOAD_GLOBAL in the bridge module resolves — this test alone would have caught all four NameErrors from #1142 before deploy. Red-proven on pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)