### PR TITLE
fix(state): break _latest_json_file mtime ties by filename

### DIFF
--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -47,10 +47,25 @@ def _safe_read_json(path: Path | None) -> Any:
 
 
 def _latest_json_file(directory: Path, pattern: str) -> Path | None:
+    """Newest match by mtime, with filename as a deterministic tiebreak.
+
+    #1168: `max` returns the FIRST maximal element, so when two files share an
+    mtime the winner was decided by `glob` order — i.e. by the filesystem. Two
+    files written back to back land on the same mtime whenever the clock has
+    not ticked between them (coarse timestamps, or simply a fast write), and
+    the "newest report" then resolved to whichever the directory happened to
+    yield first. Falling back to the name is both deterministic and correct
+    for the date-stamped patterns used here (`evolution-YYYYMMDD.json`), where
+    lexical order is chronological order.
+    """
     if not directory.exists():
         return None
     matches = directory.glob(pattern)
-    return max(matches, key=lambda p: p.stat().st_mtime if p.exists() else 0, default=None)
+    return max(
+        matches,
+        key=lambda p: (p.stat().st_mtime if p.exists() else 0, p.name),
+        default=None,
+    )
 
 
 def _workspace_looks_like_eeepc_live_runtime(workspace: Path) -> bool:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1178,3 +1179,58 @@ def test_runtime_state_promotion_not_ready_has_actionable_followthrough(tmp_path
     assert "definition_of_ready_missing" in readiness["readiness_reasons"]
     assert runtime["governance_coverage"]["next_action"] == "complete_promotion_readiness_packet"
 
+
+
+def test_latest_json_file_breaks_mtime_ties_by_name(tmp_path):
+    """#1168: identical mtimes must not let glob order pick the winner.
+
+    Two reports written back to back land on the same mtime whenever the
+    filesystem clock has not ticked between the writes. `max` keeps the first
+    maximal element, so before this fix the directory's iteration order — not
+    the date in the filename — decided which report was 'newest'. The failure
+    was invisible on Linux CI and reproduced only when a slower test module
+    ran first on Windows.
+    """
+    from nanobot.runtime.state import _latest_json_file
+
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    old = reports / "evolution-20260401.json"
+    new = reports / "evolution-20260412.json"
+    old.write_text(json.dumps({"cycle_id": "old"}), encoding="utf-8")
+    new.write_text(json.dumps({"cycle_id": "new"}), encoding="utf-8")
+
+    # Force the tie the flake depended on, instead of hoping for it.
+    stamp = 1_777_000_000
+    os.utime(old, (stamp, stamp))
+    os.utime(new, (stamp, stamp))
+    assert old.stat().st_mtime == new.stat().st_mtime
+
+    assert _latest_json_file(reports, "evolution-*.json") == new
+    # And in the other write order, so the assertion cannot pass by luck.
+    reports2 = tmp_path / "reports2"
+    reports2.mkdir()
+    new2 = reports2 / "evolution-20260412.json"
+    old2 = reports2 / "evolution-20260401.json"
+    new2.write_text(json.dumps({"cycle_id": "new"}), encoding="utf-8")
+    old2.write_text(json.dumps({"cycle_id": "old"}), encoding="utf-8")
+    os.utime(old2, (stamp, stamp))
+    os.utime(new2, (stamp, stamp))
+    assert _latest_json_file(reports2, "evolution-*.json") == new2
+
+
+def test_latest_json_file_still_prefers_a_strictly_newer_mtime(tmp_path):
+    """The tiebreak must not override a real mtime difference (#1168)."""
+    from nanobot.runtime.state import _latest_json_file
+
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    # Lexically LAST but older on disk: name must lose to mtime here.
+    zzz = reports / "evolution-29991231.json"
+    aaa = reports / "evolution-20200101.json"
+    zzz.write_text(json.dumps({"cycle_id": "stale"}), encoding="utf-8")
+    aaa.write_text(json.dumps({"cycle_id": "fresh"}), encoding="utf-8")
+    os.utime(zzz, (1_777_000_000, 1_777_000_000))
+    os.utime(aaa, (1_777_000_500, 1_777_000_500))
+
+    assert _latest_json_file(reports, "evolution-*.json") == aaa


### PR DESCRIPTION
Closes #1168.

## What was wrong

```python
return max(matches, key=lambda p: p.stat().st_mtime if p.exists() else 0, default=None)
```

`max` returns the **first** maximal element. When two files share an mtime the winner was therefore decided by `glob` order — by the filesystem, not by anything meaningful. Two reports written back to back land on the same mtime whenever the clock has not ticked between the writes, so "newest evolution report" could resolve to the oldest one.

## Change

The sort key becomes `(mtime, name)`. The tiebreak is deterministic, and for the date-stamped patterns this function is actually called with (`evolution-YYYYMMDD.json`) lexical order is chronological order, so it is correct rather than merely stable. Call sites that pass an exact filename (`latest.json`, `report.index.json`, `backlog.json`) match at most one file and are unaffected.

## Evidence

**The new tie test fails deterministically against the pre-change tree.** It forces the tie with `os.utime` instead of hoping the clock cooperates:

```
FAILED tests/test_commands.py::test_latest_json_file_breaks_mtime_ties_by_name
E  assert WindowsPath('.../evolution-20260401.json') == WindowsPath('.../evolution-20260412.json')
```

It returns the **older** file — the bug, made deterministic. It asserts both write orders so it cannot pass by luck. A second test pins the opposite direction: a lexically later name must still lose to a strictly newer mtime, so the tiebreak cannot override real ordering. That one passes both before and after by design — it guards against over-correction, it is not a bug repro, and I am not claiming it as one.

**The original intermittent test.** `test_runtime_state_prefers_newest_evolution_report` reproduces only when a slower module runs first in the same session, per the issue. Running `tests/test_autoevolve.py tests/test_commands.py` together, ten runs each side:

| | failures of the original test |
|---|---|
| pre-change | **4 / 10** |
| with this change | **0 / 10** |

Consistent with the root cause being removed, but ten runs of an intermittent failure is supporting evidence, not proof. The deterministic test above is the actual proof; this table is why I believe it addresses the reported flake rather than a neighbouring one.

Failure counts in that paired run were stable at 5 with the fix and varied 6–7 without it, the delta being exactly this test.

**Full suite** on Windows: matches the known baseline, no new failures in touched files. Linux CI is authoritative.

## Note

The fix is one line of key material plus a docstring. The docstring is longer than the change because the failure mode — `max` silently preferring iteration order on ties — is not visible from reading the expression, and this is the second time it has cost debugging effort: it produced a false alarm during #1162 review, where the failure looked like it belonged to that PR and did not.
