### PR TITLE
docs: align README naming language with #619 final state

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 This repository is the canonical `eeebot` project for the eeepc self-improving runtime and its operator-facing control/dashboard workflow.
 
-Important compatibility note:
-- the repository/project name is now `eeebot`
-- the internal Python package, CLI, and many runtime paths still use `nanobot` for compatibility with the existing deployed system, dashboard, and eeepc host
-- the package now exposes both CLI entrypoints during the compatibility window:
+Naming and compatibility (final state, decided in #619):
+- the repository/project and public identity are `eeebot`
+- the implementation and internal imports remain in the `nanobot` package permanently
+- `eeebot/` is a thin external compatibility layer for existing imports and user-facing surfaces
+- both CLI entrypoints are supported and must be preserved unless compatibility is explicitly retired:
   - `nanobot`
   - `eeebot`
-- renaming the package/runtime internals should be treated as a separate migration, not mixed into the GitHub repo rename
+- runtime paths and environment variables retain their established `nanobot` names, with documented `eeebot` fallbacks/aliases where applicable
 
 It is not a plain mirror of the upstream `HKUDS/nanobot` repository.
 It contains fork-specific work for:
@@ -64,7 +65,7 @@ Core operating docs:
 Capability specs (current product truth) live under `docs/specs/` — see `docs/specs/README.md`. Notably:
 - `docs/specs/self-evolving-runtime/spec.md`, `docs/specs/subagent-bridge/spec.md`
 - `docs/specs/promotion-and-release/spec.md`, `docs/specs/host-runtime/spec.md`
-- `docs/specs/migration/spec.md` (nanobot → eeebot rename guardrails, in progress)
+- `docs/specs/migration/spec.md` (final nanobot → eeebot naming state and permanent compatibility guardrails)
 
 Host runbooks:
 - `docs/EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ The contract layer — what is true now, per capability:
 - [`specs/model-routing`](specs/model-routing/spec.md) — task-type routing; executor = `un/qwen3.6-27b-mtp`.
 - [`specs/data-contracts`](specs/data-contracts/spec.md) — canonical schema/provenance types.
 - [`specs/chat-agent-framework`](specs/chat-agent-framework/spec.md) — pluggable channels, host↔bot comms.
-- [`specs/migration`](specs/migration/spec.md) — nanobot→eeebot rename guardrails (in progress).
+- [`specs/migration`](specs/migration/spec.md) — final nanobot→eeebot naming state and permanent compatibility guardrails.
 
 ## Reference docs (explanation)
 

--- a/tests/test_readme_naming_state.py
+++ b/tests/test_readme_naming_state.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README = REPO_ROOT / "README.md"
+DOCS_INDEX = REPO_ROOT / "docs" / "README.md"
+
+
+def test_readme_naming_docs_describe_final_state() -> None:
+    """Keep the public README wording aligned with the #619 naming decision."""
+    readme = README.read_text(encoding="utf-8")
+    docs_index = DOCS_INDEX.read_text(encoding="utf-8")
+
+    for text in (readme, docs_index):
+        assert "permanent" in text
+        assert "nanobot" in text
+        assert "eeebot" in text
+        assert "compatibility window" not in text
+        assert "in progress" not in text
+
+    assert "final state" in readme
+    assert "internal imports remain in the `nanobot` package permanently" in readme
+    assert "final nanobot→eeebot naming state" in docs_index


### PR DESCRIPTION
Closes #1180.

Updates README.md and docs/README.md to reflect the deliberate final naming state from #619/#622: internal nanobot package, public eeebot identity, and permanent compatibility shim. Adds a focused regression test preventing the stale compatibility-window and in-progress wording from returning.

No runtime code, secrets, or deployment configuration changed.