### PR TITLE
fix(1197): record every bridge invocation exit durably, with a countable streak

### DIFF
--- a/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/override.conf
+++ b/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/override.conf
@@ -20,3 +20,12 @@ Environment=HOME=/opt/eeepc-agent
 Environment=GIT_TERMINAL_PROMPT=0
 ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving
 TimeoutStartSec=3300
+# #1197: record every invocation's exit durably (state/bridge/exit_streak.json),
+# including signals, OOM kills and timeouts that no in-process hook can see.
+# The same record is written from inside the process by nanobot.crash_record;
+# a systemd record within 300 s of it is merged, not double-counted.
+# NOTE: this file is installed by host/eeepc/scripts/install.sh, NOT by
+# deploy_release.sh — the line below is INERT on the host until an operator
+# copies this file to /etc/systemd/system/eeepc-self-evolving-subagent-bridge.service.d/
+# and runs `systemctl daemon-reload`.
+ExecStopPost=/opt/eeepc-agent/venv/bin/python -m nanobot.crash_record --source systemd --exit-code ${EXIT_CODE} --exit-status ${EXIT_STATUS} --service-result ${SERVICE_RESULT}

--- a/nanobot/__init__.py
+++ b/nanobot/__init__.py
@@ -4,3 +4,19 @@ nanobot - A lightweight AI agent framework
 
 __version__ = "0.1.4.post5"
 __logo__ = "🐈"
+
+# #1197: arm the bridge exit recorder before ``nanobot.runtime.bridge`` is
+# imported — an import-time crash there (the 2026-09-01 NameError, #1000/#1142)
+# never reaches bridge.py's own code, so the hook must live upstream of it.
+# Inert unless this process is ``python -m nanobot.runtime.bridge`` (read from
+# ``sys.orig_argv``) or NANOBOT_BRIDGE_EXIT_RECORD=1; ``crash_record`` is
+# stdlib-only so arming cannot fail on package code. A failure to arm is
+# printed, never swallowed.
+try:
+    from nanobot import crash_record as _crash_record
+
+    _crash_record.arm()
+except Exception as _arm_exc:  # pragma: no cover - visible, not fatal
+    import sys as _sys
+
+    print(f"nanobot: bridge exit recorder not armed: {_arm_exc!r}", file=_sys.stderr)

