### PR TITLE
fix(deploy): match phase outcome health rows (#1153)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -350,7 +350,7 @@ while [ $SECONDS -le $END_TIME ]; do
     exit 1
   fi
 
-  OUTCOME_RAW=$(ssh "ozand@${HOST}" "sudo cat /var/lib/eeepc-agent/self-evolving-agent/state/ledger/cycles.jsonl 2>/dev/null | grep '\"type\": \"outcome\"' | tail -n 1 || true")
+  OUTCOME_RAW=$(ssh "ozand@${HOST}" "sudo cat /var/lib/eeepc-agent/self-evolving-agent/state/ledger/cycles.jsonl 2>/dev/null | grep '\"phase\": \"outcome\"' | tail -n 1 || true")
   if [ -n "$OUTCOME_RAW" ]; then
     # Very rudimentary bash grep to extract the timestamp string
     OUTCOME_TS=$(echo "$OUTCOME_RAW" | grep -o '"ts": "[^"]*"' | cut -d'"' -f4)

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -133,9 +133,10 @@ def test_c_traceback_triggers_rollback(repo, tmp_path, mock_bin):
     assert "rollback" in res.stdout.lower() or "rollback" in res.stderr.lower()
 
 def test_d_terminal_outcome_row_triggers_pass(repo, tmp_path, mock_bin):
+    """The mock must emit the real ledger key, not mirror the script's filter."""
     ssh_mock = """
     if [[ "$*" == *"| grep"* ]]; then
-        if [[ "$*" == *"'\\"type\\": \\"outcome\\"'"* ]]; then
+        if [[ "$*" == *"phase"* && "$*" == *"outcome"* ]]; then
             echo '{"cycle_id": "c1", "phase": "outcome", "ts": "2099-01-01T00:00:00Z"}'
         fi
         exit 0


### PR DESCRIPTION
## Summary

- fix post-deploy health gate to grep the ledger's actual `phase: outcome` key
- make `test_d_terminal_outcome_row_triggers_pass` emit on the real ledger row shape so it fails against the pre-fix script

## Scope

Only:
- `host/eeepc/scripts/deploy_release.sh`
- `tests/test_deploy_release.py`

## Verification

- failing-test-first: `test_d_terminal_outcome_row_triggers_pass` failed against the pre-fix script, then passed after the key correction
- deploy release tests: 5 passed
- full suite: 2758 passed, 17 skipped, 20 failures; failures are the known platform/#1146/#1152 baseline and no unrelated files were changed

Closes #1153 after live PASS verification.
