### PR TITLE
fix(runtime): preserve memory and skills under prompt cap

### DIFF
--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -6,6 +6,8 @@ import platform
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from nanobot.utils.helpers import current_time_str, estimate_prompt_tokens
 
 from nanobot.agent.memory import MemoryStore
@@ -16,7 +18,9 @@ from nanobot.utils.helpers import build_assistant_message, detect_image_mime
 class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
 
-    BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md"]
+    # Only the tracked, product-defined bootstrap contract is loaded. Optional
+    # host-only files were never present in the product workspace.
+    BOOTSTRAP_FILES = ["AGENTS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
     MAX_SYSTEM_PROMPT_CHARS = 24000
     MAX_MEDIA_BYTES = 2 * 1024 * 1024
@@ -80,11 +84,95 @@ Skills with available="false" need dependencies installed first - you can try in
         if memory:
             parts.append(f"# Memory\n\n{memory}")
 
-        system_prompt = "\n\n---\n\n".join(parts)
-        if len(system_prompt) > self.MAX_SYSTEM_PROMPT_CHARS:
-            trimmed = system_prompt[: self.MAX_SYSTEM_PROMPT_CHARS]
-            system_prompt = trimmed + "\n\n[truncated: system prompt capped by memory discipline]"
-        return system_prompt
+        sections = [("identity", parts[0])]
+        if bootstrap:
+            sections.append(("bootstrap", bootstrap))
+        if always_skills:
+            always_content = self.skills.load_skills_for_context(always_skills)
+            if always_content:
+                sections.append(("active_skills", f"# Active Skills\n\n{always_content}"))
+        if skills_summary:
+            sections.append(("skills_catalogue", f"""# Skills
+
+The following skills extend your capabilities. To use a skill, read the skill's SKILL.md file using the read_file tool.
+Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
+
+{skills_summary}"""))
+        if memory:
+            sections.append(("memory", f"# Memory\n\n{memory}"))
+        return self._fit_system_prompt(sections)
+
+    @staticmethod
+    def _join_sections(sections: list[tuple[str, str]]) -> str:
+        return "\n\n---\n\n".join(content for _, content in sections if content)
+
+    @staticmethod
+    def _trim_lines(text: str, max_chars: int) -> str:
+        """Keep only complete lines that fit, never slicing a line or token."""
+        if len(text) <= max_chars:
+            return text
+        if max_chars <= 0:
+            return ""
+        kept: list[str] = []
+        used = 0
+        for line in text.splitlines(keepends=True):
+            if used + len(line) > max_chars:
+                break
+            kept.append(line)
+            used += len(line)
+        return "".join(kept)
+
+    def _fit_system_prompt(self, sections: list[tuple[str, str]]) -> str:
+        """Fit sections without silently evicting memory or skills.
+
+        Bootstrap is the pressure source observed in #1191, so it is trimmed
+        first at complete-line boundaries. Any dropped content is reported with
+        its section name and character count; no opaque trailing marker is used.
+        """
+        original = dict(sections)
+        if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+            return self._join_sections(sections)
+
+        dropped: dict[str, int] = {}
+        # Preserve identity, active skills, catalogue, and memory before
+        # spending the remaining budget on bootstrap content.
+        bootstrap = original.pop("bootstrap", None)
+        sections = [(name, content) for name, content in sections if name != "bootstrap"]
+        protected = self._join_sections(sections)
+        bootstrap_budget = self.MAX_SYSTEM_PROMPT_CHARS - len(protected) - (9 if protected else 0)
+        if bootstrap:
+            kept_bootstrap = self._trim_lines(bootstrap, bootstrap_budget)
+            if len(kept_bootstrap) < len(bootstrap):
+                dropped["bootstrap"] = len(bootstrap) - len(kept_bootstrap)
+            if kept_bootstrap:
+                sections.insert(1 if sections and sections[0][0] == "identity" else 0, ("bootstrap", kept_bootstrap))
+
+        prompt = self._join_sections(sections)
+        if len(prompt) > self.MAX_SYSTEM_PROMPT_CHARS:
+            # A non-bootstrap section can independently exceed the cap. Trim
+            # memory first, then the catalogue, while reporting each loss.
+            for name in ("memory", "skills_catalogue", "active_skills"):
+                if len(prompt) <= self.MAX_SYSTEM_PROMPT_CHARS:
+                    break
+                current = dict(sections).get(name)
+                if not current:
+                    continue
+                without = [(section_name, content) for section_name, content in sections if section_name != name]
+                budget = self.MAX_SYSTEM_PROMPT_CHARS - len(self._join_sections(without)) - (9 if without else 0)
+                kept = self._trim_lines(current, budget)
+                if len(kept) < len(current):
+                    dropped[name] = len(current) - len(kept)
+                sections = [(section_name, content) for section_name, content in without]
+                if kept:
+                    insert_at = next((i for i, (section_name, _) in enumerate(without) if section_name == "memory"), len(without))
+                    sections.insert(insert_at, (name, kept))
+                prompt = self._join_sections(sections)
+
+        if dropped:
+            details = ", ".join(f"{name}={count} chars" for name, count in dropped.items())
+            logger.warning("System prompt cap dropped content: {}", details)
+        return prompt
+
 
     def _get_identity(self, loop_profile: bool = False) -> str:
         """Get the core identity section."""

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -50,11 +50,11 @@ class ContextBuilder:
         operator-only builtins such as weather/tmux/clawhub).  Has no effect
         on normal interactive sessions.
         """
-        parts = [self._get_identity(loop_profile=loop_profile)]
+        sections = [("identity", self._get_identity(loop_profile=loop_profile))]
 
         bootstrap = self._load_bootstrap_files()
         if bootstrap:
-            parts.append(bootstrap)
+            sections.append(("bootstrap", bootstrap))
 
         # Active Skills — always-loaded builtin/operator skills (never workspace).
         always_skills = self.skills.get_always_skills()
@@ -63,34 +63,11 @@ class ContextBuilder:
         if always_skills:
             always_content = self.skills.load_skills_for_context(always_skills)
             if always_content:
-                parts.append(f"# Active Skills\n\n{always_content}")
+                sections.append(("active_skills", f"# Active Skills\n\n{always_content}"))
 
-        # Skills catalogue — progressive loading; comes before memory so the
-        # 24 KB cap does not push it off the end when memory is large.
         skills_summary = self.skills.build_skills_summary(
             excluded_names=excluded_skill_names,
         )
-        if skills_summary:
-            parts.append(f"""# Skills
-
-The following skills extend your capabilities. To use a skill, read its SKILL.md file using the read_file tool.
-Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
-
-{skills_summary}""")
-
-        # Memory — placed after skills so large memory blocks do not push the
-        # skills catalogue past the MAX_SYSTEM_PROMPT_CHARS truncation point.
-        memory = self.memory.get_memory_context(loop=loop_profile)
-        if memory:
-            parts.append(f"# Memory\n\n{memory}")
-
-        sections = [("identity", parts[0])]
-        if bootstrap:
-            sections.append(("bootstrap", bootstrap))
-        if always_skills:
-            always_content = self.skills.load_skills_for_context(always_skills)
-            if always_content:
-                sections.append(("active_skills", f"# Active Skills\n\n{always_content}"))
         if skills_summary:
             sections.append(("skills_catalogue", f"""# Skills
 