--- a/nanobot/crash_record.py
+++ b/nanobot/crash_record.py
@@ -1,0 +1,254 @@
+"""Durable record of every bridge invocation exit (#1197).
+
+On 2026-09-01 the bridge crash-looped for 9 h 20 min (140 consecutive failed
+invocations, ``NameError`` at import, #1000/#1142) and nothing durable recorded
+it: systemd's ``Result`` describes only the latest run, a process that dies at
+import writes no ledger row, and the deploy gate waits on ledger activity.
+
+This module is the one writer for that record and is deliberately **stdlib
+only, with no package-internal imports**: it is armed from ``nanobot/__init__``
+before ``nanobot.runtime.bridge`` is imported, so an import-time crash in the
+bridge is still caught, and a recorder that could itself fail while recording
+a crash would leave exactly the silence this exists to remove.
+
+Records, under ``<state_dir>/bridge/``:
+
+- ``exits.jsonl`` — one row per recorded exit (append-only).
+- ``exit_streak.json`` — the countable state: ``consecutive_failures``, the
+  first/last failure timestamps, the last error and exit status, the last
+  success timestamp. A success resets the streak.
+
+Two sources write the same record: ``source="process"`` from inside the
+interpreter (``sys.excepthook`` for uncaught exceptions, the bridge's
+``__main__`` guard for ordinary exit codes) and ``source="systemd"`` from the
+unit's ``ExecStopPost=`` (this module's CLI), which also sees signals, OOM
+kills and timeouts. A systemd record that lands within
+:data:`MERGE_WINDOW_S` of a process record for the same outcome is merged
+into it instead of counting a second failure.
+
+Nothing here is a size cap and nothing falls back silently: a write failure
+is printed to stderr (the journal under systemd) and raised to the caller.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+# Mirrors the bridge's own default (nanobot/runtime/bridge.py: STATE_DIR) — kept
+# as a literal here because this module must not import the bridge.
+DEFAULT_STATE_DIR = "/var/lib/eeepc-agent/self-evolving-agent/state"
+STATE_ENV_VARS = ("STATE_DIR", "NANOBOT_RUNTIME_STATE_ROOT")
+# "1" arms the recorder regardless of argv (tests, ad-hoc runs); "0" disables it.
+ENV_MARKER = "NANOBOT_BRIDGE_EXIT_RECORD"
+BRIDGE_MODULE = "nanobot.runtime.bridge"
+RECORDS_REL = Path("bridge") / "exits.jsonl"
+STREAK_REL = Path("bridge") / "exit_streak.json"
+STREAK_SCHEMA = "bridge-exit-streak-v1"
+MERGE_WINDOW_S = 300.0
+_armed = False
+
+
+def _now_iso(now: datetime | None = None) -> str:
+    return (now or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def state_dir(env: Mapping[str, str] | None = None) -> Path:
+    """The bridge's state directory: ``STATE_DIR`` (the unit's env file), else
+    ``NANOBOT_RUNTIME_STATE_ROOT`` (the unit's drop-in), else the host default."""
+    env_map: Mapping[str, str] = os.environ if env is None else env
+    for name in STATE_ENV_VARS:
+        value = str(env_map.get(name) or "").strip()
+        if value:
+            return Path(value)
+    return Path(DEFAULT_STATE_DIR)
+
+
+def is_bridge_invocation(argv: list[str] | None = None, env: Mapping[str, str] | None = None) -> bool:
+    """True only for ``python -m nanobot.runtime.bridge`` (read from
+    ``sys.orig_argv``, which is set before any import runs — ``sys.argv[0]`` is
+    still ``-m`` at that point) or when :data:`ENV_MARKER` is ``1``. Every
+    other entry point (CLI, tests, other ``-m`` modules) leaves the recorder
+    inert."""
+    env_map: Mapping[str, str] = os.environ if env is None else env
+    marker = str(env_map.get(ENV_MARKER) or "").strip().lower()
+    if marker in {"0", "false", "no", "off"}:
+        return False
+    if marker in {"1", "true", "yes", "on"}:
+        return True
+    argv = list(getattr(sys, "orig_argv", []) if argv is None else argv)
+    for index, token in enumerate(argv[:-1]):
+        if token == "-m" and argv[index + 1] == BRIDGE_MODULE:
+            return True
+    return False
+
+
+def first_traceback_line(exc_type: type[BaseException], exc: BaseException, tb: Any) -> tuple[str, str]:
+    """``("NameError: name '_x' is not defined", "nanobot/runtime/bridge.py:4987")``
+    — the error line and the innermost frame, the two things a person greps
+    the journal for."""
+    error = "".join(traceback.format_exception_only(exc_type, exc)).strip().splitlines()
+    where = ""
+    frames = traceback.extract_tb(tb) if tb is not None else []
+    if frames:
+        last = frames[-1]
+        where = f"{last.filename}:{last.lineno}"
+    return (error[0] if error else exc_type.__name__), where
+
+
+def _load_streak(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        # Corrupt streak state is reported, then rebuilt from this record — the
+        # append-only exits.jsonl keeps the history.
+        print(f"bridge-exit-record: streak file unreadable ({exc!r}); rebuilding", file=sys.stderr)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_atomic(path: Path, payload: dict[str, Any]) -> None:
+    temp = path.with_name(f".{path.name}.tmp")
+    temp.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(temp, path)
+
+
+def record_exit(
+    root: str | Path,
+    *,
+    outcome: str,
+    exit_status: Any,
+    source: str = "process",
+    error: str = "",
+    where: str = "",
+    service_result: str = "",
+    exit_code: str = "",
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Append one exit row and update the streak; return the new streak state.
+
+    ``outcome`` is ``"success"`` or ``"failure"``. Raises on a write failure
+    after printing what could not be written — never a silent fallback.
+    """
+    if outcome not in ("success", "failure"):
+        raise ValueError(f"outcome must be success|failure, got {outcome!r}")
+    root = Path(root)
+    records_path, streak_path = root / RECORDS_REL, root / STREAK_REL
+    stamp = _now_iso(now)
+    row = {
+        "ts": stamp, "source": source, "outcome": outcome, "exit_status": exit_status,
+        "service_result": service_result, "exit_code": exit_code, "error": error, "where": where,
+        "pid": os.getpid(), "argv": list(getattr(sys, "orig_argv", sys.argv))[:6],
+    }
+    try:
+        records_path.parent.mkdir(parents=True, exist_ok=True)
+        streak = _load_streak(streak_path)
+        last_ts = _parse_iso(streak.get("updated_at"))
+        merged = (
+            source == "systemd"
+            and streak.get("last_source") == "process"
+            and streak.get("last_outcome") == outcome
+            and last_ts is not None
+            and 0 <= ((_parse_iso(stamp) or datetime.now(timezone.utc)) - last_ts).total_seconds() <= MERGE_WINDOW_S
+        )
+        row["merged_with_previous"] = merged
+        with records_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        streak.setdefault("schema_version", STREAK_SCHEMA)
+        streak["total_records"] = int(streak.get("total_records") or 0) + 1
+        if not merged:
+            if outcome == "failure":
+                streak["consecutive_failures"] = int(streak.get("consecutive_failures") or 0) + 1
+                streak["total_failures"] = int(streak.get("total_failures") or 0) + 1
+                if streak["consecutive_failures"] == 1:
+                    streak["first_failure_ts"] = stamp
+                streak["last_failure_ts"] = stamp
+                streak["last_exit_status"] = exit_status
+                streak["last_error"] = error
+                streak["last_where"] = where
+            else:
+                streak["consecutive_failures"] = 0
+                streak["last_success_ts"] = stamp
+                streak.pop("first_failure_ts", None)
+        if service_result:
+            streak["last_service_result"] = service_result
+        if exit_code:
+            streak["last_exit_code"] = exit_code
+        streak["last_source"] = source
+        streak["last_outcome"] = outcome
+        streak["updated_at"] = stamp
+        _write_atomic(streak_path, streak)
+        return streak
+    except OSError as exc:
+        print(f"bridge-exit-record: FAILED to write {records_path} / {streak_path}: {exc!r}; row={json.dumps(row)}", file=sys.stderr)
+        raise
+
+
+def _excepthook_recording(previous: Any, root: Path) -> Any:
+    def hook(exc_type: type[BaseException], exc: BaseException, tb: Any) -> None:
+        error, where = first_traceback_line(exc_type, exc, tb)
+        status = 130 if issubclass(exc_type, KeyboardInterrupt) else 1
+        try:
+            record_exit(root, outcome="failure", exit_status=status, error=error, where=where)
+        except Exception as record_exc:  # the original crash must still be shown
+            print(f"bridge-exit-record: recorder failed: {record_exc!r}", file=sys.stderr)
+        previous(exc_type, exc, tb)
+    return hook
+
+
+def arm(argv: list[str] | None = None, env: Mapping[str, str] | None = None) -> bool:
+    """Install the recording ``sys.excepthook`` if this process is the bridge.
+    Returns whether it armed. Idempotent."""
+    global _armed
+    if _armed or not is_bridge_invocation(argv, env):
+        return _armed
+    sys.excepthook = _excepthook_recording(sys.excepthook, state_dir(env))
+    _armed = True
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``ExecStopPost=`` entry point: ``python -m nanobot.crash_record --source
+    systemd --exit-code ${EXIT_CODE} --exit-status ${EXIT_STATUS}
+    --service-result ${SERVICE_RESULT}``. Outcome is ``success`` iff
+    ``SERVICE_RESULT`` is ``success``; ``exit-status`` may be a number or a
+    signal name. Exit 0 on a written record, 2 when it could not be written."""
+    parser = argparse.ArgumentParser(description="Record one bridge invocation exit (#1197)")
+    parser.add_argument("--source", default="systemd")
+    parser.add_argument("--exit-status", default="")
+    parser.add_argument("--exit-code", default="")
+    parser.add_argument("--service-result", default="")
+    parser.add_argument("--state-dir", default=None)
+    parser.add_argument("--error", default="")
+    args = parser.parse_args(argv)
+    root = Path(args.state_dir) if args.state_dir else state_dir()
+    outcome = "success" if args.service_result == "success" else "failure"
+    status: Any = args.exit_status
+    if str(status).isdigit():
+        status = int(status)
+    try:
+        streak = record_exit(root, outcome=outcome, exit_status=status, source=args.source,
+                             service_result=args.service_result, exit_code=args.exit_code, error=args.error)
+    except OSError:
+        return 2
+    print(json.dumps({"outcome": outcome, "consecutive_failures": streak.get("consecutive_failures", 0)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -4996,4 +4996,19 @@ def _parse_explore_mode(req: dict) -> tuple[int, str]:
 # NameError that module-importing tests can never catch (incident 2026-09-01:
 # _parse_explore_mode defined below this guard killed every cycle for 8 hours).
 if __name__ == '__main__':
-    raise SystemExit(cli_main())
+    _exit_code = cli_main()
+    # #1197: every ordinary exit of a live bridge run is recorded durably
+    # (uncaught exceptions are recorded by the sys.excepthook armed in
+    # nanobot/__init__). A disabled bridge still never touches STATE_DIR.
+    if BRIDGE_ENABLED:
+        try:
+            from nanobot import crash_record as _crash_record
+
+            _crash_record.record_exit(
+                STATE_DIR,
+                outcome="success" if _exit_code == 0 else "failure",
+                exit_status=_exit_code,
+            )
+        except Exception as _record_exc:  # already printed by the recorder; keep the run's own code
+            print(f"bridge: exit record not written: {_record_exc!r}", file=sys.stderr)
+    raise SystemExit(_exit_code)

--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -1226,6 +1226,40 @@ def _integrity_section(rows: list[dict[str, Any]]) -> dict[str, Any]:
 # ─── section: heldout (V1, #780 held-out verification pack) ─────────────────
 
 
+_BRIDGE_STREAK_MAX_BYTES = 1024 * 1024  # a fixed-shape ~600 B file; oversize is reported, not hidden
+_BRIDGE_STREAK_STALE_S = 2 * 3600
+
+
+def _bridge_section(state_dir: Path, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """#1197: the bridge exit streak from ``bridge/exit_streak.json`` (written by
+    ``nanobot.crash_record``). ``reader_status`` keeps "no record yet" apart from
+    "zero failures": ``absent``/``corrupt``/``oversize``/``permission`` come from
+    ``state_access.sidecar``; ``stale`` means the ledger shows bridge activity
+    newer than the recorder's last write by more than two hours — the recorder
+    is not writing, which is itself the #1197 defect class."""
+    from nanobot.runtime.state_access import sidecar
+
+    read = sidecar(Path(state_dir) / "bridge" / "exit_streak.json", default=None, max_bytes=_BRIDGE_STREAK_MAX_BYTES)
+    data = read.data if isinstance(read.data, dict) else {}
+    status = read.status
+    updated = _parse_ts(data.get("updated_at")) if data else None
+    latest_row = max((ts for ts in (_parse_ts(r.get("ts")) for r in rows) if ts is not None), default=None)
+    if status == "present" and updated is not None and latest_row is not None and (latest_row - updated).total_seconds() > _BRIDGE_STREAK_STALE_S:
+        status = "stale"
+    return {
+        "reader_status": status,
+        "consecutive_failures": int(data.get("consecutive_failures") or 0) if data else None,
+        "total_failures": int(data.get("total_failures") or 0) if data else None,
+        "first_failure_ts": data.get("first_failure_ts"),
+        "last_failure_ts": data.get("last_failure_ts"),
+        "last_exit_status": data.get("last_exit_status"),
+        "last_error": data.get("last_error"),
+        "last_success_ts": data.get("last_success_ts"),
+        "last_source": data.get("last_source"),
+        "updated_at": data.get("updated_at"),
+    }
+
+
 def _heldout_section(state_dir: Path) -> dict[str, Any]:
     """Counts over the persisted held-out results
     (``<state_dir>/heldout/results.json``, written by
@@ -1559,6 +1593,8 @@ def compute_scorecard(
             "heldout": _heldout_section(state_dir),
             "integrity": _integrity_section(rows),
             "feeds": _feeds_section(state_dir, now),
+            # #1197: bridge exit streak — reporting only, no fitness target.
+            "bridge": _bridge_section(state_dir, rows),
             # #1093: reporting-only knowledge lift A/B summary (no fitness target)
             "knowledge_lift": _knowledge_lift_section(state_dir),
             # #865: visibility-only snapshot of active operator flags — never

--- a/tests/test_bridge_exit_record.py
+++ b/tests/test_bridge_exit_record.py
@@ -1,0 +1,204 @@
+"""#1197: every bridge invocation exit leaves a durable, countable record.
+
+2026-09-01: the bridge crash-looped for 9 h 20 min (140 consecutive failed
+invocations, ``NameError`` at import) and systemd, the ledger and the deploy
+gate all reported healthy. Every test here fails against the pre-#1197 tree
+for the reason in its docstring.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from nanobot import crash_record
+from nanobot.runtime import scorecard
+
+REPO = Path(__file__).resolve().parents[1]
+NOW = datetime.now(timezone.utc)
+
+
+def _streak(state: Path) -> dict:
+    return json.loads((state / "bridge" / "exit_streak.json").read_text(encoding="utf-8"))
+
+
+def _rows(state: Path) -> list[dict]:
+    return [json.loads(line) for line in (state / "bridge" / "exits.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _run(code: str, state: Path, *, marker: str = "1", extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    """A fresh interpreter that imports ``nanobot`` the way ``python -m`` would:
+    the recorder is armed (or not) purely by the package import."""
+    env = {**os.environ, "PYTHONPATH": str(REPO), "STATE_DIR": str(state), crash_record.ENV_MARKER: marker, "PYTHONIOENCODING": "utf-8"}
+    env.update(extra_env or {})
+    return subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, text=True, timeout=120)
+
+
+# ─── the record and the streak ───────────────────────────────────────────────
+
+def test_consecutive_failures_count_up_and_a_success_resets(tmp_path):
+    """Pre-fix: no ``nanobot.crash_record`` module and nothing under state/bridge/."""
+    state = tmp_path / "state"
+    for i in range(3):
+        streak = crash_record.record_exit(state, outcome="failure", exit_status=1,
+                                          error="NameError: name '_parse_explore_mode' is not defined",
+                                          where="nanobot/runtime/bridge.py:4987", now=NOW + timedelta(minutes=3 * i))
+    assert streak["consecutive_failures"] == 3 and streak["total_failures"] == 3
+    assert streak["first_failure_ts"] == crash_record._now_iso(NOW)
+    assert streak["last_failure_ts"] == crash_record._now_iso(NOW + timedelta(minutes=6))
+    assert streak["last_error"].startswith("NameError: name '_parse_explore_mode'") and streak["last_where"].endswith("bridge.py:4987")
+    assert streak["last_exit_status"] == 1 and streak["schema_version"] == "bridge-exit-streak-v1"
+
+    streak = crash_record.record_exit(state, outcome="success", exit_status=0, now=NOW + timedelta(minutes=9))
+    assert streak["consecutive_failures"] == 0 and streak["total_failures"] == 3
+    assert streak["last_success_ts"] == crash_record._now_iso(NOW + timedelta(minutes=9)) and "first_failure_ts" not in streak
+    rows = _rows(state)
+    assert [r["outcome"] for r in rows] == ["failure", "failure", "failure", "success"]
+    assert rows[0]["source"] == "process" and rows[0]["error"].startswith("NameError")
+
+
+def test_systemd_record_for_the_same_invocation_is_merged_not_double_counted(tmp_path):
+    state = tmp_path / "state"
+    crash_record.record_exit(state, outcome="failure", exit_status=1, error="NameError: x", now=NOW)
+    streak = crash_record.record_exit(state, outcome="failure", exit_status=1, source="systemd",
+                                      service_result="exit-code", exit_code="exited", now=NOW + timedelta(seconds=20))
+    assert streak["consecutive_failures"] == 1 and streak["last_service_result"] == "exit-code"
+    assert _rows(state)[-1]["merged_with_previous"] is True
+    # a later systemd-only record (signal, OOM: no process record precedes it) counts on its own
+    streak = crash_record.record_exit(state, outcome="failure", exit_status="KILL", source="systemd",
+                                      service_result="signal", exit_code="killed", now=NOW + timedelta(minutes=10))
+    assert streak["consecutive_failures"] == 2 and streak["last_exit_status"] == "KILL"
+
+
+def test_write_failure_is_printed_and_raised_never_swallowed(tmp_path, capsys):
+    """Pre-fix: n/a (no writer); the AC forbids a silent fallback in the one that exists now."""
+    blocker = tmp_path / "state" / "bridge"
+    blocker.parent.mkdir()
+    blocker.write_text("not a directory", encoding="utf-8")
+    with pytest.raises(OSError):
+        crash_record.record_exit(tmp_path / "state", outcome="failure", exit_status=1, error="boom")
+    err = capsys.readouterr().err
+    assert "bridge-exit-record: FAILED to write" in err and '"error": "boom"' in err
+
+
+# ─── arming: upstream of the failing import, inert everywhere else ───────────
+
+def test_import_time_crash_is_recorded_when_armed_by_the_package_import(tmp_path):
+    """Pre-fix: ``import nanobot`` armed nothing; a crash at import left only a journal traceback."""
+    state = tmp_path / "state"
+    crash = "import nanobot\nraise NameError(\"name '_parse_explore_mode' is not defined\")\n"
+    for _ in range(2):
+        proc = _run(crash, state)
+        assert proc.returncode == 1 and "NameError: name '_parse_explore_mode'" in proc.stderr, proc.stderr
+    streak = _streak(state)
+    assert streak["consecutive_failures"] == 2 and streak["last_exit_status"] == 1
+    assert streak["last_error"] == "NameError: name '_parse_explore_mode' is not defined" and streak["last_where"].endswith("<string>:2")
+    assert _rows(state)[-1]["source"] == "process"
+
+    ok = _run("import nanobot\nfrom nanobot import crash_record\ncrash_record.record_exit(crash_record.state_dir(), outcome='success', exit_status=0)\n", state)
+    assert ok.returncode == 0, ok.stderr
+    assert _streak(state)["consecutive_failures"] == 0
+
+
+def test_recorder_arms_on_python_dash_m_bridge_argv_and_stays_inert_elsewhere(tmp_path):
+    state = tmp_path / "state"
+    armed_by_argv = (
+        "import sys\nsys.orig_argv[:] = ['python', '-m', 'nanobot.runtime.bridge']\n"
+        "import nanobot\nraise RuntimeError('boom at import')\n"
+    )
+    proc = _run(armed_by_argv, state, marker="")
+    assert proc.returncode == 1 and (state / "bridge" / "exit_streak.json").is_file(), proc.stderr
+    assert _streak(state)["last_error"] == "RuntimeError: boom at import"
+
+    other = tmp_path / "other"
+    inert = _run("import nanobot\nraise RuntimeError('not the bridge')\n", other, marker="")
+    assert inert.returncode == 1 and not (other / "bridge").exists(), "a non-bridge process must leave no record"
+    disabled = _run("import sys\nsys.orig_argv[:] = ['python', '-m', 'nanobot.runtime.bridge']\nimport nanobot\nraise RuntimeError('x')\n", other, marker="0")
+    assert disabled.returncode == 1 and not (other / "bridge").exists(), "NANOBOT_BRIDGE_EXIT_RECORD=0 disables"
+    assert crash_record.is_bridge_invocation(["python", "-m", "nanobot.crash_record"], {}) is False
+    assert crash_record.is_bridge_invocation(["/opt/eeepc-agent/venv/bin/python", "-m", "nanobot.runtime.bridge"], {}) is True
+
+
+def test_state_dir_resolution_matches_the_unit_environment():
+    assert crash_record.state_dir({"STATE_DIR": "/x/state", "NANOBOT_RUNTIME_STATE_ROOT": "/y"}) == Path("/x/state")
+    assert crash_record.state_dir({"NANOBOT_RUNTIME_STATE_ROOT": "/y"}) == Path("/y")
+    assert crash_record.state_dir({}) == Path("/var/lib/eeepc-agent/self-evolving-agent/state")
+    bridge_src = (REPO / "nanobot" / "runtime" / "bridge.py").read_text(encoding="utf-8")
+    assert f"os.environ.get('STATE_DIR', '{crash_record.DEFAULT_STATE_DIR}')" in bridge_src, "recorder default must mirror the bridge's"
+
+
+def test_recorder_is_stdlib_only():
+    """A recorder that imports package code can fail exactly when it is needed."""
+    import ast
+
+    tree = ast.parse((REPO / "nanobot" / "crash_record.py").read_text(encoding="utf-8"))
+    imported = {
+        (node.module or "") if isinstance(node, ast.ImportFrom) else alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in (node.names if isinstance(node, ast.Import) else [None])
+    }
+    assert not {name for name in imported if name.startswith("nanobot")}, imported
+
+
+# ─── the systemd route (ExecStopPost) and the bridge guard ───────────────────
+
+def test_execstoppost_cli_records_success_and_failure(tmp_path, capsys):
+    state = tmp_path / "state"
+    assert crash_record.main(["--source", "systemd", "--exit-code", "exited", "--exit-status", "1", "--service-result", "exit-code", "--state-dir", str(state)]) == 0
+    assert crash_record.main(["--source", "systemd", "--exit-code", "killed", "--exit-status", "KILL", "--service-result", "signal", "--state-dir", str(state)]) == 0
+    assert _streak(state)["consecutive_failures"] == 2
+    assert crash_record.main(["--source", "systemd", "--exit-code", "exited", "--exit-status", "0", "--service-result", "success", "--state-dir", str(state)]) == 0
+    assert _streak(state)["consecutive_failures"] == 0
+    out = capsys.readouterr().out.splitlines()
+    assert json.loads(out[-1]) == {"outcome": "success", "consecutive_failures": 0}
+    blocker = tmp_path / "blocked" / "bridge"
+    blocker.parent.mkdir()
+    blocker.write_text("file", encoding="utf-8")
+    assert crash_record.main(["--source", "systemd", "--exit-status", "1", "--service-result", "exit-code", "--state-dir", str(tmp_path / "blocked")]) == 2
+
+
+def test_tracked_drop_in_carries_the_execstoppost_line_and_says_it_is_inert():
+    """Pre-fix: the tracked drop-in had no ExecStopPost."""
+    conf = (REPO / "host" / "eeepc" / "systemd" / "drop-ins" / "eeepc-self-evolving-subagent-bridge.service.d" / "override.conf").read_text(encoding="utf-8")
+    line = next(line for line in conf.splitlines() if line.startswith("ExecStopPost="))
+    assert "-m nanobot.crash_record --source systemd --exit-code ${EXIT_CODE} --exit-status ${EXIT_STATUS} --service-result ${SERVICE_RESULT}" in line
+    assert "INERT" in conf and "install.sh" in conf
+
+
+def test_bridge_guard_records_the_exit_code_and_stays_last():
+    """Pre-fix: the guard was ``raise SystemExit(cli_main())`` — no record of the exit."""
+    import ast
+
+    src = (REPO / "nanobot" / "runtime" / "bridge.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    guard = tree.body[-1]
+    assert isinstance(guard, ast.If) and "__main__" in ast.dump(guard.test)
+    body_src = ast.get_source_segment(src, guard)
+    assert "_crash_record.record_exit(" in body_src and "if BRIDGE_ENABLED:" in body_src
+    assert "raise SystemExit(_exit_code)" in body_src
+
+
+# ─── the health surface ──────────────────────────────────────────────────────
+
+def test_scorecard_reports_the_streak_and_distinguishes_absent_from_zero(tmp_path):
+    """Pre-fix: the scorecard had no bridge section; 140 failures and a healthy loop looked identical."""
+    state = tmp_path / "state"
+    state.mkdir()
+    absent = scorecard._bridge_section(state, [])
+    assert absent["reader_status"] == "absent" and absent["consecutive_failures"] is None
+    for i in range(16):
+        crash_record.record_exit(state, outcome="failure", exit_status=1, error="NameError: x", now=NOW - timedelta(hours=1, minutes=48 - 3 * i))
+    section = scorecard._bridge_section(state, [{"ts": crash_record._now_iso(NOW - timedelta(hours=1))}])
+    assert (section["reader_status"], section["consecutive_failures"], section["total_failures"]) == ("present", 16, 16)
+    assert section["last_error"] == "NameError: x" and section["last_exit_status"] == 1
+    # the recorder stopped writing while the ledger kept moving: visible, not "0 failures"
+    stale = scorecard._bridge_section(state, [{"ts": crash_record._now_iso(NOW + timedelta(hours=3))}])
+    assert stale["reader_status"] == "stale" and stale["consecutive_failures"] == 16
+    (state / "bridge" / "exit_streak.json").write_text("{not json", encoding="utf-8")
+    assert scorecard._bridge_section(state, [])["reader_status"] == "corrupt"

--- a/tests/test_bridge_exit_record.py
+++ b/tests/test_bridge_exit_record.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import pytest
 
-from nanobot import crash_record
 from nanobot.runtime import scorecard
 
 REPO = Path(__file__).resolve().parents[1]
@@ -34,7 +33,7 @@ def _rows(state: Path) -> list[dict]:
 def _run(code: str, state: Path, *, marker: str = "1", extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     """A fresh interpreter that imports ``nanobot`` the way ``python -m`` would:
     the recorder is armed (or not) purely by the package import."""
-    env = {**os.environ, "PYTHONPATH": str(REPO), "STATE_DIR": str(state), crash_record.ENV_MARKER: marker, "PYTHONIOENCODING": "utf-8"}
+    env = {**os.environ, "PYTHONPATH": str(REPO), "STATE_DIR": str(state), "NANOBOT_BRIDGE_EXIT_RECORD": marker, "PYTHONIOENCODING": "utf-8"}
     env.update(extra_env or {})
     return subprocess.run([sys.executable, "-c", code], env=env, capture_output=True, text=True, timeout=120)
 
@@ -43,6 +42,8 @@ def _run(code: str, state: Path, *, marker: str = "1", extra_env: dict[str, str]
 
 def test_consecutive_failures_count_up_and_a_success_resets(tmp_path):
     """Pre-fix: no ``nanobot.crash_record`` module and nothing under state/bridge/."""
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     state = tmp_path / "state"
     for i in range(3):
         streak = crash_record.record_exit(state, outcome="failure", exit_status=1,
@@ -63,6 +64,8 @@ def test_consecutive_failures_count_up_and_a_success_resets(tmp_path):
 
 
 def test_systemd_record_for_the_same_invocation_is_merged_not_double_counted(tmp_path):
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     state = tmp_path / "state"
     crash_record.record_exit(state, outcome="failure", exit_status=1, error="NameError: x", now=NOW)
     streak = crash_record.record_exit(state, outcome="failure", exit_status=1, source="systemd",
@@ -77,6 +80,8 @@ def test_systemd_record_for_the_same_invocation_is_merged_not_double_counted(tmp
 
 def test_write_failure_is_printed_and_raised_never_swallowed(tmp_path, capsys):
     """Pre-fix: n/a (no writer); the AC forbids a silent fallback in the one that exists now."""
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     blocker = tmp_path / "state" / "bridge"
     blocker.parent.mkdir()
     blocker.write_text("not a directory", encoding="utf-8")
@@ -90,6 +95,7 @@ def test_write_failure_is_printed_and_raised_never_swallowed(tmp_path, capsys):
 
 def test_import_time_crash_is_recorded_when_armed_by_the_package_import(tmp_path):
     """Pre-fix: ``import nanobot`` armed nothing; a crash at import left only a journal traceback."""
+
     state = tmp_path / "state"
     crash = "import nanobot\nraise NameError(\"name '_parse_explore_mode' is not defined\")\n"
     for _ in range(2):
@@ -106,6 +112,8 @@ def test_import_time_crash_is_recorded_when_armed_by_the_package_import(tmp_path
 
 
 def test_recorder_arms_on_python_dash_m_bridge_argv_and_stays_inert_elsewhere(tmp_path):
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     state = tmp_path / "state"
     armed_by_argv = (
         "import sys\nsys.orig_argv[:] = ['python', '-m', 'nanobot.runtime.bridge']\n"
@@ -125,6 +133,8 @@ def test_recorder_arms_on_python_dash_m_bridge_argv_and_stays_inert_elsewhere(tm
 
 
 def test_state_dir_resolution_matches_the_unit_environment():
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     assert crash_record.state_dir({"STATE_DIR": "/x/state", "NANOBOT_RUNTIME_STATE_ROOT": "/y"}) == Path("/x/state")
     assert crash_record.state_dir({"NANOBOT_RUNTIME_STATE_ROOT": "/y"}) == Path("/y")
     assert crash_record.state_dir({}) == Path("/var/lib/eeepc-agent/self-evolving-agent/state")
@@ -134,6 +144,7 @@ def test_state_dir_resolution_matches_the_unit_environment():
 
 def test_recorder_is_stdlib_only():
     """A recorder that imports package code can fail exactly when it is needed."""
+
     import ast
 
     tree = ast.parse((REPO / "nanobot" / "crash_record.py").read_text(encoding="utf-8"))
@@ -149,6 +160,8 @@ def test_recorder_is_stdlib_only():
 # ─── the systemd route (ExecStopPost) and the bridge guard ───────────────────
 
 def test_execstoppost_cli_records_success_and_failure(tmp_path, capsys):
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     state = tmp_path / "state"
     assert crash_record.main(["--source", "systemd", "--exit-code", "exited", "--exit-status", "1", "--service-result", "exit-code", "--state-dir", str(state)]) == 0
     assert crash_record.main(["--source", "systemd", "--exit-code", "killed", "--exit-status", "KILL", "--service-result", "signal", "--state-dir", str(state)]) == 0
@@ -165,6 +178,7 @@ def test_execstoppost_cli_records_success_and_failure(tmp_path, capsys):
 
 def test_tracked_drop_in_carries_the_execstoppost_line_and_says_it_is_inert():
     """Pre-fix: the tracked drop-in had no ExecStopPost."""
+
     conf = (REPO / "host" / "eeepc" / "systemd" / "drop-ins" / "eeepc-self-evolving-subagent-bridge.service.d" / "override.conf").read_text(encoding="utf-8")
     line = next(line for line in conf.splitlines() if line.startswith("ExecStopPost="))
     assert "-m nanobot.crash_record --source systemd --exit-code ${EXIT_CODE} --exit-status ${EXIT_STATUS} --service-result ${SERVICE_RESULT}" in line
@@ -173,6 +187,7 @@ def test_tracked_drop_in_carries_the_execstoppost_line_and_says_it_is_inert():
 
 def test_bridge_guard_records_the_exit_code_and_stays_last():
     """Pre-fix: the guard was ``raise SystemExit(cli_main())`` — no record of the exit."""
+
     import ast
 
     src = (REPO / "nanobot" / "runtime" / "bridge.py").read_text(encoding="utf-8")
@@ -188,6 +203,8 @@ def test_bridge_guard_records_the_exit_code_and_stays_last():
 
 def test_scorecard_reports_the_streak_and_distinguishes_absent_from_zero(tmp_path):
     """Pre-fix: the scorecard had no bridge section; 140 failures and a healthy loop looked identical."""
+    from nanobot import crash_record  # module absent on the pre-#1197 tree
+
     state = tmp_path / "state"
     state.mkdir()
     absent = scorecard._bridge_section(state, [])


### PR DESCRIPTION
Closes #1197. Parent ADR #1173. Constraints comment on #1197 followed as written.

## Problem

`eeepc-self-evolving-subagent-bridge.service` crash-looped 2026-09-01 04:00 → 13:20 UTC (07:00 → 16:20 MSK): 140 consecutive failed invocations, `NameError: name '_parse_explore_mode' is not defined` at import (#1000/#1142). systemd reported healthy (`Result` describes the latest run), the ledger showed nothing (a process dying at import writes no row, and silence is indistinguishable from an idle gap), the deploy gate waits on ledger activity. No durable record existed anywhere.

## The route, decided: both, with the in-process route as the one that ships

**In-process (ships with this deploy, live-verifiable next release):** `nanobot/crash_record.py`, stdlib only with no package-internal imports, is armed from `nanobot/__init__.py` — upstream of `nanobot.runtime.bridge`, so an import-time crash in the bridge is caught. It arms only when the process is `python -m nanobot.runtime.bridge` (read from `sys.orig_argv`, which is set before any import runs; `sys.argv[0]` is still `-m` at that point) or when `NANOBOT_BRIDGE_EXIT_RECORD=1`; `=0` disables. The CLI, tests, `-m nanobot.crash_record` itself and every other entry point leave it inert (tested in a fresh interpreter). Uncaught exceptions go through the armed `sys.excepthook`; ordinary exit codes are recorded by the bridge's `__main__` guard (still the last statement; a disabled bridge still never touches `STATE_DIR`). The residual blind spots are a failure inside `nanobot/__init__.py` itself and anything that kills the interpreter from outside — signals, OOM, `TimeoutStartSec`.

**Unit route (`ExecStopPost=`), in the tracked drop-in, INERT until an operator applies it.** `host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/override.conf` gains:
```
ExecStopPost=/opt/eeepc-agent/venv/bin/python -m nanobot.crash_record --source systemd --exit-code ${EXIT_CODE} --exit-status ${EXIT_STATUS} --service-result ${SERVICE_RESULT}
```
That file is installed by `host/eeepc/scripts/install.sh` (its drop-in loop), **not** by `deploy_release.sh`, which copies only `*.service`/`*.timer`. So deploying this PR does **not** change the unit on the host. The line is inert until someone runs, as root:
```
sudo cp /opt/eeepc-agent/runtimes/self-evolving-agent/current/host/eeepc/systemd/drop-ins/eeepc-self-evolving-subagent-bridge.service.d/override.conf \
        /etc/systemd/system/eeepc-self-evolving-subagent-bridge.service.d/override.conf
sudo systemctl daemon-reload
```
The file says so in a comment above the line. Once applied it covers signals, OOM kills and timeouts, and a failure in `nanobot/__init__.py`; both routes write the same record through the same module, and a systemd record landing within 300 s of the in-process record for the same outcome is merged (`merged_with_previous: true`), not counted twice. Note: the host also carries an untracked drop-in `20-techtree-publish.conf` in the same directory; this PR does not touch it.

## The record

Under `<STATE_DIR>/bridge/` (`STATE_DIR` from the unit's env file, else `NANOBOT_RUNTIME_STATE_ROOT` from the drop-in, else the bridge's own default — the recorder's literal mirrors `bridge.py`'s and a test pins the two equal):

- `exits.jsonl` — one append-only row per exit: `ts`, `source` (`process`|`systemd`), `outcome`, `exit_status`, `service_result`, `exit_code`, `error` (first traceback line, e.g. `NameError: name '_parse_explore_mode' is not defined`), `where` (innermost frame `file:line`), `pid`, `argv`, `merged_with_previous`.
- `exit_streak.json` — the countable state: `consecutive_failures`, `first_failure_ts`, `last_failure_ts`, `last_exit_status`, `last_error`, `last_where`, `last_success_ts`, `total_failures`, `total_records`, `last_source`, `updated_at`. A success resets `consecutive_failures` to 0.

No size cap anywhere. No silent fallback: a write failure prints `bridge-exit-record: FAILED to write …` with the row to stderr (the journal under systemd) and raises; the excepthook still prints the original traceback; the guard keeps the run's own exit code and prints the recorder error.

## The health surface

`scorecard.latest.json` gains a `bridge` section (reporting only, no fitness target): `consecutive_failures`, `total_failures`, `first_failure_ts`, `last_failure_ts`, `last_exit_status`, `last_error`, `last_success_ts`, `last_source`, `updated_at`, and `reader_status` from `state_access.sidecar` — `absent` / `corrupt` / `oversize` / `permission` / `present` — plus `stale` when the ledger holds a row more than two hours newer than the recorder's last write (the recorder not writing while the loop runs is itself the #1197 defect class). `absent` is therefore never shown as `0`. The ops dashboard (ozand/eeebot-ops-dashboard) does not yet render `scorecard.bridge`; that is a one-line follow-up there and is not filed here.

## Tests

`tests/test_bridge_exit_record.py`, 11 tests. Against `origin/main` (b211f45f) in a throwaway worktree, `--tb=line` — **11 failed**, each for its own reason (the recorder is imported inside each test so the module's absence does not mask the others):

```
:45  ImportError: cannot import name 'crash_record' from 'nanobot'      # streak counts up, success resets
:67  ImportError: cannot import name 'crash_record'                     # systemd record merged, signal record counted
:83  ImportError: cannot import name 'crash_record'                     # write failure printed and raised
pathlib:537 FileNotFoundError: …\state\bridge\exit_streak.json          # import-time crash in a fresh interpreter left no record
:115 ImportError: cannot import name 'crash_record'                     # arms on -m nanobot.runtime.bridge argv, inert elsewhere, =0 disables
:136 ImportError: cannot import name 'crash_record'                     # STATE_DIR resolution mirrors the unit env + bridge default
pathlib:537 FileNotFoundError: …\nanobot\crash_record.py                # recorder is stdlib-only (AST scan)
:163 ImportError: cannot import name 'crash_record'                     # ExecStopPost CLI: exit-code/signal/success, 2 on unwritable
:183 StopIteration                                                      # tracked drop-in has no ExecStopPost line
:198 assert ('_crash_record.record_exit(' in "if __name__ == '__main__':\n    raise SystemExit(cli_main())")
:206 ImportError: cannot import name 'crash_record'                     # scorecard bridge section: absent ≠ 0, present, stale, corrupt
```

The import-time test runs a fresh interpreter with `PYTHONPATH` at the repo, `STATE_DIR` at a temp dir and the env marker set, executes `import nanobot; raise NameError(...)` twice, then a success — streak 2 then 0. The argv test sets `sys.orig_argv[:]` to `['python', '-m', 'nanobot.runtime.bridge']` before importing `nanobot`, then repeats without it and with `=0`, asserting no `bridge/` directory appears. `test_bridge_main_guard_last` (#1142) stays green: the guard is still the last top-level statement.

Full suite on the branch (Windows, `-n 4`): **2859 passed, 18 failed, 17 skipped** — the 18 are the environmental baseline set (`test_autoevolve*` 12, `test_bridge_locking` 3, `test_selfevo_export_security` 2, `test_bridge_cycle_tags` 1). `ruff` is clean on every file this PR touches except `bridge.py`, whose 23 findings pre-exist on `origin/main` and are outside the changed lines. Linux CI is authoritative.

## Live verification (operator; the host stays read-only for me)

1. **First cycle after deploy** (any outcome): `state/bridge/exit_streak.json` exists and `state/bridge/exits.jsonl` has one row with `source: process`. A normal cycle ends `outcome: success`, so expect `consecutive_failures: 0`, `last_success_ts` ≈ the cycle's end, `total_records: 1`. `scorecard/latest.json` → `bridge.reader_status: present`, `bridge.consecutive_failures: 0` (before deploy the section did not exist; `absent` after deploy would mean the recorder never ran).
2. **One deliberate failure, so the mechanism is exercised, not inferred.** Read-only for the state, but it is your call as it writes one record: as the service user, with the unit's environment,
   ```
   sudo -u eeepc-agent STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state \
     PYTHONPATH=/opt/eeepc-agent/runtimes/self-evolving-agent/current \
     /opt/eeepc-agent/venv/bin/python -c "import sys; sys.orig_argv[:] = ['python', '-m', 'nanobot.runtime.bridge']; import nanobot; raise NameError(\"name '_parse_explore_mode' is not defined\")"; echo exit=$?
   ```
   Proof: `exit=1`, the traceback still printed, and the last row of `exits.jsonl` has `outcome: failure`, `exit_status: 1`, `error: "NameError: name '_parse_explore_mode' is not defined"`, `where` ending in `<string>:1`; `exit_streak.json` shows `consecutive_failures: 1` with that `last_error`. The next natural bridge cycle resets it to 0 and sets `last_success_ts`. That sequence — 1 then 0 — is the countable streak working. If you prefer not to write a synthetic record, wait for a natural non-zero exit and quote it; if none occurs in the window, say so and quote the zero.
3. **Journal must be quiet about the recorder:** `journalctl -u eeepc-self-evolving-subagent-bridge --since "-6h" -g "bridge-exit-record"` empty. A `FAILED to write` line there is the recorder failing visibly, which is the designed behaviour, and would also show in the scorecard as `reader_status: stale` within two hours.
4. **Optional, the unit route:** after applying the drop-in as above, `systemctl cat eeepc-self-evolving-subagent-bridge.service | grep ExecStopPost` shows the line, and the next cycle's `exits.jsonl` has a `source: systemd` row with `service_result: success` and `merged_with_previous: true` right after the `process` row. Until applied, `source: systemd` rows do not appear — expected, and stated here so their absence is not read as a defect.

## Non-goals

Deploy health gate (#1163), retries, restart policy, alerting: unchanged. No ledger row is written by the recorder (a raw append would bypass `cycle_ledger`'s rotation; the sidecar is its own append-only file). The untracked host drop-in `20-techtree-publish.conf` is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
