### PR TITLE
fix(runtime): make AGENTS.md operator-owned

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -3634,9 +3634,9 @@ _SENSITIVE_WORDS = _BLOCKED_WORD_PATTERNS
 _ALLOWED_SENSITIVE_BASENAMES = frozenset({'token_report.py', 'summarize_token_costs.py', 'token_budget_check.py', 'analyze_token_usage.py', 'check_token_budget.py', 'validate_no_secrets.py', 'count_tokens.py'})
 _BLOCKED_EXACT_PATHS = frozenset({'goals.md', 'IDENTITY.md'})
 _ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/', 'skills/')
-_ALLOWED_EXACT_PATHS = frozenset({'AGENTS.md'})
+_ALLOWED_EXACT_PATHS = frozenset()
 _GATE_EXT_ALLOWLIST = frozenset(('.py', '.md', '.json', '.yaml', '.yml', '.toml', '.txt', '.sh', '.service', '.timer', '.conf', '.cron', '.html', '.css', '.ts', '.js', '.example'))
-_GATE_BASENAME_ALLOWLIST = frozenset(('Makefile', 'Dockerfile', 'AGENTS.md'))
+_GATE_BASENAME_ALLOWLIST = frozenset(('Makefile', 'Dockerfile'))
 _RUNTIME_SLICE_ENV = 'SELFEVO_RUNTIME_SLICE'
 _SMOKE_ENV_STRIP_PREFIXES = ('STATE_DIR', 'NANOBOT_', 'SUBAGENT_', 'EEEBOT_', 'TARGET_WORKSPACE', 'LITELLM_', 'GOAL_', 'SOURCE_', 'SELFEVO_')
 _CORE_SMOKE_TESTS = ('tests/test_import_hygiene.py', 'tests/test_config_schema.py', 'tests/test_config_paths.py')
@@ -3676,6 +3676,9 @@ def _validate_mutation_surfaces(changed_files: 'list[str]') -> 'list[str]':
         fname = f.rsplit('/', 1)[-1] if '/' in f else f
         if fname in _BLOCKED_EXACT_PATHS or f in _BLOCKED_EXACT_PATHS:
             violations.append(f'immutable file blocked from mutation: {f}')
