### PR TITLE
fix(1163): health gate certifies a clean post-flip run, not a terminal ledger row

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -3,7 +3,7 @@
 # eeepc deploy: push a new code release to the running host and activate it
 #
 # Usage (from dev machine, not on eeepc):
-#   bash host/eeepc/scripts/deploy_release.sh [--host eeepc] [--dry-run] [--ref <sha>] [--health-timeout <min>] [--no-health-gate] [--allow-dirty]
+#   bash host/eeepc/scripts/deploy_release.sh [--host eeepc] [--dry-run] [--ref <sha>] [--health-timeout <min>] [--no-crash-hold <sec>] [--no-health-gate] [--allow-dirty]
 #
 # What it does:
 #   1. Bundles current repo HEAD into a timestamped release archive
@@ -22,7 +22,18 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 HOST="eeepc"
 DRY_RUN=0
 REF=""
-HEALTH_TIMEOUT=15
+# #1163: the gate's positive signals no longer wait for a terminal ledger row
+# (P90 167 min, so 24% of gated deploys ended UNKNOWN at 25 min). Measured on
+# the host 2026-09-02: `systemctl restart` in step 3 blocks until the new
+# release's first run ends, the timer (OnUnitInactiveSec=3m) fires the next run
+# ~3 min after that, and a normal run's median wall time is 1.6 min — so a
+# post-flip `Finished` line lands ~4.6 min after the gate arms, and the weaker
+# no-crash verdict at first-invocation + NO_CRASH_HOLD (~8 min). 10 min covers
+# both with margin; a run longer than that is TimeoutStartSec=3300 territory.
+HEALTH_TIMEOUT=10
+# Seconds a post-flip invocation must run without a crash before the weaker
+# NO-CRASH verdict is reported (the 2026-09-01 crash loop died ~30 s in).
+NO_CRASH_HOLD=300
 NO_HEALTH_GATE=0
 ALLOW_DIRTY=0
 
@@ -32,6 +43,7 @@ while [[ $# -gt 0 ]]; do
     --dry-run)        DRY_RUN=1; shift ;;
     --ref)            REF="$2"; shift 2 ;;
     --health-timeout) HEALTH_TIMEOUT="$2"; shift 2 ;;
+    --no-crash-hold) NO_CRASH_HOLD="$2"; shift 2 ;;
     --no-health-gate) NO_HEALTH_GATE=1; shift ;;
     --allow-dirty)    ALLOW_DIRTY=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 1 ;;
@@ -337,6 +349,27 @@ FLIP_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # the bare string at 18:36:49.
 FLIP_JOURNAL_TS="$(date -u +'%Y-%m-%d %H:%M:%S') UTC"
 
+# #1163: the positive verdicts. Neither is the word PASS, on purpose — that
+# label meant "a terminal ledger row appeared" and certified a
+# `skipped-duplicate, verdict: reject` cycle on 2026-09-02; a weaker or
+# different claim must not inherit its authority.
+#   CLEAN-EXIT  an invocation that began after the flip ran to exit 0:
+#               systemd's `Finished <unit>` line (logged only on success), or
+#               state/bridge/exit_streak.json (#1200) with last_success_ts
+#               after the flip and consecutive_failures 0.
+#   NO-CRASH    an invocation began after the flip (`Starting <unit>`), no
+#               FAIL branch fired for NO_CRASH_HOLD seconds since, and it has
+#               not finished yet (a long cycle). Weaker: "did not crash yet".
+# Not used as a positive signal, measured on the 2026-09-01 crash loop: the
+# ledger's `started`/`dedup` rows (140 each, written before the code that
+# broke), "any ledger row" (294 in the window), or a silence detector (the
+# max inter-row gap in 51 days is 101.8 min; the loop never goes quiet).
+# Honest residual, unchanged from the old PASS: a release that runs, exits 0
+# and produces nothing useful passes here too.
+INVOKED_AT=""
+BRIDGE_UNIT="eeepc-self-evolving-subagent-bridge.service"
+EXIT_STREAK_PATH="/var/lib/eeepc-agent/self-evolving-agent/state/bridge/exit_streak.json"
+
 # Poll at least once before honouring the timeout. With `while [ $SECONDS -le
 # $END_TIME ]` and a zero timeout the loop could exit without checking anything,
 # so whether the gate ran at all depended on how fast the shell got here.
