### PR TITLE
fix(1176): archive-aware recent-failure suppression, and bound failures not candidates

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -123,6 +123,13 @@ try:
 except ValueError:
     FAILURE_SUPPRESS_HOURS = 24.0
 
+# #1176: how many newest artifacts (live results/ + rotated archive/) are
+# considered before the failure filter runs. state_access.artifacts caps its own
+# path scan at 256 and the host writes roughly 144 results a day, so this covers
+# the 24h window with room to spare. It bounds CANDIDATES, not how far back the
+# window reaches — the age cutoff is FAILURE_SUPPRESS_HOURS and stays separate.
+_FAILURE_SCAN_CANDIDATES = 256
+
 try:
     # #733: bounded cap on how many pre-spawn duplicate requests _main_impl
     # will bulk-skip (each a cheap, zero-LLM git check) in a single bridge
@@ -221,6 +228,50 @@ def _iter_result_entries(results_dir: 'Path',
 
     if use_cache:
         _RESULT_ENTRIES_CACHE[r_key] = records
+    return records
+
+
+def _iter_archive_entries(archive_dir: 'Path', limit: int) -> list[tuple['Path', dict, float]]:
+    """Newest `limit` archived result payloads as (path, data, mtime) (#1176).
+
+    Results migrate out of `results/` within the hour while the failure window
+    is 24h, so the live directory alone held 1 of the 9 failures inside its own
+    window when measured on the host (2026-09-02). This reads the archive to
+    close that gap.
+
+    Deliberately NOT merged into `_iter_result_entries`: that function's cache
+    is keyed on `results_dir` and is reused by every other consumer, and #1040's
+    single-scandir invariant counts passes over `results_dir` specifically. This
+    is a separate pass over a separate directory, so the invariant is unaffected.
+
+    Ordering before bounding: `stat()` every candidate, sort newest-first, then
+    take `limit` and only then parse. Bounding an unsorted listing would pick an
+    arbitrary `limit` of the archive's thousands of files.
+    """
+    records: list[tuple[Path, dict, float]] = []
+    try:
+        if not archive_dir or not archive_dir.is_dir():
+            return []
+        stamped: list[tuple[float, Path]] = []
+        with os.scandir(str(archive_dir)) as it:
+            for entry in it:
+                if not entry.name.endswith('.json'):
+                    continue
+                try:
+                    if entry.is_file():
+                        stamped.append((entry.stat().st_mtime, Path(entry.path)))
+                except Exception:
+                    continue
+        stamped.sort(key=lambda x: x[0], reverse=True)
+        for mtime, path in stamped[:max(0, limit)]:
+            try:
+                data = json.loads(path.read_text(encoding='utf-8'))
+            except Exception:
+                continue
+            if isinstance(data, dict):
+                records.append((path, data, mtime))
+    except Exception:
+        return []
     return records
 
 
@@ -4164,8 +4215,10 @@ def _recent_failure_match(
         if not dup_check_title:
             return None
         hours = FAILURE_SUPPRESS_HOURS if window_hours is None else window_hours
-        results_dir = state_dir / 'subagents' / 'results'
-        if not results_dir.exists():
+        # #1176: a missing results/ is no longer a reason to give up. Results
+        # migrate to archive/ within the hour while this window is 24h, so the
+        # history can live entirely in the archive; the scan below covers both.
+        if entries is None and not (state_dir / 'subagents').exists():
             return None
 
         import re as _re_fail
@@ -4180,13 +4233,39 @@ def _recent_failure_match(
         now = _time_fail.time()
         cutoff = now - (hours * 3600.0)
 
-        # #1040: use cached or single-pass result entries (already newest-first)
-        all_entries = _iter_result_entries(results_dir, entries=entries)
-        candidates = sorted(all_entries, key=lambda x: x[2], reverse=True)
+        # #1176: read live results/ AND the rotated archive/. Results migrate
+        # out of results/ within the hour, while this window is 24h by
+        # default, so the live directory alone held 1 of the 9 failures
+        # inside its own window when measured on the host (2026-09-02) —
+        # an 89% blind spot that looked exactly like "no recent failure".
+        # state_access.artifacts unifies both dirs newest-first and applies
+        # the age cutoff itself; #1040's cached-entries path is preserved for
+        # callers that supply their own list.
+        if entries is not None:
+            scanned = [
+                (data, mtime)
+                for _, data, mtime in sorted(entries, key=lambda x: x[2], reverse=True)
+                if mtime >= cutoff
+            ]
+        else:
+            subagents = state_dir / 'subagents'
+            merged = _iter_result_entries(subagents / 'results')
+            merged = merged + _iter_archive_entries(
+                subagents / 'archive', _FAILURE_SCAN_CANDIDATES,
+            )
+            scanned = [
+                (data, mtime)
+                for _, data, mtime in sorted(merged, key=lambda x: x[2], reverse=True)
+                if mtime >= cutoff
+            ]
 
-        for entry_path, data, mtime in candidates[:max_scan]:
-            if mtime < cutoff:
-                continue
+        # #1176: select FAILURES first, then apply max_scan. Bounding before
+        # the status filter was harmless while results/ held ~6 files, but
+        # against the archive's 3,000+ the newest `max_scan` entries are
+        # mostly successes, so the bound alone would return "no recent
+        # failure" every time — the same silence this gate is meant to break.
+        failures = []
+        for data, _mtime in scanned:
             reason = (data.get('rollback') or {}).get('reason')
             status = data.get('result_status')
             # #798: skip-path bookkeeping rows are suppressions, not failures
@@ -4199,6 +4278,11 @@ def _recent_failure_match(
                 continue
             if not reason and status not in ('blocked', 'no_commit'):
                 continue
+            failures.append(data)
+            if len(failures) >= max_scan:
+                break
+
+        for data in failures:
             title = data.get('backlog_title') or data.get('task_title') or ''
             if not title:
                 continue

--- a/tests/test_bridge_recent_failure_suppress.py
+++ b/tests/test_bridge_recent_failure_suppress.py
@@ -406,3 +406,62 @@ def test_ledger_matched_against_is_historical_title(
     dedup_rows = [r for r in rows if r["phase"] == "dedup"]
     assert [r["decision"] for r in dedup_rows] == ["skipped_recent_failure"]
     assert dedup_rows[0]["matched_against"] == historical
+
+
+def test_matches_a_failure_that_lives_only_in_the_archive(tmp_path: Path):
+    """#1176: results/ empties into archive/ within the hour, the window is 24h.
+
+    Measured on the host 2026-09-02: 6 artifacts in results/ covering ~1 hour,
+    3,059 in archive/, and of the 9 failures inside the 24h window the live
+    directory held 1. A results-only scan therefore returned "no recent
+    failure" for 89% of the history it believed it was reading — and that
+    answer is indistinguishable from there genuinely being none.
+    """
+    state_dir = tmp_path / "state"
+    archive_dir = state_dir / "subagents" / "archive"
+    (state_dir / "subagents" / "results").mkdir(parents=True, exist_ok=True)
+    _write_result(
+        archive_dir,
+        "archived-failure.json",
+        backlog_title="Wire host_metrics dashboard integration panel",
+        result_status="blocked",
+    )
+
+    assert _recent_failure_match(
+        "Wire host_metrics dashboard integration panel again",
+        state_dir,
+    ) == "Wire host_metrics dashboard integration panel"
+
+
+def test_failure_is_selected_before_the_max_scan_bound(tmp_path: Path):
+    """#1176: bound the failures, not the candidates.
+
+    `candidates[:max_scan]` ran before the failure filter. With ~6 live files
+    that never mattered; against the archive's 3,000+ the newest `max_scan`
+    entries are overwhelmingly successes, so the bound alone would report "no
+    recent failure" every time — the same silence the gate exists to break.
+    """
+    state_dir = tmp_path / "state"
+    results_dir = state_dir / "subagents" / "results"
+    old = time.time() - 3600.0
+    _write_result(
+        results_dir,
+        "the-failure.json",
+        backlog_title="Wire host_metrics dashboard integration panel",
+        result_status="blocked",
+    )
+    os.utime(results_dir / "the-failure.json", (old, old))
+    # Twenty newer successes bury it well past max_scan=10.
+    for i in range(20):
+        p = _write_result(
+            results_dir,
+            f"success-{i:02d}.json",
+            backlog_title=f"Unrelated completed chore number {i}",
+            result_status="completed",
+        )
+        os.utime(p, (old + 60 + i, old + 60 + i))
+
+    assert _recent_failure_match(
+        "Wire host_metrics dashboard integration panel again",
+        state_dir,
+    ) == "Wire host_metrics dashboard integration panel"


### PR DESCRIPTION
Closes #1176.

## What was wrong

`_recent_failure_match` scanned `state_dir/subagents/results` only. Measured on the host, 2026-09-02:

```
lookback window (FAILURE_SUPPRESS_HOURS default):  24 hours
live results/ coverage:                            ~1 hour   (6 artifacts)
archive/:                                          3,059 artifacts
failures inside the 24h window:                    9
   visible to the deployed reader:                 1
```

The archiver runs roughly twenty-four times faster than the window the code believes it is reading. The result of a blind scan — `None` — is exactly the result of a genuine absence of failures, so this has been silently returning "nothing recent" for most of its history.

## Two changes, and the second matters as much as the first

**Archive awareness.** The live half still comes from the cached `_iter_result_entries`; a new `_iter_archive_entries` adds a bounded pass over `archive/`.

Not merged into one helper, on purpose. `_iter_result_entries` caches on `results_dir` and is reused by every other consumer, and #1040's single-scandir invariant counts passes over `results_dir` specifically. My first attempt routed the whole read through `state_access.artifacts` — the designated unified reader, and the obvious choice — but it iterates `results/`, `requests/` and `archive/`, so it re-scanned `results/` and broke that invariant. `test_bridge_composition_single_scandir_across_all_consumers` caught it in the full suite; the targeted tests all passed. Recording it because "use the shared reader" was the right instinct and still the wrong call here.

**Failures are selected before `max_scan`.** The old order was `candidates[:max_scan]` and then filter by failure status. Harmless while `results/` held six files; against 3,000+ archived artifacts the newest ten are overwhelmingly successes, so the bound alone would return "no recent failure" every time.

That is the part worth dwelling on: **adding archive awareness without reordering would have reintroduced the exact silence the change exists to remove**, and it would have looked like a working fix — the reader would be scanning the right files and still finding nothing.

`_iter_archive_entries` stats and sorts newest-first *before* bounding, then parses. Taking `limit` from an unsorted listing would pick arbitrary files out of thousands. A missing `results/` no longer aborts the scan, since the history can live entirely in the archive.

## Evidence

**Both new tests fail against `origin/main`**, run by copying the test file onto unmodified main:

```
FAILED test_matches_a_failure_that_lives_only_in_the_archive
FAILED test_failure_is_selected_before_the_max_scan_bound
E  AssertionError: assert None == 'Wire host_metrics dashboard integration panel'
2 failed, 18 passed
```

Both return `None` — the defect, made deterministic. The 18 pre-existing tests in that file pass on main unchanged.

**Full suite:** `18 failed, 2861 passed, 17 skipped`. Matches the current Windows baseline exactly (10 `autoevolve*`, 3 `bridge_locking`, 2 `selfevo_export_security`, 1 `bridge_cycle_tags`, 2 `autoevolve_state`); nothing beyond it. The earlier run of the first implementation showed 19 — that extra failure was the invariant test above, and it is why this is the second implementation.

## Live verification after deploy

Not "the tests pass". Recompute from the host — failures in the last `FAILURE_SUPPRESS_HOURS` across live plus archive — and quote it beside what the deployed reader returns. Agreement is the check. Baseline to compare against: **9 true, 1 seen**.

Note this changes behaviour in the direction of *more* suppression: proposals that were re-spawned every cycle because their failure had been archived will now be suppressed. That is the intent, and it is worth watching the first day for over-suppression — the guard against that is `_SKIP_ROLLBACK_REASONS` and the #757 intent-keying, both untouched here.
