### PR TITLE
fix(curator): stop a 512 KiB cap from permanently disabling reflector minting

### DIFF
--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -900,6 +900,13 @@ def _collect_stage_items(
     return items, writes
 
 
+# Newest reflector rows considered for promotion. The tail read that finds
+# them is bounded by _MAX_LEDGER_TAIL_BYTES, which is a window into the end of
+# the file, not a limit on how large the log may grow (#1183).
+_REFLECTOR_TAIL_ROWS = 50
+_REFLECTOR_MAX_AGE_SECONDS = 90 * 86400
+
+
 def promote_reflector_recommendations_to_v2(
     workspace: Path, state_dir: Path, *, max_items: int = 2,
 ) -> int:
@@ -920,11 +927,53 @@ def promote_reflector_recommendations_to_v2(
             return 0
     try:
         stat = path.stat()
-        if stat.st_size > 512 * 1024 or time.time() - stat.st_mtime > 90 * 86400:
+        # The staleness guard stays. A reflector log untouched for 90 days
+        # describes a loop that stopped running, and promoting from it would
+        # mint lessons about a dead past. It is a claim about freshness, and it
+        # un-trips by itself the moment the loop writes again — unlike the size
+        # cap removed below, which an append-only file could only trip once.
+        if time.time() - stat.st_mtime > _REFLECTOR_MAX_AGE_SECONDS:
             return 0
-        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()[-50:] if line.strip()]
-    except Exception:
+        # #1183: this used to also `return 0` when the file exceeded 512 KiB.
+        # `reflections.jsonl` is append-only with no rotation, so it crossed
+        # that line once — on the host around 2026-08-29, at 699,393 bytes —
+        # and could never come back: the v2 reflector mint path was off
+        # permanently, and silently, because `return 0` is exactly what a
+        # healthy run with nothing to promote returns. The cap also defended
+        # nothing, since the read has always been bounded to the newest
+        # _REFLECTOR_TAIL_ROWS rows; it rejected the file to avoid a cost the
+        # next line never paid. Use the module's existing bounded tail reader
+        # instead, so cost follows the tail window and not the total size.
+        lines = _bounded_tail_lines(path, _REFLECTOR_TAIL_ROWS)
+    except OSError:
+        # Unreadable is not the same as "nothing to promote" (#1183). Both
+        # still return 0 — the caller counts promotions — but the reason is
+        # recorded so a dead path cannot pass for an idle one.
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "promote_reflector_recommendations_to_v2: cannot read %s; "
+            "no promotions attempted (unreadable, not empty)", path,
+        )
         return 0