@@ -373,15 +406,47 @@ while :; do
     exit 1
   fi
 
-  OUTCOME_RAW=$(ssh "ozand@${HOST}" "sudo cat /var/lib/eeepc-agent/self-evolving-agent/state/ledger/cycles.jsonl 2>/dev/null | grep '\"phase\": \"outcome\"' | tail -n 1 || true")
-  if [ -n "$OUTCOME_RAW" ]; then
-    # Very rudimentary bash grep to extract the timestamp string
-    OUTCOME_TS=$(echo "$OUTCOME_RAW" | grep -o '"ts": "[^"]*"' | cut -d'"' -f4)
-    if [[ "$OUTCOME_TS" > "$FLIP_TS" ]]; then
-      log "Health gate: PASS. Terminal outcome observed: $OUTCOME_RAW"
+  # #1200's recorder: a failure recorded after the flip is a crash the journal
+  # grep above may not have seen yet (or a signal/OOM once the ExecStopPost
+  # drop-in is installed); a success recorded after the flip is a full run.
+  STREAK_RAW=$(ssh "ozand@${HOST}" "sudo cat $EXIT_STREAK_PATH 2>/dev/null || true")
+  if [ -n "$STREAK_RAW" ]; then
+    STREAK_FAIL_TS=$(echo "$STREAK_RAW" | grep -o '"last_failure_ts": "[^"]*"' | cut -d'"' -f4 || true)
+    STREAK_OK_TS=$(echo "$STREAK_RAW" | grep -o '"last_success_ts": "[^"]*"' | cut -d'"' -f4 || true)
+    STREAK_N=$(echo "$STREAK_RAW" | grep -o '"consecutive_failures": [0-9]*' | grep -o '[0-9]*$' || true)
+    if [ -n "$STREAK_FAIL_TS" ] && [[ "$STREAK_FAIL_TS" > "$FLIP_TS" ]]; then
+      log "FAIL: bridge exit recorder shows a failure after the flip (consecutive_failures=${STREAK_N:-?}, last_failure_ts=$STREAK_FAIL_TS):"
+      echo "$STREAK_RAW" | grep -E '"last_(error|where|exit_status)"' || true
+      log "Rolling back to $PREV_RELEASE_PATH..."
+      ssh "ozand@${HOST}" "sudo ln -sfn \"$PREV_RELEASE_PATH\" /opt/eeepc-agent/runtimes/self-evolving-agent/current && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service"
+      exit 1
+    fi
+    if [ -n "$STREAK_OK_TS" ] && [[ "$STREAK_OK_TS" > "$FLIP_TS" ]] && [ "${STREAK_N:-0}" = "0" ]; then
+      log "Health gate: CLEAN-EXIT. Bridge run recorded exit 0 after the flip (exit_streak.json last_success_ts=$STREAK_OK_TS, consecutive_failures=0)."
       log "=== Deploy complete ==="
       exit 0
     fi
+  fi
+
+  # systemd logs `Finished <unit>` only when a oneshot run exits 0; every line
+  # in this window postdates the flip (see FLIP_JOURNAL_TS above).
+  FINISHED_LINE=$(ssh "ozand@${HOST}" "sudo journalctl -u $BRIDGE_UNIT --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -E 'systemd\[1\]: Finished $BRIDGE_UNIT' | tail -n 1 || true")
+  if [ -n "$FINISHED_LINE" ]; then
+    log "Health gate: CLEAN-EXIT. Bridge run finished after the flip: $FINISHED_LINE"
+    log "=== Deploy complete ==="
+    exit 0
+  fi
+
+  if [ -z "$INVOKED_AT" ]; then
+    STARTING_LINE=$(ssh "ozand@${HOST}" "sudo journalctl -u $BRIDGE_UNIT --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -E 'systemd\[1\]: Starting $BRIDGE_UNIT' | head -n 1 || true")
+    if [ -n "$STARTING_LINE" ]; then
+      INVOKED_AT=$SECONDS
+      log "Bridge invoked after the flip; holding ${NO_CRASH_HOLD}s for a crash before the weaker verdict: $STARTING_LINE"
+    fi
+  elif [ $(( SECONDS - INVOKED_AT )) -ge "$NO_CRASH_HOLD" ]; then
+    log "Health gate: NO-CRASH. Bridge invoked after the flip and no crash for ${NO_CRASH_HOLD}s; the run has not finished yet, so this is weaker than CLEAN-EXIT."
+    log "=== Deploy complete ==="
+    exit 0
   fi
   
   # An if-block, not `[ ... ] && break`: this script runs under `set -e`, where
