### PR TITLE
docs(1163): pin the FAIL-before-verdict order in the health gate with a test

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -406,6 +406,14 @@ while :; do
     exit 1
   fi
 
+  # ORDER MATTERS. Both FAIL branches above run before every positive verdict
+  # below, in the same poll iteration, and that ordering is the guard: during
+  # the 2026-09-01 crash loop the post-flip journal held 6 `Finished` lines
+  # against 139 `Failed with result 'exit-code'` — a few invocations did
+  # complete — so a `Finished` line alone does not prove a release sound.
+  # Hoisting the positive verdicts above the FAIL checks, or evaluating them
+  # concurrently, would re-admit exactly that release, and only during an
+  # outage. tests/test_deploy_release.py::test_r pins the order.
   # #1200's recorder: a failure recorded after the flip is a crash the journal
   # grep above may not have seen yet (or a signal/OOM once the ExecStopPost
   # drop-in is installed); a success recorded after the flip is a full run.

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -452,3 +452,20 @@ def test_q_gate_script_never_reports_pass_and_documents_the_measurement():
     assert "Health gate: CLEAN-EXIT" in text and "Health gate: NO-CRASH" in text and "Health gate: UNKNOWN" in text
     assert "HEALTH_TIMEOUT=10" in text and "median wall time is 1.6 min" in text
     assert '"phase": "outcome"' not in text.split("# 4. Post-deploy health gate")[1], "the terminal-row signal is gone"
+
+
+def test_r_finished_line_never_outranks_a_crash_in_the_same_window(repo, tmp_path, mock_bin):
+    """Guard on statement order, not a repro: during the 2026-09-01 crash loop the
+    journal carried 6 `Finished` lines against 139 `Failed with result 'exit-code'`,
+    so a post-flip Finished line and a non-zero exit in the same window must roll
+    back — the FAIL branches are evaluated before any positive verdict."""
+    set_ssh_mock(mock_bin, _journal_replay_mock(
+        STARTING_TEXT,
+        FINISHED_TEXT,
+        f"eeepc systemd[1]: {BRIDGE_UNIT}: Main process exited, code=exited, status=1/FAILURE",
+        f"eeepc systemd[1]: {BRIDGE_UNIT}: Failed with result 'exit-code'.",
+    ))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode != 0
+    assert "rolling back" in combined and "clean-exit" not in combined, combined


### PR DESCRIPTION
Follow-up to #1201, from the review against the host (https://github.com/ozand/eeebot/issues/1163#issuecomment-5505945614).

**Finding:** CLEAN-EXIT rests on systemd logging `Finished <unit>` only when a oneshot run exits 0. True per run — but during the 2026-09-01 crash loop the post-flip journal held **6 `Finished` lines against 139 `Failed with result 'exit-code'`**: a few invocations did complete. So a Finished line alone does not prove the release sound. The gate is safe anyway because both FAIL branches (traceback, non-zero exit) run before every positive verdict in the same poll iteration and roll back on the first poll. That safety lived in statement order only.

**Change:** a comment above the positive verdicts recording the 6-vs-139 numbers as the reason the order must not change, and `test_r`: a post-flip journal carrying `Starting`, `Finished` **and** `status=1/FAILURE` rolls back and never says CLEAN-EXIT. This is a guard on ordering, not a repro — it passes on current main by design, which is stated here rather than dressed up.

No behaviour change. `bash -n` clean; `test_deploy_release.py` 18 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)