@@ -98,6 +75,8 @@ The following skills extend your capabilities. To use a skill, read the skill's 
 Skills with available="false" need dependencies installed first - you can try installing them with apt/brew.
 
 {skills_summary}"""))
+
+        memory = self.memory.get_memory_context(loop=loop_profile)
         if memory:
             sections.append(("memory", f"# Memory\n\n{memory}"))
         return self._fit_system_prompt(sections)
@@ -122,6 +101,33 @@ Skills with available="false" need dependencies installed first - you can try in
             used += len(line)
         return "".join(kept)
 
+    def _trim_section_to_fit(
+        self,
+        sections: list[tuple[str, str]],
+        name: str,
+    ) -> tuple[list[tuple[str, str]], int]:
+        """Trim one section to the cap and return its dropped character count."""
+        index = next((i for i, (section_name, _) in enumerate(sections) if section_name == name), None)
+        if index is None:
+            return sections, 0
+        current = sections[index][1]
+        if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+            return sections, 0
+
+        low, high = 0, len(current)
+        best = ""
+        while low <= high:
+            middle = (low + high) // 2
+            candidate = self._trim_lines(current, middle)
+            trial = sections[:index] + [(name, candidate)] + sections[index + 1:]
+            if len(self._join_sections(trial)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+                best = candidate
+                low = middle + 1
+            else:
+                high = middle - 1
+        updated = sections[:index] + ([(name, best)] if best else []) + sections[index + 1:]
+        return updated, len(current) - len(best)
+
     def _fit_system_prompt(self, sections: list[tuple[str, str]]) -> str:
         """Fit sections without silently evicting memory or skills.
 
