### PR TITLE
fix(1184): count goal-gap futility attempts by lever surface, and make suppression follow the unit

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -2654,6 +2654,40 @@ def _uncapped(builder: Any, *args: Any, **kwargs: Any) -> list[dict[str, str]]:
         return builder(*args, **kwargs)
 
 
+def _apply_futile_surfaces(state_dir: Path, items: list[dict[str, str]]) -> list[dict[str, str]]:
+    """#1184: a futile lever-addressable gap suppresses every non-``defect`` item
+    aimed at its surface, not just the goal-gap item itself — 11 of the 12
+    live ``stale_feeds`` attacks came from the priority/reflection/hypothesis
+    lanes, which the per-id filter never saw. ``defect`` items survive: a
+    broken feed or checker script must stay repairable. Class A (#1173): a
+    lower-bound count may suppress. Fail-open: any error returns ``items``."""
+    try:
+        from nanobot.runtime import goal_gap_futility
+
+        surfaces = goal_gap_futility.futile_surfaces(state_dir)
+        if not surfaces:
+            return items
+        kept: list[dict[str, str]] = []
+        dropped: list[tuple[str, str]] = []
+        for item in items:
+            if item.get("kind") == "defect":
+                kept.append(item)
+                continue
+            paths = [item.get("affected_path", "")] + [
+                m.strip(".,;:()[]{}") for m in _PATH_TOKEN_RE.findall(str(item.get("summary") or ""))[:20]
+            ]
+            hit = next((s for s in surfaces if goal_gap_futility.surface_hits(s["surface"], paths)), None)
+            if hit is None:
+                kept.append(item)
+            else:
+                dropped.append((item["id"], str(hit.get("gap_id"))))
+        if dropped:
+            _LOG.warning("futile surface: dropped %d demand item(s): %s", len(dropped), dropped[:5])
+        return kept
+    except Exception:
+        return items
+
+
 def collect_demand(
     state_dir: Path, selfevo_repo: Path | None, *, emit_split: bool = False
 ) -> list[dict[str, str]]:
