### PR TITLE
fix(1182): make the strategist's archive inputs alive, bounded and provenance-carrying

### DIFF
--- a/docs/TRUST_KERNEL.md
+++ b/docs/TRUST_KERNEL.md
@@ -45,6 +45,7 @@ nanobot/runtime/goal_gap_futility.py
 nanobot/runtime/state_access.py
 nanobot/runtime/skill_candidate_mining.py
 nanobot/runtime/strategist.py
+nanobot/runtime/strategist_inputs.py
 nanobot/runtime/test_guard.py
 ```
 
@@ -83,6 +84,7 @@ manifest and compares it to the code constant, preserving an exact-set check.
 | Repeat-failure metric laundering | Only `recent_duplicate_failure` skips and `self_dedup` rejects enter `repeat_failure_rate`; healthy skips and steering-only records do not | `nanobot/runtime/scorecard.py` module contract and `_loop_section` | `tests/test_scorecard.py`; #977/#980/#983 |
 | Context/identity steering confusion | Product and instance `AGENTS.md` are distinct; steering text is not trusted as fitness or gate evidence | `AGENTS.md`, `CONSTITUTION.md`, runtime prompt construction and harness trust boundaries | import/hygiene and harness tests; #619/#789 |
 | Test-weakening reward hack | Deterministic pre-smoke-gate diff scan blocks deleted/gutted/newly-skipped existing test files; runs on every gate re-run, recorded reason `test_weakening` | `nanobot/runtime/test_guard.py:evaluate`; `nanobot/runtime/bridge.py:_check_test_weakening` | `tests/test_test_guard.py`; #1119 |
+| Strategist advising from an empty archive view | Bounded, status-carrying archive readers; the run refuses the LLM call when more than one of the five inputs is empty and records `inputs_status` in every decision | `nanobot/runtime/strategist_inputs.py:INPUT_NAMES`, `should_refuse`, `ledger_rows`; `nanobot/runtime/strategist.py:run_strategist`, `collect_inputs` | `tests/test_strategist_inputs.py`; #1182 |
 
 ## Deliberate reader asymmetry
 

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -132,6 +132,9 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     'nanobot/runtime/skill_candidate_mining.py',
     # #999: strategist periodic archive reviewer.
     'nanobot/runtime/strategist.py',
+    # #1182: the strategist's bounded archive inputs and the refuse-to-advise
+    # gate; the instance must not widen what the advisor reads or disable the gate.
+    'nanobot/runtime/strategist_inputs.py',
     # #1119: deterministic test-weakening detector — the module itself must
     # be immutable, otherwise the instance could simply neuter its own
     # reward-hack check instead of restoring the weakened test it flags. No

--- a/nanobot/runtime/strategist.py
+++ b/nanobot/runtime/strategist.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from nanobot.runtime import strategist_inputs
 from nanobot.runtime.model_registry import resolve_model
 
 LOG = logging.getLogger(__name__)
@@ -19,8 +20,20 @@ SCHEMA = "strategist-hadi-v1"
 DEFAULT_H = 3
 DEFAULT_F = 2
 _MAX_SECTION = 8_000
-_MAX_TEXT = 4_000
 _MAX_PROMPT_CHARS = 48_000
+# Size guards for the small point-in-time files this module reads itself
+# (watermark, decisions tail, futility sidecar). Archive inputs live in
+# strategist_inputs with their own bounds.
+_MAX_JSON_BYTES = 256_000
+_MAX_LINES_FILE_BYTES = 256_000
+# Decision reason when the archive view is too empty to advise on (#1182).
+REASON_INPUTS_UNAVAILABLE = "inputs_unavailable"
+# Prompt budget: while the payload is over the cap, the largest of these
+# sections is halved (goals, the tree digest, the futility sidecar and
+# inputs_status are never shrunk); every halving is recorded in inputs_status.
+_HALVING_SECTIONS = ("lessons", "prior_decisions", "recent_cycles", "insights", "funnel", "scorecard")
+_HALVING_STEPS = 48  # 6 sections x 8 halvings (1/256 each) before the truncated fallback
+_HALVING_KEEP = {"columns"}  # table headers inside a section, not data
 
 def _now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -42,7 +55,7 @@ def _env_int(name: str, default: int) -> int:
 
 def _load_json(path: Path, default: Any = None) -> Any:
     try:
-        if not path.is_file() or path.stat().st_size > 256_000:
+        if not path.is_file() or path.stat().st_size > _MAX_JSON_BYTES:
             return default
         return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
@@ -82,7 +95,7 @@ def save_watermark(state_root: Path, value: dict[str, Any]) -> None:
 
 def _read_lines(path: Path, limit: int) -> list[str]:
     try:
-        if not path.is_file() or path.stat().st_size > 256_000:
+        if not path.is_file() or path.stat().st_size > _MAX_LINES_FILE_BYTES:
             return []
         opener = gzip.open if path.name.endswith(".gz") else open
         with opener(path, "rt", encoding="utf-8") as fh:
@@ -97,131 +110,50 @@ def _read_lines(path: Path, limit: int) -> list[str]:
         return []
 
 def _tree_digest(state_root: Path) -> dict[str, Any]:
-    tree = _load_json(Path(state_root) / "evolution" / "tree.json", {})
-    if not isinstance(tree, dict):
-        return {"node_count": 0, "current_best_path": [], "fitness_summary": {"chain_depth": 0, "reward_count": 0, "reward_mean": None, "reward_max": None}}
-    nodes_raw = tree.get("nodes")
-    node_map: dict[str, dict[str, Any]] = {}
-    if isinstance(nodes_raw, dict):
-        node_map = {str(k): v for k, v in nodes_raw.items() if isinstance(v, dict)}
-    elif isinstance(nodes_raw, list):
-        node_map = {
-            str(node.get("sha") or node.get("id")): node
-            for node in nodes_raw
-            if isinstance(node, dict) and (node.get("sha") or node.get("id"))
-        }
-    nodes = list(node_map.values())
-    current = tree.get("current_sha")
-    current_str = str(current) if current else ""
-    best_path: list[str] = []
-    curr = current_str
-    while curr and curr in node_map and len(best_path) < 20:
-        best_path.append(curr)
-        parent = node_map[curr].get("parent_sha")
-        curr = str(parent) if parent else ""
-
-    rewards: list[float] = []
-    for node in nodes[:500]:
-        fitness = node.get("fitness")
-        if isinstance(fitness, dict):
-            reward = fitness.get("reward")
-            if isinstance(reward, (int, float)):
-                rewards.append(float(reward))
-
-    return {
-        "node_count": len(nodes),
-        "current_best_path": best_path,
-        "fitness_summary": {
-            "chain_depth": len(best_path),
-            "reward_count": len(rewards),
-            "reward_mean": sum(rewards) / len(rewards) if rewards else None,
-            "reward_max": max(rewards) if rewards else None,
-        },
-    }
-
-def _scorecard_input(state_root: Path) -> dict[str, Any]:
-    latest = _load_json(Path(state_root) / "scorecard" / "latest.json", {})
-    if not isinstance(latest, dict) or not latest:
-        legacy = _load_json(Path(state_root) / "scorecard.json", {})
-        latest = legacy if isinstance(legacy, dict) else {}
-    history: list[Any] = []
-    cutoff = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=7)
-    for line in _read_lines(Path(state_root) / "scorecard" / "history.jsonl", 200):
-        try:
-            row = json.loads(line)
-            stamp = row.get("computed_at_utc") or row.get("timestamp") or row.get("ts")
-            parsed = dt.datetime.fromisoformat(str(stamp).replace("Z", "+00:00")) if stamp else None
-            if parsed is not None and parsed >= cutoff:
-                history.append(row)
-        except Exception:
-            continue
-    return {
-        "latest": _cap(latest, _MAX_SECTION),
-        "history_7d": _cap(history, 100),
-    }
-
-def _funnel_input(state_root: Path) -> dict[str, Any]:
-    records: dict[str, dict[str, int]] = {}
-    cycle_demands: dict[str, str] = {}
-    rows: list[dict[str, Any]] = []
-    ledger = Path(state_root) / "ledger" / "cycles.jsonl"
-    ledger_paths = [ledger, *sorted(ledger.parent.glob("cycles-*.jsonl.gz"))]
-    for ledger_path in ledger_paths:
-        rows.extend(json.loads(line) for line in _read_lines(ledger_path, 500) if _json_object(line))
-    for row in rows:
-        demand_id = str(row.get("demand_id") or "").strip()
-        phase = str(row.get("phase") or "")
-        cycle_id = str(row.get("cycle_id") or "").strip()
-        if phase == "proposed" and demand_id:
-            cycle_demands[cycle_id] = demand_id
-            records.setdefault(demand_id, {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0})["proposed"] += 1
-        elif phase == "proposer_reject" and demand_id and str(row.get("reason")) == "self_dedup":
-            records.setdefault(demand_id, {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0})["self_dedup"] += 1
-        elif phase == "outcome" and str(row.get("outcome")) == "success":
-            linked = cycle_demands.get(cycle_id)
-            if linked:
-                records[linked]["integrated"] += 1
-    futile = _load_json(Path(state_root) / "demand" / "futility.json", {})
-    futile_ids = set(futile.get("futile_gap_ids", [])) if isinstance(futile, dict) else set()
-    for demand_id in futile_ids:
-        records.setdefault(str(demand_id), {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0})["futile"] = 1
-    return {"by_demand_id": _cap(records, 200), "futility_sidecar": _cap(futile, 2_000)}
-
-def _insight_input(repo_root: Path) -> dict[str, Any]:
-    reusable: list[str] = []
-    for path in sorted((Path(repo_root) / "lessons").glob("*.yaml")):
-        reusable.extend(line[:500] for line in _read_lines(path, 200) if "reusable_insight" in line)
-    indexes = {}
-    for rel in ("memory/index.md", "docs/index.md"):
-        path = Path(repo_root) / rel
-        try:
-            indexes[rel] = path.read_text(encoding="utf-8")[:_MAX_TEXT]
-        except Exception:
-            indexes[rel] = ""
-    return {"reusable_insights": reusable[-30:], "indexes": indexes}
+    """Tree digest without the ledger outcome join; :func:`collect_inputs`
+    uses the joined form from ``strategist_inputs.tree_digest``."""
+    return strategist_inputs.tree_digest(Path(state_root))[0]
 
 def collect_inputs(state_root: Path, repo_root: Path) -> dict[str, Any]:
-    """Build capped archive inputs; never enumerate the repo."""
-    goals = ""
-    try:
-        goals = (Path(repo_root) / "goals.md").read_text(encoding="utf-8")[:_MAX_TEXT]
-    except Exception:
-        pass
-    scorecard = _scorecard_input(state_root)
-    funnel = _funnel_input(state_root)
-    insight_data = _insight_input(repo_root)
+    """Build capped archive inputs with per-input provenance; never enumerate the repo.
+
+    Each archive section comes from ``strategist_inputs`` and reports its
+    status under ``inputs_status`` so :func:`run_strategist` can refuse to
+    advise on a mostly empty view (#1182). ``recent_cycles`` and
+    ``prior_decisions`` are context, not inputs, and carry no status.
+    """
+    state_root, repo_root = Path(state_root), Path(repo_root)
+    goals, goals_meta = strategist_inputs.charter_input(state_root)
+    scorecard, scorecard_meta = strategist_inputs.scorecard_input(state_root)
+    rows, ledger_meta = strategist_inputs.ledger_rows(state_root)
+    futility = _load_json(state_root / "demand" / "futility.json", {})
+    funnel, funnel_meta = strategist_inputs.funnel_input(rows, futility)
+    tree, tree_meta = strategist_inputs.tree_digest(state_root, rows)
+    insights, insights_meta = strategist_inputs.insights_input(repo_root)
+    live_ledger = state_root / "ledger" / "cycles.jsonl"
+    recent_path = live_ledger if live_ledger.is_file() else state_root / "cycle_ledger.jsonl"
+    recent = [json.loads(line) for line in _read_lines(recent_path, 50) if _json_object(line)]
+    prior = [json.loads(line) for line in _read_lines(state_root / "strategist" / "decisions.jsonl", 10) if _json_object(line)]
     return {
-        "evolution_tree": _tree_digest(state_root),
-        "scorecard": scorecard,
+        "evolution_tree": tree,
+        "scorecard": {"latest": _cap(scorecard["latest"], _MAX_SECTION), "history_7d": scorecard["history_7d"]},
         "funnel": funnel,
-        "futility": funnel.get("futility_sidecar", {}),
-        "insights": insight_data,
+        "futility": _cap(futility, 2_000),
+        "insights": {key: value for key, value in insights.items() if key != "legacy_insights"},
         "goals": goals,
-        "lessons": insight_data.get("reusable_insights", []) + _read_lines(Path(repo_root) / "lessons" / "lessons.yaml", 30),
-        "recent_cycles": [json.loads(line) for line in _read_lines(
-            Path(state_root) / "ledger" / "cycles.jsonl" if (Path(state_root) / "ledger" / "cycles.jsonl").is_file() else Path(state_root) / "cycle_ledger.jsonl", 50
-        ) if _json_object(line)],
-        "prior_decisions": [json.loads(line) for line in _read_lines(Path(state_root) / "strategist" / "decisions.jsonl", 10) if _json_object(line)],
+        "lessons": insights["legacy_insights"],  # legacy lessons.yaml rows; v2 cards are insights.cards
+        "recent_cycles": recent,
+        # a prior row's own inputs_status is provenance, not advice context
+        "prior_decisions": [{k: v for k, v in row.items() if k != "inputs_status"} for row in prior],
+        "inputs_status": {
+            "goals": goals_meta,
+            "scorecard": scorecard_meta,
+            "funnel": {**funnel_meta, "ledger": ledger_meta},
+            "insights": insights_meta,
+            "evolution_tree": tree_meta,
+            "recent_cycles": len(recent),
+            "halved": [],  # filled by build_strategist_prompt when it shrinks sections
+        },
     }
 
 def _json_object(line: str) -> bool:
@@ -248,22 +180,43 @@ def build_strategist_prompt(inputs: dict[str, Any], watermark: dict[str, Any]) -
     encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
     if len(encoded) > _MAX_PROMPT_CHARS:
         archive = payload["archive"]
-        for key in ("lessons", "prior_decisions", "recent_cycles", "insights", "funnel", "scorecard"):
+        status = archive.get("inputs_status")
+        halved = status.setdefault("halved", []) if isinstance(status, dict) else []
+        for _ in range(_HALVING_STEPS):
             if len(encoded) <= _MAX_PROMPT_CHARS:
                 break
-            value = archive.get(key)
-            if isinstance(value, list):
-                archive[key] = value[: max(1, len(value) // 2)]
-            elif isinstance(value, dict):
-                archive[key] = {k: v for k, v in list(value.items())[: max(1, len(value) // 2)]}
-            elif isinstance(value, str):
-                archive[key] = value[: max(1, len(value) // 2)]
+            sizes = {key: len(json.dumps(archive.get(key), ensure_ascii=False)) for key in _HALVING_SECTIONS}
+            label = _halve_section(archive, max(sizes, key=sizes.get))
+            if label is None:
+                break
+            halved.append(label)
             encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         if len(encoded) > _MAX_PROMPT_CHARS:
             encoded = json.dumps({"schema": SCHEMA, "watermark": _cap(watermark, 200), "archive": {"truncated": True}}, ensure_ascii=False)
         if len(encoded) > _MAX_PROMPT_CHARS:
             encoded = encoded[:_MAX_PROMPT_CHARS]
     return system, encoded
+
+def _halve_section(archive: dict[str, Any], key: str) -> str | None:
+    """Halve one prompt section in place. Lists and strings keep their first
+    half; a dict halves its largest list/dict/str member (so a one-key section
+    such as ``funnel.by_demand_id`` still shrinks, newest ids first). Returns
+    the label recorded under ``inputs_status.halved``, ``None`` if nothing
+    shrinkable is left."""
+    value = archive.get(key)
+    if isinstance(value, (list, str)):
+        if len(value) <= 1:
+            return None
+        archive[key] = value[: len(value) // 2]
+        return key
+    if not isinstance(value, dict):
+        return None
+    members = [(k, v) for k, v in value.items() if k not in _HALVING_KEEP and isinstance(v, (list, dict, str)) and len(v) > 1]
+    if not members:
+        return None
+    name, member = max(members, key=lambda item: len(json.dumps(item[1], ensure_ascii=False)))
+    value[name] = dict(list(member.items())[: len(member) // 2]) if isinstance(member, dict) else member[: len(member) // 2]
+    return f"{key}.{name}"
 
 def _text_field(value: Any, limit: int = 1_000) -> bool:
     return isinstance(value, str) and bool(value.strip()) and len(value) <= limit
@@ -343,6 +296,15 @@ def run_strategist(state_root: Path, repo_root: Path, llm: Callable[[list[dict[s
     decision: dict[str, Any] = {"timestamp": _now(), "model": model, "success": False}
     try:
         inputs = collect_inputs(state_root, repo_root)
+        decision["inputs_status"] = inputs["inputs_status"]
+        if strategist_inputs.should_refuse(inputs["inputs_status"]):
+            # Class B reader (#1173): advice generated from a mostly empty
+            # archive view is worse than none. No LLM call, no writes; the
+            # watermark stays so the next run retries against fresh inputs.
+            decision.update({"prompt_chars": 0, "reason": REASON_INPUTS_UNAVAILABLE,
+                             "empty_inputs": strategist_inputs.empty_inputs(inputs["inputs_status"])})
+            _record_decision(state_root, decision)
+            return decision
         system, user = build_strategist_prompt(inputs, old)
         decision["prompt_chars"] = len(user)
         raw = (llm or _default_llm)([{"role": "system", "content": system}, {"role": "user", "content": user}], model)
@@ -366,19 +328,41 @@ def run_strategist(state_root: Path, repo_root: Path, llm: Callable[[list[dict[s
             _append_jsonl(Path(state_root) / "strategist" / "errors.jsonl", {"timestamp": decision["timestamp"], "error": str(exc)[:500]})
         except Exception:
             LOG.exception("unable to record strategist error")
+    _record_decision(state_root, decision)
+    return decision
+
+def _record_decision(state_root: Path, decision: dict[str, Any]) -> None:
     try:
         _append_jsonl(Path(state_root) / "strategist" / "decisions.jsonl", decision)
     except Exception:
         LOG.exception("unable to record strategist decision")
-    return decision
+
+def inputs_report(state_root: Path, repo_root: Path) -> dict[str, Any]:
+    """What :func:`run_strategist` would see and decide, without the LLM call
+    and without writing anything: the operator's pre-enable check (#1182)."""
+    state_root = Path(state_root)
+    inputs = collect_inputs(state_root, Path(repo_root))
+    _, user = build_strategist_prompt(inputs, load_watermark(state_root))
+    status = inputs["inputs_status"]
+    return {"timestamp": _now(), "dry_run": True, "inputs_status": status, "prompt_chars": len(user),
+            "empty_inputs": strategist_inputs.empty_inputs(status), "would_refuse": strategist_inputs.should_refuse(status)}
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the eeebot strategist (#999)")
     parser.add_argument("--state-root", type=Path, required=True)
     parser.add_argument("--repo", type=Path, required=True)
-    result = run_strategist(parser.parse_args().state_root, parser.parse_args().repo)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print inputs_status and the refusal verdict; no LLM call, no writes")
+    args = parser.parse_args()
+    if args.dry_run:
+        print(json.dumps(inputs_report(args.state_root, args.repo), ensure_ascii=False))
+        return 0
+    result = run_strategist(args.state_root, args.repo)
     print(json.dumps(result, ensure_ascii=False))
-    return 0 if result.get("success") else 1
+    # Refusing to advise is the input gate working, not a failure: exit 0 so
+    # systemd does not mark the timer's service failed; the decisions.jsonl
+    # row carries the reason.
+    return 0 if result.get("success") or result.get("reason") == REASON_INPUTS_UNAVAILABLE else 1
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/nanobot/runtime/strategist_inputs.py
+++ b/nanobot/runtime/strategist_inputs.py
@@ -1,0 +1,325 @@
+"""Bounded, provenance-carrying archive inputs for the strategist role (#1182).
+
+Every reader returns a value AND a status ("complete" | "partial" | "empty") so
+:func:`nanobot.runtime.strategist.run_strategist` can refuse the LLM call when
+the archive view is mostly empty instead of advising from nothing. Readers never
+raise; failures degrade to "empty" with a note. Stdlib only.
+
+:func:`ledger_rows` is a narrow, horizon-bounded read of the live
+``cycles.jsonl`` plus the rotated ``cycles-YYYY-MM-DD.jsonl.gz`` archives
+(``cycle_ledger`` writes one per UTC day). It should collapse into the shared
+``state_access.ledger_window`` reader from #1174 when that lands; it mirrors
+that contract's meta fields (``covered_from``, ``files_read``, ``files_skipped``,
+``bytes_read``, ``status``).
+"""
+from __future__ import annotations
+
+import datetime as dt
+import gzip
+import json
+import statistics
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+# Point-in-time JSON sidecars (tree, scorecard latest, goal_text).
+_MAX_JSON_BYTES = 256_000
+# Ledger window for the funnel and the tree outcome mix.
+_FUNNEL_HORIZON_DAYS = 30
+_FUNNEL_MAX_IDS = 200
+FUNNEL_COLUMNS = ("proposed", "integrated", "self_dedup", "futile", "attempt_count")
+_LEDGER_MAX_BYTES = 8 * 1024 * 1024
+_LEDGER_PHASES = ("proposed", "proposer_reject", "outcome", "evolution_tree")
+# scorecard/history.jsonl: one ~3 KB row per recompute (~48/day live), so the
+# prompt gets a sampled trend of numeric leaves, not rows.
+_HISTORY_TAIL_ROWS = 400
+_HISTORY_MAX_FILE_BYTES = 8 * 1024 * 1024
+_HISTORY_DAYS = 7
+_HISTORY_SAMPLES = 8
+_HISTORY_MAX_SERIES = 60
+_HISTORY_MAX_DEPTH = 3
+# Insight sources: v2 lesson cards, legacy ``generalized_insight`` rows, errors.
+_INSIGHTS_V2 = 10
+_INSIGHTS_LEGACY = 10
+_INSIGHTS_ERRORS = 5
+_INSIGHT_TEXT_CHARS = 200
+_INDEX_CHARS = 2_000
+_TREE_BEST_PATH_HOPS = 20
+_MAX_TEXT = 4_000
+# Inputs the strategist conditions on; more than _MAX_EMPTY_INPUTS empty => refuse.
+INPUT_NAMES = ("goals", "scorecard", "funnel", "insights", "evolution_tree")
+_MAX_EMPTY_INPUTS = 1
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+def _parse_ts(value: Any) -> dt.datetime | None:
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
+    except Exception:
+        return None
+
+def load_json(path: Path, default: Any = None, max_bytes: int = _MAX_JSON_BYTES) -> Any:
+    """Bounded JSON read; ``default`` on absent/oversize/corrupt."""
+    try:
+        if not path.is_file() or path.stat().st_size > max_bytes:
+            return default
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+def _read_lines(path: Path) -> list[str] | None:
+    """All lines of a text or ``.gz`` file; ``None`` when unreadable/corrupt."""
+    opener = gzip.open if path.name.endswith(".gz") else open
+    try:
+        with opener(path, "rt", encoding="utf-8") as handle:
+            return handle.readlines()
+    except Exception:
+        return None
+
+def ledger_rows(state_root: Path, horizon_days: int = _FUNNEL_HORIZON_DAYS) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Rows with a phase in :data:`_LEDGER_PHASES` from archives inside the
+    horizon (oldest first, by the date in the file name) then the live file.
+    Substring-prefilters before ``json.loads``; skips corrupt files per file."""
+    ledger_dir = Path(state_root) / "ledger"
+    cutoff = (_utcnow() - dt.timedelta(days=horizon_days)).date()
+    meta: dict[str, Any] = {"files_read": 0, "files_skipped": 0, "bytes_read": 0, "covered_from": None, "status": "empty", "notes": []}
+    paths: list[Path] = []
+    for gz_path in sorted(ledger_dir.glob("cycles-*.jsonl.gz")):
+        try:
+            day = dt.date.fromisoformat(gz_path.name[len("cycles-"):-len(".jsonl.gz")])
+        except ValueError:
+            meta["files_skipped"] += 1
+            meta["notes"].append(f"bad_name:{gz_path.name}")
+            continue
+        if day >= cutoff:
+            paths.append(gz_path)
+    live = ledger_dir / "cycles.jsonl"
+    if live.is_file():
+        paths.append(live)
+    # cycle_ledger writes json.dumps default separators; accept the compact form too.
+    needles = tuple(f'"phase":{sep}"{phase}"' for phase in _LEDGER_PHASES for sep in (" ", ""))
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        lines = _read_lines(path)
+        if lines is None:
+            meta["files_skipped"] += 1
+            meta["notes"].append(f"unreadable:{path.name}")
+            meta["status"] = "partial"
+            continue
+        meta["files_read"] += 1
+        for line in lines:
+            meta["bytes_read"] += len(line)
+            if meta["bytes_read"] > _LEDGER_MAX_BYTES:
+                meta["status"] = "partial"
+                meta["notes"].append("cap_bytes")
+                break
+            if not any(needle in line for needle in needles):
+                continue
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(row, dict):
+                rows.append(row)
+        if "cap_bytes" in meta["notes"]:
+            break
+    stamps = [str(r.get("ts")) for r in rows if r.get("ts")]
+    meta["covered_from"] = min(stamps) if stamps else None
+    if rows and meta["status"] != "partial":
+        meta["status"] = "complete"
+    return rows, meta
+
+def charter_input(state_root: Path) -> tuple[str, dict[str, Any]]:
+    """The operator charter: ``<RELEASE_ROOT>/goals.md`` (the path the proposer
+    reads, #944), falling back to ``state/goals/goal_text.json`` ``text``."""
+    from nanobot.runtime.goal_review import read_charter_text
+    from nanobot.runtime.llm_proposer import _release_root_from_env
+
+    text = read_charter_text(_release_root_from_env())
+    source = "release_root"
+    if not text:
+        legacy = load_json(Path(state_root) / "goals" / "goal_text.json", {})
+        text = str(legacy.get("text") or "") if isinstance(legacy, dict) else ""
+        source = "goal_text.json" if text else "none"
+    text = text[:_MAX_TEXT]
+    return text, {"chars": len(text), "source": source, "status": "complete" if text else "empty"}
+
+def _history_rows(path: Path) -> list[dict[str, Any]]:
+    """Newest :data:`_HISTORY_TAIL_ROWS` rows of ``path`` inside the 7-day window."""
+    try:
+        if not path.is_file() or path.stat().st_size > _HISTORY_MAX_FILE_BYTES:
+            return []
+    except OSError:
+        return []
+    tail: deque[str] = deque((line for line in _read_lines(path) or () if line.strip()), maxlen=_HISTORY_TAIL_ROWS)
+    cutoff = _utcnow() - dt.timedelta(days=_HISTORY_DAYS)
+    rows: list[dict[str, Any]] = []
+    for line in tail:
+        try:
+            row = json.loads(line)
+        except Exception:
+            continue
+        stamp = _parse_ts(row.get("computed_at_utc") or row.get("timestamp") or row.get("ts")) if isinstance(row, dict) else None
+        if stamp is not None and stamp >= cutoff:
+            rows.append(row)
+    return rows
+
+def _sample(rows: list[Any], limit: int) -> list[Any]:
+    """Evenly spaced subsequence of ``rows`` from the oldest to the newest row."""
+    if len(rows) <= limit:
+        return rows
+    step = (len(rows) - 1) / (limit - 1)
+    return [rows[round(i * step)] for i in range(limit)]
+
+def _numeric_leaves(value: Any, prefix: str = "", depth: int = 0, out: dict[str, float] | None = None) -> dict[str, float]:
+    out = {} if out is None else out
+    if isinstance(value, dict) and depth < _HISTORY_MAX_DEPTH:
+        for key, member in value.items():
+            _numeric_leaves(member, f"{prefix}{key}.", depth + 1, out)
+    elif isinstance(value, (int, float)) and not isinstance(value, bool):
+        out[prefix[:-1]] = round(float(value), 4)
+    return out
+
+def history_series(rows: list[dict[str, Any]], samples: int = _HISTORY_SAMPLES) -> dict[str, Any]:
+    """Trend view: ``samples`` rows evenly spaced oldest→newest, one series per
+    dotted numeric path (depth ≤ 3); paths whose value moved come first."""
+    picked = _sample(rows, samples)
+    flat = [_numeric_leaves(row) for row in picked]
+    series = {path: [row.get(path) for row in flat] for path in sorted({p for row in flat for p in row})}
+    moved = sorted(series, key=lambda p: (len({v for v in series[p] if v is not None}) <= 1, p))
+    return {"samples": [str(r.get("computed_at_utc") or r.get("timestamp") or r.get("ts")) for r in picked],
+            "series": {path: series[path] for path in moved[:_HISTORY_MAX_SERIES]}}
+
+def scorecard_input(state_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    root = Path(state_root)
+    latest = load_json(root / "scorecard" / "latest.json", {})
+    if not isinstance(latest, dict) or not latest:
+        legacy = load_json(root / "scorecard.json", {})
+        latest = legacy if isinstance(legacy, dict) else {}
+    history = _history_rows(root / "scorecard" / "history.jsonl")
+    if not history:
+        archives = sorted((root / "scorecard" / "archive").glob("*.jsonl.gz"))
+        if archives:
+            history = _history_rows(archives[-1])
+    trend = history_series(history)
+    status = "empty" if not latest else ("complete" if history else "partial")
+    meta = {"latest_keys": len(latest), "history_rows": len(history), "history_samples": len(trend["samples"]), "status": status}
+    return {"latest": latest, "history_7d": trend}, meta
+
+def funnel_input(rows: list[dict[str, Any]], futility: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Per-demand-id :data:`FUNNEL_COLUMNS` over ``rows`` (as compact lists,
+    newest-proposed id first); keeps the :data:`_FUNNEL_MAX_IDS` most recently
+    proposed ids. ``futile``/``attempt_count`` come from the per-gap records of
+    ``demand/futility.json`` (keyed by gap id, #996)."""
+    counts: dict[str, dict[str, Any]] = {}
+    cycle_demands: dict[str, str] = {}
+    last_ts: dict[str, str] = {}
+    def rec(demand_id: str) -> dict[str, Any]:
+        return counts.setdefault(demand_id, {"proposed": 0, "integrated": 0, "self_dedup": 0, "futile": 0, "attempt_count": None})
+    for row in rows:
+        demand_id = str(row.get("demand_id") or "").strip()
+        phase = str(row.get("phase") or "")
+        cycle_id = str(row.get("cycle_id") or "").strip()
+        if phase == "proposed" and demand_id:
+            cycle_demands[cycle_id] = demand_id
+            rec(demand_id)["proposed"] += 1
+            last_ts[demand_id] = max(last_ts.get(demand_id, ""), str(row.get("ts") or ""))
+        elif phase == "proposer_reject" and demand_id and str(row.get("reason")) == "self_dedup":
+            rec(demand_id)["self_dedup"] += 1
+        elif phase == "outcome" and str(row.get("outcome")) == "success" and cycle_demands.get(cycle_id):
+            rec(cycle_demands[cycle_id])["integrated"] += 1
+    for gap_id, record in (futility.items() if isinstance(futility, dict) else ()):
+        if isinstance(record, dict) and (record.get("futile") is True or str(gap_id) in counts):
+            rec(str(gap_id)).update(futile=int(record.get("futile") is True), attempt_count=record.get("attempt_count"))
+    ordered = sorted(counts, key=lambda key: last_ts.get(key, ""), reverse=True)[:_FUNNEL_MAX_IDS]
+    kept = {key: [counts[key][column] for column in FUNNEL_COLUMNS] for key in ordered}
+    meta = {"ids": len(kept), "ids_dropped": len(counts) - len(kept), "status": "complete" if kept else "empty"}
+    return {"columns": list(FUNNEL_COLUMNS), "by_demand_id": kept}, meta
+
+def tree_digest(state_root: Path, rows: list[dict[str, Any]] | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Node count, best-path depth, fitness summary over the fields
+    ``evolution_tree.record_node`` actually populates, and the outcome mix of
+    the nodes' cycles joined from ledger ``outcome`` rows."""
+    tree = load_json(Path(state_root) / "evolution" / "tree.json", {})
+    tree = tree if isinstance(tree, dict) else {}
+    nodes_raw = tree.get("nodes")
+    node_map: dict[str, dict[str, Any]] = {}
+    if isinstance(nodes_raw, dict):
+        node_map = {str(k): v for k, v in nodes_raw.items() if isinstance(v, dict)}
+    elif isinstance(nodes_raw, list):
+        node_map = {str(n.get("sha") or n.get("id")): n for n in nodes_raw if isinstance(n, dict) and (n.get("sha") or n.get("id"))}
+    best_path: list[str] = []
+    curr = str(tree.get("current_sha") or "")
+    while curr and curr in node_map and len(best_path) < _TREE_BEST_PATH_HOPS:
+        best_path.append(curr)
+        curr = str(node_map[curr].get("parent_sha") or "")
+    fitness: dict[str, list[float]] = {}
+    for node in node_map.values():
+        for key, value in (node.get("fitness") or {}).items() if isinstance(node.get("fitness"), dict) else ():
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                fitness.setdefault(str(key), []).append(float(value))
+    rewards = fitness.get("reward", [])
+    summary: dict[str, Any] = {"chain_depth": len(best_path), "reward_count": len(rewards),
+                               "reward_mean": statistics.fmean(rewards) if rewards else None, "reward_max": max(rewards) if rewards else None}
+    for key, values in sorted(fitness.items()):
+        if key != "reward":
+            summary[key] = {"count": len(values), "mean": round(statistics.fmean(values), 4), "max": max(values)}
+    cycle_ids = {str(n.get("cycle_id")) for n in node_map.values() if n.get("cycle_id")}
+    outcome_mix: dict[str, int] = {}
+    for row in rows or ():
+        if row.get("phase") == "outcome" and str(row.get("cycle_id")) in cycle_ids:
+            outcome_mix[str(row.get("outcome") or "unknown")] = outcome_mix.get(str(row.get("outcome") or "unknown"), 0) + 1
+    stamps = sorted(str(n.get("ts")) for n in node_map.values() if n.get("ts"))
+    digest = {"node_count": len(node_map), "current_best_path": best_path, "fitness_summary": summary, "outcome_mix": outcome_mix,
+              "switches": len(tree.get("switches") or []), "ts_span": [stamps[0], stamps[-1]] if stamps else None}
+    fitness_values = sum(len(v) for v in fitness.values())
+    status = "empty" if not node_map else ("complete" if fitness_values else "partial")
+    return digest, {"nodes": len(node_map), "fitness_values": fitness_values, "status": status}
+
+def _clip(value: Any) -> str:
+    return " ".join(str(value or "").split())[:_INSIGHT_TEXT_CHARS]
+
+def insights_input(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    """v2 lesson cards (``problem`` -> ``solution``, filler skipped via
+    ``lesson_v2.solution_is_meaningful``), distinct legacy
+    ``generalized_insight`` lines, ``errors.yaml`` summaries, plus the two
+    index files. The historical ``reusable_insight`` key never existed."""
+    from nanobot.runtime.lesson_v2 import bounded_load_yaml, solution_is_meaningful
+
+    root = Path(repo_root)
+    cards: list[dict[str, str]] = []
+    legacy: list[str] = []
+    filler_skipped = 0
+    for entry in sorted(bounded_load_yaml(root / "lessons" / "lessons.yaml"), key=lambda e: str(e.get("first_seen") or e.get("date") or ""), reverse=True):
+        if "problem" in entry or "solution" in entry:
+            if not solution_is_meaningful(entry.get("problem"), entry.get("solution")):
+                filler_skipped += 1
+            elif len(cards) < _INSIGHTS_V2:
+                cards.append({"id": str(entry.get("id") or ""), "problem": _clip(entry.get("problem")),
+                              "solution": _clip(entry.get("solution")), "first_seen": str(entry.get("first_seen") or "")})
+        elif entry.get("generalized_insight"):
+            text = _clip(entry.get("generalized_insight"))
+            if text not in legacy and len(legacy) < _INSIGHTS_LEGACY:
+                legacy.append(text)
+    errors = [{"title": _clip(e.get("title")), "root_cause": _clip(e.get("root_cause")), "prevention": _clip(e.get("prevention"))}
+              for e in bounded_load_yaml(root / "lessons" / "errors.yaml")[-_INSIGHTS_ERRORS:]]
+    indexes: dict[str, str] = {}
+    for rel in ("memory/index.md", "docs/index.md"):
+        try:
+            indexes[rel] = (root / rel).read_text(encoding="utf-8")[:_INDEX_CHARS]
+        except Exception:
+            indexes[rel] = ""
+    data = {"cards": cards, "legacy_insights": legacy, "errors": errors, "indexes": indexes}
+    meta = {"cards": len(cards), "filler_skipped": filler_skipped, "legacy": len(legacy), "errors": len(errors),
+            "status": "complete" if cards or legacy or errors else "empty"}
+    return data, meta
+
+def empty_inputs(inputs_status: dict[str, Any]) -> list[str]:
+    """Names in :data:`INPUT_NAMES` whose status is ``empty``."""
+    return [name for name in INPUT_NAMES if (inputs_status.get(name) or {}).get("status") == "empty"]
+
+def should_refuse(inputs_status: dict[str, Any]) -> bool:
+    return len(empty_inputs(inputs_status)) > _MAX_EMPTY_INPUTS

--- a/nanobot/runtime/strategist_inputs.py
+++ b/nanobot/runtime/strategist_inputs.py
@@ -5,12 +5,9 @@ Every reader returns a value AND a status ("complete" | "partial" | "empty") so
 the archive view is mostly empty instead of advising from nothing. Readers never
 raise; failures degrade to "empty" with a note. Stdlib only.
 
-:func:`ledger_rows` is a narrow, horizon-bounded read of the live
-``cycles.jsonl`` plus the rotated ``cycles-YYYY-MM-DD.jsonl.gz`` archives
-(``cycle_ledger`` writes one per UTC day). It should collapse into the shared
-``state_access.ledger_window`` reader from #1174 when that lands; it mirrors
-that contract's meta fields (``covered_from``, ``files_read``, ``files_skipped``,
-``bytes_read``, ``status``).
+Ledger access goes through ``state_access.ledger_window`` (#1174): the live
+``cycles.jsonl`` plus the rotated ``cycles-YYYY-MM-DD.jsonl.gz`` archives inside
+the horizon, phase-prefiltered, byte-capped, never raising.
 """
 from __future__ import annotations
 
@@ -80,57 +77,15 @@ def _read_lines(path: Path) -> list[str] | None:
         return None
 
 def ledger_rows(state_root: Path, horizon_days: int = _FUNNEL_HORIZON_DAYS) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Rows with a phase in :data:`_LEDGER_PHASES` from archives inside the
-    horizon (oldest first, by the date in the file name) then the live file.
-    Substring-prefilters before ``json.loads``; skips corrupt files per file."""
-    ledger_dir = Path(state_root) / "ledger"
-    cutoff = (_utcnow() - dt.timedelta(days=horizon_days)).date()
-    meta: dict[str, Any] = {"files_read": 0, "files_skipped": 0, "bytes_read": 0, "covered_from": None, "status": "empty", "notes": []}
-    paths: list[Path] = []
-    for gz_path in sorted(ledger_dir.glob("cycles-*.jsonl.gz")):
-        try:
-            day = dt.date.fromisoformat(gz_path.name[len("cycles-"):-len(".jsonl.gz")])
-        except ValueError:
-            meta["files_skipped"] += 1
-            meta["notes"].append(f"bad_name:{gz_path.name}")
-            continue
-        if day >= cutoff:
-            paths.append(gz_path)
-    live = ledger_dir / "cycles.jsonl"
-    if live.is_file():
-        paths.append(live)
-    # cycle_ledger writes json.dumps default separators; accept the compact form too.
-    needles = tuple(f'"phase":{sep}"{phase}"' for phase in _LEDGER_PHASES for sep in (" ", ""))
-    rows: list[dict[str, Any]] = []
-    for path in paths:
-        lines = _read_lines(path)
-        if lines is None:
-            meta["files_skipped"] += 1
-            meta["notes"].append(f"unreadable:{path.name}")
-            meta["status"] = "partial"
-            continue
-        meta["files_read"] += 1
-        for line in lines:
-            meta["bytes_read"] += len(line)
-            if meta["bytes_read"] > _LEDGER_MAX_BYTES:
-                meta["status"] = "partial"
-                meta["notes"].append("cap_bytes")
-                break
-            if not any(needle in line for needle in needles):
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
-            if isinstance(row, dict):
-                rows.append(row)
-        if "cap_bytes" in meta["notes"]:
-            break
-    stamps = [str(r.get("ts")) for r in rows if r.get("ts")]
-    meta["covered_from"] = min(stamps) if stamps else None
-    if rows and meta["status"] != "partial":
-        meta["status"] = "complete"
-    return rows, meta
+    """Rows with a phase in :data:`_LEDGER_PHASES` from the last ``horizon_days``,
+    oldest first, with the window's provenance as a plain dict."""
+    from nanobot.runtime.state_access import ledger_window
+
+    since = (_utcnow() - dt.timedelta(days=horizon_days)).isoformat().replace("+00:00", "Z")
+    window = ledger_window(Path(state_root), since_ts=since, phases=frozenset(_LEDGER_PHASES), max_bytes=_LEDGER_MAX_BYTES)
+    meta = {"files_read": window.files_read, "files_skipped": window.files_skipped, "bytes_read": window.bytes_read,
+            "covered_from": window.covered_from, "covered_to": window.covered_to, "status": window.status, "notes": list(window.notes)}
+    return list(window.rows), meta
 
 def charter_input(state_root: Path) -> tuple[str, dict[str, Any]]:
     """The operator charter: ``<RELEASE_ROOT>/goals.md`` (the path the proposer

--- a/tests/test_strategist.py
+++ b/tests/test_strategist.py
@@ -22,11 +22,16 @@ from nanobot.runtime.strategist import (
 
 
 @pytest.fixture
-def mock_state_and_repo(tmp_path: Path):
+def mock_state_and_repo(tmp_path: Path, monkeypatch):
     state_root = tmp_path / "state"
     state_root.mkdir(parents=True)
     repo_root = tmp_path / "repo"
     repo_root.mkdir(parents=True)
+    # #1182: the charter lives in the release tree, never in the instance repo.
+    release_root = tmp_path / "release"
+    release_root.mkdir()
+    (release_root / "goals.md").write_text("# Goals\n1. Improve runtime\n", encoding="utf-8")
+    monkeypatch.setenv("RELEASE_ROOT", str(release_root))
 
     # Setup some initial state
     (state_root / "demand").mkdir(parents=True)
@@ -44,10 +49,23 @@ def mock_state_and_repo(tmp_path: Path):
         encoding="utf-8",
     )
 
-    # Repo docs
-    (repo_root / "goals.md").write_text("# Goals\n1. Improve runtime\n", encoding="utf-8")
+    # Evolution tree: keeps the input gate (#1182) satisfied; the funnel is the
+    # only empty input in this fixture (no ledger rows with a phase). Written
+    # directly because record_node also appends a ledger row.
+    (state_root / "evolution").mkdir()
+    (state_root / "evolution" / "tree.json").write_text(json.dumps({
+        "nodes": {"f1x": {"parent_sha": None, "cycle_id": "c-0", "fitness": {"integrations": 1}}}, "current_sha": "f1x",
+    }), encoding="utf-8")
+
+    # Repo docs: one v2 lesson card (#1071 shape) and one legacy row.
     (repo_root / "lessons").mkdir(parents=True)
-    (repo_root / "lessons" / "lessons.yaml").write_text("- lesson: check timers\n", encoding="utf-8")
+    (repo_root / "lessons" / "lessons.yaml").write_text(
+        "- id: L1\n  schema_version: 2\n  problem: check timers drift after deploy\n"
+        "  solution: assert the timer unit is enabled in the deploy smoke test\n"
+        "  first_seen: 2026-08-30T00:00:00Z\n"
+        "- id: L0\n  generalized_insight: pin the model name in the unit env\n",
+        encoding="utf-8",
+    )
 
     return state_root, repo_root
 
@@ -60,7 +78,10 @@ def test_collect_inputs(mock_state_and_repo):
     assert inputs["scorecard"]["latest"]["cycles_total"] == 42
     assert len(inputs["recent_cycles"]) == 2
     assert "Improve runtime" in inputs["goals"]
-    assert any("check timers" in line for line in inputs["lessons"])
+    assert inputs["inputs_status"]["goals"]["source"] == "release_root"
+    assert "check timers" in inputs["insights"]["cards"][0]["problem"]
+    assert inputs["lessons"] == ["pin the model name in the unit env"]
+    assert inputs["inputs_status"]["insights"]["status"] == "complete"
 
 
 def test_tree_digest_from_real_record_node(tmp_path):

--- a/tests/test_strategist_inputs.py
+++ b/tests/test_strategist_inputs.py
@@ -320,6 +320,7 @@ def test_dry_run_reports_inputs_and_writes_nothing(roots, monkeypatch, capsys):
 
 
 def test_ledger_rows_skip_an_unreadable_archive_and_report_partial(roots):
+    """Provenance of the window (state_access.ledger_window, #1174) reaches inputs_status verbatim."""
     from nanobot.runtime import strategist_inputs
 
     state_root, _, _ = roots
@@ -328,8 +329,8 @@ def test_ledger_rows_skip_an_unreadable_archive_and_report_partial(roots):
     (state_root / "ledger" / "cycles-notadate.jsonl.gz").write_bytes(b"")
     rows, meta = strategist_inputs.ledger_rows(state_root)
     assert [row["demand_id"] for row in rows] == ["d1"]
-    assert meta["files_read"] == 1 and meta["files_skipped"] == 2 and meta["status"] == "partial"
-    assert sorted(note.split(":")[0] for note in meta["notes"]) == ["bad_name", "unreadable"]
+    assert meta["files_read"] == 1 and meta["files_skipped"] == 1 and meta["status"] == "partial"
+    assert {note.split(":")[0] for note in meta["notes"]} >= {"gz_corrupt", "invalid_archive"}, meta["notes"]
 
 
 def test_ledger_rows_ignore_archives_outside_the_horizon(roots):

--- a/tests/test_strategist_inputs.py
+++ b/tests/test_strategist_inputs.py
@@ -1,0 +1,354 @@
+"""#1182: the strategist's archive inputs are alive, bounded and carry provenance.
+
+Every repro test here fails against the pre-#1182 tree for the reason named
+in its docstring; the existence test at the end is the exception required by
+the try/except rule (names used inside helpers must be proven to exist).
+"""
+from __future__ import annotations
+
+import datetime as dt
+import gzip
+import inspect
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nanobot.runtime import strategist
+from nanobot.runtime.strategist import (
+    collect_inputs,
+    load_watermark,
+    run_strategist,
+    save_watermark,
+)
+
+VALID_OUTPUT = {
+    "schema": "strategist-hadi-v1",
+    "period_reviewed": "2026-W36",
+    "hypotheses": [{
+        "title": "t", "hypothesis": "h", "action": "a", "data_to_collect": "d",
+        "insight_criterion": "c", "priority": "low",
+    }],
+    "futility_advisories": [],
+}
+FILLER = "Apply the reflected approach hint."
+
+
+def _iso(days_ago: int, hour: int = 12) -> str:
+    stamp = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days_ago)
+    return stamp.replace(hour=hour, minute=0, second=0, microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _card(idx: int, solution: str) -> str:
+    return (f"- id: L{idx}\n  schema_version: 2\n  problem: problem {idx}\n"
+            f"  solution: {solution}\n  first_seen: 2026-08-{10 + idx:02d}T00:00:00Z\n")
+
+
+@pytest.fixture
+def roots(tmp_path: Path, monkeypatch):
+    """Bare state/repo/release roots; RELEASE_ROOT points at an empty dir."""
+    state_root, repo_root, release_root = tmp_path / "state", tmp_path / "repo", tmp_path / "release"
+    for root in (state_root, repo_root, release_root):
+        root.mkdir()
+    monkeypatch.setenv("RELEASE_ROOT", str(release_root))
+    monkeypatch.setenv("SELFEVO_STRATEGIST_MODEL", "cl/test-strategist-model")
+    return state_root, repo_root, release_root
+
+
+def _write_ledger(state_root: Path, rows: list[dict], *, day_file: str | None = None) -> None:
+    ledger = state_root / "ledger"
+    ledger.mkdir(exist_ok=True)
+    text = "".join(json.dumps(row) + "\n" for row in rows)
+    if day_file is None:
+        (ledger / "cycles.jsonl").write_text(text, encoding="utf-8")
+    else:
+        with gzip.open(ledger / f"cycles-{day_file}.jsonl.gz", "wt", encoding="utf-8") as handle:
+            handle.write(text)
+
+
+def _write_lessons(repo_root: Path, text: str) -> None:
+    (repo_root / "lessons").mkdir(exist_ok=True)
+    (repo_root / "lessons" / "lessons.yaml").write_text(text, encoding="utf-8")
+
+
+def _write_tree(state_root: Path, nodes: dict, current: str) -> None:
+    (state_root / "evolution").mkdir(exist_ok=True)
+    (state_root / "evolution" / "tree.json").write_text(json.dumps({"nodes": nodes, "current_sha": current, "switches": []}), encoding="utf-8")
+
+
+def _healthy(state_root: Path, repo_root: Path, release_root: Path) -> None:
+    """All five inputs non-empty (live shape after the fix)."""
+    (release_root / "goals.md").write_text("# Charter\nKeep the loop honest.\n", encoding="utf-8")
+    (state_root / "scorecard").mkdir(exist_ok=True)
+    (state_root / "scorecard" / "latest.json").write_text(json.dumps({"confirmed_ratio": 0.45}), encoding="utf-8")
+    (state_root / "scorecard" / "history.jsonl").write_text(
+        "".join(json.dumps({"computed_at_utc": _iso(d), "confirmed_ratio": 0.4}) + "\n" for d in range(6, -1, -1)), encoding="utf-8")
+    _write_ledger(state_root, [
+        {"phase": "proposed", "cycle_id": "c1", "demand_id": "d1", "ts": _iso(1)},
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": _iso(1, 13)},
+        {"phase": "proposed", "cycle_id": "c2", "demand_id": "d2", "ts": _iso(0)},
+        {"phase": "outcome", "cycle_id": "c2", "outcome": "failure", "ts": _iso(0, 13)},
+    ])
+    _write_tree(state_root, {
+        "s1": {"parent_sha": None, "cycle_id": "c1", "ts": _iso(1), "fitness": {"reward": None, "integrations": 3, "confirmed_integrations": 1, "repeat_failure_rate": 0.25}},
+        "s2": {"parent_sha": "s1", "cycle_id": "c2", "ts": _iso(0), "fitness": {"reward": None, "integrations": 5, "confirmed_integrations": 2, "repeat_failure_rate": 0.2}},
+    }, "s2")
+    _write_lessons(repo_root, _card(1, "pin the checker list in the fixture"))
+
+
+# --- repro tests: each FAILS on the pre-#1182 tree ---------------------------
+
+def test_charter_is_read_from_release_root_not_instance_repo(roots):
+    """Pre-fix: collect_inputs read <repo_root>/goals.md, which the instance repo lacks -> ''."""
+    state_root, repo_root, release_root = roots
+    (release_root / "goals.md").write_text("# Charter\nOnly here.\n", encoding="utf-8")
+    inputs = collect_inputs(state_root, repo_root)
+    assert "Only here." in inputs["goals"]
+    assert inputs["inputs_status"]["goals"] == {"chars": len(inputs["goals"]), "source": "release_root", "status": "complete"}
+
+
+def test_charter_falls_back_to_goal_text_json(roots):
+    state_root, repo_root, _ = roots
+    (state_root / "goals").mkdir()
+    (state_root / "goals" / "goal_text.json").write_text(json.dumps({"text": "fallback charter"}), encoding="utf-8")
+    inputs = collect_inputs(state_root, repo_root)
+    assert inputs["goals"] == "fallback charter"
+    assert inputs["inputs_status"]["goals"]["source"] == "goal_text.json"
+
+
+def test_insights_come_from_v2_cards_and_report_filler_skipped(roots):
+    """Pre-fix: grepped for a 'reusable_insight' key that never existed -> []."""
+    state_root, repo_root, _ = roots
+    _write_lessons(repo_root, _card(1, "add a deploy smoke test for the timer unit") + _card(2, "pin the runtime version in the unit env")
+                   + _card(3, "split the module below the size cap") + _card(4, FILLER))
+    inputs = collect_inputs(state_root, repo_root)
+    assert [card["id"] for card in inputs["insights"]["cards"]] == ["L3", "L2", "L1"]
+    assert inputs["inputs_status"]["insights"]["filler_skipped"] == 1
+    assert inputs["inputs_status"]["insights"]["status"] == "complete"
+    assert "reusable_insight" not in inspect.getsource(strategist)
+
+
+def test_funnel_reads_per_gap_futile_flag(roots):
+    """Pre-fix: read a 'futile_gap_ids' key that lives in the scorecard, not futility.json -> futile 0."""
+    state_root, repo_root, _ = roots
+    _write_ledger(state_root, [{"phase": "proposed", "cycle_id": "c1", "demand_id": "goal-gap-a820", "ts": _iso(1)}])
+    (state_root / "demand").mkdir()
+    (state_root / "demand" / "futility.json").write_text(json.dumps({
+        "goal-gap-a820": {"gap_id": "goal-gap-a820", "metric": "stale_feeds", "attempt_count": 3, "futile": True},
+        "goal-gap-c095": {"gap_id": "goal-gap-c095", "metric": "heldout_gap", "attempt_count": 1, "futile": False},
+    }), encoding="utf-8")
+    funnel = collect_inputs(state_root, repo_root)["funnel"]
+    assert funnel["columns"] == ["proposed", "integrated", "self_dedup", "futile", "attempt_count"]
+    assert funnel["by_demand_id"]["goal-gap-a820"] == [1, 0, 0, 1, 3]
+    assert "goal-gap-c095" not in funnel["by_demand_id"], "not futile and never proposed in the window"
+
+
+def test_funnel_keeps_the_200_most_recently_proposed_ids(roots):
+    """Pre-fix: kept the first 200 dict keys (oldest file first) and read at most 500 lines per file."""
+    state_root, repo_root, _ = roots
+    plan = [(2, range(0, 125)), (1, range(125, 250)), (0, range(250, 300))]
+    for days_ago, ids in plan:
+        rows = [{"phase": "proposed", "cycle_id": f"c{i}", "demand_id": f"d{i:03d}", "ts": _iso(days_ago)} for i in ids]
+        _write_ledger(state_root, rows, day_file=(dt.date.today() - dt.timedelta(days=days_ago)).isoformat())
+    inputs = collect_inputs(state_root, repo_root)
+    kept = set(inputs["funnel"]["by_demand_id"])
+    assert len(kept) == 200
+    assert {f"d{i:03d}" for i in range(125, 300)} <= kept, "the two newest days must survive the cap whole"
+    assert len(kept & {f"d{i:03d}" for i in range(0, 125)}) == 25, "only the oldest day is cut"
+    status = inputs["inputs_status"]["funnel"]
+    assert (status["ids"], status["ids_dropped"], status["status"]) == (200, 100, "complete")
+    assert status["ledger"]["files_read"] == 3 and status["ledger"]["covered_from"] is not None
+
+
+def test_tree_digest_summarises_populated_fitness_and_outcome_mix(roots):
+    """Pre-fix: only fitness.reward (always None on the host) -> reward_count 0 and nothing else."""
+    state_root, repo_root, release_root = roots
+    _healthy(state_root, repo_root, release_root)
+    tree = collect_inputs(state_root, repo_root)["evolution_tree"]
+    assert tree["node_count"] == 2 and tree["current_best_path"] == ["s2", "s1"]
+    assert tree["fitness_summary"]["reward_count"] == 0
+    assert tree["fitness_summary"]["integrations"] == {"count": 2, "mean": 4.0, "max": 5}
+    assert tree["fitness_summary"]["repeat_failure_rate"]["max"] == 0.25
+    assert tree["outcome_mix"] == {"success": 1, "failure": 1}
+    assert tree["ts_span"][0] < tree["ts_span"][1]
+    # the wrapper the older test imports keeps its shape
+    assert strategist._tree_digest(state_root)["fitness_summary"]["chain_depth"] == 2
+
+
+def test_decision_row_carries_inputs_status(roots):
+    """Pre-fix: decisions.jsonl had prompt_chars only; the prompt record truncates at 1,000 chars."""
+    state_root, repo_root, release_root = roots
+    _healthy(state_root, repo_root, release_root)
+    result = run_strategist(state_root, repo_root, llm=lambda *_: json.dumps(VALID_OUTPUT))
+    assert result["success"] is True
+    row = json.loads((state_root / "strategist" / "decisions.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    status = row["inputs_status"]
+    assert set(status) == {"goals", "scorecard", "funnel", "insights", "evolution_tree", "recent_cycles", "halved"}
+    assert status["goals"]["chars"] > 0
+    assert status["scorecard"] == {"latest_keys": 1, "history_rows": 7, "history_samples": 7, "status": "complete"}
+    assert status["funnel"]["ids"] == 2 and status["funnel"]["ledger"]["status"] == "complete"
+    assert status["insights"]["cards"] == 1
+    assert status["evolution_tree"]["fitness_values"] == 6
+    assert status["recent_cycles"] == 4 and status["halved"] == []
+
+
+def test_refuses_the_llm_call_when_two_inputs_are_empty(roots, monkeypatch, capsys):
+    """Pre-fix: the LLM was called on an empty view and advice was applied."""
+    state_root, repo_root, _ = roots
+    # scorecard latest present but no charter, no lessons, no tree; funnel from one row
+    (state_root / "scorecard.json").write_text(json.dumps({"cycles_total": 1}), encoding="utf-8")
+    _write_ledger(state_root, [{"phase": "proposed", "cycle_id": "c1", "demand_id": "d1", "ts": _iso(0)}])
+    save_watermark(state_root, {"total_runs": 4, "last_run": "2026-09-01T00:00:00Z"})
+    llm = MagicMock(return_value=json.dumps(VALID_OUTPUT))
+    result = run_strategist(state_root, repo_root, llm=llm)
+    assert llm.call_count == 0
+    assert result["success"] is False and result["reason"] == "inputs_unavailable"
+    assert result["empty_inputs"] == ["goals", "insights", "evolution_tree"]
+    assert result["prompt_chars"] == 0
+    assert load_watermark(state_root) == {"total_runs": 4, "last_run": "2026-09-01T00:00:00Z"}
+    assert not (state_root / "hypotheses").exists()
+    rows = (state_root / "strategist" / "decisions.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1 and json.loads(rows[0])["reason"] == "inputs_unavailable"
+    assert not (state_root / "strategist" / "errors.jsonl").exists()
+    # the systemd entry point treats the refusal as a clean run
+    monkeypatch.setattr(sys, "argv", ["strategist", "--state-root", str(state_root), "--repo", str(repo_root)])
+    with patch("nanobot.runtime.strategist._default_llm", side_effect=AssertionError("must not be called")):
+        assert strategist.main() == 0
+    assert json.loads(capsys.readouterr().out)["reason"] == "inputs_unavailable"
+
+
+def test_one_empty_input_is_tolerated(roots):
+    state_root, repo_root, release_root = roots
+    _healthy(state_root, repo_root, release_root)
+    (repo_root / "lessons" / "lessons.yaml").unlink()  # insights empty, the other four alive
+    llm = MagicMock(return_value=json.dumps(VALID_OUTPUT))
+    result = run_strategist(state_root, repo_root, llm=llm)
+    assert llm.call_count == 1 and result["success"] is True
+    assert result["inputs_status"]["insights"]["status"] == "empty"
+
+
+def test_prompt_stays_within_cap_and_records_halved_sections(roots):
+    """Pre-fix: one halving per section, silently; 600 long lessons fell through to {"truncated": true}."""
+    state_root, repo_root, release_root = roots
+    _healthy(state_root, repo_root, release_root)
+    inputs = collect_inputs(state_root, repo_root)
+    inputs["lessons"] = [f"lesson {i} " + "x" * 200 for i in range(600)]
+    _, user = strategist.build_strategist_prompt(inputs, {})
+    assert len(user) <= strategist._MAX_PROMPT_CHARS
+    archive = json.loads(user)["archive"]
+    assert "truncated" not in archive and archive["goals"].startswith("# Charter")
+    assert inputs["inputs_status"]["halved"] == ["lessons", "lessons"], "the largest section is halved until the payload fits"
+    assert archive["inputs_status"]["halved"] == inputs["inputs_status"]["halved"]
+
+
+def _live_shape(state_root: Path, repo_root: Path, release_root: Path) -> None:
+    """Sizes read on the host 2026-09-02: latest.json 6.8 KB, history rows 3 KB
+    (48/day), 100 tree nodes, 250 demand ids in 30 days, 228 B ledger rows."""
+    _healthy(state_root, repo_root, release_root)
+    (state_root / "scorecard" / "latest.json").write_text(json.dumps(
+        {f"section_{i}": {f"metric_{j}": 0.1 * j for j in range(12)} for i in range(20)}), encoding="utf-8")
+    rows = []
+    for i in range(7 * 48):
+        stamp = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=30 * (7 * 48 - 1 - i))).isoformat().replace("+00:00", "Z")
+        rows.append({"computed_at_utc": stamp, "quality": {"confirmed_ratio": 0.40 + i / 5000, "stale_feeds": 1.0},
+                     "padding": {f"k{j}": "v" * 40 for j in range(60)}})
+    (state_root / "scorecard" / "history.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    ledger = []
+    for i in range(250):
+        ledger.append({"phase": "proposed", "cycle_id": f"c{i}", "demand_id": f"demand-{i:04d}", "ts": _iso(29 - i // 9, hour=i % 24),
+                       "target_path": f"scripts/tool_{i % 40}.py", "task_title": "t" * 60, "request_id": "r" * 32})
+        ledger.append({"phase": "outcome", "cycle_id": f"c{i}", "outcome": "success" if i % 3 else "failure", "ts": _iso(29 - i // 9, hour=i % 24),
+                       "files_changed": [f"scripts/tool_{i % 40}.py"], "elapsed_seconds": 120})
+    _write_ledger(state_root, ledger)
+    _write_tree(state_root, {f"sha{i:03d}": {"parent_sha": f"sha{i - 1:03d}" if i else None, "cycle_id": f"c{i}", "ts": _iso(29 - i // 4),
+                             "fitness": {"reward": None, "integrations": i, "confirmed_integrations": i // 2, "repeat_failure_rate": 0.1}}
+                             for i in range(100)}, "sha099")
+    _write_lessons(repo_root, "".join(_card(i, f"solution {i} " + "pin the exact version in the fixture " * 3) for i in range(1, 11))
+                   + "".join(f"- id: G{i}\n  generalized_insight: legacy insight {i} " + "words " * 20 + "\n" for i in range(10)))
+    (repo_root / "lessons" / "errors.yaml").write_text("".join(
+        f"- id: E{i}\n  title: error {i}\n  root_cause: {'cause ' * 30}\n  prevention: {'guard ' * 30}\n" for i in range(16)), encoding="utf-8")
+    (repo_root / "memory").mkdir()
+    (repo_root / "memory" / "index.md").write_text("- memory line\n" * 300, encoding="utf-8")
+    (repo_root / "docs").mkdir()
+    (repo_root / "docs" / "index.md").write_text("- doc line\n" * 150, encoding="utf-8")
+    for i in range(10):
+        strategist._append_jsonl(state_root / "strategist" / "decisions.jsonl",
+                                 {"timestamp": _iso(10 - i), "success": True, "reason": "valid bounded advisory output applied",
+                                  "prompt_chars": 40000, "inputs_status": {"goals": {"chars": 2749}}, "counts": {"hypotheses_appended": 2}})
+
+
+def test_live_shape_prompt_fits_and_keeps_every_input(roots):
+    """Pre-fix: history_7d was 100 raw 3 KB rows or nothing; the halving pass ran once per section."""
+    from nanobot.runtime import strategist_inputs
+
+    state_root, repo_root, release_root = roots
+    _live_shape(state_root, repo_root, release_root)
+    inputs = collect_inputs(state_root, repo_root)
+    status = inputs["inputs_status"]
+    assert strategist_inputs.empty_inputs(status) == []
+    assert status["scorecard"]["history_rows"] == 336 and status["scorecard"]["history_samples"] == 8
+    assert status["funnel"]["ids"] == 200 and status["funnel"]["ids_dropped"] == 50
+    assert status["insights"] == {"cards": 10, "filler_skipped": 0, "legacy": 10, "errors": 5, "status": "complete"}
+    assert status["evolution_tree"]["nodes"] == 100
+    trend = inputs["scorecard"]["history_7d"]
+    assert len(trend["samples"]) == 8 and trend["samples"][0] < trend["samples"][-1]
+    assert list(trend["series"])[0] == "quality.confirmed_ratio", "the metric that moved sorts first"
+    assert trend["series"]["quality.confirmed_ratio"][0] < trend["series"]["quality.confirmed_ratio"][-1]
+    assert "inputs_status" not in json.dumps(inputs["prior_decisions"])
+    _, user = strategist.build_strategist_prompt(inputs, {"total_runs": 9})
+    assert len(user) <= strategist._MAX_PROMPT_CHARS
+    archive = json.loads(user)["archive"]
+    assert "truncated" not in archive
+    for name in strategist_inputs.INPUT_NAMES:
+        assert archive[name], name
+    assert archive["inputs_status"]["halved"] == status["halved"]
+
+
+def test_dry_run_reports_inputs_and_writes_nothing(roots, monkeypatch, capsys):
+    """Pre-fix: no --dry-run; the only way to see the inputs was a real LLM run."""
+    state_root, repo_root, release_root = roots
+    _healthy(state_root, repo_root, release_root)
+    monkeypatch.setattr(sys, "argv", ["strategist", "--state-root", str(state_root), "--repo", str(repo_root), "--dry-run"])
+    with patch("nanobot.runtime.strategist._default_llm", side_effect=AssertionError("must not be called")):
+        assert strategist.main() == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["dry_run"] is True and report["would_refuse"] is False and report["empty_inputs"] == []
+    assert report["inputs_status"]["goals"]["chars"] > 0 and report["prompt_chars"] > 0
+    assert not (state_root / "strategist").exists(), "dry run must not create decisions or watermark"
+
+
+def test_ledger_rows_skip_an_unreadable_archive_and_report_partial(roots):
+    from nanobot.runtime import strategist_inputs
+
+    state_root, _, _ = roots
+    _write_ledger(state_root, [{"phase": "proposed", "cycle_id": "c1", "demand_id": "d1", "ts": _iso(1)}], day_file=(dt.date.today() - dt.timedelta(days=1)).isoformat())
+    (state_root / "ledger" / f"cycles-{dt.date.today().isoformat()}.jsonl.gz").write_bytes(b"not gzip")
+    (state_root / "ledger" / "cycles-notadate.jsonl.gz").write_bytes(b"")
+    rows, meta = strategist_inputs.ledger_rows(state_root)
+    assert [row["demand_id"] for row in rows] == ["d1"]
+    assert meta["files_read"] == 1 and meta["files_skipped"] == 2 and meta["status"] == "partial"
+    assert sorted(note.split(":")[0] for note in meta["notes"]) == ["bad_name", "unreadable"]
+
+
+def test_ledger_rows_ignore_archives_outside_the_horizon(roots):
+    from nanobot.runtime import strategist_inputs
+
+    state_root, _, _ = roots
+    _write_ledger(state_root, [{"phase": "proposed", "cycle_id": "c0", "demand_id": "old", "ts": _iso(40)}], day_file=(dt.date.today() - dt.timedelta(days=40)).isoformat())
+    _write_ledger(state_root, [{"phase": "proposed", "cycle_id": "c1", "demand_id": "new", "ts": _iso(1)}])
+    rows, meta = strategist_inputs.ledger_rows(state_root)
+    assert [row["demand_id"] for row in rows] == ["new"] and meta["files_read"] == 1
+
+
+# --- names referenced inside helpers must exist (passes on both trees) -------
+
+def test_helper_names_used_by_strategist_inputs_exist():
+    from nanobot.runtime import goal_review, lesson_v2, llm_proposer
+
+    assert callable(goal_review.read_charter_text)
+    assert callable(llm_proposer._release_root_from_env)
+    assert callable(lesson_v2.bounded_load_yaml)
+    assert callable(lesson_v2.solution_is_meaningful)
+    assert not lesson_v2.solution_is_meaningful("p", FILLER)


### PR DESCRIPTION
Closes #1182. Parent ADR #1173; gates #999 (`status:test`, timer currently `disabled`/`inactive` per the operator's note on #999).

## What was wrong (host, 2026-09-02, release `20260902T010947Z-canonical-a48975c1`)

Three of the five inputs the strategist conditions on were dead for reasons unrelated to rotation, and nothing recorded it:

| input | what the strategist saw | cause |
|---|---|---|
| goal charter | `""` | read `<repo_root>/goals.md`; the instance repo has none, the charter is `<RELEASE_ROOT>/goals.md` (2,749 B) |
| insights | `[]` | grepped for a `reusable_insight` key that occurs 0 times in `lessons/*.yaml` |
| futility | `futile: 0` for every id | read `futile_gap_ids` from a file keyed by gap id with per-record `futile: bool` |
| funnel | oldest 200 of 381 ids | `_cap(records, 200)` kept the first dict keys, live file then archives oldest-first; `_read_lines(path, 500)` dropped the head of four day files |
| scorecard history | `[]` | `history.jsonl` 522 KB > the 256 KB cliff |
| tree digest | `reward_count: 0` | only `fitness.reward`, which `record_node` never sets; `integrations` etc. are populated |
| provenance | `prompt_chars` only | the prompt record truncates at 1,000 chars |

All 8 successful runs since 2026-08-26 recorded `"valid bounded advisory output applied"` on top of that view.

## What this PR does

**New `nanobot/runtime/strategist_inputs.py`** (deny-set + TRUST_KERNEL manifest; stdlib plus three internal imports; 280 physical lines, about 220 code lines after docstrings/comments, against the "about 300 LOC" rule in `docs/TRUST_KERNEL.md`). Every reader returns `(value, meta)` with `status ∈ {complete, partial, empty}`:

- `charter_input`: `goal_review.read_charter_text(llm_proposer._release_root_from_env())`, the same resolution the proposer uses (`RELEASE_ROOT` env, default `/opt/eeepc-agent/runtimes/self-evolving-agent/current`); fallback `state/goals/goal_text.json["text"]`; `source` recorded.
- `insights_input`: v2 cards (`problem -> solution`, newest 10 by `first_seen`) filtered by `lesson_v2.solution_is_meaningful`, with `filler_skipped` counted; 10 distinct legacy `generalized_insight` lines; last 5 `errors.yaml` entries; both index files capped at 2,000 chars.
- `ledger_rows`: `state_access.ledger_window(since=now-30d, phases={proposed, proposer_reject, outcome, evolution_tree}, max_bytes=8 MiB)` (#1174 merged as #1186 while this PR was open; the local reader from the first commit was replaced in the third). The window's provenance (`files_read`, `files_skipped`, `bytes_read`, `covered_from`, `covered_to`, `status`, `notes`) reaches `inputs_status.funnel.ledger` verbatim. `goal_gap_futility.py` / `state_access.py` untouched; no hygiene-allowlist entry needed.
- `funnel_input`: per-id `[proposed, integrated, self_dedup, futile, attempt_count]` (columns named in the section), `futile`/`attempt_count` from the per-gap records of `demand/futility.json`; keeps the **200 most recently proposed** ids, `ids_dropped` reported.
- `scorecard_input`: `latest.json` (fallback `scorecard.json`); history as the newest 400 rows of `history.jsonl` within 7 days (8 MiB file cap; live rows are 3 KB, 48/day), rendered as a **trend series**: 8 evenly spaced samples, one series per dotted numeric path (depth ≤ 3), paths whose value moved first, 60 max. Raw rows would not fit the prompt (live prompt was already 46k of the 48k cap with three inputs dead).
- `tree_digest`: fitness summary over every numeric fitness field (`integrations`, `confirmed_integrations`, `repeat_failure_rate`, plus `reward` when present), chain depth, switches, ts span, and the outcome mix of the nodes' cycles joined from ledger `outcome` rows.
- `empty_inputs` / `should_refuse`: refuse when **more than one** of `goals, scorecard, funnel, insights, evolution_tree` is `empty`.

**`nanobot/runtime/strategist.py`**

- `collect_inputs` delegates to the module above and returns `inputs_status` (`goals{chars,source,status}`, `scorecard{latest_keys,history_rows,history_samples,status}`, `funnel{ids,ids_dropped,status,ledger{files_read,files_skipped,bytes_read,covered_from,covered_to,status,notes}}`, `insights{cards,filler_skipped,legacy,errors,status}`, `evolution_tree{nodes,fitness_values,status}`, `recent_cycles`, `halved`). `lessons` is now the legacy `generalized_insight` lines (the raw YAML tail is gone); v2 cards are `insights.cards`. `prior_decisions` are stripped of their own `inputs_status`.
- `run_strategist`: `inputs_status` goes into every `decisions.jsonl` row. When `should_refuse`: **no LLM call, no writes, watermark unmoved**, row `{"success": false, "reason": "inputs_unavailable", "empty_inputs": [...], "prompt_chars": 0, "inputs_status": {...}}`. `main()` exits 0 on that reason so systemd does not mark the service failed.
- Prompt budget: while over `_MAX_PROMPT_CHARS`, the largest of `lessons, prior_decisions, recent_cycles, insights, funnel, scorecard` is halved (a dict section halves its largest member, `columns` protected; `goals`, the tree digest, `futility`, `inputs_status` never shrink); each halving is appended to `inputs_status.halved`. Previously one silent halving per section, then `{"truncated": true}`.
- `--dry-run`: prints `inputs_status`, `empty_inputs`, `would_refuse`, `prompt_chars`; no LLM call, no file written.
- The two `256_000` magic numbers are named (`_MAX_JSON_BYTES`, `_MAX_LINES_FILE_BYTES`); the `_tree_digest` wrapper the older test imports keeps its shape.

**Also:** `runtime_deny.py` + `docs/TRUST_KERNEL.md` manifest/table entry for the new module.

## Tests

`tests/test_strategist_inputs.py` (15 tests) + fixture update in `tests/test_strategist.py`. Run against `origin/main` (c1cf6355) in a throwaway worktree with the new test files copied in — **15 failed, 10 passed** (the 9 untouched strategist tests and the existence test, see below). Observed failures, `--tb=line`:

```
tests/test_strategist.py:80: AssertionError: assert 'Improve runtime' in ''
tests/test_strategist_inputs.py:108: AssertionError: assert 'Only here.' in ''                       # charter from RELEASE_ROOT
tests/test_strategist_inputs.py:117: AssertionError: assert '' == 'fallback charter'                  # goal_text.json fallback
tests/test_strategist_inputs.py:127: KeyError: 'cards'                                                # v2 cards + filler_skipped
tests/test_strategist_inputs.py:143: KeyError: 'columns'                                              # per-gap futile flag
tests/test_strategist_inputs.py:158: AssertionError: the two newest days must survive the cap whole   # newest-200 funnel
tests/test_strategist_inputs.py:172: KeyError: 'integrations'                                         # tree fitness fields + outcome mix
tests/test_strategist_inputs.py:187: KeyError: 'inputs_status'                                        # decisions row provenance
tests/test_strategist_inputs.py:206: AssertionError: assert 1 == 0                                    # LLM was called on an empty view
tests/test_strategist_inputs.py:229: KeyError: 'inputs_status'                                        # one empty input tolerated
tests/test_strategist_inputs.py:241: AssertionError: assert ('truncated' not in {'truncated': True})  # halving fell through
tests/test_strategist_inputs.py:284: ImportError: cannot import name 'strategist_inputs'              # live-shape prompt fit
C:\Python313\Lib\argparse.py:2632: SystemExit: 2                                                      # --dry-run
tests/test_strategist_inputs.py:323: ImportError: cannot import name 'strategist_inputs'              # ledger_rows skips unreadable
tests/test_strategist_inputs.py:336: ImportError: cannot import name 'strategist_inputs'              # ledger_rows horizon
```

Exception, stated: `test_helper_names_used_by_strategist_inputs_exist` passes on both trees by design — it is the "names used inside a helper must be proven to exist" check for `read_charter_text`, `_release_root_from_env`, `bounded_load_yaml`, `solution_is_meaningful`.

Live-shape fixture (sizes read on the host: 6.8 KB `latest.json`, 336 × 3 KB history rows, 250 ids, 100 nodes, 500 ledger rows, 10+10 lessons, 16 errors, both indexes, 10 prior decisions): all five inputs non-empty, prompt **33,995 chars**, `halved: []`.

Full suite on the branch before the rebase (Windows, `-n 4`): **2800 passed, 19 failed, 17 skipped**. 18 of the 19 fail identically on plain `origin/main` in the same environment (`test_autoevolve*`, `test_bridge_locking`, `test_bridge_cycle_tags`, `test_selfevo_export_security`: `error: src refspec master does not match any`, `flock`) — Windows-only; the 19th was the TRUST_KERNEL manifest test, fixed in the second commit. The first CI run (merge commit against a main that had just received #1186) failed only `test_state_access_hygiene` on the local ledger reader; after the switch to `ledger_window`, CI is green on 3.11/3.12/3.13. Linux CI is authoritative.

## Live verification (operator runs; host stays read-only for me)

The re-enable conditions on #999, mapped:

**1 + 3 — before re-enabling the timer**, as the service user, with the unit's environment (this is what makes `RELEASE_ROOT` resolve):

```
sudo systemd-run --wait --pipe -p User=eeepc-agent \
  -p EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env \
  -E PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current \
  /opt/eeepc-agent/venv/bin/python -m nanobot.runtime.strategist \
  --state-root /var/lib/eeepc-agent/self-evolving-agent/state \
  --repo /var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving --dry-run
```
(interpreter, `--state-root`, `--repo` and the bridge env file are the ones in the unit's `ExecStart`/`EnvironmentFile=`, read 2026-09-02; `litellm.env` is deliberately not loaded — neither check calls the LLM.) Writes nothing. Proof it worked: `would_refuse: false`, `empty_inputs: []`, `inputs_status.goals.chars` = 2749 with `source: release_root`, `scorecard.history_rows` ≥ 7 with `history_samples` = min(8, rows), `funnel.ids: 200` with `ids_dropped` > 0 and `ledger.files_read` = 31 (30 day files inside the horizon today + live), `insights.legacy` ≥ 1 and `cards` = 0 with `filler_skipped` = 4 while #1171 is open, `evolution_tree.nodes: 100` with `fitness_values` > 0, `prompt_chars` ≤ 48000.

**2 — exercise the refusal once, visibly in the record**: same command without `--dry-run`, with the charter and the lessons made unreachable (`RELEASE_ROOT=/nonexistent`, `--repo /var/empty`):

```
sudo systemd-run --wait --pipe -p User=eeepc-agent \
  -p EnvironmentFile=/etc/eeepc-agent/instances/self-evolving-subagent-bridge.env \
  -E PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current -E RELEASE_ROOT=/nonexistent \
  /opt/eeepc-agent/venv/bin/python -m nanobot.runtime.strategist \
  --state-root /var/lib/eeepc-agent/self-evolving-agent/state --repo /var/empty ; echo exit=$?
```
Proof: `exit=0`; the last row of `state/strategist/decisions.jsonl` has `"reason": "inputs_unavailable"`, `"empty_inputs": ["goals", "insights"]`, `"success": false`, `"prompt_chars": 0`; `watermark.json` unchanged (today: `total_runs: 7`, `last_run: 2026-09-02T00:00:09Z`); no new LiteLLM call for component `strategist` in the LLM telemetry for that minute; `hypotheses/durable.json` mtime unchanged. (`-E RELEASE_ROOT` after the env file wins, so the charter is unreachable; `/var/empty` has no `lessons/`.)

**1 — after re-enabling** (`sudo systemctl enable --now eeebot-strategist.timer`, or `systemctl start eeebot-strategist.service` for an immediate run): the new `decisions.jsonl` row has `success: true`, `inputs_status` with the same values as the dry run, `halved` (expected `[]`), and the first hypothesis in `hypotheses/durable.json` with `source: strategist` and `created_at` after the run should cite a demand id that appears in `funnel.by_demand_id` of the dry-run output. Quote the row on #999 and #1182.

## Not in scope

HADI schema, caps, model resolution, advisories sidecar (no consumer), `MAX_NODES`, lesson minting (#1171), the `history.jsonl` cliff in other readers (#1178 — this PR reads history through its own 8 MiB bound, not `_load_json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
