### PR TITLE
fix(deploy): stop rolling back on a clean SIGTERM

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -342,7 +342,13 @@ while [ $SECONDS -le $END_TIME ]; do
     exit 1
   fi
   
-  MAIN_PID_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'main process exited, code=(exited|dumped|killed), status=[1-9]' || true")
+  # A clean SIGTERM is not a crash. The bridge is timer-driven, so systemd ends
+  # every run with `code=killed, status=15/TERM`, and this deploy's own
+  # `systemctl restart` logs the same line. A bare `status=[1-9]` matches the
+  # "15" in "15/TERM", so once #1155 made these queries readable the pattern
+  # matched routine operation and rolled back every deploy. Count only a
+  # non-zero exit, a core dump, or a kill by a fault signal.
+  MAIN_PID_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'main process exited, (code=exited, status=[1-9]|code=dumped|code=killed, status=(4|6|8|11)/)' || true")
   if [ -n "$MAIN_PID_EXIT" ]; then
     log "FAIL: Bridge process crashed:"
     echo "$MAIN_PID_EXIT"

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 from pathlib import Path
 import pytest
@@ -82,6 +83,26 @@ def run_deploy(repo_root, mock_bin, args):
 def set_ssh_mock(mock_bin, script_content):
     _write_mock(mock_bin / "ssh", script_content)
 
+
+def _journal_replay_mock(*journal_lines):
+    r"""An ssh stub that runs the remote command's own filter over fixture text.
+
+    A stub that just echoes a canned answer proves nothing about the script's
+    grep pattern -- it replaces the pipeline the pattern lives in. This one
+    feeds the fixture journal lines into the `| grep ...` half of whatever
+    command was asked for, so the pattern under test is the thing being
+    exercised.
+    """
+    payload = "\n".join(journal_lines)
+    return f"""
+    cmd="$*"
+    if [[ "$cmd" == *journalctl* && "$cmd" == *"| grep"* ]]; then
+        printf '%s\\n' {shlex.quote(payload)} | eval "${{cmd#*| }}"
+        exit 0
+    fi
+    exit 0
+    """
+
 def test_a_local_head_not_origin_main(repo, tmp_path, mock_bin):
     _git("branch", "-M", "main", cwd=repo, check=True)
     _git("clone", "--bare", str(repo), str(tmp_path / "origin.git"), check=True)
@@ -153,6 +174,37 @@ def test_d_terminal_outcome_row_triggers_pass(repo, tmp_path, mock_bin):
     res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
     assert res.returncode == 0
     assert "health gate: pass" in (res.stdout + res.stderr).lower()
+
+def test_f_routine_sigterm_does_not_trigger_rollback(repo, tmp_path, mock_bin):
+    """A clean SIGTERM stop is not a crash.
+
+    The bridge is timer-driven: systemd stops each run with SIGTERM and logs
+    `Main process exited, code=killed, status=15/TERM` every few minutes, and
+    the deploy's own `systemctl restart` produces the same line. `status=[1-9]`
+    matches the "15" in 15/TERM, so once #1155 made the journal queries
+    readable this pattern matched routine operation and rolled back every
+    deploy — observed live on 2026-09-01 at 18:48 UTC.
+    """
+    set_ssh_mock(mock_bin, _journal_replay_mock(
+        "Sep 01 21:52:10 eeepc systemd[1]: eeepc-self-evolving-subagent-bridge.service: "
+        "Main process exited, code=killed, status=15/TERM"
+    ))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert "rolling back" not in combined, combined
+    assert res.returncode == 0
+
+
+def test_g_real_crash_still_triggers_rollback(repo, tmp_path, mock_bin):
+    """Narrowing the SIGTERM false positive must not disarm real crashes."""
+    set_ssh_mock(mock_bin, _journal_replay_mock(
+        "Sep 01 21:52:10 eeepc systemd[1]: eeepc-self-evolving-subagent-bridge.service: "
+        "Main process exited, code=exited, status=1/FAILURE"
+    ))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    assert res.returncode != 0
+    assert "rolling back" in (res.stdout + res.stderr).lower()
+
 
 def test_e_timeout_returns_unknown(repo, tmp_path, mock_bin):
     ssh_mock = """


### PR DESCRIPTION
Closes #1157.

#1155 made the health gate's journal queries readable for the first time. The crash detector behind them was never correct, and it now fires on routine operation — every deploy rolls back.

The bridge is timer-driven, so systemd ends every run with `Main process exited, code=killed, status=15/TERM`, and the deploy's own `systemctl restart` logs the same line. `status=[1-9]` matches the `15` in `15/TERM`.

Observed live: the deploy of `37b247e6` at 18:48 UTC rolled back to `20260901T182342Z-canonical-e7585f63` with **zero** traceback matches in the window and nothing wrong with the release.

Match only a non-zero exit, a core dump, or a kill by a fault signal.

## Why the tests could not catch it

The ssh stub returned a canned answer, which replaces the very pipeline the pattern lives in — the script's `grep` never ran, so any pattern passed. `_journal_replay_mock` now feeds fixture journal lines through the `| grep ...` half of whatever command the script actually issued, so the pattern under test is what gets exercised.

Third instance today of the same family (#1153, dashboard #129, this): a test proving the code is self-consistent rather than that it matches the system it talks to.

## Tests

- `test_f_routine_sigterm_does_not_trigger_rollback` — fails against the previous commit.
- `test_g_real_crash_still_triggers_rollback` — pins that narrowing the pattern does not disarm real crash detection.

## Evidence

- `tests/test_deploy_release.py` — 7 passed
- Full suite — 2768 passed, 17 skipped, 18 failed; the known Windows-only baseline. Linux CI is authoritative.