### PR TITLE
fix(1166): count futility attempts across ledger rotation

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -479,19 +479,29 @@ def _make_item(
 
 
 _MAX_LEDGER_BYTES = 2 * 1024 * 1024  # 2MB size limit (#1040)
+# Bounded archive reads for _load_ledger_rows: same discipline as _FOLD_MAX_GZ_FILES.
+# Only the N most-recent rotated archives are read so cost stays fixed and callers
+# that pass ledger_rows to goal_gap_futility.futile_gap_ids never trigger an
+# unbounded scan — futility supplements with its own horizon-bounded _rows_archives.
+_LEDGER_MAX_GZ_FILES = 2
 
 
 def _load_ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
     """Load and parse ledger rows from ``state_dir/ledger/cycles.jsonl``.
 
-    Bounded to ``_MAX_LEDGER_BYTES``. Returns a list of parsed JSON dict rows.
+    Bounded to ``_MAX_LEDGER_BYTES`` for the active file, plus the
+    ``_LEDGER_MAX_GZ_FILES`` most-recent rotated ``cycles-*.jsonl.gz``
+    archives (#1166).  Returns a list of parsed JSON dict rows.
+
+    The oversized-active-file case is distinguishable from an empty/missing
+    file via a logged warning so a stuck counter can be diagnosed; callers
+    remain fail-open and receive whatever archive rows are available.
     """
-    try:
-        ledger = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if not ledger.is_file() or ledger.stat().st_size > _MAX_LEDGER_BYTES:
-            return []
-        rows: list[dict[str, Any]] = []
-        for line in ledger.read_text(encoding="utf-8").splitlines():
+    ledger_dir = Path(state_dir) / "ledger"
+    rows: list[dict[str, Any]] = []
+
+    def _parse_lines(lines: list[str]) -> None:
+        for line in lines:
             line = line.strip()
             if not line:
                 continue
@@ -501,9 +511,37 @@ def _load_ledger_rows(state_dir: Path) -> list[dict[str, Any]]:
                     rows.append(row)
             except Exception:
                 continue
-        return rows
+
+    # Archives first (oldest information), active file last — same ordering as
+    # _fold_completed — so the active file's rows win on any same-cycle collision.
+    try:
+        archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"), reverse=True)
     except Exception:
-        return []
+        archives = []
+    for gz_path in reversed(archives[:_LEDGER_MAX_GZ_FILES]):
+        try:
+            with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
+                _parse_lines(fh.read().splitlines())
+        except Exception:
+            continue
+
+    try:
+        ledger = ledger_dir / "cycles.jsonl"
+        if not ledger.is_file():
+            return rows
+        if ledger.stat().st_size > _MAX_LEDGER_BYTES:
+            import logging as _logging
+            _logging.getLogger(__name__).warning(
+                "ledger active file oversized (>%d B), active rows skipped"
+                " (not empty — archives still included)",
+                _MAX_LEDGER_BYTES,
+            )
+            return rows
+        _parse_lines(ledger.read_text(encoding="utf-8").splitlines())
+    except Exception:
+        pass
+
+    return rows
 
 
 def _read_json(path: Path, default: Any) -> Any:

--- a/nanobot/runtime/goal_gap_futility.py
+++ b/nanobot/runtime/goal_gap_futility.py
@@ -192,6 +192,7 @@ def _integrated_count(
     gap_id: str,
     after: datetime,
     ledger_rows: list[dict[str, Any]] | None = None,
+    archive_rows: list[dict[str, Any]] | None = None,
 ) -> int:
     proposed: set[str] = set()
     successful: set[str] = set()
@@ -200,7 +201,7 @@ def _integrated_count(
     # proposed→success pair split by midnight rotation is counted correctly.
     # When ledger_rows is None, _rows handles both active and archives.
     if ledger_rows is not None:
-        rows = _rows_archives(state_dir, after) + ledger_rows
+        rows = (archive_rows if archive_rows is not None else _rows_archives(state_dir, after)) + ledger_rows
     else:
         rows = _rows(state_dir, horizon=after)
     for row in rows:
@@ -260,6 +261,7 @@ def _update(
     records: dict[str, dict[str, Any]],
     now: datetime,
     ledger_rows: list[dict[str, Any]] | None = None,
+    archive_rows: list[dict[str, Any]] | None = None,
 ) -> bool:
     gap_id = str(gap.get("id") or "").strip()
     if not gap_id:
@@ -297,7 +299,13 @@ def _update(
     record["metric"] = str(gap.get("metric") or record.get("metric") or "")
     record["current_metric"] = gap.get("current")
     record["metric_delta"] = _delta(record.get("first_metric"), gap.get("current"))
-    record["attempt_count"] = _integrated_count(state_dir, gap_id, first_seen, ledger_rows=ledger_rows)
+    record["attempt_count"] = _integrated_count(
+        state_dir,
+        gap_id,
+        first_seen,
+        ledger_rows=ledger_rows,
+        archive_rows=archive_rows,
+    )
     now_futile = (
         record["attempt_count"] >= _threshold()
         and not _improved(str(gap.get("direction") or ""), record.get("first_metric"), gap.get("current"))
@@ -324,10 +332,26 @@ def futile_gap_ids(
     try:
         records = _load(state_dir)
         now = datetime.now(timezone.utc)
+        archive_rows = None
+        if ledger_rows is not None:
+            horizons = [
+                _parse_ts(records.get(str(gap.get("id") or ""), {}).get("first_seen_ts"))
+                for gap in gaps
+            ]
+            horizons = [value for value in horizons if value is not None]
+            if horizons:
+                archive_rows = _rows_archives(state_dir, min(horizons))
         result = {
             str(gap.get("id"))
             for gap in gaps
-            if _update(state_dir, gap, records, now, ledger_rows=ledger_rows)
+            if _update(
+                state_dir,
+                gap,
+                records,
+                now,
+                ledger_rows=ledger_rows,
+                archive_rows=archive_rows,
+            )
         }
         _save(state_dir, records)
         return {item for item in result if item}

--- a/nanobot/runtime/goal_gap_futility.py
+++ b/nanobot/runtime/goal_gap_futility.py
@@ -110,30 +110,38 @@ def _rows_active(state_dir: Path) -> list[dict[str, Any]] | object:
 
 
 def _rows_archives(state_dir: Path, horizon: datetime) -> list[dict[str, Any]]:
-    """Read rotated ``.gz`` archives whose day-stamp >= *horizon*'s date.
+    """Read only rotated archives in the gap's own tracking horizon.
 
-    Bounded by the gap's ``first_seen_ts``: only archives from the horizon
-    date onward are read, never an unbounded full scan. (#1166)
+    The lower bound is the record's ``first_seen_ts`` rather than a fixed
+    archive count.  This is the smallest window that can contain an attempt
+    for this gap, while remaining bounded by that timestamp: archives before
+    the horizon are never opened.  The active ledger is read separately.
     """
     import gzip as _gzip
 
     ledger_dir = Path(state_dir) / "ledger"
     if not ledger_dir.is_dir():
         return []
-    horizon_day = horizon.astimezone(timezone.utc).strftime("%Y-%m-%d")
+    horizon_day = horizon.astimezone(timezone.utc).date()
+    today = datetime.now(timezone.utc).date()
     result: list[dict[str, Any]] = []
     try:
-        archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"))
+        archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"), reverse=True)
     except Exception:
         return []
     for gz_path in archives:
-        # Extract day from filename: cycles-YYYY-MM-DD.jsonl.gz
         name = gz_path.name
         if not (name.startswith("cycles-") and name.endswith(".jsonl.gz")):
             continue
-        day = name[len("cycles-"):-len(".jsonl.gz")]
-        if day < horizon_day:  # lexicographic compare works for YYYY-MM-DD
+        day_text = name[len("cycles-"):-len(".jsonl.gz")]
+        try:
+            archive_day = datetime.strptime(day_text, "%Y-%m-%d").date()
+        except ValueError:
             continue
+        if archive_day > today:
+            continue
+        if archive_day < horizon_day:
+            break
         try:
             with _gzip.open(gz_path, "rt", encoding="utf-8") as fh:
                 for line in fh:

--- a/nanobot/runtime/goal_gap_futility.py
+++ b/nanobot/runtime/goal_gap_futility.py
@@ -3,6 +3,13 @@
 Stdlib-only and fail-open.  The demand layer supplies current scorecard gaps;
 this module records bounded observations and suppresses a gap only after a
 bounded number of successful integrated proposals without metric movement.
+
+#1166: ledger reading is rotation-aware — the active ``cycles.jsonl`` is read
+plus any rotated ``cycles-YYYY-MM-DD.jsonl.gz`` archives whose day falls at or
+after the gap's ``first_seen_ts`` horizon. This is *bounded*: only as many
+archives as the horizon requires are loaded, never an unbounded full scan.  The
+oversized-active-file case is distinguishable from an empty file via
+``_OVERSIZED`` (see :data:`_OVERSIZED`) so a stuck counter can be diagnosed.
 """
 from __future__ import annotations
 
@@ -16,6 +23,12 @@ _DEFAULT_THRESHOLD = 10
 _DEFAULT_TTL_DAYS = 14
 _EPSILON = 1e-6
 _MAX_LEDGER_BYTES = 2 * 1024 * 1024
+
+# Sentinel returned by _rows_active when the active ledger file exceeds
+# _MAX_LEDGER_BYTES. Distinct from [] so callers can log/observe the
+# oversize case instead of silently treating it as "nothing happened".
+# (#1166 secondary defect fix.)
+_OVERSIZED = object()
 
 
 def _threshold() -> int:
@@ -69,12 +82,21 @@ def _save(state_dir: Path, records: dict[str, dict[str, Any]]) -> None:
         pass
 
 
-def _rows(state_dir: Path) -> list[dict[str, Any]]:
+def _rows_active(state_dir: Path) -> list[dict[str, Any]] | object:
+    """Read the active (un-rotated) ledger file.
+
+    Returns a list of parsed dict rows, or the :data:`_OVERSIZED` sentinel
+    when the file exceeds *_MAX_LEDGER_BYTES* (#1166: oversize is
+    distinguishable from an empty file so callers can log rather than silently
+    treat it as zero attempts).
+    """
     try:
         path = Path(state_dir) / "ledger" / "cycles.jsonl"
-        if not path.is_file() or path.stat().st_size > _MAX_LEDGER_BYTES:
+        if not path.is_file():
             return []
-        result = []
+        if path.stat().st_size > _MAX_LEDGER_BYTES:
+            return _OVERSIZED  # type: ignore[return-value]
+        result: list[dict[str, Any]] = []
         for line in path.read_text(encoding="utf-8").splitlines():
             try:
                 row = json.loads(line)
@@ -87,6 +109,76 @@ def _rows(state_dir: Path) -> list[dict[str, Any]]:
         return []
 
 
+def _rows_archives(state_dir: Path, horizon: datetime) -> list[dict[str, Any]]:
+    """Read rotated ``.gz`` archives whose day-stamp >= *horizon*'s date.
+
+    Bounded by the gap's ``first_seen_ts``: only archives from the horizon
+    date onward are read, never an unbounded full scan. (#1166)
+    """
+    import gzip as _gzip
+
+    ledger_dir = Path(state_dir) / "ledger"
+    if not ledger_dir.is_dir():
+        return []
+    horizon_day = horizon.astimezone(timezone.utc).strftime("%Y-%m-%d")
+    result: list[dict[str, Any]] = []
+    try:
+        archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"))
+    except Exception:
+        return []
+    for gz_path in archives:
+        # Extract day from filename: cycles-YYYY-MM-DD.jsonl.gz
+        name = gz_path.name
+        if not (name.startswith("cycles-") and name.endswith(".jsonl.gz")):
+            continue
+        day = name[len("cycles-"):-len(".jsonl.gz")]
+        if day < horizon_day:  # lexicographic compare works for YYYY-MM-DD
+            continue
+        try:
+            with _gzip.open(gz_path, "rt", encoding="utf-8") as fh:
+                for line in fh:
+                    try:
+                        row = json.loads(line)
+                    except Exception:
+                        continue
+                    if isinstance(row, dict):
+                        result.append(row)
+        except Exception:
+            continue
+    return result
+
+
+def _rows(state_dir: Path, horizon: datetime | None = None) -> list[dict[str, Any]]:
+    """Read ledger rows for the futility path (#1166 rotation-aware).
+
+    When *horizon* is given (a gap's ``first_seen_ts``), rotated ``.gz``
+    archives whose filename day >= horizon's date are also read and prepended,
+    so a ``proposed`` row written on a prior day and its matching
+    ``outcome:success`` row in today's active file both appear in the result.
+    The scan is bounded by *horizon* — no archive older than that date is
+    read.
+
+    The active file is always read first; if it exceeds *_MAX_LEDGER_BYTES*
+    the :data:`_OVERSIZED` sentinel is noted and an empty active slice is used
+    (fail-open: archives are still scanned normally).
+    """
+    active = _rows_active(state_dir)
+    if active is _OVERSIZED:
+        import logging as _logging
+        _logging.getLogger(__name__).warning(
+            "goal_gap_futility: active ledger exceeds %d bytes; "
+            "active rows skipped for futility counting (oversized, not empty)",
+            _MAX_LEDGER_BYTES,
+        )
+        active_rows: list[dict[str, Any]] = []
+    else:
+        active_rows = active  # type: ignore[assignment]
+    if horizon is None:
+        return active_rows
+    archive_rows = _rows_archives(state_dir, horizon)
+    return archive_rows + active_rows
+
+
 def _integrated_count(
     state_dir: Path,
     gap_id: str,
@@ -95,7 +187,14 @@ def _integrated_count(
 ) -> int:
     proposed: set[str] = set()
     successful: set[str] = set()
-    rows = ledger_rows if ledger_rows is not None else _rows(state_dir)
+    # #1166: when ledger_rows is provided (from demand.py's collect_demand,
+    # active file only), supplement with rotation-aware archive rows so a
+    # proposed→success pair split by midnight rotation is counted correctly.
+    # When ledger_rows is None, _rows handles both active and archives.
+    if ledger_rows is not None:
+        rows = _rows_archives(state_dir, after) + ledger_rows
+    else:
+        rows = _rows(state_dir, horizon=after)
     for row in rows:
         cycle = str(row.get("cycle_id") or "").strip()
         if not cycle:

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -3276,6 +3276,48 @@ class TestIssue1090DocGuard:
         assert len(calls) >= 2
 
 
+class TestIssue1166RotatedLedger:
+    """#1166: demand's shared ledger reader keeps rotation bounded and observable."""
+
+    def test_load_ledger_rows_reads_newest_rotated_archives_only(self, tmp_path):
+        import gzip
+
+        state_dir = _state_dir(tmp_path)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True)
+
+        def write_archive(day: str, cycle_id: str) -> None:
+            with gzip.open(ledger_dir / f"cycles-{day}.jsonl.gz", "wt", encoding="utf-8") as fh:
+                fh.write(json.dumps({"phase": "started", "cycle_id": cycle_id}) + "\n")
+
+        write_archive("2026-08-01", "too-old")
+        write_archive("2026-08-30", "newer-1")
+        write_archive("2026-08-31", "newer-2")
+        (ledger_dir / "cycles.jsonl").write_text(
+            json.dumps({"phase": "started", "cycle_id": "active"}) + "\n",
+            encoding="utf-8",
+        )
+
+        rows = demand._load_ledger_rows(state_dir)
+        cycle_ids = {row.get("cycle_id") for row in rows}
+        assert {"newer-1", "newer-2", "active"} <= cycle_ids
+        assert "too-old" not in cycle_ids
+
+    def test_oversized_active_ledger_is_observable_and_fail_open(self, tmp_path, caplog):
+        state_dir = _state_dir(tmp_path)
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True)
+        (ledger_dir / "cycles.jsonl").write_text(
+            "x" * (demand._MAX_LEDGER_BYTES + 1), encoding="utf-8"
+        )
+
+        with caplog.at_level("WARNING"):
+            rows = demand._load_ledger_rows(state_dir)
+
+        assert rows == []
+        assert any("oversized" in record.message for record in caplog.records)
+
+
 class TestIssue1040DemandIODiet:
     """#1040: cycle I/O diet test suite."""
 

--- a/tests/test_goal_gap_futility.py
+++ b/tests/test_goal_gap_futility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -110,3 +111,203 @@ def test_no_llm_and_snapshot(tmp_path):
     source = Path("nanobot/runtime/goal_gap_futility.py").read_text()
     assert not any(token in source for token in ("openai", "litellm", "LLMProvider"))
     assert futility.futility_snapshot(tmp_path / "state") == {"futile_gap_ids": [], "total_tracked": 0}
+
+
+# ---------------------------------------------------------------------------
+# #1166: rotation-aware ledger reading
+# ---------------------------------------------------------------------------
+
+def _write_gz_archive(state: Path, day: str, rows: list[dict]) -> None:
+    """Write rows to a rotated .gz archive named cycles-<day>.jsonl.gz."""
+    gz_path = state / "ledger" / f"cycles-{day}.jsonl.gz"
+    gz_path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(gz_path, "wt", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _write_active(state: Path, rows: list[dict]) -> None:
+    """Append rows to the active cycles.jsonl."""
+    active = state / "ledger" / "cycles.jsonl"
+    active.parent.mkdir(parents=True, exist_ok=True)
+    with active.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def test_rotation_split_proposed_gz_success_active(tmp_path, monkeypatch):
+    """#1166 primary fix: a proposed row in a rotated .gz archive plus its
+    matching outcome:success in the active file must be counted as one
+    integrated attempt.  This test FAILS against pre-#1166 code because the
+    old _rows() only scanned the active file and missed the archived proposed
+    row, so integrated_count returned 0 forever (futility never fired).
+    """
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "1")
+    state = tmp_path / "state"
+    gap_id = "goal-gap-rotated"
+
+    # First call to seed the first_seen_ts
+    first_ts = datetime(2026, 8, 31, 6, 0, 0, tzinfo=timezone.utc)
+    # Manually pre-seed the sidecar so first_seen is the known day before rotation
+    (state / "demand").mkdir(parents=True, exist_ok=True)
+    sidecar = state / "demand" / "futility.json"
+    sidecar.write_text(json.dumps({
+        gap_id: {
+            "gap_id": gap_id,
+            "metric": "repeat_failure_rate",
+            "first_seen_ts": first_ts.isoformat().replace("+00:00", "Z"),
+            "first_metric": 0.5,
+            "current_metric": 0.5,
+            "metric_delta": 0.0,
+            "attempt_count": 0,
+            "futile": False,
+        }
+    }), encoding="utf-8")
+
+    # proposed row in rotated archive (the day of first_seen)
+    _write_gz_archive(state, "2026-08-31", [
+        {
+            "phase": "proposed",
+            "cycle_id": "c-split",
+            "demand_id": gap_id,
+            "ts": "2026-08-31T10:00:00Z",
+        }
+    ])
+    # matching success row in active file (today)
+    _write_active(state, [
+        {
+            "phase": "outcome",
+            "cycle_id": "c-split",
+            "outcome": "success",
+            "integrated": True,
+            "ts": "2026-09-01T08:00:00Z",
+        }
+    ])
+
+    gap = _gap(gap_id=gap_id, current=0.5, direction="max")
+    result = futility.futile_gap_ids(state, [gap])
+    assert gap_id in result, (
+        f"Expected {gap_id!r} to be futile (rotation-split proposed+success), got {result!r}. "
+        "This indicates the archive was not scanned (pre-#1166 behavior)."
+    )
+
+
+def test_archive_bound_stops_at_horizon(tmp_path, monkeypatch):
+    """#1166 bound requirement: archives whose day is BEFORE the gap's
+    first_seen_ts horizon must NOT be read; only archives on or after the
+    horizon date are loaded.  This verifies the scan is bounded rather than
+    an unbounded full scan of all archives.
+    """
+    state = tmp_path / "state"
+    gap_id = "goal-gap-bound"
+
+    horizon = datetime(2026, 9, 1, 0, 0, 0, tzinfo=timezone.utc)  # bound is Sep 1
+
+    # Archive BEFORE horizon (Aug 30) – must NOT be read by _rows(horizon=...)
+    _write_gz_archive(state, "2026-08-30", [
+        {
+            "phase": "proposed",
+            "cycle_id": "c-before",
+            "demand_id": gap_id,
+            "ts": "2026-08-30T10:00:00Z",
+        }
+    ])
+    # Archive ON horizon (Sep 1) – MUST be read
+    _write_gz_archive(state, "2026-09-01", [
+        {
+            "phase": "proposed",
+            "cycle_id": "c-on-horizon",
+            "demand_id": gap_id,
+            "ts": "2026-09-01T01:00:00Z",
+        }
+    ])
+
+    rows = futility._rows(state, horizon=horizon)
+    cycle_ids = {r.get("cycle_id") for r in rows}
+
+    assert "c-on-horizon" in cycle_ids, "Archive on the horizon day must be included"
+    assert "c-before" not in cycle_ids, (
+        "Archive from before the horizon day must NOT be included (unbounded scan)"
+    )
+
+
+def test_oversized_vs_empty_distinguishable(tmp_path):
+    """#1166 secondary fix: an active ledger exceeding _MAX_LEDGER_BYTES must
+    return the _OVERSIZED sentinel, not [] (empty list), so the two cases are
+    distinguishable.  Empty file (or missing) must still return [].
+    """
+    state = tmp_path / "state"
+
+    # Missing file → plain empty list
+    result_missing = futility._rows_active(state)
+    assert result_missing == [], f"Missing ledger should return [], got {result_missing!r}"
+    assert result_missing is not futility._OVERSIZED
+
+    # Oversized file → _OVERSIZED sentinel (not a list)
+    ledger = state / "ledger" / "cycles.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    # Write enough bytes to exceed _MAX_LEDGER_BYTES (2 MiB)
+    big_row = "x" * 1024  # 1 KiB line
+    with ledger.open("w", encoding="utf-8") as fh:
+        for _ in range(3000):  # 3000 * ~1 KiB = ~3 MiB
+            fh.write(big_row + "\n")
+    result_oversized = futility._rows_active(state)
+    assert result_oversized is futility._OVERSIZED, (
+        f"Oversized ledger must return _OVERSIZED sentinel, got {result_oversized!r}"
+    )
+    assert result_oversized != [], "Oversized must not equal []"
+
+
+def test_rotation_split_via_ledger_rows_path(tmp_path, monkeypatch):
+    """#1166 ledger_rows supplementation: when demand.py passes ledger_rows
+    (active file only), futility must still supplement with archive rows so a
+    proposed→success pair split by midnight rotation is counted.
+    """
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "1")
+    state = tmp_path / "state"
+    gap_id = "goal-gap-lr-path"
+
+    first_ts = datetime(2026, 8, 31, 6, 0, 0, tzinfo=timezone.utc)
+    (state / "demand").mkdir(parents=True, exist_ok=True)
+    sidecar = state / "demand" / "futility.json"
+    sidecar.write_text(json.dumps({
+        gap_id: {
+            "gap_id": gap_id,
+            "metric": "repeat_failure_rate",
+            "first_seen_ts": first_ts.isoformat().replace("+00:00", "Z"),
+            "first_metric": 0.5,
+            "current_metric": 0.5,
+            "metric_delta": 0.0,
+            "attempt_count": 0,
+            "futile": False,
+        }
+    }), encoding="utf-8")
+
+    # proposed row in archive (only – NOT in active file)
+    _write_gz_archive(state, "2026-08-31", [
+        {
+            "phase": "proposed",
+            "cycle_id": "c-lr",
+            "demand_id": gap_id,
+            "ts": "2026-08-31T10:00:00Z",
+        }
+    ])
+    # success row in active file
+    success_row = {
+        "phase": "outcome",
+        "cycle_id": "c-lr",
+        "outcome": "success",
+        "integrated": True,
+        "ts": "2026-09-01T08:00:00Z",
+    }
+    _write_active(state, [success_row])
+
+    # Simulate demand.py passing ledger_rows with ONLY the active file rows
+    ledger_rows = [success_row]  # no archive rows (as demand.py would provide)
+
+    gap = _gap(gap_id=gap_id, current=0.5, direction="max")
+    result = futility.futile_gap_ids(state, [gap], ledger_rows=ledger_rows)
+    assert gap_id in result, (
+        f"Expected {gap_id!r} to be futile even via ledger_rows path (archive supplementation), "
+        f"got {result!r}"
+    )

--- a/tests/test_goal_gap_futility.py
+++ b/tests/test_goal_gap_futility.py
@@ -193,10 +193,10 @@ def test_rotation_split_proposed_gz_success_active(tmp_path, monkeypatch):
 
 
 def test_archive_bound_stops_at_horizon(tmp_path, monkeypatch):
-    """#1166 bound requirement: archives whose day is BEFORE the gap's
-    first_seen_ts horizon must NOT be read; only archives on or after the
-    horizon date are loaded.  This verifies the scan is bounded rather than
-    an unbounded full scan of all archives.
+    """#1166 bound requirement: archives before first_seen are not opened.
+
+    The open-call assertion proves this is a bounded horizon read rather than
+    merely filtering rows after decompressing every archive.
     """
     state = tmp_path / "state"
     gap_id = "goal-gap-bound"
@@ -222,12 +222,21 @@ def test_archive_bound_stops_at_horizon(tmp_path, monkeypatch):
         }
     ])
 
+    opened: list[str] = []
+    original_open = gzip.open
+
+    def recording_open(path, *args, **kwargs):
+        opened.append(Path(path).name)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(gzip, "open", recording_open)
     rows = futility._rows(state, horizon=horizon)
     cycle_ids = {r.get("cycle_id") for r in rows}
 
     assert "c-on-horizon" in cycle_ids, "Archive on the horizon day must be included"
-    assert "c-before" not in cycle_ids, (
-        "Archive from before the horizon day must NOT be included (unbounded scan)"
+    assert "c-before" not in cycle_ids, "Pre-horizon archive row must be excluded"
+    assert opened == ["cycles-2026-09-01.jsonl.gz"], (
+        "reader must not open archives older than first_seen horizon"
     )
 
 


### PR DESCRIPTION
## Summary

Fix goal-gap futility counting across ledger rotation without an unbounded archive scan. The futility reader uses each record’s `first_seen_ts` as its lower horizon, and the normal demand path supplies bounded rotated rows while the futility tracker shares one horizon-bounded archive read across all current gaps. Oversized active ledgers remain fail-open but emit a distinguishable warning.

## Architecture and safety

- `nanobot/runtime/goal_gap_futility.py` remains stdlib-only and has no LLM/provider calls.
- **No LLM is used anywhere in this path.**
- The futility archive reader opens only valid `cycles-YYYY-MM-DD.jsonl.gz` archives from the earliest current gap `first_seen_ts` date through today, iterating newest-first and stopping at the horizon. It does not scan archives older than the tracking horizon and does not reopen the same archive once per gap.
- `demand.py` follows the existing #790 bounded rotated-ledger discipline with `_LEDGER_MAX_GZ_FILES = 2` for its shared collection read. The futility tracker supplements the injected rows with one shared horizon-bounded archive read, because its tracking horizon is longer than the fixed demand fan-out bound.
- Oversized active ledgers are fail-open: active rows are skipped, archives remain readable, and a warning distinguishes `oversized` from an empty ledger. No cycle is blocked.

## Failing-test-first evidence

The decisive split fixture was run against pre-change `origin/main` before implementation. Verbatim result:

```text
E       AssertionError: Expected 'goal-gap-rotated' to be futile (rotation-split proposed+success), got set(). This indicates the archive was not scanned (pre-#1166 behavior).
E       assert 'goal-gap-rotated' in set()
```

After the fix, the fixture passes. The bound test instruments gzip opening and asserts that the pre-horizon archive is not opened, proving the reader does not decompress every archive and filter afterward.

## Test mapping

- Rotated proposed + live success: `test_rotation_split_proposed_gz_success_active`.
- Horizon bound / no pre-horizon archive open: `test_archive_bound_stops_at_horizon`.
- Oversized-vs-empty futility reader: `test_oversized_vs_empty_distinguishable`.
- `ledger_rows` path archive supplementation: `test_rotation_split_via_ledger_rows_path`.
- Shared demand reader rotated archive bound: `TestIssue1166RotatedLedger::test_load_ledger_rows_reads_newest_rotated_archives_only`.
- Shared demand reader oversized observability/fail-open: `TestIssue1166RotatedLedger::test_oversized_active_ledger_is_observable_and_fail_open`.

## Fixture provenance

Before shaping fixtures, sanitized read-only inspection of `eeepc-lan` confirmed the real schema and evidence shape: the live sidecar contains stable IDs `goal-gap-5d4d5a9dc822` and `goal-gap-acb65b1911ab`, with `metric`, `first_seen_ts`, numeric `first_metric`/`current_metric`, `metric_delta`, and `attempt_count`; the ledger is flat JSONL with `phase`, `cycle_id`, `demand_id`, `outcome`, `integrated`, and `ts`, and has 51 rotated `.jsonl.gz` archives. The issue’s supplied recomputation reports 19 proposed cycles and 8 successful intersections for `goal-gap-2d9ab3aa9d09`, while the live sidecar was still at zero. Tests preserve these real field names and row shapes, but use isolated disposable IDs and cycle rows; no live state was modified and no fabricated event is presented as live evidence. Host timestamps are MSK; all reported issue evidence timestamps are UTC.

## Verification

- Focused futility + demand tests: **183 passed**.
- `git diff --check`: passed.
- Branch commits: `2c8bb169`, `3f179dc1`, `8a225d15`.
- Branch is pushed and clean; `git log origin/fix/1166-rotated-futility..HEAD` is empty.
- A full local pytest attempt reached collection but is blocked by a pre-existing syntax error in `nanobot/agent/subagent.py:579`: `SyntaxError: duplicate argument 'context_usage' in function definition`. This is outside the four changed files and is not attributed to #1166. CI is authoritative.

Closes #1166 after merge; live verification is intentionally deferred to the operator-owned deploy. The dependent #996 issue remains `status:test` until a natural post-deploy sidecar count or `goal_gap_futile` event is observed.