+    rows = []
+    skipped = 0
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except ValueError:
+            # One malformed row previously aborted the whole promotion, and in
+            # an append-only log that too would have been permanent (#1183).
+            skipped += 1
+    if skipped:
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "promote_reflector_recommendations_to_v2: skipped %d unparseable "
+            "row(s) in %s", skipped, path,
+        )
     target = Path(workspace) / "lessons" / "lessons.yaml"
     existing = bounded_load_yaml(target)
     if not existing and target.exists():

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -186,6 +186,81 @@ def test_curator_folds_duplicate_and_upgrades_meaningless_solution(tmp_path: Pat
     assert cards[0]["seen_count"] == 2
 
 
+def _write_reflections_over(path: Path, min_bytes: int, tail_row: dict[str, object]) -> int:
+    """Write padding rows until *path* exceeds *min_bytes*, then *tail_row* last.
+
+    Padding rows carry no ``recommendations``, so nothing but *tail_row* is
+    promotable and the assertions cannot be satisfied by the filler.
+    """
+    filler = "x" * 800
+    written = 0
+    with path.open("w", encoding="utf-8") as handle:
+        while written <= min_bytes:
+            line = json.dumps({"cycle_id": f"cycle-pad-{written}", "summary": filler}) + "\n"
+            handle.write(line)
+            written += len(line)
+        handle.write(json.dumps(tail_row) + "\n")
+    return path.stat().st_size
+
+
+def test_curator_promotes_from_log_larger_than_the_old_size_cap(tmp_path: Path) -> None:
+    """#1183: a 512 KiB cap used to discard the whole file and return 0.
+
+    ``reflections.jsonl`` is append-only with no rotation, so on the host it
+    crossed that line once (699,393 bytes) and the reflector mint path was off
+    permanently. Only the newest rows are ever read, so total size must not
+    decide whether the file is readable at all.
+    """
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state" / "reflector"
+    workspace.mkdir()
+    state.mkdir(parents=True)
+    size = _write_reflections_over(
+        state / "reflections.jsonl",
+        512 * 1024,
+        {
+            "cycle_id": "cycle-oversize",
+            "summary": "Reflector found an unbounded read on a growing log",
+            "recommendations": [
+                {"kind": "approach_hint", "detail": "Read a bounded tail instead of the whole file"}
+            ],
+        },
+    )
+    assert size > 512 * 1024, size
+
+    assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    assert lessons["lessons"][0]["solution"] == "Read a bounded tail instead of the whole file"
+
+
+def test_curator_skips_unparseable_row_instead_of_abandoning_the_file(tmp_path: Path) -> None:
+    """#1183: one malformed line used to abort the whole promotion.
+
+    In an append-only log that failure is permanent too, so a single bad write
+    would silently retire the path in the same way the size cap did.
+    """
+    workspace = tmp_path / "workspace"
+    state = tmp_path / "state" / "reflector"
+    workspace.mkdir()
+    state.mkdir(parents=True)
+    (state / "reflections.jsonl").write_text(
+        '{"cycle_id": "cycle-truncated", "recommendations": [\n'
+        + json.dumps({
+            "cycle_id": "cycle-good",
+            "summary": "Reflector found a parser that aborts on one bad row",
+            "recommendations": [
+                {"kind": "error_pattern", "detail": "Skip the unparseable row and keep the rest"}
+            ],
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+    assert lessons["lessons"][0]["solution"] == "Skip the unparseable row and keep the rest"
+
+
 def test_curator_rejects_missing_or_filler_recommendation_detail(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     state = tmp_path / "state" / "reflector"


### PR DESCRIPTION
Closes #1183.

## What was wrong

`promote_reflector_recommendations_to_v2` opened with a cap that discarded the whole file:

```python
if stat.st_size > 512 * 1024 or time.time() - stat.st_mtime > 90 * 86400:
    return 0
rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()[-50:] if line.strip()]
```

`reflections.jsonl` is append-only with no rotation. On the host it is **699,393 bytes**, so the function returned 0 before parsing anything — and `return 0` is exactly what a healthy run with nothing to promote returns. The v2 reflector mint path has been off since roughly 2026-08-29, silently, with **386 validly-structured recommendations** sitting unread (measured on #1171).

The cap also defended nothing: the line immediately after it reads only `[-50:]`. It rejected the file to avoid a cost the next statement never paid, and because the file only grows, the trip was one-way.

Downstream consequence: #1106 fixed the *content* of minted reflector lessons and measured zero knowledge lift. This is why — there was nothing being minted for it to improve.

## Change

- Read the newest rows with the module's existing `_bounded_tail_lines` (already used twice in this file at lines 316 and 468), whose cost follows the 256,000-byte tail window rather than total file size. On the host the newest 50 rows are **23,416 bytes**, so the window has an order of magnitude of headroom. Largest single row in the last 200 is 3,012 bytes.
- Keep the 90-day staleness guard deliberately. It is a claim about freshness and un-trips as soon as the loop writes again; a size cap on an append-only file can only trip once. The comment says so.
- Skip and count unparseable rows instead of aborting the whole promotion. One malformed line previously killed the entire pass, and in an append-only log that failure would have been permanent too — the same defect in a different costume.
- Log unreadable distinctly from "nothing to promote", so a dead path cannot pass for an idle one.

## Evidence

**New tests fail against the pre-change tree.** Ran both against `origin/main` before the fix existed:

```
FAILED tests/test_lesson_v2.py::test_curator_promotes_from_log_larger_than_the_old_size_cap
FAILED tests/test_lesson_v2.py::test_curator_skips_unparseable_row_instead_of_abandoning_the_file
E       AssertionError: assert 0 == 1
2 failed, 17 deselected
```

**Real host data, before and after.** Copied the live `reflections.jsonl` (701,916 bytes at the time of the run) into a sandbox and called the function on a detached worktree at `a76c9a81` and on this branch:

```
pre-fix  (a76c9a81, cap present): promoted 0,  lessons.yaml written: False
post-fix (this branch):           promoted 2
  LESS-REF-ede3db143e66-d77f  solution: Isolate validator parsing logic and test error-handling edge cases…
  LESS-REF-9f814922e174-d200  solution: Check existing CLI arguments and function signatures prior to proposing new feature tasks…
```

Neither solution is the `Apply the reflected approach hint.` filler that all four existing v2 cards carry — so #1106's content fix works; it simply had no events to act on.

**Full suite** (shared runtime module, so not just the touched files): `19 failed, 2787 passed, 17 skipped` on Windows. That matches the known Windows baseline exactly — 10 `autoevolve*`, 3 `bridge_locking` (flock), 2 `selfevo_export_security`, 1 `bridge_cycle_tags`, 1 `test_commands.py::test_runtime_state_prefers_newest_evolution_report` (the #1168 mtime-tie flake), 2 `autoevolve_state`. **None in `test_lesson_v2.py` or any curator test.** Linux CI is the authority.

## Live verification (mine to run, not claimed here)

The path is live: `eeebot-knowledge-curator.timer` fires daily at 00:00 MSK and last ran 2026-09-02 00:00:19 MSK, writing `state/curator/decisions.jsonl` and `watermark.json`. `run_curation` calls this function on its first line (`knowledge_curator.py:1059`).

So the check is the next curator run after deploy — **2026-09-03 00:00 MSK / 2026-09-02 21:00 UTC**. Expected: at least one new `LESS-REF-*` card in `lessons.yaml` with a non-filler solution, dated after the deploy. If none appears, that is a result to report, not to explain away.

## Note on the class

This is the third instance this week of a bound meant to keep a read cheap becoming a permanent silent zero — #1166 (rotation), #1178 (256 KB scorecard-history cliff), this one. Belongs under ADR #1173. I did not add a replacement cap, deliberately: the tail read is the bound.