@@ -2854,7 +2888,7 @@ def collect_demand(
                 if steering_note not in summary:
                     item["summary"] = f"{summary} {steering_note}".strip()
             post_doc_guard.append(item)
-        result = post_doc_guard
+        result = _apply_futile_surfaces(state_dir, post_doc_guard)
 
         # #815: best-effort, operator-visible V1-vs-V2 split of what's
         # actually presented — never affects the returned list. Opt-in

--- a/nanobot/runtime/goal_gap_futility.py
+++ b/nanobot/runtime/goal_gap_futility.py
@@ -1,11 +1,14 @@
-"""Deterministic, bounded goal-gap futility tracking (#996, #1166).
+"""Deterministic, bounded goal-gap futility tracking (#996, #1166, #1175, #1184).
 
-Stdlib-only and fail-open.  The demand layer supplies scorecard gaps; this
-module records integrated attempts and suppresses only flat gaps after the
-configured threshold. Ledger rows come from ``state_access.ledger_window``
-from each gap's first-seen date through today (#1175); a window that is not
-``complete`` can raise a gap's persisted attempt count but never lower it,
-and an unavailable window leaves the record's verdict as it was.
+Stdlib-only, fail-open. Counts integrated attempts against each scorecard gap
+and suppresses only flat gaps after the threshold. Attempt unit (#1184): a gap
+with a lever surface (``gap["surface"]`` from ``scorecard``: stale feed names,
+registered held-out checkers, failing compile paths) counts every integrated
+cycle from any lane except ``defect`` whose ``files_changed`` hits the surface
+(``attempt_unit: lever_surface``); other gaps keep the per-demand-id count
+(``attempt_unit: demand_id``). Rows come from ``state_access.ledger_window``
+(#1175): a partial window may raise a persisted count, never lower it; an
+unavailable window leaves the verdict as it was.
 """
 from __future__ import annotations
 
@@ -20,7 +23,14 @@ _DEFAULT_TTL_DAYS = 14
 _EPSILON = 1e-6
 _PHASES = frozenset({"proposed", "outcome"})
 _STATUS_RANK = {"complete": 0, "partial": 1, "unavailable": 2}
-
+# Lanes whose integrations never count as attempts on a lever surface: a broken
+# feed or checker script must stay repairable (#1184, measured on the host
+# 2026-09-02: 0 of the 10 stale_feeds surface hits came from the defect lane;
+# 5 of the 9 heldout_gap ones did, and those moved the metric).
+_EXEMPT_LANES = frozenset({"defect"})
+_MAX_ATTEMPT_SOURCES = 20
+ATTEMPT_UNIT_SURFACE = "lever_surface"
+ATTEMPT_UNIT_ID = "demand_id"
 
 def _threshold() -> int:
     try:
@@ -28,13 +38,11 @@ def _threshold() -> int:
     except (TypeError, ValueError):
         return _DEFAULT_THRESHOLD
 
-
 def _ttl_days() -> int:
     try:
         return max(1, int(os.environ.get("SELFEVO_GOAL_GAP_FUTILITY_TTL_DAYS", "14")))
     except (TypeError, ValueError):
         return _DEFAULT_TTL_DAYS
-
 
 def _parse_ts(value: Any) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
@@ -45,14 +53,11 @@ def _parse_ts(value: Any) -> datetime | None:
     except (TypeError, ValueError):
         return None
 
-
 def _iso(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
-
 def _sidecar(state_dir: Path) -> Path:
     return Path(state_dir) / "demand" / "futility.json"
-
 
 def _load(state_dir: Path) -> dict[str, dict[str, Any]]:
     try:
@@ -60,7 +65,6 @@ def _load(state_dir: Path) -> dict[str, dict[str, Any]]:
         return data if isinstance(data, dict) else {}
     except Exception:
         return {}
-
 
 def _save(state_dir: Path, records: dict[str, dict[str, Any]]) -> None:
     try:
@@ -72,7 +76,6 @@ def _save(state_dir: Path, records: dict[str, dict[str, Any]]) -> None:
     except Exception:
         pass
 
-
 def _window(state_dir: Path, after: datetime):
     """``proposed``/``outcome`` rows since ``after`` across the live ledger and
     its rotated archives (``state_access.ledger_window``)."""
@@ -80,10 +83,8 @@ def _window(state_dir: Path, after: datetime):
 
     return ledger_window(Path(state_dir), since_ts=_iso(after), phases=_PHASES)
 
-
 def _worse(left: str, right: str) -> str:
     return left if _STATUS_RANK.get(left, 2) >= _STATUS_RANK.get(right, 2) else right
-
 
 def _evidence(
     state_dir: Path,
@@ -110,6 +111,18 @@ def _evidence(
         archive_rows, archive_status = list(window.rows), evidence_status(window)
     return list(archive_rows) + list(ledger_rows), _worse(status, archive_status)
 
+def _lane(demand_id: str) -> str:
+    """Demand lane = the id prefix (``reflection-…`` → ``reflection``)."""
+    return demand_id.split("-", 1)[0] if demand_id else ""
+
+def _norm(path: Any) -> str:
+    return str(path or "").replace("\\", "/").strip().lstrip("./")
+
+def surface_hits(surface: list[str], paths: list[Any]) -> bool:
+    """True when any path equals or contains any surface entry (feed names are
+    tokens such as ``host_metrics``; checker and compile entries are paths)."""
+    entries = [_norm(entry) for entry in surface if _norm(entry)]
+    return any(entry == path or entry in path for path in (_norm(p) for p in paths) if path for entry in entries)
 
 def _integrated_count(rows: list[dict[str, Any]], gap_id: str, after: datetime) -> int:
     """Cycles after ``after`` whose ``proposed`` row serves ``gap_id`` and whose
@@ -132,13 +145,32 @@ def _integrated_count(rows: list[dict[str, Any]], gap_id: str, after: datetime) 
                 successful.add(cycle)
     return len(proposed & successful)
 
+def _surface_attempts(rows: list[dict[str, Any]], surface: list[str], after: datetime) -> list[dict[str, str]]:
+    """Integrated cycles after ``after`` whose ``files_changed`` hit ``surface``,
+    from any lane except :data:`_EXEMPT_LANES`, oldest first, one per cycle. A
+    cycle without a ``proposed`` row has no lane and is not counted."""
+    demand_by_cycle: dict[str, str] = {}
+    for row in rows:
+        if row.get("phase") == "proposed" and row.get("cycle_id"):
+            demand_by_cycle[str(row["cycle_id"]).strip()] = str(row.get("demand_id") or "").strip()
+    attempts: dict[str, dict[str, str]] = {}
+    for row in rows:
+        cycle = str(row.get("cycle_id") or "").strip()
+        if row.get("phase") != "outcome" or row.get("outcome") != "success" or cycle not in demand_by_cycle:
+            continue
+        if row.get("integrated", True) is False or _lane(demand_by_cycle[cycle]) in _EXEMPT_LANES:
+            continue
+        ts = _parse_ts(row.get("ts") or row.get("timestamp"))
+        if ts is None or ts <= after or not surface_hits(surface, row.get("files_changed") or []):
+            continue
+        attempts[cycle] = {"cycle_id": cycle, "demand_id": demand_by_cycle[cycle], "ts": _iso(ts)}
+    return sorted(attempts.values(), key=lambda item: item["ts"])
 
 def _delta(first: Any, current: Any) -> float | None:
     try:
         return round(float(current) - float(first), 12)
     except (TypeError, ValueError):
         return None
-
 
 def _improved(direction: str, first: Any, current: Any) -> bool:
     try:
@@ -151,7 +183,6 @@ def _improved(direction: str, first: Any, current: Any) -> bool:
         return delta > _EPSILON
     return False
 
-
 def _emit(state_dir: Path, record: dict[str, Any], futile: bool) -> None:
     try:
         from nanobot.runtime.cycle_ledger import append_event
@@ -160,12 +191,19 @@ def _emit(state_dir: Path, record: dict[str, Any], futile: bool) -> None:
             "gap_id": record.get("gap_id", ""),
             "metric": record.get("metric", ""),
             "attempt_count": record.get("attempt_count", 0),
+            "attempt_unit": record.get("attempt_unit", ATTEMPT_UNIT_ID),
             "metric_delta": record.get("metric_delta"),
             "futile": futile,
         })
     except Exception:
         pass
 
+def _fresh(gap_id: str, gap: dict[str, Any], now: datetime) -> dict[str, Any]:
+    return {
+        "gap_id": gap_id, "metric": str(gap.get("metric") or ""), "first_seen_ts": _iso(now),
+        "first_metric": gap.get("current"), "current_metric": gap.get("current"), "metric_delta": 0.0,
+        "attempt_count": 0, "futile": False,
+    }
 
 def _update(
     state_dir: Path,
@@ -181,16 +219,7 @@ def _update(
         return False
     record = records.get(gap_id)
     if not isinstance(record, dict):
-        record = {
-            "gap_id": gap_id,
-            "metric": str(gap.get("metric") or ""),
-            "first_seen_ts": _iso(now),
-            "first_metric": gap.get("current"),
-            "current_metric": gap.get("current"),
-            "metric_delta": 0.0,
-            "attempt_count": 0,
-            "futile": False,
-        }
+        record = _fresh(gap_id, gap, now)
     until = _parse_ts(record.get("futile_until"))
     if until is not None and now < until:
         record["current_metric"] = gap.get("current")
@@ -198,16 +227,7 @@ def _update(
         records[gap_id] = record
         return True
     if until is not None and now >= until:
-        record = {
-            "gap_id": gap_id,
-            "metric": str(gap.get("metric") or ""),
-            "first_seen_ts": _iso(now),
-            "first_metric": gap.get("current"),
-            "current_metric": gap.get("current"),
-            "metric_delta": 0.0,
-            "attempt_count": 0,
-            "futile": False,
-        }
+        record = _fresh(gap_id, gap, now)
     first_seen = _parse_ts(record.get("first_seen_ts")) or now
     record["metric"] = str(gap.get("metric") or record.get("metric") or "")
     record["current_metric"] = gap.get("current")
@@ -219,12 +239,18 @@ def _update(
         # verdict, only the metric view above was refreshed.
         records[gap_id] = record
         return False
-    counted = _integrated_count(rows, gap_id, first_seen)
+    raw_surface = gap.get("surface")
+    surface = [str(entry) for entry in raw_surface if str(entry).strip()] if isinstance(raw_surface, list) else []
+    attempts = _surface_attempts(rows, surface, first_seen) if surface else []
+    counted = len(attempts) if surface else _integrated_count(rows, gap_id, first_seen)
     if status == "partial":
         # #1175 rule (2): a partial window is a lower bound — it may raise the
         # persisted count (and suppress on it), never lower it.
         counted = max(int(record.get("attempt_count") or 0), counted)
     record["attempt_count"] = counted
+    record["attempt_unit"] = ATTEMPT_UNIT_SURFACE if surface else ATTEMPT_UNIT_ID
+    record["surface"] = surface
+    record["attempt_sources"] = attempts[-_MAX_ATTEMPT_SOURCES:]
     now_futile = (
         record["attempt_count"] >= _threshold()
         and not _improved(str(gap.get("direction") or ""), record.get("first_metric"), gap.get("current"))
@@ -239,7 +265,6 @@ def _update(
     if now_futile != was_futile:
         _emit(state_dir, record, now_futile)
     return now_futile
-
 
 def futile_gap_ids(
     state_dir: Path,
@@ -262,20 +287,15 @@ def futile_gap_ids(
             ]
             horizons = [value for value in horizons if value is not None]
             if horizons:
-                # one horizon read for every gap; _integrated_count filters per gap
+                # one horizon read for every gap; the counters filter per gap
                 window = _window(state_dir, min(horizons))
                 archive_rows, archive_status = list(window.rows), evidence_status(window)
         result = {
             str(gap.get("id"))
             for gap in gaps
             if _update(
-                state_dir,
-                gap,
-                records,
-                now,
-                ledger_rows=ledger_rows,
-                archive_rows=archive_rows,
-                archive_status=archive_status,
+                state_dir, gap, records, now,
+                ledger_rows=ledger_rows, archive_rows=archive_rows, archive_status=archive_status,
             )
         }
         _save(state_dir, records)
@@ -283,6 +303,27 @@ def futile_gap_ids(
     except Exception:
         return set()
 
+def futile_surfaces(state_dir: Path, now: datetime | None = None) -> list[dict[str, Any]]:
+    """Lever surfaces of the gaps currently suppressed (#1184): what demand and
+    the proposer must stop aiming at. Records with an id-count unit have no
+    surface and never appear here. Fail-open to ``[]``."""
+    try:
+        now = now or datetime.now(timezone.utc)
+        out: list[dict[str, Any]] = []
+        for record in _load(state_dir).values():
+            if not isinstance(record, dict):
+                continue
+            until = _parse_ts(record.get("futile_until"))
+            surface = record.get("surface")
+            if record.get("futile") and until is not None and now < until and isinstance(surface, list) and surface:
+                out.append({key: record.get(key) for key in ("gap_id", "metric", "surface", "attempt_count", "first_seen_ts", "metric_delta")})
+        return out
+    except Exception:
+        return []
+
+def futile_surface_for(state_dir: Path, path: Any, now: datetime | None = None) -> dict[str, Any] | None:
+    """The futile gap whose surface ``path`` hits, or ``None``."""
+    return next((gap for gap in futile_surfaces(state_dir, now) if surface_hits(gap["surface"], [path])), None)
 
 def futility_snapshot(state_dir: Path) -> dict[str, Any]:
     try:

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2231,6 +2231,21 @@ def _is_duplicate_proposal(
         title = str(proposal.get("task_title") or "").strip()
         if not title:
             return False, "", ""
+        # #1184: a target on the lever surface of a futile goal gap is refused
+        # before any title heuristic — the loop has already integrated
+        # ``attempt_count`` changes there without moving the metric. Recorded
+        # as ``proposer_reject reason=futile_surface`` by the caller.
+        from nanobot.runtime import goal_gap_futility
+
+        target = str(proposal.get("target_path") or "").strip()
+        futile = goal_gap_futility.futile_surface_for(state_dir, target) if target else None
+        if futile:
+            return True, (
+                f"your proposal targets '{target}', which lies on the lever surface of the "
+                f"futile goal gap {futile.get('metric')} ({futile.get('gap_id')}): "
+                f"{futile.get('attempt_count')} integrated attempts since {futile.get('first_seen_ts')} "
+                f"moved the metric by {futile.get('metric_delta')}; propose work on a DIFFERENT surface"
+            ), f"futile_surface:{futile.get('gap_id')}"
         git_log = _recent_git_log(Path(selfevo_repo)) if selfevo_repo else ""
         ledger_rows = _load_ledger_rows(state_dir)
         recent_titles = _recent_proposed_titles(ledger_rows)
@@ -2862,7 +2877,9 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             # presenting an item whose proposals keep self-dedup-rejecting.
             _record_proposer_reject(
                 state_dir,
-                "self_dedup",
+                # #1184: a futile-surface refusal is its own ledger reason so a
+                # suppressed lever surface is distinguishable from title dedup.
+                "futile_surface" if str(dup_matched).startswith("futile_surface:") else "self_dedup",
                 task_title=str(proposal.get("task_title") or ""),
                 target_path=str(proposal.get("target_path") or ""),
                 matched_against=dup_matched,

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -1356,8 +1356,34 @@ def _metric_value(snapshot: dict[str, Any], section: str, metric: str) -> Any:
 # ─── gap analysis ───────────────────────────────────────────────────────────
 
 
+def _lever_surface(metric: str, snapshot: dict[str, Any], state_dir: Path | None) -> list[str]:
+    """#1184: the deterministic files/tokens that can move ``metric`` — the unit
+    ``goal_gap_futility`` counts attempts over. ``[]`` for a metric without one
+    (those keep the per-demand-id count). Derived from data the loop already
+    writes: stale feed names (``feeds.stale_names`` plus the metric token),
+    the registered held-out checkers, the failing paths of demand's
+    HEAD-watermarked compile scan. Fail-open to ``[]``."""
+    try:
+        if metric == "stale_feeds":
+            sec = snapshot.get("feeds")
+            names = [str(n) for n in (sec.get("stale_names") or []) if n] if isinstance(sec, dict) else []
+            return names + ["stale_feed"] if names else []
+        if metric == "heldout_gap":
+            from nanobot.runtime.heldout import checkers as _checkers
+
+            return sorted(_checkers.CHECKERS)
+        if metric == "compile_clean_ratio" and state_dir is not None:
+            watermark = _read_json(Path(state_dir) / "demand" / "py_compile_watermark.json", None)
+            failures = watermark.get("failures") if isinstance(watermark, dict) else None
+            if isinstance(failures, list):
+                return sorted({str(f.get("path")) for f in failures if isinstance(f, dict) and f.get("path")})
+    except Exception:
+        pass
+    return []
+
+
 def _compute_gaps(
-    snapshot: dict[str, Any], history: list[dict[str, Any]], now: datetime
+    snapshot: dict[str, Any], history: list[dict[str, Any]], now: datetime, state_dir: Path | None = None
 ) -> list[dict[str, Any]]:
     """Metrics violating their :data:`_TARGETS` entry, ordered V1 before V2
     (then by rank). A ``None`` current value never gaps (fail-open toward
@@ -1401,6 +1427,11 @@ def _compute_gaps(
                     f"{threshold} over the last {_WINDOW_DAYS}d window "
                     f"(goal vector {spec['vector']})"
                 ),
+                # #1184: goal_gap_futility reads both — direction to tell an
+                # improving gap from a flat one, surface to count attempts by
+                # what could have moved the metric rather than by demand id.
+                "direction": direction,
+                "surface": _lever_surface(metric, snapshot, state_dir),
             }
             lever_hint = spec.get("lever_hint")
             if not lever_hint and metric == "stale_feeds":
@@ -1537,7 +1568,7 @@ def compute_scorecard(
         # Gap analysis runs against the PRE-append history so the trend
         # window never compares the snapshot against itself.
         history = _read_history(state_dir)
-        snapshot["gaps"] = _compute_gaps(snapshot, history, now)
+        snapshot["gaps"] = _compute_gaps(snapshot, history, now, state_dir=Path(state_dir))
 
         # #879: tech-tree of improvement directions — a RANKING INPUT to
         # demand/goal-review (mirrors the #815 soft vector bias), never a

--- a/tests/test_goal_gap_lever_surface.py
+++ b/tests/test_goal_gap_lever_surface.py
@@ -1,0 +1,278 @@
+"""#1184: goal-gap futility counts attempts by lever surface, not demand id, and
+suppression follows the unit.
+
+Live measurement (host, 2026-09-02, comment on #996): the flat ``stale_feeds``
+gap had ``attempt_count: 1`` while 10 integrated cycles from the priority,
+reflection and hypothesis lanes had edited ``scripts/collect_host_metrics.py``
+and ``scripts/check_stale_feeds.py`` under 9 fresh demand ids. Every test here
+fails against the pre-#1184 tree for the reason in its docstring.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime import demand, goal_gap_futility, llm_proposer, scorecard
+from nanobot.runtime.heldout import checkers
+
+NOW = datetime.now(timezone.utc)
+SURFACE = ["host_metrics", "stale_feed"]
+GAP_ID = "goal-gap-a820ca0c8bb3"
+
+
+def _iso(hours_ago: float) -> str:
+    return (NOW - timedelta(hours=hours_ago)).isoformat().replace("+00:00", "Z")
+
+
+def _state(tmp_path: Path) -> Path:
+    state = tmp_path / "state"
+    (state / "goals").mkdir(parents=True)
+    (state / "ledger").mkdir()
+    (state / "demand").mkdir()
+    return state
+
+
+def _write_live(state: Path, rows: list[dict]) -> None:
+    with (state / "ledger" / "cycles.jsonl").open("w", encoding="utf-8") as fh:
+        fh.writelines(json.dumps(r) + "\n" for r in rows)
+
+
+def _cycle(cycle: str, demand_id: str, files: list[str], hours_ago: float) -> list[dict]:
+    """A proposed row (lane = demand id prefix) and its integrated outcome."""
+    return [
+        {"phase": "proposed", "cycle_id": cycle, "demand_id": demand_id, "target_path": files[0], "ts": _iso(hours_ago)},
+        {"phase": "outcome", "cycle_id": cycle, "outcome": "success", "files_changed": files, "ts": _iso(hours_ago - 0.2)},
+    ]
+
+
+def _record(state: Path, gap_id: str, metric: str, *, attempt_count: int = 0, first_seen_hours_ago: float = 48, **extra) -> Path:
+    path = state / "demand" / "futility.json"
+    path.write_text(json.dumps({gap_id: {
+        "gap_id": gap_id, "metric": metric, "first_seen_ts": _iso(first_seen_hours_ago), "first_metric": 1.0,
+        "current_metric": 1.0, "metric_delta": 0.0, "attempt_count": attempt_count, "futile": False, **extra,
+    }}), encoding="utf-8")
+    return path
+
+
+def _gap(gap_id: str = GAP_ID, metric: str = "stale_feeds", surface: list[str] | None = SURFACE, current: float = 1.0, direction: str = "max") -> dict:
+    return {"id": gap_id, "metric": metric, "current": current, "target": 0.0, "direction": direction, "vector": "V1", "surface": list(surface or [])}
+
+
+def _load_record(state: Path, gap_id: str = GAP_ID) -> dict:
+    return json.loads((state / "demand" / "futility.json").read_text(encoding="utf-8"))[gap_id]
+
+
+def _futile_row(state: Path) -> dict:
+    rows = [json.loads(line) for line in (state / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines() if "goal_gap_futile" in line]
+    assert rows, "no goal_gap_futile ledger row"
+    return rows[-1]
+
+
+# ─── counting ────────────────────────────────────────────────────────────────
+
+def test_stale_feeds_counts_cross_lane_surface_hits_not_its_own_id(tmp_path):
+    """Pre-fix: only cycles whose proposed row carried the gap's own demand id counted -> 2, never futile."""
+    state = _state(tmp_path)
+    _record(state, GAP_ID, "stale_feeds")
+    lanes = ["priority-338ed4f63940", "reflection-241392e2feba", "hypothesis-9f06864f04c1"]
+    rows: list[dict] = []
+    for i in range(10):  # ten fresh ids across three lanes, all on the surface
+        files = ["tests/test_collect_host_metrics.py"] if i == 9 else ["scripts/collect_host_metrics.py"]
+        rows += _cycle(f"c{i}", f"{lanes[i % 3]}{i}", files, 40 - i)
+    rows += _cycle("own-1", GAP_ID, ["scripts/verify_imports.py"], 20)  # the gap's own id, off the surface
+    rows += _cycle("own-2", GAP_ID, ["docs/feeds.md"], 19)
+    _write_live(state, rows)
+
+    assert goal_gap_futility.futile_gap_ids(state, [_gap()]) == {GAP_ID}
+    record = _load_record(state)
+    assert (record["attempt_count"], record["attempt_unit"], record["surface"], record["futile"]) == (10, "lever_surface", SURFACE, True)
+    assert len(record["attempt_sources"]) == 10
+    assert record["attempt_sources"][0].keys() == {"cycle_id", "demand_id", "ts"}
+    assert {s["demand_id"].split("-")[0] for s in record["attempt_sources"]} == {"priority", "reflection", "hypothesis"}
+    row = _futile_row(state)
+    assert (row["attempt_unit"], row["attempt_count"], row["futile"], row["gap_id"]) == ("lever_surface", 10, True, GAP_ID)
+
+
+def test_defect_lane_is_exempt_and_unlinked_cycles_do_not_count(tmp_path):
+    """Pre-fix: no lane concept at all (id-count only)."""
+    state = _state(tmp_path)
+    _record(state, GAP_ID, "stale_feeds")
+    rows: list[dict] = []
+    for i in range(10):
+        rows += _cycle(f"d{i}", f"defect-4a4d672f6ac{i}", ["scripts/collect_host_metrics.py"], 40 - i)
+    rows.append({"phase": "outcome", "cycle_id": "orphan", "outcome": "success", "files_changed": ["scripts/collect_host_metrics.py"], "ts": _iso(5)})
+    rows += _cycle("r1", "reflection-aaaaaaaaaaaa", ["scripts/collect_host_metrics.py"], 4)
+    _write_live(state, rows)
+
+    assert goal_gap_futility.futile_gap_ids(state, [_gap()]) == set()
+    record = _load_record(state)
+    assert (record["attempt_count"], record["attempt_unit"]) == (1, "lever_surface")
+    assert [s["cycle_id"] for s in record["attempt_sources"]] == ["r1"]
+
+
+def test_heldout_counts_checker_hits_and_ignores_own_off_surface_proposals(tmp_path):
+    """Pre-fix: the gap's own 3 proposals on non-checker files counted (3); the 2 checker edits did not."""
+    state = _state(tmp_path)
+    gap_id = "goal-gap-c09521b7459a"
+    _record(state, gap_id, "heldout_gap")
+    rows: list[dict] = []
+    for i, path in enumerate(["scripts/verify_imports.py", "tests/test_summarize_failure_reasons.py", "tests/test_workspace_validation_helpers.py"]):
+        rows += _cycle(f"own{i}", gap_id, [path], 30 - i)
+    rows += _cycle("h1", "hypothesis-000000000001", ["scripts/eeebot_dashboard.py"], 20)
+    rows += _cycle("h2", "hypothesis-000000000002", ["scripts/loop_health_report.py", "tests/test_loop_health_report.py"], 10)
+    _write_live(state, rows)
+
+    gap = _gap(gap_id, "heldout_gap", sorted(checkers.CHECKERS), current=0.5)
+    goal_gap_futility.futile_gap_ids(state, [gap])
+    record = _load_record(state, gap_id)
+    assert (record["attempt_count"], record["attempt_unit"]) == (2, "lever_surface")
+    assert record["surface"] == sorted(checkers.CHECKERS)
+    assert [s["cycle_id"] for s in record["attempt_sources"]] == ["h1", "h2"]
+
+
+def test_global_ratio_keeps_the_id_count_and_says_so(tmp_path):
+    """Pre-fix: no attempt_unit / surface / attempt_sources on the record."""
+    state = _state(tmp_path)
+    gap_id = "goal-gap-2d9ab3aa9d09"
+    _record(state, gap_id, "confirmed_ratio")
+    rows = _cycle("o1", gap_id, ["scripts/eeebot_dashboard.py"], 30) + _cycle("o2", gap_id, ["scripts/x.py"], 20)
+    rows += _cycle("shared", "reflection-bbbbbbbbbbbb", ["scripts/eeebot_dashboard.py"], 10)  # same path, other lane
+    _write_live(state, rows)
+
+    goal_gap_futility.futile_gap_ids(state, [_gap(gap_id, "confirmed_ratio", surface=[], current=0.41, direction="min")])
+    record = _load_record(state, gap_id)
+    assert (record["attempt_count"], record["attempt_unit"], record["surface"], record["attempt_sources"]) == (2, "demand_id", [], [])
+
+
+def test_attempt_sources_keep_the_newest_twenty(tmp_path):
+    state = _state(tmp_path)
+    _record(state, GAP_ID, "stale_feeds")
+    rows: list[dict] = []
+    for i in range(25):
+        rows += _cycle(f"c{i:02d}", f"reflection-{i:012d}", ["scripts/check_stale_feeds.py"], 47 - i)
+    _write_live(state, rows)
+    goal_gap_futility.futile_gap_ids(state, [_gap()])
+    record = _load_record(state)
+    assert record["attempt_count"] == 25
+    assert [s["cycle_id"] for s in record["attempt_sources"]] == [f"c{i:02d}" for i in range(5, 25)]
+
+
+def test_partial_window_applies_the_never_lower_rule_to_the_surface_count(tmp_path):
+    """Pre-fix: the surface unit did not exist, so the id-count (0) was floored at the persisted 4."""
+    state = _state(tmp_path)
+    _record(state, GAP_ID, "stale_feeds", attempt_count=4, attempt_unit="lever_surface", surface=SURFACE)
+    (state / "ledger" / f"cycles-{(NOW - timedelta(days=1)).date().isoformat()}.jsonl.gz").write_bytes(b"not gzip")
+    rows: list[dict] = []
+    for i in range(6):
+        rows += _cycle(f"c{i}", f"reflection-{i:012d}", ["scripts/collect_host_metrics.py"], 10 - i)
+    _write_live(state, rows)
+    goal_gap_futility.futile_gap_ids(state, [_gap()])
+    record = _load_record(state)
+    assert (record["attempt_count"], record["window_status"], record["attempt_unit"]) == (6, "partial", "lever_surface")
+
+
+# ─── the surface comes from the scorecard, with the direction ────────────────
+
+def _snapshot() -> dict:
+    return {
+        "loop": {"repeat_failure_rate": 0.5},
+        "quality": {"compile_clean_ratio": 0.9, "script_count": 10},
+        "cost": {"tokens_per_integration": 100.0},
+        "value": {"confirmed_ratio": 0.2, "completed_declared": 5, "owner_live_ratio": 0.9, "owner_live_inventory": 5},
+        "heldout": {"heldout_gap": 0.5},
+        "feeds": {"stale": 1, "total": 5, "stale_names": ["host_metrics"]},
+    }
+
+
+def test_scorecard_gaps_carry_direction_and_lever_surface(tmp_path):
+    """Pre-fix: gap dicts had neither key, so futility's improvement test never fired and no surface existed."""
+    state = _state(tmp_path)
+    (state / "demand" / "py_compile_watermark.json").write_text(json.dumps({
+        "schema_version": "demand-py-compile-watermark-v1", "git_head": "abc",
+        "failures": [{"path": "scripts/broken_b.py", "error": "SyntaxError"}, {"path": "scripts/broken_a.py", "error": "SyntaxError"}],
+    }), encoding="utf-8")
+    gaps = {g["metric"]: g for g in scorecard._compute_gaps(_snapshot(), [], NOW, state_dir=state)}
+    assert gaps["stale_feeds"]["direction"] == "max" and gaps["stale_feeds"]["surface"] == ["host_metrics", "stale_feed"]
+    assert gaps["heldout_gap"]["surface"] == sorted(checkers.CHECKERS)
+    assert gaps["compile_clean_ratio"]["surface"] == ["scripts/broken_a.py", "scripts/broken_b.py"]
+    assert (gaps["confirmed_ratio"]["direction"], gaps["confirmed_ratio"]["surface"]) == ("min", [])
+    assert (gaps["repeat_failure_rate"]["direction"], gaps["repeat_failure_rate"]["surface"]) == ("max", [])
+    assert scorecard._compute_gaps(_snapshot(), [], NOW)  # state_dir stays optional for existing callers
+
+
+def test_improving_gap_from_the_scorecard_is_not_futile(tmp_path, monkeypatch):
+    """Pre-fix: scorecard gaps carried no direction, so _improved() was always False and an
+    improving heldout_gap with enough attempts was marked futile anyway."""
+    monkeypatch.setenv("SELFEVO_GOAL_GAP_FUTILITY_THRESHOLD", "2")
+    state = _state(tmp_path)
+    gap = next(g for g in scorecard._compute_gaps(_snapshot(), [], NOW, state_dir=state) if g["metric"] == "heldout_gap")
+    gap_id = "goal-gap-c09521b7459a"
+    path = _record(state, gap_id, "heldout_gap")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data[gap_id]["first_metric"] = 0.8  # metric fell 0.8 -> 0.5 (direction max): improving
+    path.write_text(json.dumps(data), encoding="utf-8")
+    rows = _cycle("h1", "hypothesis-000000000001", ["scripts/eeebot_dashboard.py"], 20) + _cycle("h2", "hypothesis-000000000002", ["scripts/prune_failed_backlog.py"], 10)
+    _write_live(state, rows)
+    assert goal_gap_futility.futile_gap_ids(state, [{**gap, "id": gap_id}]) == set()
+    record = _load_record(state, gap_id)
+    assert (record["attempt_count"], record["futile"]) == (2, False)
+
+
+# ─── suppression follows the unit ────────────────────────────────────────────
+
+def _futile_record(state: Path) -> None:
+    _record(state, GAP_ID, "stale_feeds", attempt_count=10, attempt_unit="lever_surface", surface=SURFACE,
+            futile=True, futile_until=(NOW + timedelta(days=7)).isoformat().replace("+00:00", "Z"))
+
+
+def test_demand_drops_non_defect_items_aimed_at_a_futile_surface(tmp_path, monkeypatch, caplog):
+    """Pre-fix: only the goal-gap item itself was hidden; 11 of 12 live attacks came from other lanes."""
+    state = _state(tmp_path)
+    _futile_record(state)
+    reflection = demand._make_item("reflection", "Harden the host metrics collector retry loop", "cycle c: flaky", affected_path="scripts/collect_host_metrics.py")
+    priority = demand._make_item("priority", "Priority 3 — restore scripts/check_stale_feeds.py output", "Fix the stale feed checker")
+    defect = demand._make_item("defect", "scripts/collect_host_metrics.py fails to compile", "SyntaxError", affected_path="scripts/collect_host_metrics.py")
+    elsewhere = demand._make_item("reflection", "Speed up scripts/test_runner.py", "slow", affected_path="scripts/test_runner.py")
+    monkeypatch.setattr(demand, "_priority_items", lambda *a, **k: [priority, reflection, defect, elsewhere])
+
+    with caplog.at_level(logging.WARNING, logger="nanobot.runtime.demand"):
+        items = demand.collect_demand(state, None)
+    assert [i["id"] for i in items] == [defect["id"], elsewhere["id"]]
+    assert any("futile surface: dropped 2" in r.message for r in caplog.records)
+    assert goal_gap_futility.futile_surfaces(state)[0]["gap_id"] == GAP_ID
+
+
+def test_proposer_refuses_a_target_on_a_futile_surface_with_its_own_reason(tmp_path, monkeypatch):
+    """Pre-fix: the proposal passed dedup and would have been written; no futile_surface reason existed."""
+    state = _state(tmp_path)
+    _futile_record(state)
+    proposal = {"task_title": "Add retry to the host metrics collector", "target_path": "scripts/collect_host_metrics.py", "serves": "priority 1", "rationale": "r"}
+    dup, feedback, matched = llm_proposer._is_duplicate_proposal(state, None, proposal)
+    assert dup is True and matched == f"futile_surface:{GAP_ID}"
+    assert "lever surface" in feedback and "10 integrated attempts" in feedback
+    assert llm_proposer._is_duplicate_proposal(state, None, {**proposal, "target_path": "scripts/other.py"})[0] is False
+
+    # same gates as tests/test_llm_proposer.py's autouse fixture: proposer on, the
+    # pre-#760 supply-driven policy (no demand items needed to fire)
+    monkeypatch.setenv("SELFEVO_LLM_PROPOSER_ENABLED", "1")
+    monkeypatch.setenv("SELFEVO_DEMAND_DRIVEN_ENABLED", "0")
+    (state / "goals" / "goal_text.json").write_text(json.dumps({"text": "no priority section, so should_propose is True"}), encoding="utf-8")
+    monkeypatch.setattr(llm_proposer, "propose", lambda context, *, rejection_reason=None, timeout=120.0, system_prompt=None: dict(proposal))
+    assert llm_proposer.maybe_propose(state, None) is None
+    rows = [json.loads(line) for line in (state / "ledger" / "cycles.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+    rejects = [r for r in rows if r.get("phase") == "proposer_reject"]
+    assert rejects and rejects[-1]["reason"] == "futile_surface"
+    assert rejects[-1]["target_path"] == "scripts/collect_host_metrics.py" and rejects[-1]["matched_against"] == f"futile_surface:{GAP_ID}"
+
+
+def test_expired_or_id_count_records_expose_no_surface(tmp_path):
+    state = _state(tmp_path)
+    _record(state, GAP_ID, "stale_feeds", attempt_count=10, attempt_unit="lever_surface", surface=SURFACE,
+            futile=True, futile_until=_iso(1))  # expired an hour ago
+    assert goal_gap_futility.futile_surfaces(state) == []
+    _record(state, "goal-gap-2d9ab3aa9d09", "confirmed_ratio", attempt_count=12, attempt_unit="demand_id", surface=[],
+            futile=True, futile_until=(NOW + timedelta(days=7)).isoformat().replace("+00:00", "Z"))
+    assert goal_gap_futility.futile_surfaces(state) == []
+    assert goal_gap_futility.futile_surface_for(state, "scripts/collect_host_metrics.py") is None


### PR DESCRIPTION
Closes #1184. Parent ADR #1173; follow-on to #996 / #1166; builds on #1175 (`state_access` windows, partial-window rule). Design comment with the measurement: https://github.com/ozand/eeebot/issues/996#issuecomment-5503052161.

## Problem

`goal_gap_futility` counted cycles whose `proposed` row carried the gap's own demand id. The unit was the demand lane; futility is a property of the metric. Host, 2026-09-02 (UTC): the flat `stale_feeds` gap (`goal-gap-a820ca0c8bb3`, 1.0 → 1.0 since 2026-08-27 06:03) had `attempt_count: 1` while **9 integrated cycles** from the priority (1), goal-gap (2), reflection (3) and hypothesis (3) lanes had edited `scripts/collect_host_metrics.py`, `scripts/check_stale_feeds.py` and their tests under 9 distinct ids; 0 of them came from the defect lane. The `heldout_gap` gap's own 3 proposals targeted files that are not registered checkers and could not move the metric, while 9 checker edits from other lanes (5 defect) did move it. `futile_gap_ids` is consulted by exactly one decision (`demand._goal_gap_items`), so even a correct count gated 1 of 12 attack routes. Threshold lowering was ruled out on data (N=1 suppresses one route of one gap; N=2..5 suppress nothing).

## What this PR does

**Attempt unit = lever-surface hit.** `scorecard._compute_gaps` now emits two more keys per gap:
- `direction` (`max`/`min`) — previously never passed to futility, so its `_improved()` check was always `False` and an improving gap with enough attempts would have been marked futile anyway. Found while wiring the surface; fixed and tested here.
- `surface` — the deterministic files/tokens that can move the metric: `stale_feeds` → `feeds.stale_names` + `"stale_feed"`; `heldout_gap` → the registered `heldout.checkers.CHECKERS` paths; `compile_clean_ratio` → the failing paths of demand's HEAD-watermarked compile scan (`demand/py_compile_watermark.json`); everything else → `[]`.

`goal_gap_futility._update`: a gap with a surface counts every integrated cycle after `first_seen_ts`, from any lane except `defect`, whose outcome `files_changed` equals or contains a surface entry — one per cycle, `attempt_unit: lever_surface`. A cycle without a `proposed` row has no lane and is not counted. Gaps without a surface keep the id count, labelled `attempt_unit: demand_id`. Records carry `attempt_unit`, `surface`, `attempt_sources` (newest 20 `{cycle_id, demand_id, ts}`); the `goal_gap_futile` ledger row carries `attempt_unit`. The #1175 partial-window rule applies to both units (a partial window may raise the count, never lower it; unavailable keeps the verdict).

**Suppression follows the unit.**
- `demand.collect_demand`: a futile lever-addressable gap drops every non-`defect` item whose `affected_path` or summary paths hit its surface (one `WARNING` journal line naming the dropped ids and the gap). `defect` items survive: a broken feed or checker script must stay repairable. New `goal_gap_futility.futile_surfaces` / `futile_surface_for` read the sidecar; expired or id-count records expose no surface.
- `llm_proposer._is_duplicate_proposal`: a proposal whose `target_path` lies on a futile surface is refused before any title heuristic, with feedback naming the gap, its attempt count and metric delta; the reject row is `proposer_reject reason=futile_surface`, `matched_against=futile_surface:<gap_id>` — distinct from `self_dedup`.

No LLM, no similarity, no embeddings: string membership over `files_changed` inside the window futility already reads. No threshold or TTL change, no new cap, no new sidecar.

**Ordering vs #1179**, decided: proceed now, do not wait. The mechanism is per-metric and independent of whether `host_metrics` stays in `_FEEDS`. If #1179 drops the feed, the `stale_feeds` gap vanishes and the live tripwire moves to the next flat lever-addressable gap (today there is none: `heldout_gap` is 0.0, compile is clean); until then `stale_feeds` is the live verification target below. Stated on #1184.

`goal_gap_futility.py`: 336 physical lines, 260 code lines (36 docstring, 11 comment) against the "about 300 LOC" rule in `docs/TRUST_KERNEL.md`; deny-set membership unchanged; stdlib only.

## Tests

`tests/test_goal_gap_lever_surface.py`, 11 tests. Against `origin/main` (e3dd469c) in a throwaway worktree, `--tb=line` — **11 failed**:

```
test_goal_gap_lever_surface.py:88:  AssertionError: assert set() == {'goal-gap-a820ca0c8bb3'}      # 10 cross-lane surface hits, id-count 2 -> not futile
test_goal_gap_lever_surface.py:111: KeyError: 'attempt_unit'                                        # defect lane exempt / orphan cycle
test_goal_gap_lever_surface.py:130: KeyError: 'attempt_unit'                                        # heldout: checker hits count, own off-surface proposals do not
test_goal_gap_lever_surface.py:146: KeyError: 'attempt_unit'                                        # global ratio keeps id-count, says so
test_goal_gap_lever_surface.py:158: assert 0 == 25                                                  # attempt_sources newest 20
test_goal_gap_lever_surface.py:173: assert (4, 'partial', 'lever_surface') == (6, 'partial', 'lever_surface')  # never-lower rule on the surface unit
test_goal_gap_lever_surface.py:196: TypeError: _compute_gaps() got an unexpected keyword argument 'state_dir'   # gaps carry direction + surface
test_goal_gap_lever_surface.py:210: TypeError: _compute_gaps() got an unexpected keyword argument 'state_dir'   # improving scorecard gap is not futile
test_goal_gap_lever_surface.py:242: assert ['priority-b1...'] == ['defect-b93a...']                 # demand drops non-defect items on the surface
test_goal_gap_lever_surface.py:253: assert (False is True)                                          # proposer refuses a surface target
test_goal_gap_lever_surface.py:274: AttributeError: no attribute 'futile_surfaces'
```

Fixture for the first test is the issue's AC verbatim: flat `stale_feeds`, surface `["host_metrics", "stale_feed"]`, 10 integrated cycles from priority/reflection/hypothesis lanes touching `scripts/collect_host_metrics.py` (one via its test file), 0 with `demand_id == gap`, plus 2 of the gap's own cycles off the surface → `attempt_count == 10`, futile, ledger row `attempt_unit: lever_surface`. The end-to-end proposer test drives `maybe_propose` with a mocked `propose` and asserts the `futile_surface` ledger row. Existing `test_goal_gap_futility.py` (#996/#1166/#1175) and `test_class_a_windows.py` stay green unchanged.

Full suite on the branch (Windows, `-n 4`): **2848 passed, 18 failed, 17 skipped** — the 18 are the environmental baseline set (`test_autoevolve*` 12, `test_bridge_locking` 3, `test_selfevo_export_security` 2, `test_bridge_cycle_tags` 1). Linux CI is authoritative.

## Live verification (operator; the host stays read-only for me)

1. **The count, first cycle after deploy.** `state/demand/futility.json` → `goal-gap-a820ca0c8bb3` must show `attempt_unit: "lever_surface"`, `surface: ["host_metrics", "stale_feed"]`, and `attempt_count` equal to this independent count (as the service user, read-only):
   ```
   sudo -u eeepc-agent PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current \
     /opt/eeepc-agent/venv/bin/python - <<'PY'
   import gzip, json, glob
   L = "/var/lib/eeepc-agent/self-evolving-agent/state/ledger"
   FIRST_SEEN = "2026-08-27T06:03:37.601657Z"
   rows = []
   for p in sorted(glob.glob(f"{L}/cycles-*.jsonl.gz")) + [f"{L}/cycles.jsonl"]:
       op = gzip.open if p.endswith(".gz") else open
       rows += [json.loads(l) for l in op(p, "rt", encoding="utf-8") if '"phase": "proposed"' in l or '"phase": "outcome"' in l]
   lane = {r["cycle_id"]: str(r.get("demand_id") or "") for r in rows if r.get("phase") == "proposed" and r.get("cycle_id")}
   hits = {r["cycle_id"] for r in rows if r.get("phase") == "outcome" and r.get("outcome") == "success" and r.get("ts", "") > FIRST_SEEN
           and r.get("cycle_id") in lane and not lane[r["cycle_id"]].startswith("defect-")
           and any(t in f for f in (r.get("files_changed") or []) for t in ("host_metrics", "stale_feed"))}
   print("independent_lever_surface_count", len(hits))
   PY
   ```
   Pre-fix the record said `attempt_count: 1`; the independent count read 9 at 2026-09-02 02:00 UTC (05:00 MSK). Equality is the proof. Also quote `attempt_sources[-1]` — its `demand_id` should be from a non-defect lane.
2. **The verdict.** If `attempt_count ≥ 10` and `metric_delta == 0.0`: `futile: true`, and the ledger has a `goal_gap_futile` row with `attempt_unit: "lever_surface"` (`zgrep -h goal_gap_futile` over live + newest archive). If below 10: quote the count and say the threshold is not reached — that is the honest state, not a failure.
3. **Suppression, only once futile.** `proposer_reject` rows with `reason: futile_surface` and `target_path` on the surface, and bridge journal lines `futile surface: dropped N demand item(s)`. Zero of both while the gap is not futile is correct.
4. If #1179 has dropped `host_metrics` from `_FEEDS` before this deploys, the gap is gone: name the gap used instead (any record with `attempt_unit: lever_surface`), or state that no lever-addressable gap is open.

## Non-goals

Thresholds (10) and TTL (14 d) unchanged. No cross-lane dedup of repeated `target_path` attacks in general (33 of 145 target paths since 08-26 hit by ≥2 ids from ≥2 lanes — the existence-index/zombie class, #1114). `compile_clean_ratio` stays lever-addressable via the compile watermark's failing set; if the moving-target concern from the design comment materialises, drop it to two metrics in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