@@ -129,43 +135,29 @@ Skills with available="false" need dependencies installed first - you can try in
         first at complete-line boundaries. Any dropped content is reported with
         its section name and character count; no opaque trailing marker is used.
         """
-        original = dict(sections)
         if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
             return self._join_sections(sections)
 
         dropped: dict[str, int] = {}
-        # Preserve identity, active skills, catalogue, and memory before
-        # spending the remaining budget on bootstrap content.
-        bootstrap = original.pop("bootstrap", None)
-        sections = [(name, content) for name, content in sections if name != "bootstrap"]
-        protected = self._join_sections(sections)
-        bootstrap_budget = self.MAX_SYSTEM_PROMPT_CHARS - len(protected) - (9 if protected else 0)
-        if bootstrap:
-            kept_bootstrap = self._trim_lines(bootstrap, bootstrap_budget)
-            if len(kept_bootstrap) < len(bootstrap):
-                dropped["bootstrap"] = len(bootstrap) - len(kept_bootstrap)
-            if kept_bootstrap:
-                sections.insert(1 if sections and sections[0][0] == "identity" else 0, ("bootstrap", kept_bootstrap))
+        # Defend the later sections from bootstrap growth first. If the
+        # protected sections are themselves too large, report each additional
+        # section that must lose complete lines rather than hiding the loss.
+        for name in ("bootstrap", "memory", "skills_catalogue", "active_skills", "identity"):
+            if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+                break
+            sections, count = self._trim_section_to_fit(sections, name)
+            if count:
+                dropped[name] = count
 
         prompt = self._join_sections(sections)
         if len(prompt) > self.MAX_SYSTEM_PROMPT_CHARS:
-            # A non-bootstrap section can independently exceed the cap. Trim
-            # memory first, then the catalogue, while reporting each loss.
-            for name in ("memory", "skills_catalogue", "active_skills"):
+            # A section without line breaks cannot be partially retained. Drop
+            # it explicitly so the hard cap remains a real bound.
+            for name, content in list(sections):
                 if len(prompt) <= self.MAX_SYSTEM_PROMPT_CHARS:
                     break
-                current = dict(sections).get(name)
-                if not current:
-                    continue
-                without = [(section_name, content) for section_name, content in sections if section_name != name]
-                budget = self.MAX_SYSTEM_PROMPT_CHARS - len(self._join_sections(without)) - (9 if without else 0)
-                kept = self._trim_lines(current, budget)
-                if len(kept) < len(current):
-                    dropped[name] = len(current) - len(kept)
-                sections = [(section_name, content) for section_name, content in without]
-                if kept:
-                    insert_at = next((i for i, (section_name, _) in enumerate(without) if section_name == "memory"), len(without))
-                    sections.insert(insert_at, (name, kept))
+                sections = [(section_name, value) for section_name, value in sections if section_name != name]
+                dropped[name] = dropped.get(name, 0) + len(content)
                 prompt = self._join_sections(sections)
 
         if dropped:

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -38,12 +38,10 @@ class ContextBuilder:
     ) -> str:
         """Build the system prompt from identity, bootstrap files, skills, and memory.
 
