### PR TITLE
test(proposer): cover the negative direction of the dedup-exhaustion skip (#998)

### DIFF
--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2358,6 +2358,71 @@ class TestProposerRejectLedger:
         skips = [r for r in _ledger_rows(state_dir) if r.get("phase") == "proposer_skip"]
         assert skips[-1]["reason"] == f"dedup_exhausted: demand {demand_id}"
 
+    def _run_with_dedup_history(self, state_dir, monkeypatch, demand_id, rejects):
+        """Drive maybe_propose past the pre-call skip and report whether the LLM ran.
+
+        Mirrors test_dedup_exhaustion_skips_before_llm_call, except `propose`
+        records the call instead of failing it, so the two directions of the
+        #998 skip are exercised by the same setup.
+        """
+        for kwargs in rejects:
+            _append_reject(state_dir, "self_dedup", demand_id=demand_id, **kwargs)
+        item = {"id": demand_id, "kind": "defect", "summary": "same issue", "evidence": "e"}
+        called = []
+        monkeypatch.setenv(demand.ENABLED_ENV, "1")
+        monkeypatch.setattr(llm_proposer, "should_propose", lambda *_: True)
+        monkeypatch.setattr(demand, "collect_demand", lambda *a, **k: [item])
+        monkeypatch.setattr(llm_proposer, "_select_assigned_demand", lambda *a, **k: [item])
+        monkeypatch.setattr(llm_proposer, "propose", lambda *a, **k: called.append(True))
+        llm_proposer.maybe_propose(state_dir, None)
+        skipped = [
+            r
+            for r in _ledger_rows(state_dir)
+            if r.get("phase") == "proposer_skip"
+            and str(r.get("reason") or "").startswith("dedup_exhausted")
+        ]
+        return bool(called), skipped
+
+    def test_shorter_dedup_history_still_gets_its_llm_call(self, tmp_path, monkeypatch):
+        """#998 AC2: below K self_dedup rejections, the LLM call must still happen.
+
+        The skip is an efficiency measure, not a mute button. Testing only the
+        positive direction would let a too-eager predicate (or a later
+        off-by-one on K) silently stop the proposer from ever calling the model
+        while every existing test stayed green.
+        """
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        rejects = [{}] * (llm_proposer._DEFAULT_DEDUP_EXHAUSTION_K - 1)
+        assert rejects, "K must be >= 2 for a 'shorter history' case to exist"
+        called, skipped = self._run_with_dedup_history(
+            state_dir, monkeypatch, "defect-shorter", rejects
+        )
+        assert called, "LLM was skipped on a history shorter than K"
+        assert not skipped
+
+    def test_expired_dedup_history_still_gets_its_llm_call(self, tmp_path, monkeypatch):
+        """#998 AC2: K rejections older than D days no longer exhaust the item.
+
+        `_dedup_exhausted` stops counting at the first row older than the
+        window, so a demand item the model gave up on weeks ago becomes
+        eligible again instead of being skipped forever.
+        """
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "no priority section, so should_propose is True")
+        stale = datetime.now(timezone.utc) - timedelta(
+            days=llm_proposer._DEFAULT_DEDUP_EXHAUSTION_DAYS + 1
+        )
+        rejects = [
+            {"ts": stale.isoformat().replace("+00:00", "Z")}
+            for _ in range(llm_proposer._DEFAULT_DEDUP_EXHAUSTION_K)
+        ]
+        called, skipped = self._run_with_dedup_history(
+            state_dir, monkeypatch, "defect-expired", rejects
+        )
+        assert called, "LLM was skipped on a dedup history outside the D-day window"
+        assert not skipped
+
     @pytest.fixture(autouse=True)
     def _enable(self, monkeypatch):
         monkeypatch.setenv(ENV_VAR, "1")


### PR DESCRIPTION
Closes the last open acceptance criterion of #998.

The proposer efficiency work itself landed in #1014 (67741325, 2026-08-26) along with tests for three of the four AC bullets:

| #998 AC bullet | covered by |
|---|---|
| dedup-exhausted item short-circuits before any LLM call | `test_dedup_exhaustion_skips_before_llm_call` |
| older/shorter dedup history still gets its LLM call | **this PR** |
| network failure records `llm_unavailable`, invalid reply still records `sizing_rejected` | `test_network_failure_sets_unavailable_status`, `test_double_sizing_failure_records_reject_with_title` |
| neither reason counts as a repeat failure | `test_new_proposer_reasons_do_not_count_as_repeat_failures` |

## What this adds

Only the negative direction of the skip, which nothing tested:

- `test_shorter_dedup_history_still_gets_its_llm_call` — a history of K-1 `self_dedup` rejections.
- `test_expired_dedup_history_still_gets_its_llm_call` — K rejections stamped older than the D-day window.

Both drive the same `maybe_propose` path as the existing positive test, and assert that `propose` ran and that no `dedup_exhausted` row was written.

## Why the direction matters

The skip is an efficiency measure, not a mute button. A predicate that is too eager — or a later off-by-one on K — stops the proposer from ever calling the model, and the loop goes quiet while every existing test stays green. Narrowing a guard is how a guard gets silently disarmed; both directions need an assertion.

## Proof these are not decoration

With `_dedup_exhausted` forced to `return True`:

```
FAILED tests/test_llm_proposer.py::TestProposerRejectLedger::test_shorter_dedup_history_still_gets_its_llm_call
FAILED tests/test_llm_proposer.py::TestProposerRejectLedger::test_expired_dedup_history_still_gets_its_llm_call
2 failed, 1 passed
```

The one that still passes is the existing positive test, as it should. Source restored afterwards; this PR touches only `tests/test_llm_proposer.py`.

`tests/test_llm_proposer.py` + `tests/test_scorecard.py`: 255 passed.

## Supersedes

PR #1161 targeted the same issue with a new parallel test file. It is redundant with the #1014 tests above, its CI is red, and its scorecard case asserts `sc.get(key, 0) == 0`, which passes whether or not the key exists. Closing that one in favour of this.
