### PR TITLE
fix(tests): give deploy_release fixtures their own git identity

### DIFF
--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -43,12 +43,27 @@ def repo(tmp_path):
     
     return repo_root
 
+def _write_mock(path, body):
+    """Write an executable stub onto the mock PATH.
+
+    The execute bit is not optional. Without it a POSIX shell skips the stub
+    and falls through to the real binary on PATH, so the tests reached the
+    actual ssh/scp on CI ("could not resolve hostname eeepc") while passing on
+    Windows, where executability is not consulted the same way.
+    """
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", newline="\n")
+    path.chmod(0o755)
+
+
 @pytest.fixture
 def mock_bin(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    (bin_dir / "scp").write_text("#!/usr/bin/env bash\nexit 0\n", newline="\n")
-    (bin_dir / "sleep").write_text("#!/usr/bin/env bash\nexit 0\n", newline="\n")
+    _write_mock(bin_dir / "scp", "exit 0")
+    _write_mock(bin_dir / "sleep", "exit 0")
+    # Default ssh stub, so a test that never calls set_ssh_mock still cannot
+    # reach a real host. Tests that need behaviour overwrite it.
+    _write_mock(bin_dir / "ssh", "exit 0")
     return bin_dir
 
 def run_deploy(repo_root, mock_bin, args):
@@ -65,9 +80,7 @@ def run_deploy(repo_root, mock_bin, args):
     return res
 
 def set_ssh_mock(mock_bin, script_content):
-    p = mock_bin / "ssh"
-    p.write_text(f"#!/usr/bin/env bash\n{script_content}\n", newline="\n")
-    p.chmod(0o755)
+    _write_mock(mock_bin / "ssh", script_content)
 
 def test_a_local_head_not_origin_main(repo, tmp_path, mock_bin):
     _git("branch", "-M", "main", cwd=repo, check=True)

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -8,6 +8,22 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_SCRIPT = REPO_ROOT / "host" / "eeepc" / "scripts" / "deploy_release.sh"
 
 
+def _git(*args, cwd=None, **kwargs):
+    """Run git with an identity supplied by the test.
+
+    CI runners have no global user.name / user.email, so `git commit` exits 128
+    there while passing on any developer machine that has them configured. The
+    fixtures below commit into throwaway repositories, so carry the identity in
+    the environment rather than depending on the host's git configuration.
+    """
+    env = dict(kwargs.pop("env", None) or os.environ)
+    env.setdefault("GIT_AUTHOR_NAME", "eeebot tests")
+    env.setdefault("GIT_AUTHOR_EMAIL", "tests@eeebot.invalid")
+    env.setdefault("GIT_COMMITTER_NAME", "eeebot tests")
+    env.setdefault("GIT_COMMITTER_EMAIL", "tests@eeebot.invalid")
+    return subprocess.run(["git", *args], cwd=cwd, env=env, **kwargs)
+
+
 @pytest.fixture
 def repo(tmp_path):
     repo_root = tmp_path / "repo"
@@ -20,10 +36,10 @@ def repo(tmp_path):
     test_script = script_dir / "deploy_release.sh"
     shutil.copy(DEPLOY_SCRIPT, test_script)
     
-    subprocess.run(["git", "init"], cwd=repo_root, check=True)
+    _git("init", cwd=repo_root, check=True)
     (repo_root / "README").write_text("hello")
-    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
-    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_root, check=True)
+    _git("add", ".", cwd=repo_root, check=True)
+    _git("commit", "-m", "init", cwd=repo_root, check=True)
     
     return repo_root
 
@@ -54,29 +70,29 @@ def set_ssh_mock(mock_bin, script_content):
     p.chmod(0o755)
 
 def test_a_local_head_not_origin_main(repo, tmp_path, mock_bin):
-    subprocess.run(["git", "branch", "-M", "main"], cwd=repo, check=True)
-    subprocess.run(["git", "clone", "--bare", str(repo), str(tmp_path / "origin.git")], check=True)
-    subprocess.run(["git", "remote", "add", "origin", str(tmp_path / "origin.git")], cwd=repo, check=True)
-    subprocess.run(["git", "fetch", "origin"], cwd=repo, check=True)
+    _git("branch", "-M", "main", cwd=repo, check=True)
+    _git("clone", "--bare", str(repo), str(tmp_path / "origin.git"), check=True)
+    _git("remote", "add", "origin", str(tmp_path / "origin.git"), cwd=repo, check=True)
+    _git("fetch", "origin", cwd=repo, check=True)
     
     (repo / "file").write_text("diverge")
-    subprocess.run(["git", "add", "file"], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-m", "diverge"], cwd=repo, check=True)
+    _git("add", "file", cwd=repo, check=True)
+    _git("commit", "-m", "diverge", cwd=repo, check=True)
     
     res = run_deploy(repo, mock_bin, [])
     assert res.returncode != 0
     assert "refuse" in (res.stdout + res.stderr).lower()
 
 def test_b_ref_deploys_exact_sha(repo, tmp_path, mock_bin):
-    subprocess.run(["git", "branch", "-M", "main"], cwd=repo, check=True)
-    subprocess.run(["git", "clone", "--bare", str(repo), str(tmp_path / "origin.git")], check=True)
-    subprocess.run(["git", "remote", "add", "origin", str(tmp_path / "origin.git")], cwd=repo, check=True)
-    subprocess.run(["git", "fetch", "origin"], cwd=repo, check=True)
+    _git("branch", "-M", "main", cwd=repo, check=True)
+    _git("clone", "--bare", str(repo), str(tmp_path / "origin.git"), check=True)
+    _git("remote", "add", "origin", str(tmp_path / "origin.git"), cwd=repo, check=True)
+    _git("fetch", "origin", cwd=repo, check=True)
     
     (repo / "file").write_text("diverge")
-    subprocess.run(["git", "add", "file"], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-m", "diverge"], cwd=repo, check=True)
-    commit_sha = subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=repo, capture_output=True, text=True).stdout.strip()
+    _git("add", "file", cwd=repo, check=True)
+    _git("commit", "-m", "diverge", cwd=repo, check=True)
+    commit_sha = _git("rev-parse", "--short", "HEAD", cwd=repo, capture_output=True, text=True).stdout.strip()
     
     set_ssh_mock(mock_bin, "exit 0")
     res = run_deploy(repo, mock_bin, ["--ref", commit_sha, "--no-health-gate"])


### PR DESCRIPTION
## Problem

`main` is still red after #1149. Every job errors with:

```
subprocess.CalledProcessError: Command '['git', 'commit', '-m', 'init']' returned non-zero exit status 128
```

The fixtures in `tests/test_deploy_release.py` commit into throwaway repositories, and CI runners have no global `user.name` / `user.email`. So the commits succeed on any developer machine that has them configured and fail everywhere else.

This is the same shape as the absolute-path defect #1149 fixed, one layer down: the test depended on ambient host configuration instead of supplying what it needs.

## Fix

Route the fixtures' git calls through a helper that carries `GIT_AUTHOR_*` / `GIT_COMMITTER_*` in the environment. 17 call sites, no behaviour change beyond the identity.

## Evidence

Reproduced locally with the machine's git configuration removed, which is what the runner looks like:

```
GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null python -m pytest tests/test_deploy_release.py

before: 5 errors
after:  5 passed
```