@@ -393,7 +458,7 @@ while :; do
   sleep 10
 done
 
-log "Health gate: UNKNOWN. Timeout reached without observing definitive signal."
+log "Health gate: UNKNOWN. Timeout reached without a post-flip invocation, clean exit, or crash."
 log "Do not roll back; an active cycle may still be running."
 log "=== Deploy complete ==="
 exit 0

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -244,12 +244,18 @@ def test_i_service_traceback_still_triggers_rollback(repo, tmp_path, mock_bin):
     assert "rolling back" in (res.stdout + res.stderr).lower()
 
 
-def test_d_terminal_outcome_row_triggers_pass(repo, tmp_path, mock_bin):
-    """The mock must emit the real ledger key, not mirror the script's filter."""
+def test_d_terminal_outcome_row_no_longer_passes(repo, tmp_path, mock_bin):
+    """#1163: a terminal ledger row is not a health signal any more.
+
+    The old PASS branch accepted any `"phase": "outcome"` row after the flip —
+    on 2026-09-02 a deploy passed on `outcome: skipped-duplicate, verdict:
+    reject`. The mock answers the old query the way the ledger would; the gate
+    must neither ask nor say PASS.
+    """
     ssh_mock = """
     if [[ "$*" == *"| grep"* ]]; then
         if [[ "$*" == *"phase"* && "$*" == *"outcome"* ]]; then
-            echo '{"cycle_id": "c1", "phase": "outcome", "ts": "2099-01-01T00:00:00Z"}'
+            echo '{"cycle_id": "c1", "phase": "outcome", "outcome": "skipped-duplicate", "verdict": "reject", "ts": "2099-01-01T00:00:00Z"}'
         fi
         exit 0
     else
@@ -258,8 +264,10 @@ def test_d_terminal_outcome_row_triggers_pass(repo, tmp_path, mock_bin):
     """
     set_ssh_mock(mock_bin, ssh_mock)
     res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
     assert res.returncode == 0