-        Prompt ordering (#939 Part E — fixes skills summary truncation):
-          1. Identity + bootstrap files (never truncated away)
-          2. Active Skills  (always=true, already loaded)
-          3. Skills summary (progressive-disclosure catalogue)
-          4. Memory         (large; placed last so skills are not truncated
-                             when the memory block is huge)
+        Prompt ordering is identity, bootstrap, active skills, skills
+        catalogue, then memory. Under the cap, bootstrap is trimmed first so
+        growth at the bootstrap end cannot evict the later skills and memory
+        sections; any resulting loss is reported by the builder.
 
         *excluded_skill_names* is an optional list of skill names to omit from
         the summary (used by the self-evolving loop subagent to suppress

--- a/tests/test_context_prompt_budget.py
+++ b/tests/test_context_prompt_budget.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from nanobot.agent import context as context_module
+from nanobot.agent.context import ContextBuilder
+
+
+def _oversized_builder(tmp_path):
+    builder = ContextBuilder(tmp_path)
+    builder._get_identity = lambda loop_profile=False: "# identity"
+    builder._load_bootstrap_files = lambda: "## AGENTS.md\n\n" + "bootstrap line\n" * 5000
+    builder.skills.get_always_skills = lambda: ["memory"]
+    builder.skills.load_skills_for_context = lambda names: "always skill content"
+    builder.skills.build_skills_summary = lambda excluded_names=None: "<skills>\n  <skill><name>catalogue</name></skill>\n</skills>"
+    builder.memory.get_memory_context = lambda loop=False: "## Long-term Memory\nremembered fact"
+    return builder
+
+
+def test_oversized_bootstrap_preserves_memory_and_skills_and_reports_drop(tmp_path, monkeypatch):
+    messages: list[str] = []
+    monkeypatch.setattr(
+        context_module.logger,
+        "warning",
+        lambda message, *args: messages.append(message.format(*args)),
+    )
+
+    prompt = _oversized_builder(tmp_path).build_system_prompt()
+
+    assert len(prompt) <= ContextBuilder.MAX_SYSTEM_PROMPT_CHARS
+    assert "# Memory" in prompt
+    assert "# Skills" in prompt
+    assert "# Active Skills" in prompt
+    assert prompt.endswith("\n") or prompt.splitlines()[-1] in {"</skills>", "remembered fact"}
+    assert any("bootstrap" in message and "dropped" in message for message in messages)
+    assert any("chars" in message for message in messages)
+
+
+def test_bootstrap_configuration_contains_only_tracked_file():
+    assert ContextBuilder.BOOTSTRAP_FILES == ["AGENTS.md"]


### PR DESCRIPTION
## Summary

Closes #1191.

`ContextBuilder` now trims oversized bootstrap content at complete line boundaries before allowing bootstrap pressure to evict active skills, the skills catalogue, or memory. Prompt-cap loss is reported through a structured warning naming each affected section and dropped character count. The obsolete trailing truncation marker is removed.

`BOOTSTRAP_FILES` is now explicitly `['AGENTS.md']`; `SOUL.md`, `USER.md`, and `TOOLS.md` were not tracked product bootstrap files and are no longer silently probed.

## Design choice

The pressure observed in #1191 comes from the bootstrap end of the prompt: `AGENTS.md` alone exceeds the cap before memory and skills are appended. We defend the sections after bootstrap by trimming bootstrap first at line boundaries. If a protected section itself exceeds the cap, that section is also trimmed at line boundaries and the loss is reported. No second silent cap or opaque trailing marker is used.

## Regression evidence

The new tests were run against the pre-change `origin/main` before implementation and failed as required:

- `test_oversized_bootstrap_preserves_memory_and_skills_and_reports_drop`: failed because `nanobot.agent.context` had no `logger` and the old implementation had no observable drop report.
- `test_bootstrap_configuration_contains_only_tracked_file`: failed because the old value was `['AGENTS.md', 'SOUL.md', 'USER.md', 'TOOLS.md']`.

After the change: `python -m pytest tests/test_context_prompt_budget.py -q` → **2 passed**.

## Verification

- Focused context tests: **26 passed**
- Full pytest on Windows: **2804 passed, 19 failed, 17 skipped, 11 warnings**. The 19 failures match the known baseline list from #1191; no new failures were introduced.
- CI: Python 3.11, 3.12, and 3.13 all passed — https://github.com/ozand/eeebot/actions/runs/33589950497
- Live verification is intentionally not performed by this PR author. After deploy, call `build_system_prompt` read-only on the host workspace and verify:
  - `contains "# Memory"` is `True`
  - `contains "Skills"` is `True` (preferably also `contains "# Skills"`)
  - `len(prompt) <= 24000`
  - report the observed prompt length and cap.

No production caller behavior was otherwise migrated, and no host/deployment state was changed here.