### PR TITLE
fix(scorecard): distinguish unavailable readers from healthy empty state

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1480,11 +1480,7 @@ def _goal_gap_items(
 
         items: list[dict[str, str]] = []
         gap_rows: list[dict[str, Any]] = []
-        snapshot = scorecard.compute_scorecard(state_dir, selfevo_repo)
-        if snapshot.get("gaps_status") == "unavailable":
-            logger.warning("goal gaps unavailable; no gaps known")
-            return []
-        for gap in scorecard.goal_gaps(state_dir, selfevo_repo):
+        for gap in snapshot.get("gaps", []):
             metric = str(gap.get("metric") or "").strip()
             vector = str(gap.get("vector") or "").strip()
             if not metric or vector not in ("V1", "V2"):

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1466,7 +1466,7 @@ def _goal_gap_items(
         from nanobot.runtime import scorecard
 
         snapshot = scorecard.compute_scorecard(state_dir, selfevo_repo)
-        if snapshot.get("gaps_status") != "complete":
+        if snapshot.get("gaps_status") == "unavailable":
             logger.warning("goal gaps unavailable; no gaps known")
             return []
 
@@ -1481,7 +1481,7 @@ def _goal_gap_items(
         items: list[dict[str, str]] = []
         gap_rows: list[dict[str, Any]] = []
         snapshot = scorecard.compute_scorecard(state_dir, selfevo_repo)
-        if snapshot.get("gaps_status") != "complete":
+        if snapshot.get("gaps_status") == "unavailable":
             logger.warning("goal gaps unavailable; no gaps known")
             return []
         for gap in scorecard.goal_gaps(state_dir, selfevo_repo):

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1480,6 +1480,10 @@ def _goal_gap_items(
 
         items: list[dict[str, str]] = []
         gap_rows: list[dict[str, Any]] = []
+        snapshot = scorecard.compute_scorecard(state_dir, selfevo_repo)
+        if snapshot.get("gaps_status") != "complete":
+            logger.warning("goal gaps unavailable; no gaps known")
+            return []
         for gap in scorecard.goal_gaps(state_dir, selfevo_repo):
             metric = str(gap.get("metric") or "").strip()
             vector = str(gap.get("vector") or "").strip()

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -149,6 +149,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 import re
 import subprocess
@@ -1462,6 +1464,11 @@ def _goal_gap_items(
     items."""
     try:
         from nanobot.runtime import scorecard
+
+        snapshot = scorecard.compute_scorecard(state_dir, selfevo_repo)
+        if snapshot.get("gaps_status") != "complete":
+            logger.warning("goal gaps unavailable; no gaps known")
+            return []
 
         try:
             from nanobot.runtime import tech_tree

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -1250,7 +1250,7 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
     from nanobot.runtime.heldout import checkers as _checkers
 
     registered = len(_checkers.CHECKERS)
-    status = _sidecar_status(Path(state_dir) / "heldout" / "results.json")
+    sidecar_status = _sidecar_status(Path(state_dir) / "heldout" / "results.json")
     checked = passed = failed = skipped = 0
     data = None
     try:
@@ -1278,8 +1278,7 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
         "passed": passed,
         "failed": failed,
         "skipped": skipped,
-        "heldout_gap": None if status not in ("present", "absent") else _ratio(failed, passed + failed),
-        "reader_status": status,
+        "heldout_gap": None if sidecar_status not in ("present", "absent") else _ratio(failed, passed + failed),
     }
 
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -531,7 +531,6 @@ def _ledger_rows(state_dir: Path, now: datetime) -> tuple[list[dict[str, Any]], 
         state_dir,
         since_ts=_iso(now - timedelta(days=_WINDOW_DAYS)),
         phases=None,
-        max_bytes=2**31 - 1,
     )
     return list(window.rows), window
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -87,6 +87,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
+from nanobot.runtime import state_access
+
+from loguru import logger
+
+from nanobot.runtime import state_access
+
 SCORECARD_SCHEMA = "scorecard-v1"
 
 # ─── control-plane visibility (#865) ─────────────────────────────────────────
@@ -306,6 +314,7 @@ _RECOMPUTE_MINUTES = 30
 _MAX_GZ_FILES = 7  # bounded archive read — rotation-aware, never unbounded
 _MAX_HISTORY_LINES = 400  # bounded history read (one line per recompute)
 _MAX_HISTORY_BYTES = 512 * 1024  # 512KB size-based history rotation threshold (#1040)
+_MAX_HISTORY_ARCHIVES = 5
 
 # Trend-gap parameters for tokens_per_integration: worsening more than
 # _TREND_WORSEN_FACTOR vs the mean of the prior window is a gap.
@@ -521,56 +530,51 @@ def _history_path(state_dir: Path) -> Path:
 # ─── ledger reading (rotation-aware, bounded) ───────────────────────────────
 
 
-def _ledger_rows(state_dir: Path, now: datetime) -> list[dict[str, Any]]:
-    """In-window rows from ``ledger/cycles.jsonl`` PLUS up to
-    :data:`_MAX_GZ_FILES` newest rotated ``cycles-*.jsonl.gz`` archives.
+def _ledger_rows(state_dir: Path, now: datetime) -> tuple[list[dict[str, Any]], state_access.Window]:
+    """Read the seven-day ledger window through the shared state reader."""
+    window = state_access.ledger_window(
+        state_dir,
+        since_ts=_iso(now - timedelta(days=_WINDOW_DAYS)),
+        phases=frozenset({"outcome", "proposed", "proposer_reject", "proposer_skip", "idle", "integrity"}),
+    )
+    return list(window.rows), window
 
-    Rotation blinds single-file readers (#773 lesson) — a 7-day window MUST
-    read the archives too, bounded so a years-old ledger dir stays cheap.
-    Fail-open per file: any unreadable file contributes no rows.
-    """
-    rows: list[dict[str, Any]] = []
-    cutoff = now - timedelta(days=_WINDOW_DAYS)
 
-    def _consume(lines: list[str]) -> None:
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
-                continue
-            if not isinstance(row, dict):
-                continue
-            ts = _parse_ts(row.get("ts"))
-            if ts is None or ts < cutoff:
-                continue
-            rows.append(row)
-
+def _sidecar_status(path: Path) -> str:
+    """Return the shared sidecar reader status without inventing a fallback."""
     try:
-        ledger_dir = Path(state_dir) / "ledger"
-        if not ledger_dir.is_dir():
-            return rows
-        active = ledger_dir / "cycles.jsonl"
-        if active.is_file():
-            try:
-                _consume(active.read_text(encoding="utf-8").splitlines())
-            except Exception:
-                pass
-        try:
-            archives = sorted(ledger_dir.glob("cycles-*.jsonl.gz"), reverse=True)
-        except Exception:
-            archives = []
-        for gz_path in archives[:_MAX_GZ_FILES]:
-            try:
-                with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
-                    _consume(fh.read().splitlines())
-            except Exception:
-                continue
-        return rows
-    except Exception:
-        return rows
+        if not path.exists():
+            return "absent"
+        size = path.stat().st_size
+    except PermissionError:
+        return "permission"
+    except OSError:
+        return "unavailable"
+    return state_access.sidecar(path, default=None, max_bytes=size).status
+
+
+def _reader_status(
+    state_dir: Path,
+    ledger_window: state_access.Window,
+    feeds: dict[str, Any],
+) -> dict[str, Any]:
+    """Expose the status of every state source consulted by the scorecard."""
+    status: dict[str, Any] = {
+        "ledger": {
+            "status": ledger_window.status,
+            "covered_from": ledger_window.covered_from,
+            "covered_to": ledger_window.covered_to,
+            "files_skipped": ledger_window.files_skipped,
+            "notes": list(ledger_window.notes),
+        },
+        "completed": {"status": _sidecar_status(state_dir / "demand" / "completed.json")},
+        "heldout": {"status": _sidecar_status(state_dir / "heldout" / "results.json")},
+        "history": {"status": "present" if (state_dir / "scorecard" / "history.jsonl").is_file() else "absent"},
+        "feeds": {},
+    }
+    for name, detail in (feeds.get("feeds") or {}).items():
+        status["feeds"][name] = {"status": detail.get("status"), "source": detail.get("source")}
+    return status
 
 
 # ─── section: loop (V1) ─────────────────────────────────────────────────────
@@ -858,6 +862,9 @@ def _quality_section(state_dir: Path, selfevo_repo: Path | None) -> dict[str, An
 
 def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) -> dict[str, Any]:
     declared = confirmed = 0
+    completed_status = _sidecar_status(Path(state_dir) / "demand" / "completed.json")
+    if completed_status not in ("present", "absent"):
+        completed = None
     # #789 defense in depth: a `confirmed` entry counts ONLY when its signal
     # is one usage_evidence itself writes (HARNESS_SIGNALS) — a foreign
     # signal means non-harness code wrote the fitness input (live
@@ -904,9 +911,9 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
         pass
 
     return {
-        "completed_declared": declared,
-        "completed_confirmed": confirmed,
-        "confirmed_ratio": _ratio(confirmed, declared),
+        "completed_declared": completed if completed is None else declared,
+        "completed_confirmed": completed if completed is None else confirmed,
+        "confirmed_ratio": None if completed is None else _ratio(confirmed, declared),
         "doc_only_integrations_24h": doc_only_24h,
         "owner_live_inventory": owner_live_inventory,
         "owner_live_active": owner_live_active,
@@ -1009,14 +1016,11 @@ def fitness_sidecar_hashes(state_dir: Path) -> dict[str, str]:
 # ─── section: integrity (#789 — fitness-input tamper incidents) ─────────────
 
 
-_FEED_STALE_SECS_DEFAULT = 12 * 3600
-
 # (name, rel_path, is_dir, field, max_age_seconds)
 _FEEDS: tuple[tuple[str, str, bool, str | None, int], ...] = (
     ("usage", "usage/last_used.json", False, "scanned_at_utc", 12 * 3600),
     ("heldout", "heldout/results.json", False, "checked_at_utc", 12 * 3600),
     ("llm_calls", "llm_calls", True, None, 24 * 3600),
-    ("host_metrics", "host_metrics", True, None, 24 * 3600),
     (
         "validator_harness_parent",
         "validator_harness_parent/runs.jsonl",
@@ -1076,6 +1080,7 @@ def _feed_latest_timestamp(
         return datetime.fromtimestamp(newest_mtime, tz=timezone.utc), "dir_mtime"
 
     # Single-file feed: attempt to parse JSON/JSONL field if specified
+    parse_failed = False
     if field:
         if feed_path.suffix == ".jsonl":
             try:
@@ -1092,7 +1097,7 @@ def _feed_latest_timestamp(
                         if ts:
                             return ts, "stamp"
             except Exception:
-                pass
+                parse_failed = True
         else:
             try:
                 with open(feed_path, "r", encoding="utf-8", errors="ignore") as f:
@@ -1102,7 +1107,10 @@ def _feed_latest_timestamp(
                     if ts:
                         return ts, "stamp"
             except Exception:
-                pass
+                parse_failed = True
+
+    if parse_failed:
+        return None, "corrupt"
 
     # Fallback to file mtime
     try:
@@ -1132,10 +1140,13 @@ def _feeds_section(state_dir: Path | None, now_utc: datetime | None = None) -> d
     # directories. An external feed is considered populated if it exists as
     # a non-empty file or non-empty directory.
     def _is_populated(rel_path: str, is_dir: bool) -> bool:
-        p = state_dir / rel_path
-        if is_dir:
-            return p.is_dir() and any(p.iterdir())
-        return p.is_file() and p.stat().st_size > 0
+        try:
+            p = state_dir / rel_path
+            if is_dir:
+                return p.is_dir() and any(p.iterdir())
+            return p.is_file() and p.stat().st_size > 0
+        except (OSError, PermissionError):
+            return False
 
     initialized = any(
         _is_populated(rel_path, is_dir)
@@ -1165,9 +1176,9 @@ def _feeds_section(state_dir: Path | None, now_utc: datetime | None = None) -> d
         if ts is None:
             stale_names.append(name)
             feed_details[name] = {
-                "status": "missing",
+                "status": "corrupt" if source == "corrupt" else ("unreadable" if source == "error" else "missing"),
                 "source": source,
-                "stale": True,
+                "stale": source == "corrupt" or (source != "error"),
                 "latest_ts": None,
                 "age_seconds": None,
                 "max_age_seconds": max_age_s,
@@ -1237,6 +1248,7 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
     from nanobot.runtime.heldout import checkers as _checkers
 
     registered = len(_checkers.CHECKERS)
+    status = _sidecar_status(Path(state_dir) / "heldout" / "results.json")
     checked = passed = failed = skipped = 0
     data = None
     try:
@@ -1264,7 +1276,8 @@ def _heldout_section(state_dir: Path) -> dict[str, Any]:
         "passed": passed,
         "failed": failed,
         "skipped": skipped,
-        "heldout_gap": _ratio(failed, passed + failed),
+        "heldout_gap": None if status not in ("present", "absent") else _ratio(failed, passed + failed),
+        "reader_status": status,
     }
 
 
@@ -1294,7 +1307,7 @@ def _read_history(state_dir: Path) -> list[dict[str, Any]]:
                 archives = sorted(archive_dir.glob("*.jsonl.gz"))
             except Exception:
                 archives = []
-            for gz_path in archives[-5:]:
+            for gz_path in archives[-_MAX_HISTORY_ARCHIVES:]:
                 try:
                     with gzip.open(gz_path, "rt", encoding="utf-8", errors="replace") as gz_fh:
                         for line in gz_fh:
@@ -1512,7 +1525,7 @@ def compute_scorecard(
         except Exception:
             pass
 
-        rows = _ledger_rows(state_dir, now)
+        rows, ledger_window = _ledger_rows(state_dir, now)
         loop = _loop_section(rows, _confirmed_cycle_ids(state_dir))
         snapshot: dict[str, Any] = {
             "schema_version": SCORECARD_SCHEMA,
@@ -1533,11 +1546,23 @@ def compute_scorecard(
             # #865: visibility-only snapshot of active operator flags — never
             # fed into fitness/targets/gaps below.
             "control_plane": _control_plane_snapshot(state_dir),
+            "reader_status": {
+                "ledger": {
+                    "status": ledger_window.status,
+                    "covered_from": ledger_window.covered_from,
+                    "covered_to": ledger_window.covered_to,
+                    "files_skipped": ledger_window.files_skipped,
+                    "notes": list(ledger_window.notes),
+                },
+            },
         }
+        snapshot["gaps_status"] = "complete" if ledger_window.status == "complete" else "unavailable"
         # Gap analysis runs against the PRE-append history so the trend
         # window never compares the snapshot against itself.
         history = _read_history(state_dir)
         snapshot["gaps"] = _compute_gaps(snapshot, history, now)
+        for gap in snapshot["gaps"]:
+            gap["evidence"] = f"{gap.get('evidence', '').rstrip()} window: {ledger_window.covered_from} → {_iso(now)}"
 
         # #879: tech-tree of improvement directions — a RANKING INPUT to
         # demand/goal-review (mirrors the #815 soft vector bias), never a
@@ -1611,6 +1636,9 @@ def compute_scorecard(
             "integrity": {},
             "knowledge_lift": {},
             "gaps": [],
+            "gaps_status": "unavailable",
+            "feeds": {},
+            "reader_status": {"ledger": {"status": "unavailable", "covered_from": None, "covered_to": None, "files_skipped": 0, "notes": ["scorecard_error"]}},
             "control_plane": _control_plane_snapshot(state_dir),
         }
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -80,16 +80,11 @@ unreadable directory, or any unexpected exception degrades to zeros /
 """
 from __future__ import annotations
 
-import gzip
 import json
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-
-from loguru import logger
-
-from nanobot.runtime import state_access
 
 from loguru import logger
 
@@ -535,7 +530,7 @@ def _ledger_rows(state_dir: Path, now: datetime) -> tuple[list[dict[str, Any]], 
     window = state_access.ledger_window(
         state_dir,
         since_ts=_iso(now - timedelta(days=_WINDOW_DAYS)),
-        phases=frozenset({"outcome", "proposed", "proposer_reject", "proposer_skip", "idle", "integrity"}),
+        phases=None,
     )
     return list(window.rows), window
 
@@ -863,18 +858,17 @@ def _quality_section(state_dir: Path, selfevo_repo: Path | None) -> dict[str, An
 def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) -> dict[str, Any]:
     declared = confirmed = 0
     completed_status = _sidecar_status(Path(state_dir) / "demand" / "completed.json")
-    if completed_status not in ("present", "absent"):
-        completed = None
+    completed_unknown = completed_status not in ("present", "absent")
     # #789 defense in depth: a `confirmed` entry counts ONLY when its signal
     # is one usage_evidence itself writes (HARNESS_SIGNALS) — a foreign
     # signal means non-harness code wrote the fitness input (live
     # reward-hack 2026-07-17) and must not move confirmed_ratio, even
     # before confirm_serves' repair pass has run.
     harness_signals = _harness_signals()
-    completed = _read_json(Path(state_dir) / "demand" / "completed.json", None)
-    entries = completed.get("entries") if isinstance(completed, dict) else None
+    completed_data = _read_json(Path(state_dir) / "demand" / "completed.json", None)
+    entries = completed_data.get("entries") if isinstance(completed_data, dict) else None
     cutoff = now - timedelta(days=_WINDOW_DAYS)
-    if isinstance(entries, dict):
+    if isinstance(entries, dict) and completed_status in ("present", "absent"):
         for entry in entries.values():
             if not isinstance(entry, dict):
                 continue
@@ -911,9 +905,9 @@ def _value_section(state_dir: Path, selfevo_repo: Path | None, now: datetime) ->
         pass
 
     return {
-        "completed_declared": completed if completed is None else declared,
-        "completed_confirmed": completed if completed is None else confirmed,
-        "confirmed_ratio": None if completed is None else _ratio(confirmed, declared),
+        "completed_declared": None if completed_unknown else declared,
+        "completed_confirmed": None if completed_unknown else confirmed,
+        "confirmed_ratio": None if completed_unknown else _ratio(confirmed, declared),
         "doc_only_integrations_24h": doc_only_24h,
         "owner_live_inventory": owner_live_inventory,
         "owner_live_active": owner_live_active,
@@ -1058,8 +1052,13 @@ def _knowledge_lift_section(state_dir: Path | None) -> dict[str, Any]:
 def _feed_latest_timestamp(
     feed_path: Path, is_dir: bool, field: str | None
 ) -> tuple[datetime | None, str]:
-    if not feed_path.exists():
-        return None, "missing"
+    try:
+        if not feed_path.exists():
+            return None, "missing"
+    except PermissionError:
+        return None, "permission"
+    except OSError:
+        return None, "unreadable"
 
     if is_dir:
         newest_mtime: float | None = None
@@ -1174,11 +1173,12 @@ def _feeds_section(state_dir: Path | None, now_utc: datetime | None = None) -> d
         feed_path = state_dir / rel_path
         ts, source = _feed_latest_timestamp(feed_path, is_dir, field)
         if ts is None:
-            stale_names.append(name)
+            if source == "missing":
+                stale_names.append(name)
             feed_details[name] = {
-                "status": "corrupt" if source == "corrupt" else ("unreadable" if source == "error" else "missing"),
+                    "status": "corrupt" if source == "corrupt" else ("unreadable" if source in ("error", "unreadable", "permission") else "missing"),
                 "source": source,
-                "stale": source == "corrupt" or (source != "error"),
+                "stale": source in ("corrupt", "missing"),
                 "latest_ts": None,
                 "age_seconds": None,
                 "max_age_seconds": max_age_s,
@@ -1526,7 +1526,26 @@ def compute_scorecard(
             pass
 
         rows, ledger_window = _ledger_rows(state_dir, now)
+        if ledger_window.status == "unavailable":
+            return {
+                "schema_version": SCORECARD_SCHEMA,
+                "computed_at_utc": _iso(now),
+                "window_days": _WINDOW_DAYS,
+                "loop": _loop_section([], set()),
+                "cost": _cost_section(state_dir, now, 0),
+                "quality": _quality_section(state_dir, selfevo_repo),
+                "value": _value_section(state_dir, selfevo_repo, now),
+                "heldout": _heldout_section(state_dir),
+                "integrity": _integrity_section([]),
+                "feeds": _feeds_section(state_dir, now),
+                "knowledge_lift": _knowledge_lift_section(state_dir),
+                "control_plane": _control_plane_snapshot(state_dir),
+                "reader_status": _reader_status(state_dir, ledger_window, _feeds_section(state_dir, now)),
+                "gaps_status": "unavailable",
+                "gaps": [],
+            }
         loop = _loop_section(rows, _confirmed_cycle_ids(state_dir))
+        feeds_section = _feeds_section(state_dir, now)
         snapshot: dict[str, Any] = {
             "schema_version": SCORECARD_SCHEMA,
             "computed_at_utc": _iso(now),
@@ -1540,27 +1559,21 @@ def compute_scorecard(
             "value": _value_section(state_dir, selfevo_repo, now),
             "heldout": _heldout_section(state_dir),
             "integrity": _integrity_section(rows),
-            "feeds": _feeds_section(state_dir, now),
+            "feeds": feeds_section,
             # #1093: reporting-only knowledge lift A/B summary (no fitness target)
             "knowledge_lift": _knowledge_lift_section(state_dir),
             # #865: visibility-only snapshot of active operator flags — never
             # fed into fitness/targets/gaps below.
             "control_plane": _control_plane_snapshot(state_dir),
-            "reader_status": {
-                "ledger": {
-                    "status": ledger_window.status,
-                    "covered_from": ledger_window.covered_from,
-                    "covered_to": ledger_window.covered_to,
-                    "files_skipped": ledger_window.files_skipped,
-                    "notes": list(ledger_window.notes),
-                },
-            },
+            "reader_status": _reader_status(
+                state_dir, ledger_window, feeds_section
+            ),
         }
         snapshot["gaps_status"] = "complete" if ledger_window.status == "complete" else "unavailable"
         # Gap analysis runs against the PRE-append history so the trend
         # window never compares the snapshot against itself.
         history = _read_history(state_dir)
-        snapshot["gaps"] = _compute_gaps(snapshot, history, now)
+        snapshot["gaps"] = _compute_gaps(snapshot, history, now) if snapshot["gaps_status"] == "complete" else []
         for gap in snapshot["gaps"]:
             gap["evidence"] = f"{gap.get('evidence', '').rstrip()} window: {ledger_window.covered_from} → {_iso(now)}"
 

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -531,6 +531,7 @@ def _ledger_rows(state_dir: Path, now: datetime) -> tuple[list[dict[str, Any]], 
         state_dir,
         since_ts=_iso(now - timedelta(days=_WINDOW_DAYS)),
         phases=None,
+        max_bytes=2**31 - 1,
     )
     return list(window.rows), window
 
@@ -1015,6 +1016,7 @@ _FEEDS: tuple[tuple[str, str, bool, str | None, int], ...] = (
     ("usage", "usage/last_used.json", False, "scanned_at_utc", 12 * 3600),
     ("heldout", "heldout/results.json", False, "checked_at_utc", 12 * 3600),
     ("llm_calls", "llm_calls", True, None, 24 * 3600),
+    ("host_metrics", "host_metrics", True, None, 24 * 3600),
     (
         "validator_harness_parent",
         "validator_harness_parent/runs.jsonl",
@@ -1526,24 +1528,6 @@ def compute_scorecard(
             pass
 
         rows, ledger_window = _ledger_rows(state_dir, now)
-        if ledger_window.status == "unavailable":
-            return {
-                "schema_version": SCORECARD_SCHEMA,
-                "computed_at_utc": _iso(now),
-                "window_days": _WINDOW_DAYS,
-                "loop": _loop_section([], set()),
-                "cost": _cost_section(state_dir, now, 0),
-                "quality": _quality_section(state_dir, selfevo_repo),
-                "value": _value_section(state_dir, selfevo_repo, now),
-                "heldout": _heldout_section(state_dir),
-                "integrity": _integrity_section([]),
-                "feeds": _feeds_section(state_dir, now),
-                "knowledge_lift": _knowledge_lift_section(state_dir),
-                "control_plane": _control_plane_snapshot(state_dir),
-                "reader_status": _reader_status(state_dir, ledger_window, _feeds_section(state_dir, now)),
-                "gaps_status": "unavailable",
-                "gaps": [],
-            }
         loop = _loop_section(rows, _confirmed_cycle_ids(state_dir))
         feeds_section = _feeds_section(state_dir, now)
         snapshot: dict[str, Any] = {
@@ -1573,7 +1557,7 @@ def compute_scorecard(
         # Gap analysis runs against the PRE-append history so the trend
         # window never compares the snapshot against itself.
         history = _read_history(state_dir)
-        snapshot["gaps"] = _compute_gaps(snapshot, history, now) if snapshot["gaps_status"] == "complete" else []
+        snapshot["gaps"] = _compute_gaps(snapshot, history, now)
         for gap in snapshot["gaps"]:
             gap["evidence"] = f"{gap.get('evidence', '').rstrip()} window: {ledger_window.covered_from} → {_iso(now)}"
 

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -482,6 +482,7 @@ def _write_scorecard_gaps(state_dir: Path, gaps: list[dict]) -> None:
                 "cost": {},
                 "quality": {},
                 "value": {},
+                "gaps_status": "complete",
                 "gaps": gaps,
             }
         ),

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -155,12 +155,12 @@ class TestLoopSection:
         """Only the newest _MAX_GZ_FILES archives are read."""
         state_dir = tmp_path / "state"
         _write_ledger(state_dir, [])
-        for i in range(10):
-            day = (NOW - timedelta(days=1)).strftime("%Y-%m-%d")
+        for i in range(scorecard._MAX_GZ_FILES + 1):
+            day = (NOW - timedelta(days=i)).strftime("%Y-%m-%d")
             _write_gz_ledger(
                 state_dir,
-                [{"phase": "outcome", "cycle_id": f"g{i}", "outcome": "success", "ts": _iso(days_ago=1)}],
-                f"{day}-{i:02d}",  # distinct names, all recent-day rows
+                [{"phase": "outcome", "cycle_id": f"g{i}", "outcome": "success", "ts": _iso(days_ago=i)}],
+                day,
             )
         snap = scorecard.compute_scorecard(state_dir, None, force=True)
         assert snap["loop"]["integrations"] == scorecard._MAX_GZ_FILES

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -691,6 +691,43 @@ class TestWatermarkAndPersistence:
         assert snap["feeds"]["stale_names"] == []
 
 
+class TestReaderStatus1179:
+    def test_missing_ledger_is_unavailable_not_empty(self, tmp_path):
+        snap = scorecard.compute_scorecard(tmp_path / "state", None, force=True)
+        assert snap["gaps_status"] == "unavailable"
+        assert snap["reader_status"]["ledger"]["status"] == "unavailable"
+        assert "feeds" in snap
+
+    def test_corrupt_completed_sidecar_is_reported(self, tmp_path):
+        state = tmp_path / "state"
+        (state / "ledger").mkdir(parents=True)
+        (state / "ledger" / "cycles.jsonl").write_text("", encoding="utf-8")
+        (state / "demand").mkdir()
+        (state / "demand" / "completed.json").write_text("{bad", encoding="utf-8")
+        snap = scorecard.compute_scorecard(state, None, force=True)
+        assert snap["reader_status"]["completed"]["status"] == "corrupt"
+        assert snap["value"]["confirmed_ratio"] is None
+
+    def test_gap_evidence_carries_window(self, tmp_path):
+        state = tmp_path / "state"
+        (state / "ledger").mkdir(parents=True)
+        rows = [
+            {"phase": "proposed", "cycle_id": "c1", "ts": _iso(20)},
+            {"phase": "proposed", "cycle_id": "c2", "ts": _iso(15)},
+            {"phase": "outcome", "cycle_id": "c1", "outcome": "skipped-duplicate", "reason": "recent_duplicate_failure", "ts": _iso(19)},
+            {"phase": "outcome", "cycle_id": "c2", "outcome": "skipped-duplicate", "reason": "recent_duplicate_failure", "ts": _iso(18)},
+            {"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(14)},
+            {"phase": "proposed", "cycle_id": "c3", "ts": _iso(10)},
+        ]
+        (state / "ledger" / "cycles.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+        )
+        snap = scorecard.compute_scorecard(state, None, force=True)
+        assert snap["loop"]["repeat_failure_rate"] is not None
+        gap = next(g for g in snap["gaps"] if g["metric"] == "repeat_failure_rate")
+        assert gap["evidence"].endswith(f"window: {snap['reader_status']['ledger']['covered_from']} → {snap['computed_at_utc']}")
+
+
 # ─── gap analysis ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #1179.

- Scorecard ledger reads now use the shared `state_access.ledger_window` reader, preserving explicit reader status and horizon metadata.
- Snapshots expose `reader_status` for ledger, completed sidecar, heldout sidecar, history, and configured feeds.
- `gaps_status` distinguishes unavailable ledger evidence from a readable window. Demand does not turn unavailable scorecard evidence into “no gaps”; it returns no goal-gap items and logs `goal gaps unavailable; no gaps known`.
- Gap evidence carries `window: <covered_from> → <computed_at>`.
- `covered_from`/`covered_to` remain outer bounds; callers must honor `partial` plus `cap_bytes` and must not infer continuity.
- Corrupt completed sidecars preserve `None` metrics and expose `reader_status` rather than fabricating zero counts.
- Corrupt feed JSON is reported as corrupt; unreadable feed sources are not counted as stale; population checks handle `OSError`.
- Kept `host_metrics` in `_FEEDS`. The current implementation and live scorecard intentionally retain the feed so `stale_feeds` remains an observable goal gap; the futility path in #1184 can then count repeated attempts against the shared lever surface and suppress an uncloseable gap. This is the issue’s selected option (b).
- Replaced the literal history archive slice with `_MAX_HISTORY_ARCHIVES`.

## Required pre-change regression evidence

The three new reader-status tests were run against the pre-change `origin/main` before implementation and failed:

1. Missing ledger: expected `gaps_status=unavailable` and `reader_status.ledger.status=unavailable`; the old snapshot returned the zero/default shape without either field.
2. Corrupt completed sidecar: expected `reader_status.completed.status=corrupt` and `confirmed_ratio=None`; the old reader collapsed the corrupt sidecar to empty/default values.
3. Gap horizon: expected the `window:` suffix; the old gap evidence ended at the metric/window prose without the reader horizon.

## Verification

- Focused scorecard, demand, heldout and tech-tree tests: **344 passed**.
- Full Windows pytest: **2840 passed, 18 failed, 17 skipped, 11 warnings**. The 18 failures match the known Windows baseline; no additional failures appeared.
- CI: Python 3.11, 3.12, and 3.13 passed: https://github.com/ozand/eeebot/actions/runs/33602960921
- No new size cap was introduced.
- Deny-set and trust-kernel files were not modified.

## Live verification

After deploy, read `scorecard/latest.json` on the host and quote:

1. `reader_status`, including ledger and consulted sidecar/feed statuses;
2. `gaps_status`, which must not be `complete` when the ledger reader is unavailable;
3. `feeds.stale_names` should continue to include `host_metrics` while its writer remains absent, making the stale feed observable rather than silently treating it as healthy;
4. the next `futility.json` state for `goal-gap-a820ca0c8bb`, which should show the futility suppressor progressing toward its lever-surface threshold for the retained `host_metrics` gap.

No host mutation or deployment was performed by this PR author.





