### PR TITLE
fix(runtime): mint lessons from reflector detail (#1106)

### DIFF
--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -32,7 +32,6 @@ from typing import Any, Callable, Iterable
 
 from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
 from nanobot.runtime.lesson_v2 import (
-    validate_lesson_for_mint,
     atomic_write_yaml,
     bounded_load_yaml,
     fill_related_links,
@@ -958,31 +957,15 @@ def promote_reflector_recommendations_to_v2(
                 card_id = f"{base_id}-{digest}{idx}"
                 idx += 1
 
-            finding_detail = ""
-            for finding in row.get("findings", []):
-                if isinstance(finding, dict) and str(finding.get("detail") or "").strip():
-                    finding_detail = str(finding["detail"]).strip()
-                    break
-            problem = str(
-                row.get("summary") or finding_detail
-                or f"Reflector recommendation requiring verification in {row.get('cycle_id', 'cycle')}"
-            ).strip()
             card = {"schema_version": 2, "id": card_id,
 
-                    "title": detail[:200], "problem": problem[:400],
-                    "solution": detail[:500],
+                    "title": detail[:200], "problem": detail[:400],
+                    "solution": f"Apply the reflected {item['kind'].replace('_', ' ')}.",
                     "tags": ["reflector"], "severity": "medium", "seen_count": 1,
                     "first_seen": datetime.now(timezone.utc).date().isoformat(),
                     "last_seen": datetime.now(timezone.utc).date().isoformat(),
                     "evidence": [str(row.get("cycle_id") or "reflector")]}
-            if not validate_lesson_for_mint(card):
-                print(
-                    f"curator-lesson: rejected reflector recommendation for {card_id}"
-                )
-                continue
             duplicate = find_duplicate(card["problem"], existing)
-            if duplicate is not None and duplicate.get("solution") != card["solution"]:
-                duplicate = None
             if duplicate is not None:
                 duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
                 duplicate["last_seen"] = card["last_seen"]

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -958,14 +958,9 @@ def promote_reflector_recommendations_to_v2(
                 card_id = f"{base_id}-{digest}{idx}"
                 idx += 1
 
-            finding_detail = ""
-            for finding in row.get("findings", []):
-                if isinstance(finding, dict) and str(finding.get("detail") or "").strip():
-                    finding_detail = str(finding["detail"]).strip()
-                    break
             problem = str(
-                row.get("summary") or finding_detail
-                or f"Reflector recommendation requiring verification in {row.get('cycle_id', 'cycle')}"
+                row.get("summary")
+                or f"Reflected issue: {detail[:60]}"
             ).strip()
             card = {"schema_version": 2, "id": card_id,
 

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Iterable
 
 from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
 from nanobot.runtime.lesson_v2 import (
+    validate_lesson_for_mint,
     atomic_write_yaml,
     bounded_load_yaml,
     fill_related_links,
@@ -957,16 +958,33 @@ def promote_reflector_recommendations_to_v2(
                 card_id = f"{base_id}-{digest}{idx}"
                 idx += 1
 
+            finding_detail = ""
+            for finding in row.get("findings", []):
+                if isinstance(finding, dict) and str(finding.get("detail") or "").strip():
+                    finding_detail = str(finding["detail"]).strip()
+                    break
+            problem = str(
+                row.get("summary") or finding_detail
+                or f"Reflector recommendation requiring verification in {row.get('cycle_id', 'cycle')}"
+            ).strip()
             card = {"schema_version": 2, "id": card_id,
 
-                    "title": detail[:200], "problem": detail[:400],
-                    "solution": f"Apply the reflected {item['kind'].replace('_', ' ')}.",
+                    "title": detail[:200], "problem": problem[:400],
+                    "solution": detail[:500],
                     "tags": ["reflector"], "severity": "medium", "seen_count": 1,
                     "first_seen": datetime.now(timezone.utc).date().isoformat(),
                     "last_seen": datetime.now(timezone.utc).date().isoformat(),
                     "evidence": [str(row.get("cycle_id") or "reflector")]}
+            if not validate_lesson_for_mint(card):
+                print(
+                    f"curator-lesson: rejected reflector recommendation for {card_id}"
+                )
+                continue
             duplicate = find_duplicate(card["problem"], existing)
             if duplicate is not None:
+                from nanobot.runtime.lesson_v2 import solution_is_meaningful
+                if not solution_is_meaningful(duplicate.get("problem"), duplicate.get("solution")):
+                    duplicate["solution"] = card["solution"]
                 duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
                 duplicate["last_seen"] = card["last_seen"]
             else:

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Iterable
 
 from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
 from nanobot.runtime.lesson_v2 import (
+    validate_lesson_for_mint,
     atomic_write_yaml,
     bounded_load_yaml,
     fill_related_links,
@@ -957,15 +958,31 @@ def promote_reflector_recommendations_to_v2(
                 card_id = f"{base_id}-{digest}{idx}"
                 idx += 1
 
+            finding_detail = ""
+            for finding in row.get("findings", []):
+                if isinstance(finding, dict) and str(finding.get("detail") or "").strip():
+                    finding_detail = str(finding["detail"]).strip()
+                    break
+            problem = str(
+                row.get("summary") or finding_detail
+                or f"Reflector recommendation requiring verification in {row.get('cycle_id', 'cycle')}"
+            ).strip()
             card = {"schema_version": 2, "id": card_id,
 
-                    "title": detail[:200], "problem": detail[:400],
-                    "solution": f"Apply the reflected {item['kind'].replace('_', ' ')}.",
+                    "title": detail[:200], "problem": problem[:400],
+                    "solution": detail[:500],
                     "tags": ["reflector"], "severity": "medium", "seen_count": 1,
                     "first_seen": datetime.now(timezone.utc).date().isoformat(),
                     "last_seen": datetime.now(timezone.utc).date().isoformat(),
                     "evidence": [str(row.get("cycle_id") or "reflector")]}
+            if not validate_lesson_for_mint(card):
+                print(
+                    f"curator-lesson: rejected reflector recommendation for {card_id}"
+                )
+                continue
             duplicate = find_duplicate(card["problem"], existing)
+            if duplicate is not None and duplicate.get("solution") != card["solution"]:
+                duplicate = None
             if duplicate is not None:
                 duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
                 duplicate["last_seen"] = card["last_seen"]

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -137,6 +137,55 @@ def test_solution_validator_rejects_reflector_template() -> None:
     )
 
 
+def test_solution_validator_rejects_trivial() -> None:
+    # Meaningful_chars = 5 (less than 12)
+    assert not solution_is_meaningful("Database crashes on load.", "Fix it.")
+
+
+def test_solution_validator_rejects_near_duplicate() -> None:
+    # Problem and solution are near duplicates (Jaccard >= 0.8)
+    p = "The server crashes on load with a segmentation fault at address 0x0."
+    s = "Server crashes on load with a segmentation fault at address 0x0."
+    assert not solution_is_meaningful(p, s)
+
+
+def test_curator_folds_duplicate_and_upgrades_meaningless_solution(tmp_path: Path) -> None:
+    from nanobot.runtime.knowledge_curator import promote_reflector_recommendations_to_v2
+    import yaml
+
+    # State path needs to have a file at reflector/reflections.jsonl
+    state_dir = tmp_path / "state"
+    reflector_dir = state_dir / "reflector"
+    reflector_dir.mkdir(parents=True)
+    source = reflector_dir / "reflections.jsonl"
+    source.write_text('{"phase":"reflect","summary":"Node missing","recommendations":[{"kind":"error_pattern","detail":"Run apt-get update to fix missing package listings."}]}\n', encoding="utf-8")
+
+    lessons_dir = tmp_path / "lessons"
+    lessons_dir.mkdir(parents=True)
+    target = lessons_dir / "lessons.yaml"
+    target.write_text(yaml.dump({
+        "lessons": [{
+            "id": "LESS-000000000000-0000-0000-0000-000000000000",
+            "problem": "Node missing",
+            "solution": "Apply the reflected error pattern.",
+            "seen_count": 1,
+            "last_seen": "old-date"
+        }]
+    }), encoding="utf-8")
+
+    count = promote_reflector_recommendations_to_v2(tmp_path, state_dir)
+
+    with target.open(encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    cards = doc.get("lessons", [])
+    
+    # Assert card count is strictly 1 (deduped rather than proliferating)
+    assert len(cards) == 1
+    # Assert the meaningless template solution was upgraded to the new concrete one extracted from reflector output
+    assert cards[0]["solution"] == "Run apt-get update to fix missing package listings."
+    assert cards[0]["seen_count"] == 2
+
+
 def test_curator_rejects_missing_or_filler_recommendation_detail(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     state = tmp_path / "state" / "reflector"

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -16,7 +16,9 @@ from nanobot.runtime.lesson_v2 import (
     keyword_jaccard,
     normalize_problem,
     record_citations,
+    solution_is_meaningful,
     validate_lesson,
+    validate_lesson_for_mint,
 )
 from nanobot.runtime.schemas import CONTROLLED_LESSON_TAGS
 
@@ -115,11 +117,40 @@ def test_curator_promotes_reflector_delta(tmp_path: Path) -> None:
     state.mkdir(parents=True)
     (state / "reflections.jsonl").write_text(json.dumps({
         "cycle_id": "cycle-reflect",
-        "recommendations": [{"kind": "approach_hint", "detail": "Use bounded parser reads"}],
+        "timestamp": "2026-08-31T12:00:00Z",
+        "summary": "Reflector found an inefficient parser path",
+        "recommendations": [{"kind": "approach_hint", "detail": "Use bounded parser reads incrementally for large files"}],
     }) + "\n", encoding="utf-8")
+    import os
+    old_time = time.time() - 10
+    os.utime(state / "reflections.jsonl", (old_time, old_time))
     assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
     lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
-    assert validate_lesson(lessons["lessons"][0])
+    assert validate_lesson_for_mint(lessons["lessons"][0])
+    assert lessons["lessons"][0]["solution"] == "Use bounded parser reads incrementally for large files"
+
+
+def test_solution_validator_rejects_reflector_template() -> None:
+    assert not solution_is_meaningful(
+        "A concrete parser issue was observed",
+        "Apply the reflected approach hint.",
+    )
+
+
+def test_curator_rejects_missing_or_filler_recommendation_detail(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state" / "reflector"
+    workspace.mkdir()
+    state.mkdir(parents=True)
+    rows = [
+        {"cycle_id": "cycle-empty", "recommendations": [{"kind": "approach_hint", "detail": ""}]},
+        {"cycle_id": "cycle-filler", "recommendations": [{"kind": "error_pattern", "detail": "Apply the reflected error pattern."}]},
+    ]
+    (state / "reflections.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+    assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 0
+    assert not (workspace / "lessons" / "lessons.yaml").exists()
 
 
 def test_prompt_includes_lesson_citation_instruction() -> None:


### PR DESCRIPTION
## Summary\n- fix the live curator reflector->v2 path to use bounded recommendation detail as solution text\n- reject missing/filler/problem-shaped minted cards before writing\n- preserve schema v2, rotation, related links, and surrounding fail-open cycle behavior\n\n## Scope\n- nanobot/runtime/knowledge_curator.py\n- tests/test_lesson_v2.py\n- no deploy_release.sh, bridge control flow, curator verification, or knowledge-lift changes\n\n## AC-to-test mapping\n- concrete recommendation solution: test_curator_promotes_reflector_delta\n- empty/filler rejection: test_curator_rejects_missing_or_filler_recommendation_detail; test_solution_validator_rejects_reflector_template\n- problem/solution near-duplicate rejection: test_write_structured_lesson_rejects_problem_equal_or_near_duplicate_solution\n- existing valid v2 + related/rotation compatibility: test_write_structured_lesson_valid_v2_lesson_remains_accepted and full lesson/curator regression suite\n\n## Verification\n- focused lesson/curator/ID tests: 32 passed\n- full suite and baseline comparison will be reported after CI/local completion\n- live verification remains honest status:test until a natural post-deploy reflector v2 lesson with real solution text is observed\n