### PR TITLE
fix(deploy): stop rolling back on source code the agent is editing

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -330,9 +330,18 @@ END_TIME=$(( SECONDS + HEALTH_TIMEOUT * 60 ))
 FLIP_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 FLIP_JOURNAL_TS=$(date -u +"%Y-%m-%d %H:%M:%S")
 
-while [ $SECONDS -le $END_TIME ]; do
-  # Check for traceback or failure
-  TRACEBACK_LINE=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'traceback|exception:|error:' || true")
+# Poll at least once before honouring the timeout. With `while [ $SECONDS -le
+# $END_TIME ]` and a zero timeout the loop could exit without checking anything,
+# so whether the gate ran at all depended on how fast the shell got here.
+while :; do
+  # Look for a real traceback from the service, not for words in the log text.
+  # The bridge logs the full arguments of an edit_file tool call at DEBUG, so
+  # the source of whatever file a cycle is editing reaches the journal; a bare
+  # `error:` substring then matched any ordinary CLI error message in that
+  # source and rolled back a healthy release. Drop the `error:`/`exception:`
+  # substrings, skip DEBUG lines, and anchor the traceback to the start of the
+  # message (after journalctl's `host process[pid]:` prefix).
+  TRACEBACK_LINE=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -v ' DEBUG ' | grep -E ': Traceback \(most recent call last\):' || true")
   if [ -n "$TRACEBACK_LINE" ]; then
     log "FAIL: Traceback or error observed in journal:"
     echo "$TRACEBACK_LINE"
@@ -368,6 +377,12 @@ while [ $SECONDS -le $END_TIME ]; do
     fi
   fi
   
+  # An if-block, not `[ ... ] && break`: this script runs under `set -e`, where
+  # a false `&&` list exits with status 1 and would kill the deploy on the very
+  # first iteration that decides to keep polling.
+  if [ $SECONDS -gt $END_TIME ]; then
+    break
+  fi
   sleep 10
 done
 

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -137,9 +137,11 @@ def test_c_traceback_triggers_rollback(repo, tmp_path, mock_bin):
     ssh_mock = """
     if [[ "$*" == *"| grep"* ]]; then
         if [[ "$*" == *"--since"* && "$*" == *"--utc"* && "$*" != *Z* ]]; then
-            if [[ "$*" == *"grep -iE 'traceback"* ]]; then
-                echo "Traceback (most recent call last):"
-                echo "Exception: crashed"
+            if [[ "$*" == *Traceback* ]]; then
+                # Shaped like a real journal line: journalctl prefixes every
+                # message with `host process[pid]:`, and the gate anchors on it.
+                echo "Sep 01 20:15:31 eeepc python[22826]: Traceback (most recent call last):"
+                echo "Sep 01 20:15:31 eeepc python[22826]: Exception: crashed"
             fi
         else
             echo "Failed to parse timestamp" >&2
@@ -157,6 +159,39 @@ def test_c_traceback_triggers_rollback(repo, tmp_path, mock_bin):
     res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
     assert res.returncode != 0
     assert "rollback" in res.stdout.lower() or "rollback" in res.stderr.lower()
+
+def test_h_edited_source_in_debug_log_does_not_trigger_rollback(repo, tmp_path, mock_bin):
+    """Source code the agent is editing is not a failure signal.
+
+    The bridge logs the full arguments of an `edit_file` tool call at DEBUG
+    level, so the contents of whatever file a cycle is editing reach the
+    journal. `grep -iE 'error:'` then matches any ordinary CLI error message in
+    that source and rolls back a healthy release — observed live on
+    2026-09-01, deploy of 611e44d5 at 20:13 UTC.
+    """
+    set_ssh_mock(mock_bin, _journal_replay_mock(
+        'Sep 01 20:15:31 eeepc python[22826]: 2026-09-01 20:15:31.559 | DEBUG    | '
+        'nanobot.agent.subagent:_run_subagent:336 - Subagent [b071997a] executing: '
+        'edit_file with arguments: {"path": "scripts/summarize_failure_outcomes.py", '
+        '"new_text": "    print(f\\"error: file not found: {target_file}\\", file=sys.stderr)"}'
+    ))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert "rolling back" not in combined, combined
+    assert res.returncode == 0
+
+
+def test_i_service_traceback_still_triggers_rollback(repo, tmp_path, mock_bin):
+    """Narrowing the pattern must not disarm real traceback detection."""
+    set_ssh_mock(mock_bin, _journal_replay_mock(
+        "Sep 01 20:15:31 eeepc python[22826]: Traceback (most recent call last):",
+        'Sep 01 20:15:31 eeepc python[22826]:   File "/opt/.../bridge.py", line 12, in <module>',
+        "Sep 01 20:15:31 eeepc python[22826]: NameError: name '_parse_explore_mode' is not defined",
+    ))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    assert res.returncode != 0
+    assert "rolling back" in (res.stdout + res.stderr).lower()
+
 
 def test_d_terminal_outcome_row_triggers_pass(repo, tmp_path, mock_bin):
     """The mock must emit the real ledger key, not mirror the script's filter."""


### PR DESCRIPTION
Closes #1159.

The health gate's failure query was a substring search over the whole journal:

```sh
grep -iE 'traceback|exception:|error:'
```

The bridge logs the **full arguments of an `edit_file` tool call at DEBUG**, so the source of whatever file a cycle is editing lands in the journal. The deploy of `611e44d5` at 20:13 UTC rolled back a healthy release on this line:

```
print(f"error: file not found: {target_file}", file=sys.stderr)
```

An ordinary CLI error message inside a file the agent happened to be editing. Most cycles edit Python containing the literal `error:`, so this fired often. Second false positive in the same gate after #1158 — between the two, the gate rolled back every deploy attempt since it started working.

## Fix

Skip DEBUG lines, drop the bare `error:` / `exception:` substrings, and anchor the traceback to the start of the journal message. The systemd unit-failure query already covers the crash case.

## Two loop fixes found while testing this

- The gate polled under `while [ $SECONDS -le $END_TIME ]`, so with a zero timeout it could exit without checking anything — whether the gate ran at all depended on how fast the shell got there. That was making the suite flaky. It now polls once, then honours the timeout.
- The continuation check is an if-block, not `[ ... ] && break`. This script runs under `set -euo pipefail`, where a false `&&` list exits 1 and would have killed the deploy on the first iteration that decided to keep polling. **Every test passes `--health-timeout 0` and therefore only ever takes the break branch, which is exactly why the suite could not have caught it.** Verified separately that the loop survives multiple iterations under `set -e`.

## Tests

- `test_h_edited_source_in_debug_log_does_not_trigger_rollback` — fails against the previous commit.
- `test_i_service_traceback_still_triggers_rollback` — pins that narrowing does not disarm real detection.
- `test_c`'s stub now emits journal-shaped lines rather than bare text, so it exercises the anchor.

## Evidence

- `tests/test_deploy_release.py` — 9 passed, stable across repeated runs (previously order-dependent).
- Full suite — 2770 passed, 17 skipped, 18 failed; the known Windows-only baseline.

## Note

Two deploys ran concurrently during this investigation (releases `20260901T201304Z` and `20260901T201343Z`, 39 s apart), each flipping the same symlink and restarting the same service. Worth a deploy lock, tracked separately in #1159's body.