### PR TITLE
ops(bridge): remove stale approval keeper ordering reference

### DIFF
--- a/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
+++ b/host/eeepc/systemd/eeepc-self-evolving-subagent-bridge.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Run eeepc self-evolving subagent bridge
-After=network-online.target eeepc-self-evolving-approval-keeper.service
+After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Closes #1185.

Remove only the retired `eeepc-self-evolving-approval-keeper.service` from the bridge unit’s `After=` ordering list. Preserve the static oneshot service, timer cadence, and all other unit configuration.

Post-merge rollout will run daemon-reload and one bounded bridge/timer smoke check.