+            continue
+        if f == 'AGENTS.md':
+            violations.append(f'operator_owned_path: {f}')
             continue
         if f in _ALLOWED_EXACT_PATHS:
             continue

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -2888,6 +2888,14 @@ def collect_demand(
                 summary = item.get("summary", "")
                 if notice not in summary:
                     item["summary"] = f"{summary} [STEERING NOTICE: {notice}]" if summary else notice
+            if k == "reflection" and affected == "AGENTS.md":
+                operator_owned_note = (
+                    "[OPERATOR-OWNED TARGET: encode this as a skill under skills/ "
+                    "or a lesson card, not as an instruction edit]"
+                )
+                summary = item.get("summary", "")
+                if operator_owned_note not in summary:
+                    item["summary"] = f"{summary} {operator_owned_note}".strip()
             if k == "reflection" and is_non_confirmable_target(affected):
                 item["non_confirmable_target"] = "true"
                 item["steering_only"] = "true"

--- a/nanobot/runtime/gate.py
+++ b/nanobot/runtime/gate.py
@@ -102,10 +102,9 @@ def _is_blocked_filename(
 
 # Allowed path prefixes for changed files (relative to repo root).
 # 'skills/' — workspace/instance skill directories (SKILL.md + bundled resources).
-# 'AGENTS.md' is the repo-root operator instruction file and may be updated by the
-# instance; goals.md remains explicitly denied via _BLOCKED_EXACT_PATHS.
+# The repo-root AGENTS.md is operator-owned and is not a mutable loop surface.
 _ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/', 'skills/')
-_ALLOWED_EXACT_PATHS = frozenset({'AGENTS.md'})
+_ALLOWED_EXACT_PATHS = frozenset()
 
 # #863: the gate can only exercise/see-through these file types. Prefix
 # rules bound WHERE the instance may write; this bounds WHAT KIND of file
@@ -121,7 +120,7 @@ _GATE_EXT_ALLOWLIST = frozenset((
     ".sh", ".service", ".timer", ".conf", ".cron", ".html", ".css",
     ".ts", ".js", ".example",
 ))
-_GATE_BASENAME_ALLOWLIST = frozenset(("Makefile", "Dockerfile", "AGENTS.md"))
+_GATE_BASENAME_ALLOWLIST = frozenset(("Makefile", "Dockerfile"))
 
 
 def _validate_mutation_surfaces(
@@ -156,7 +155,10 @@ def _validate_mutation_surfaces(
         if fname in blocked_exact_paths or f in blocked_exact_paths:
             violations.append(f'immutable file blocked from mutation: {f}')
             continue
-        # Allowed exact paths (root AGENTS.md only) bypass the prefix check.
+        if f == 'AGENTS.md':
+            violations.append(f'operator_owned_path: {f}')
+            continue
+        # Allowed exact paths bypass the prefix check.
         if f in allowed_exact_paths:
             continue
         # Blocked filename patterns
@@ -260,7 +262,10 @@ def _classify_mutation_surface(
         if fname in blocked_exact_paths or f in blocked_exact_paths:
             blocked.append(f'immutable file blocked from mutation: {f}')
             continue
-        # Allowed exact paths (root AGENTS.md) bypass prefix and pattern checks.
+        if f == 'AGENTS.md':
+            violations.append(f'operator_owned_path: {f}')
+            continue
+        # Allowed exact paths bypass the prefix and pattern checks.
         if f in allowed_exact_paths:
             basename2 = Path(f).name
             suffix2 = Path(f).suffix.lower()

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -65,10 +65,8 @@ _TRUTHY = {"1", "true", "yes", "on"}
 # 'skills/' opens the workspace/instance skill tree (SKILL.md + bundled resources).
 _ALLOWED_PATH_PREFIXES = ("surfaces/", "scripts/", "memory/", "lessons/", "docs/", "tests/", "skills/")
 
-# Allowed exact root paths (basename match). Root AGENTS.md is open so the
-# instance can update operator instructions; it is NOT a prefix match, so
-# only the true repo-root file is permitted.
-_ALLOWED_EXACT_PATHS = frozenset({'AGENTS.md'})
+# Root AGENTS.md is operator-owned and is not a mutable proposal target.
+_ALLOWED_EXACT_PATHS = frozenset()
 
 # #944: explicitly blocked paths (immutable files that proposals may never
 # target), mirroring bridge._BLOCKED_EXACT_PATHS. goals.md is the immutable
@@ -259,8 +257,7 @@ _PROPOSER_SYSTEM_PROMPT = (
     "claim; it is never required. task_title must be non-empty and at most 120 characters, "
     "describing a single behavior/bug (not a bundle). target_path must name "
     "exactly ONE path (file or directory) under one of these mutable "
-    "surfaces: surfaces/, scripts/, memory/, lessons/, docs/, tests/, skills/ "
-    "or the root-level file AGENTS.md — no "
+    "surfaces: surfaces/, scripts/, memory/, lessons/, docs/, tests/, skills/ — no "
     "other path is acceptable. serves must name what goal this task serves — "
     "non-empty, at most 160 characters, starting with one of: 'priority <N>' "
     "(a numbered goal_text priority, e.g. 'priority 5'), 'vector 1' or "
@@ -300,8 +297,7 @@ _DEMAND_PROPOSER_SYSTEM_PROMPT = (
     "must be non-empty and at most 120 characters, describing a single "
     "behavior/bug (not a bundle). target_path must name exactly ONE path "
     "(file or directory) under one of these mutable surfaces: surfaces/, "
-    "scripts/, memory/, lessons/, docs/, tests/, skills/ or the root-level "
-    "file AGENTS.md — no other path is "
+    "scripts/, memory/, lessons/, docs/, tests/, skills/ — no other path is "
     "acceptable. serves must be 'demand <id>' where <id> is the bracketed id "
     "of the ONE demand item this task addresses (e.g. 'demand "
     "defect-1a2b3c4d5e6f'). rationale must briefly explain how the task "
@@ -1409,8 +1405,7 @@ def build_context(
         recent_failed_titles = _recent_failed_titles(ledger_rows)
         surface_rule = (
             "Mutable surface rule: target_path MUST be a single path under "
-            "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + ", or the root "
-            "file AGENTS.md — no other path is acceptable."
+            "one of: " + ", ".join(_ALLOWED_PATH_PREFIXES) + " — no other path is acceptable."
         )
         # #823/#812: when the operator has opened a runtime slice, the proposer
         # may also target those specific nanobot/runtime modules for Vector-1
@@ -1860,9 +1855,9 @@ def validate_sizing(proposal: dict[str, Any] | None) -> tuple[bool, str]:
         return False, f"target_path matches a blocked filename pattern: {target_path}"
     if _target_basename in _BLOCKED_EXACT_PATHS or _norm_target in _BLOCKED_EXACT_PATHS:
         return False, f"target_path is an immutable file that proposals may never modify: {target_path}"
-    # Allowed exact root paths (e.g. AGENTS.md) bypass the prefix check.
-    _in_exact_allowed = _norm_target in _ALLOWED_EXACT_PATHS
-    _in_script_surface = _in_exact_allowed or any(target_path.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES)
+    if _norm_target == "AGENTS.md":
+        return False, "operator_owned_path"
+    _in_script_surface = any(target_path.startswith(prefix) for prefix in _ALLOWED_PATH_PREFIXES)
     _in_runtime_slice = _norm_target in _runtime_slice_paths()
     if not (_in_script_surface or _in_runtime_slice):
         return False, f"target_path outside allowed surfaces {_ALLOWED_PATH_PREFIXES}: {target_path}"
@@ -2819,7 +2814,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             return f"{reason_text}; reply={snippet}"
 
         if not ok:
-            reject_reason = "llm_unavailable" if _last_propose_failure else "sizing_rejected"
+            reject_reason = "llm_unavailable" if _last_propose_failure else ("operator_owned_path" if reason == "operator_owned_path" else "sizing_rejected")
             detail = (
                 f"{_last_propose_failure}"
                 if _last_propose_failure
@@ -2853,7 +2848,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
                 # rejection, recorded as such.
                 _record_proposer_reject(
                     state_dir,
-                    "sizing_rejected",
+                    "operator_owned_path" if reason == "operator_owned_path" else "sizing_rejected",
                     task_title=str((proposal or {}).get("task_title") or "") if isinstance(proposal, dict) else "",
                     target_path=str((proposal or {}).get("target_path") or "") if isinstance(proposal, dict) else "",
                     detail=_sizing_detail(reason, proposal),

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -3166,6 +3166,21 @@ class TestIssue1090DocGuard:
         assert completed["entries"]["d-doc"]["change_tier"] == "doc-only"
         assert completed["entries"]["d-code"]["change_tier"] == "code-bearing"
 
+    def test_reflection_agents_target_is_annotated_and_kept(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        reflector_dir = state_dir / "reflector"
+        reflector_dir.mkdir(parents=True)
+        row = {
+            "cycle_id": "c-agents",
+            "created_at": _now_iso(1),
+            "recommendations": [{"detail": "Update AGENTS.md with the repeated lesson", "target_artifact": "AGENTS.md"}],
+        }
+        (reflector_dir / "reflections.jsonl").write_text(json.dumps(row) + "\n", encoding="utf-8")
+        items = demand.collect_demand(state_dir, None)
+        reflections = [item for item in items if item["kind"] == "reflection"]
+        assert reflections
+        assert "[OPERATOR-OWNED TARGET: encode this as a skill under skills/ or a lesson card, not as an instruction edit]" in reflections[0]["summary"]
+
     def test_reflection_steering_only_for_non_confirmable_targets(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         reflector_dir = state_dir / "reflector"

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -969,10 +969,12 @@ class TestValidateSizing:
         assert ok is False
         assert "immutable" in reason
 
-    def test_accepts_skill_and_root_agents_surfaces(self):
-        for target in ("skills/review/SKILL.md", "AGENTS.md"):
-            ok, reason = llm_proposer.validate_sizing(self._good(target_path=target))
-            assert ok is True, reason
+    def test_rejects_operator_owned_agents_and_accepts_skill_surface(self):
+        ok, reason = llm_proposer.validate_sizing(self._good(target_path="AGENTS.md"))
+        assert ok is False
+        assert reason == "operator_owned_path"
+        ok, reason = llm_proposer.validate_sizing(self._good(target_path="skills/review/SKILL.md"))
+        assert ok is True, reason
 
     def test_nested_agents_is_not_root_exact_allowance(self):
         ok, reason = llm_proposer.validate_sizing(self._good(target_path="other/AGENTS.md"))

--- a/tests/test_mutation_surfaces.py
+++ b/tests/test_mutation_surfaces.py
@@ -108,9 +108,10 @@ def test_goals_md_is_explicitly_immutable():
     assert violations == ['immutable file blocked from mutation: goals.md']
 
 
-def test_root_agents_and_skill_files_are_allowed():
+def test_root_agents_is_operator_owned_and_skill_files_are_allowed():
     fn = _get_validate()
-    assert fn(['AGENTS.md']) == []
+    violations = fn(['AGENTS.md'])
+    assert violations == ['operator_owned_path: AGENTS.md']
     assert fn(['skills/review/SKILL.md']) == []
 
 
@@ -184,4 +185,5 @@ def test_build_task_surfaces_come_from_gate_constants():
     prompt = bridge.build_task(req, "derived", "", max_iterations=17)
     for surface in list(bridge._ALLOWED_PATH_PREFIXES) + list(bridge._ALLOWED_EXACT_PATHS):
         assert surface in prompt
+    assert "AGENTS.md" not in prompt
     assert "Creating or improving skills for repeated patterns is valuable work." in prompt

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -62,7 +62,7 @@ def _extract_fn(name: str, extra_setup: str = '') -> object:
         f'import importlib.util, subprocess, json, os, re, sys, time\nfrom pathlib import Path\n'
         f'from unittest.mock import MagicMock\n'
         f'_ALLOWED_PATH_PREFIXES=("surfaces/", "scripts/", "memory/", "lessons/", "docs/", "tests/", "skills/")\n'
-        f'_ALLOWED_EXACT_PATHS={"AGENTS.md"!r}\n'
+        f'_ALLOWED_EXACT_PATHS={set()!r}\n'
         f'{extra_setup}\n'
         f'{ordered_src}',
         ns,


### PR DESCRIPTION
## Summary

Closes #1193.

`AGENTS.md` is now operator-owned. It is removed from the gate and proposer exact-path/basename allowlists, and all three proposer prompt surfaces list only `_ALLOWED_PATH_PREFIXES`. A root `AGENTS.md` proposal is rejected with the distinct `operator_owned_path` ledger reason; a gate diff reaching `AGENTS.md` is rejected with the same violation reason. Reflection recommendations naming root `AGENTS.md` continue flowing and receive the required operator-owned annotation directing the content to a skill or lesson card.

`demand._DOC_ONLY_BASENAMES` and historical `classify_change_tier(["AGENTS.md"]) == "doc-only"` behavior are unchanged. The runtime deny-set and `docs/TRUST_KERNEL.md` manifest are unchanged.

## Required pre-change regression evidence

The three acceptance tests were changed before implementation and run against the pre-change `origin/main`; they failed as required:

- proposer sizing test: failed because `validate_sizing(... target_path="AGENTS.md")` returned `ok=True` instead of `operator_owned_path`.
- gate surface test: failed because `AGENTS.md` returned no violations instead of `operator_owned_path: AGENTS.md`.
- proposer prompt test: failed because the source still contained the root-file `AGENTS.md` wording.

After implementation, the new/updated acceptance coverage passes.

## Verification

- Focused runtime and regression tests: **432 passed** (`test_mutation_surfaces.py`, `test_llm_proposer.py`, `test_demand.py`, `test_runtime_slice.py`, `test_repair_loop.py`).
- Full Windows pytest: **2820 passed, 19 failed, 17 skipped, 11 warnings**. The 19 failures match the known baseline from #1191; no additional failures appeared.
- CI: **pending**; Linux matrix is authoritative.
- Live verification is intentionally not performed here. 72 hours after deploy, check:
  1. integrated cycles whose `files_changed` contains `AGENTS.md`: expected **0** (baseline 20 in five days);
  2. `proposer_reject` rows with `reason=operator_owned_path`: expected **>0** if reflector recommendations continue, otherwise report 0 together with the count of annotated reflection items;
  3. `AGENTS.md` line count and `git log -1 -- AGENTS.md` author: expected unchanged, or the operator's consolidation commit.

No size cap was added to `AGENTS.md` or any bootstrap file. No deployment or host state was changed.