### PR TITLE
fix(deploy): use journal-compatible health timestamp (#1155)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -328,10 +328,11 @@ fi
 log "Waiting up to ${HEALTH_TIMEOUT}m for post-deploy health signals..."
 END_TIME=$(( SECONDS + HEALTH_TIMEOUT * 60 ))
 FLIP_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+FLIP_JOURNAL_TS=$(date -u +"%Y-%m-%d %H:%M:%S")
 
 while [ $SECONDS -le $END_TIME ]; do
   # Check for traceback or failure
-  TRACEBACK_LINE=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --since \"$FLIP_TS\" --no-pager | grep -iE 'traceback|exception:|error:' || true")
+  TRACEBACK_LINE=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'traceback|exception:|error:' || true")
   if [ -n "$TRACEBACK_LINE" ]; then
     log "FAIL: Traceback or error observed in journal:"
     echo "$TRACEBACK_LINE"
@@ -341,7 +342,7 @@ while [ $SECONDS -le $END_TIME ]; do
     exit 1
   fi
   
-  MAIN_PID_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --since \"$FLIP_TS\" --no-pager | grep -iE 'main process exited, code=(exited|dumped|killed), status=[1-9]' || true")
+  MAIN_PID_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'main process exited, code=(exited|dumped|killed), status=[1-9]' || true")
   if [ -n "$MAIN_PID_EXIT" ]; then
     log "FAIL: Bridge process crashed:"
     echo "$MAIN_PID_EXIT"

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -115,9 +115,14 @@ def test_b_ref_deploys_exact_sha(repo, tmp_path, mock_bin):
 def test_c_traceback_triggers_rollback(repo, tmp_path, mock_bin):
     ssh_mock = """
     if [[ "$*" == *"| grep"* ]]; then
-        if [[ "$*" == *"traceback|exception:|error:"* ]]; then
-            echo "Traceback (most recent call last):"
-            echo "Exception: crashed"
+        if [[ "$*" == *"--since"* && "$*" == *"--utc"* && "$*" != *Z* ]]; then
+            if [[ "$*" == *"grep -iE 'traceback"* ]]; then
+                echo "Traceback (most recent call last):"
+                echo "Exception: crashed"
+            fi
+        else
+            echo "Failed to parse timestamp" >&2
+            exit 1
         fi
         exit 0
     elif [[ "$*" == *"sudo ln -sfn"* ]]; then


### PR DESCRIPTION
## Summary

- keep the Z-suffixed UTC stamp for ledger ordering
- derive a separate UTC `YYYY-MM-DD HH:MM:SS` stamp for journalctl with `--utc`
- strengthen `test_c_traceback_triggers_rollback` so the mock rejects unparseable Z timestamps
- surface a journal parse failure through the test's nonzero ssh result instead of treating it as no traceback

## Verification

- failing-test-first: strengthened `test_c_traceback_triggers_rollback` fails against the pre-fix script with `Failed to parse timestamp`, then passes after the fix
- deploy-release tests: 5 passed
- scope: only `host/eeepc/scripts/deploy_release.sh` and `tests/test_deploy_release.py`

Closes #1155 after live verification.