-    assert "health gate: pass" in (res.stdout + res.stderr).lower()
+    assert "health gate: pass" not in combined, combined
+    assert "health gate: unknown" in combined, combined
 
 def test_f_routine_sigterm_does_not_trigger_rollback(repo, tmp_path, mock_bin):
     """A clean SIGTERM stop is not a crash.
@@ -333,3 +341,114 @@ def test_e_timeout_returns_unknown(repo, tmp_path, mock_bin):
     res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
     assert res.returncode == 0
     assert "unknown" in (res.stdout + res.stderr).lower()
+
+
+# ─── #1163: positive verdicts that do not wait for a terminal ledger row ─────
+
+BRIDGE_UNIT = "eeepc-self-evolving-subagent-bridge.service"
+STARTING_TEXT = f"eeepc systemd[1]: Starting {BRIDGE_UNIT} - Run eeepc self-evolving subagent bridge..."
+FINISHED_TEXT = f"eeepc systemd[1]: Finished {BRIDGE_UNIT} - Run eeepc self-evolving subagent bridge."
+
+
+def _streak_mock(streak_json: str, *journal_lines):
+    """ssh stub: canned exit_streak.json for the recorder read, journal replay otherwise."""
+    replay = _journal_replay_mock(*journal_lines)
+    return f"""
+    if [[ "$*" == *exit_streak.json* ]]; then
+        printf '%s\n' {shlex.quote(streak_json)}
+        exit 0
+    fi
+    if [[ "$*" == *"sudo ln -sfn"* ]]; then
+        echo "Rolling back"
+        exit 0
+    fi
+    {replay}
+    """
+
+
+def test_l_post_flip_finished_line_is_clean_exit_never_pass(repo, tmp_path, mock_bin):
+    """Pre-#1163: a `Finished <unit>` line was not read at all, so the gate ended UNKNOWN.
+
+    systemd writes `Finished <unit>` only when a oneshot run exits 0 (host
+    journal 2026-09-02: 164 Finished / 164 Deactivated successfully against 100
+    `Failed with result 'exit-code'`). A pre-flip Finished must not count.
+    """
+    set_ssh_mock(mock_bin, _journal_since_mock((_utc(-120), FINISHED_TEXT)))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert "clean-exit" not in combined and "health gate: unknown" in combined, combined
+
+    set_ssh_mock(mock_bin, _journal_since_mock((_utc(1), STARTING_TEXT), (_utc(2), FINISHED_TEXT)))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode == 0
+    assert "health gate: clean-exit" in combined, combined
+    assert "health gate: pass" not in combined and "rolling back" not in combined
+
+
+def test_m_invocation_without_finish_is_no_crash_after_the_hold(repo, tmp_path, mock_bin):
+    """Pre-#1163: `--no-crash-hold` did not exist and a Starting line meant nothing.
+
+    2026-09-01 crash loop: the bridge wrote `started`/`dedup` ledger rows 140
+    times before dying ~30 s in, so an invocation alone proves nothing; the
+    verdict needs the hold to pass with neither FAIL branch firing, and it must
+    carry its own label — weaker than CLEAN-EXIT, never PASS.
+    """
+    set_ssh_mock(mock_bin, _journal_replay_mock(STARTING_TEXT))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "1", "--no-crash-hold", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode == 0, combined
+    assert "health gate: no-crash" in combined, combined
+    assert "weaker than clean-exit" in combined
+    assert "health gate: pass" not in combined and "health gate: clean-exit" not in combined
+
+
+def test_n_invocation_then_crash_within_the_hold_rolls_back(repo, tmp_path, mock_bin):
+    """The FAIL branches keep their authority over the hold: Starting + a non-zero exit -> rollback."""
+    set_ssh_mock(mock_bin, _journal_replay_mock(
+        STARTING_TEXT,
+        f"eeepc systemd[1]: {BRIDGE_UNIT}: Main process exited, code=exited, status=1/FAILURE",
+    ))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "1", "--no-crash-hold", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode != 0
+    assert "rolling back" in combined and "no-crash" not in combined, combined
+
+
+def test_o_exit_streak_failure_after_flip_rolls_back(repo, tmp_path, mock_bin):
+    """Pre-#1163: state/bridge/exit_streak.json (#1200) was not consulted."""
+    streak = ('{"schema_version": "bridge-exit-streak-v1", "consecutive_failures": 3, '
+              '"last_failure_ts": "2099-01-01T00:00:00Z", "last_exit_status": 1, '
+              '"last_error": "NameError: name \'_parse_explore_mode\' is not defined", "last_where": "bridge.py:4987"}')
+    set_ssh_mock(mock_bin, _streak_mock(streak))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode != 0
+    assert "rolling back" in combined and "exit recorder shows a failure" in combined, combined
+    assert "_parse_explore_mode" in combined
+
+
+def test_p_exit_streak_success_after_flip_is_clean_exit(repo, tmp_path, mock_bin):
+    """Pre-#1163: the recorder's post-flip success was invisible to the gate."""
+    stale = '{"schema_version": "bridge-exit-streak-v1", "consecutive_failures": 0, "last_success_ts": "2000-01-01T00:00:00Z"}'
+    set_ssh_mock(mock_bin, _streak_mock(stale))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert "clean-exit" not in combined and "health gate: unknown" in combined, "a pre-flip success is the old release's"
+
+    fresh = '{"schema_version": "bridge-exit-streak-v1", "consecutive_failures": 0, "last_success_ts": "2099-01-01T00:00:00Z"}'
+    set_ssh_mock(mock_bin, _streak_mock(fresh))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode == 0
+    assert "health gate: clean-exit" in combined and "exit_streak.json" in combined, combined
+    assert "health gate: pass" not in combined
+
+
+def test_q_gate_script_never_reports_pass_and_documents_the_measurement():
+    """Pre-#1163: the PASS label and the 15-minute default with no measurement next to it."""
+    text = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    assert "Health gate: PASS" not in text
+    assert "Health gate: CLEAN-EXIT" in text and "Health gate: NO-CRASH" in text and "Health gate: UNKNOWN" in text
+    assert "HEALTH_TIMEOUT=10" in text and "median wall time is 1.6 min" in text
+    assert '"phase": "outcome"' not in text.split("# 4. Post-deploy health gate")[1], "the terminal-row signal is gone"


### PR DESCRIPTION
Closes #1163. Builds on the gate as it stands after #1155 / #1162 and on #1200's exit recorder.

## What was wrong, precisely

The FAIL side was already right and is untouched: the traceback grep and the `main process exited, (code=exited, status=[1-9]|code=dumped|code=killed, status=(4|6|8|11)/)` grep over the post-flip journal window would have caught a deploy landing in the 2026-09-01 crash loop on its first poll, and the `--since … UTC` boundary (#1162) keeps pre-deploy history out.

The PASS side asked the wrong question: it waited for any post-flip `"phase": "outcome"` row and never checked the outcome. A terminal row has a P90 of 167 min, so 24% of gated deploys ended UNKNOWN at 25 min, and when one did arrive it certified whatever it was — on 2026-09-02 a deploy passed on `outcome: skipped-duplicate, verdict: reject`.

## The change

Two positive verdicts, neither of them the word `PASS`:

| verdict | evidence | claim |
|---|---|---|
| `Health gate: CLEAN-EXIT` | a post-flip `systemd[1]: Finished eeepc-self-evolving-subagent-bridge.service` line — systemd logs `Finished` only when a oneshot run exits 0 (host journal, last 24 h: 164 `Finished` / 164 `Deactivated successfully` against 100 `Failed with result 'exit-code'`); **or** `state/bridge/exit_streak.json` (#1200) with `last_success_ts` after the flip and `consecutive_failures: 0` | an invocation that began on the new release ran to exit 0 |
| `Health gate: NO-CRASH` | a post-flip `systemd[1]: Starting <unit>` line, then `--no-crash-hold` seconds (default 300) with neither FAIL branch firing and no `Finished` yet | the new release was invoked and has not crashed; the run is still going (a long cycle). Logged as "weaker than CLEAN-EXIT" |
| `Health gate: UNKNOWN` | timeout with no post-flip invocation | unchanged: fail-open, no rollback |

Added FAIL signal: `exit_streak.json` with `last_failure_ts` after the flip rolls back and prints the recorded `last_error` / `last_where` / `last_exit_status` — the same crash the journal grep sees, plus signals/OOM once the ExecStopPost drop-in from #1200 is installed. The `"phase": "outcome"` read is gone from the gate.

**`exit_streak.json` at gate time — it works, and here is why.** `systemctl restart` in step 3 blocks until the new release's first run ends, so that run's success timestamp predates `FLIP_TS` and does not count. The timer (`OnUnitInactiveSec=3m`) fires the next run ~3 min after the gate arms; a normal run's median wall time is 1.6 min; the recorder writes `last_success_ts` at that run's exit. So the streak-based CLEAN-EXIT lands ~4.6 min after arming, the same moment as the `Finished` line — the two are redundant on purpose (one survives a release without #1200, the other a journal that is not readable). Verified on the host 2026-09-02 06:54 UTC (09:54 MSK): the first post-#1200 run wrote `exit_streak.json` with `consecutive_failures: 0` and `last_success_ts: 2026-09-02T06:54:15Z`.

**Default timeout 15 → 10 min**, derived from that cadence and recorded in the comment next to the constant: invocation at +3 min, CLEAN-EXIT at ~+4.6 min, NO-CRASH at first invocation + 5 min ≈ +8 min. Anything longer is `TimeoutStartSec=3300` territory and ends UNKNOWN, as before.

**Not used as a positive signal, per the 2026-09-01 measurements on #1163:** `started` or `dedup` ledger rows (140 each in the crash window, written before the code that broke), "any ledger row" (294 in the window), or a silence detector (max inter-row gap in 51 days is 101.8 min; only 6 gaps reach an hour, 0.6% of the span). Recorded in the script comment so nobody re-proposes them.

**Honest residual, unchanged from the old PASS:** a release that runs, exits 0 and produces nothing useful passes under both the old signal and the new ones. Neither CLEAN-EXIT nor NO-CRASH claims otherwise; the label says what was observed and no more.

## Tests

`tests/test_deploy_release.py`: `test_d` rewritten (a terminal row must no longer PASS) plus `test_l`–`test_q`. Against `origin/main` (7733727f), `--tb=line` — **7 failed, 10 passed** (the untouched a/b/c/e/f/g/h/i/j/k):

```
test_deploy_release.py:269: AssertionError  # test_d: main still says "Health gate: PASS" on a skipped-duplicate row
test_deploy_release.py:385: AssertionError  # test_l: post-flip Finished line -> main ends UNKNOWN, no CLEAN-EXIT
test_deploy_release.py:400: AssertionError: unknown arg: --no-crash-hold   # test_m
test_deploy_release.py:415: AssertionError: unknown arg: --no-crash-hold   # test_n
test_deploy_release.py:426: AssertionError: assert 0 != 0                  # test_o: exit_streak failure after the flip not read -> no rollback
test_deploy_release.py:444: AssertionError  # test_p: exit_streak success after the flip -> main ends UNKNOWN
test_deploy_release.py:451: assert 'Health gate: PASS' not in '#!/usr/bin/...'   # test_q
```

The mocks follow the file's own discipline: `_journal_replay_mock` feeds fixture lines through the script's real `grep` (so the `Finished`/`Starting` patterns are what is exercised), `_journal_since_mock` enforces the MSK-vs-UTC `--since` rule (test_l first proves a pre-flip `Finished` does not count), and the new `_streak_mock` answers only the `exit_streak.json` read. `test_n` proves the FAIL branches keep authority inside the hold: `Starting` plus `status=1/FAILURE` rolls back and never says NO-CRASH.

Full suite on the branch (Windows, `-n 4`): **2865 passed, 18 failed, 17 skipped** — the 18 are the environmental baseline set (`test_autoevolve*` 12, `test_bridge_locking` 3, `test_selfevo_export_security` 2, `test_bridge_cycle_tags` 1). `bash -n` clean. The 7 `ruff` findings in `tests/test_deploy_release.py` (import order, whitespace) pre-exist on `origin/main` outside the changed lines. Linux CI is authoritative.

## Live verification (operator; the next gated deploy)

This one verifies itself on your next `deploy_release.sh` run — no host action of mine:

1. The gate log should show, in order: `Bridge invoked after the flip; holding 300s …` about 3 min after `Waiting up to 10m …`, then `Health gate: CLEAN-EXIT. …` about 1.6 min later, citing either the `Finished` line or `exit_streak.json last_success_ts=<ts>` with that `<ts>` later than the `Waiting…` line's time. Quote the two lines with their timestamps on #1163 (that is the issue's AC: release name plus the gate line). Total gate time should be ~5 min, not 15–25.
2. If instead you see `Health gate: NO-CRASH … weaker than CLEAN-EXIT`, the first post-flip run took longer than the 5-min hold; quote it, and check `state/bridge/exit_streak.json` a few minutes later shows `last_success_ts` past the flip. That is the weak verdict doing exactly what it says.
3. `Health gate: UNKNOWN` now means the timer never fired within 10 min; quote `systemctl list-timers eeepc-self-evolving-subagent-bridge.timer` next to it — with `OnUnitInactiveSec=3m` that should not happen unless the unit is stopped.
4. Negative control, only if you want it: nothing to inject — a real crash is caught by the unchanged FAIL branches (tested), and the old PASS path no longer exists to compare against.

## Non-goals

FAIL-branch patterns, rollback mechanics and the `--since UTC` boundary unchanged. No silence detector, no ledger-row signal, no retry policy. The ops dashboard's rendering of the gate verdict, if any, is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
