### PR TITLE
fix(1178): rotate reflections.jsonl, read across the rotation, digest bounded tails, guard read-modify-write sidecars

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -2589,20 +2589,16 @@ def _reflection_items(
     """
     items: list[dict[str, str]] = []
     try:
-        path = Path(state_dir) / "reflector" / "reflections.jsonl"
-        if not path.is_file():
+        from nanobot.runtime import reflector
+
+        # #1178: the journal rotates at 512 KiB into reflector/archive/; read the
+        # newest archives plus the live file through the reflector's own reader.
+        if not reflector.reflection_files(state_dir):
             return items
         if now is None:
             now = datetime.now(timezone.utc)
         cutoff = now - timedelta(days=_REFLECTION_MAX_AGE_DAYS)
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line_str = line.strip()
-            if not line_str:
-                continue
-            try:
-                row = json.loads(line_str)
-            except Exception:
-                continue
+        for row in reflector.iter_reflection_rows(state_dir):
             if not isinstance(row, dict) or not row.get("cycle_id"):
                 continue
             row_status = str(row.get("status") or "").strip().lower()

--- a/nanobot/runtime/evolution_tree.py
+++ b/nanobot/runtime/evolution_tree.py
@@ -145,8 +145,24 @@ def read_tree(state_dir: Any) -> dict[str, Any]:
         return _empty_tree()
 
 
+# A tree is bounded by MAX_NODES / MAX_SWITCHES (~50 KB live); anything past
+# this was not written by this module and is not overwritten by it (#1178).
+_TREE_MAX_BYTES = 16 * 1024 * 1024
+
+
 def _write_tree(state_dir: Any, tree: dict[str, Any]) -> None:
     path = _tree_path(state_dir)
+    # #1178 Class B: the read that produced ``tree`` returns a blank default
+    # on a corrupt/oversize/unreadable file; writing that back would erase the
+    # history. Skip and say so; an absent file is created normally.
+    from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+    status = rewrite_status(path, max_bytes=_TREE_MAX_BYTES)
+    if status not in WRITABLE_STATUSES:
+        import logging
+
+        logging.getLogger(__name__).warning("evolution_tree: write skipped, existing file is %s: %s", status, path)
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(tree, indent=2, ensure_ascii=False), encoding="utf-8")
 

--- a/nanobot/runtime/heldout/__init__.py
+++ b/nanobot/runtime/heldout/__init__.py
@@ -128,6 +128,29 @@ def _git_head(selfevo_repo: Path | None) -> str | None:
         return None
 
 
+_RESULTS_MAX_BYTES = 16 * 1024 * 1024  # one entry per registered checker; see #1178
+
+
+def _save_results(state_dir: Path, data: dict[str, Any]) -> None:
+    """Write ``heldout/results.json`` unless the file on disk is one this
+    module could not read (#1178 Class B): ``_load_results`` returns a blank
+    schema for a corrupt file, and writing that back would erase the results
+    history. Absent is created normally; skips are logged."""
+    path = _results_path(state_dir)
+    # #1178 Class B: the read that produced ``data`` returns a blank default
+    # on a corrupt/oversize/unreadable file; writing that back would erase the
+    # history. Skip and say so; an absent file is created normally.
+    from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+    status = rewrite_status(path, max_bytes=_RESULTS_MAX_BYTES)
+    if status not in WRITABLE_STATUSES:
+        import logging
+
+        logging.getLogger(__name__).warning("heldout: write skipped, existing file is %s: %s", status, path)
+        return
+    _write_json(path, data)
+
+
 def _load_results(state_dir: Path) -> dict[str, Any]:
     data = _read_json(_results_path(state_dir), None)
     if not isinstance(data, dict) or not isinstance(data.get("results"), dict):
@@ -308,7 +331,7 @@ def run_heldout(
             "regressions": regressions,  # #841: artifacts that flipped pass->fail this run
             "flaky": flaky,  # #842: artifacts excluded as skip due to a non-deterministic verdict
         }
-        _write_json(_results_path(state_dir), data)
+        _save_results(state_dir, data)
         return data
     except Exception:
         try:

--- a/nanobot/runtime/heldout/microbench.py
+++ b/nanobot/runtime/heldout/microbench.py
@@ -436,6 +436,29 @@ def _microbench_path(state_dir: "Path") -> Path:
     return Path(state_dir) / _MICROBENCH_DIR / _MICROBENCH_FILENAME
 
 
+_MICROBENCH_MAX_BYTES = 16 * 1024 * 1024  # _MAX_ENTRIES bounds the corpus; see #1178
+
+
+def _save_microbench_file(state_dir: "Path", data: dict) -> None:
+    """Write ``microbench.json`` unless the file on disk is one
+    ``_load_microbench_file`` could not read (#1178 Class B) — that read
+    returns an empty corpus, and writing it back would erase every baseline."""
+    path = _microbench_path(state_dir)
+    # #1178 Class B: the read that produced ``data`` returns a blank default
+    # on a corrupt/oversize/unreadable file; writing that back would erase the
+    # history. Skip and say so; an absent file is created normally.
+    from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+    status = rewrite_status(path, max_bytes=_MICROBENCH_MAX_BYTES)
+    if status not in WRITABLE_STATUSES:
+        import logging
+
+        logging.getLogger(__name__).warning("microbench: write skipped, existing file is %s: %s", status, path)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
 def _load_microbench_file(state_dir: "Path") -> dict:
     path = _microbench_path(state_dir)
     try:
@@ -579,9 +602,7 @@ def measure_cycle(
         data["entries"] = entries
         data["schema_version"] = _SCHEMA
 
-        out_path = _microbench_path(state_dir)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _save_microbench_file(state_dir, data)
         return entry
     except Exception:
         return None

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -32,13 +32,13 @@ from typing import Any, Callable, Iterable
 
 from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
 from nanobot.runtime.lesson_v2 import (
-    validate_lesson_for_mint,
     atomic_write_yaml,
     bounded_load_yaml,
     fill_related_links,
     find_duplicate,
     inline_related_slugs,
     related_hint,
+    validate_lesson_for_mint,
 )
 from nanobot.runtime.model_registry import resolve_model
 
@@ -151,8 +151,8 @@ def iter_lessons(workspace: Path, state_dir: Path | None = None) -> Iterable[dic
             continue
         seen_reflection_paths.add(ref_path)
         try:
-            with ref_path.open("r", encoding="utf-8") as fh:
-                for line in fh:
+            if True:  # #1178: rotated archives first, then the live journal
+                for line in _reflection_lines(ref_path):
                     line = line.strip()
                     if not line:
                         continue
@@ -292,6 +292,42 @@ def _fact_path(path: str) -> Path | None:
 # ---------------------------------------------------------------------------
 # Evidence resolution (#1094) — deterministic, fail-closed per item
 # ---------------------------------------------------------------------------
+
+def _reflection_archives(live: Path, newest: int = 2) -> list[Path]:
+    """The newest rotated journals next to ``live`` (``archive/reflections-*.jsonl.gz``,
+    #1178), oldest first."""
+    archive_dir = live.parent / "archive"
+    if not archive_dir.is_dir():
+        return []
+    names = sorted(p for p in archive_dir.glob("reflections-*.jsonl.gz") if p.is_file())
+    return names[-newest:] if newest else []
+
+
+def _reflection_lines(live: Path):
+    """Lines of the newest rotated journals then the live journal (#1178)."""
+    for path in [*_reflection_archives(live), live]:
+        opener = gzip.open if path.name.endswith(".gz") else open
+        try:
+            with opener(path, "rt", encoding="utf-8") as fh:
+                yield from fh
+        except OSError:
+            continue
+
+
+def _reflection_tail_lines(live: Path, max_lines: int) -> list[str]:
+    """The last ``max_lines`` journal lines across the newest archive and the
+    live file — a freshly rotated live journal is nearly empty (#1178)."""
+    lines = _bounded_tail_lines(live, max_lines)
+    if len(lines) < max_lines:
+        for archive in reversed(_reflection_archives(live, newest=1)):
+            try:
+                with gzip.open(archive, "rt", encoding="utf-8") as fh:
+                    older = fh.read().splitlines()
+            except OSError:
+                continue
+            lines = older[-(max_lines - len(lines)):] + lines if older else lines
+    return lines
+
 
 def _bounded_tail_lines(path: Path, max_lines: int) -> list[str]:
     """Read only a bounded byte/line tail from a JSONL file."""
@@ -944,7 +980,7 @@ def promote_reflector_recommendations_to_v2(
         # _REFLECTOR_TAIL_ROWS rows; it rejected the file to avoid a cost the
         # next line never paid. Use the module's existing bounded tail reader
         # instead, so cost follows the tail window and not the total size.
-        lines = _bounded_tail_lines(path, _REFLECTOR_TAIL_ROWS)
+        lines = _reflection_tail_lines(path, _REFLECTOR_TAIL_ROWS)
     except OSError:
         # Unreadable is not the same as "nothing to promote" (#1183). Both
         # still return 0 — the caller counts promotions — but the reason is

--- a/nanobot/runtime/knowledge_lift.py
+++ b/nanobot/runtime/knowledge_lift.py
@@ -29,6 +29,11 @@ WATERMARK_REL = "knowledge_lift/watermark.json"
 
 # Operational constraints & sizing
 MAX_FILE_BYTES = 50_000
+# #1178: the digest hashes the newest bytes of each knowledge file instead of
+# skipping any file over MAX_FILE_BYTES — on the host both lessons.yaml
+# (77,843 B) and reflections.jsonl (738,050 B) were past it, so the
+# "knowledge unchanged" watermark ignored every lesson and reflection change.
+DIGEST_TAIL_BYTES = 128_000
 MAX_PLAN_BYTES = 256_000
 MAX_CASES_PER_SET = 20
 MAX_ASSERTIONS_PER_CASE = 10
@@ -166,10 +171,10 @@ def compute_knowledge_digest(repo_or_state: Path, state_dir: Path | None = None)
         paths.append((Path(state_dir) if state_dir else root) / "reflector" / "reflections.jsonl")
         for path in paths:
             try:
-                if not path.is_file() or path.stat().st_size > MAX_FILE_BYTES:
+                if not path.is_file():
                     continue
                 hasher.update(path.name.encode("utf-8"))
-                hasher.update(path.read_bytes())
+                hasher.update(_tail_bytes(path, DIGEST_TAIL_BYTES))
             except Exception:
                 continue
     except Exception:
@@ -262,6 +267,15 @@ def _row_well_formed(row: Any) -> bool:
     )
 
 
+def _tail_bytes(path: Path, limit: int) -> bytes:
+    """The last ``limit`` bytes of ``path`` (the whole file when smaller)."""
+    with path.open("rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        fh.seek(max(0, size - limit))
+        return fh.read()
+
+
 def _read_eval_rows(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     try:
@@ -281,6 +295,16 @@ def _read_eval_rows(path: Path) -> list[dict[str, Any]]:
 
 
 def _atomic_write_eval_rows(path: Path, rows: list[dict[str, Any]]) -> None:
+    # #1178 Class B: _read_eval_rows returns [] past MAX_FILE_BYTES * 40, so a
+    # rewrite from that read would truncate the history to the current rows.
+    from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+    status = rewrite_status(path, max_bytes=MAX_FILE_BYTES * 40, json_object=False)
+    if status not in WRITABLE_STATUSES:
+        import logging
+
+        logging.getLogger(__name__).warning("knowledge_lift: eval rows not rewritten, sidecar is %s: %s", status, path)
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_file = tempfile.NamedTemporaryFile(
         mode="w",

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -6,6 +6,8 @@ import gzip
 import inspect
 import json
 import os
+import re
+import sys
 import tempfile
 import time
 from datetime import datetime, timedelta, timezone
@@ -20,6 +22,17 @@ _MAX_RECOMMENDATIONS = 3
 _MAX_CONSECUTIVE_ERRORS = 3
 _MAX_RUNTIME_SECONDS = 600
 _JOURNAL_TAIL = 10
+# #1178: reflections.jsonl rotation. The journal was append-only with no
+# rotation and crossed 512 KiB on the host around 2026-08-29 (738,050 B on
+# 2026-09-02), which is what switched the curator's reflector promotion off
+# (#1183). At the cap the live file is gzip-archived whole to
+# reflector/archive/reflections-YYYY-MM-DD.jsonl.gz and truncated; archives
+# older than the retention are removed; readers consult the newest
+# _ARCHIVE_READ_FILES archives in addition to the live file.
+_MAX_JOURNAL_BYTES = 512 * 1024
+_ARCHIVE_RETENTION_DAYS = 90
+_ARCHIVE_READ_FILES = 2
+_ARCHIVE_RE = re.compile(r"^reflections-(\d{4}-\d{2}-\d{2})(?:-(\d+))?\.jsonl\.gz$")
 _MAX_TRANSCRIPT_CHARS = 48_000
 _MAX_LEDGER_CHARS = 12_000
 _MAX_JOURNAL_CHARS = 12_000
@@ -151,15 +164,96 @@ def _save_watermark(state_dir: Path, cycle_id: str) -> None:
             pass
 
 
+def _journal_path(state_dir: Path | str) -> Path:
+    return Path(state_dir) / "reflector" / "reflections.jsonl"
+
+
+def _archives(state_dir: Path | str) -> list[Path]:
+    """Rotated journals, oldest first (by the date and sequence in the name)."""
+    archive_dir = _journal_path(state_dir).parent / "archive"
+    found: list[tuple[str, int, Path]] = []
+    if archive_dir.is_dir():
+        for candidate in archive_dir.iterdir():
+            match = _ARCHIVE_RE.match(candidate.name)
+            if match and candidate.is_file():
+                found.append((match.group(1), int(match.group(2) or 0), candidate))
+    return [path for _, _, path in sorted(found)]
+
+
+def _rotate_journal(state_dir: Path | str) -> Path | None:
+    """Archive and truncate the live journal once it passes :data:`_MAX_JOURNAL_BYTES`.
+
+    Archive first (gzip of the whole live file, written via tmp + replace under
+    a date name that is never reused), truncate second (empty tmp + replace),
+    so an interruption between the two leaves a duplicate archive, never a
+    lost row. Then drop archives older than :data:`_ARCHIVE_RETENTION_DAYS`.
+    Returns the archive path when a rotation happened."""
+    path = _journal_path(state_dir)
+    if not path.is_file() or path.stat().st_size <= _MAX_JOURNAL_BYTES:
+        return None
+    payload = path.read_bytes()
+    archive_dir = path.parent / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    dest = archive_dir / f"reflections-{today}.jsonl.gz"
+    sequence = 1
+    while dest.exists():
+        dest = archive_dir / f"reflections-{today}-{sequence}.jsonl.gz"
+        sequence += 1
+    fd, temporary = tempfile.mkstemp(prefix=".reflections.", suffix=".gz.tmp", dir=str(archive_dir))
+    os.close(fd)
+    try:
+        with gzip.open(temporary, "wb") as fh:
+            fh.write(payload)
+        os.replace(temporary, dest)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+    fd, temporary = tempfile.mkstemp(prefix=".reflections.", dir=str(path.parent))
+    os.close(fd)
+    os.replace(temporary, path)  # the live journal starts empty
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=_ARCHIVE_RETENTION_DAYS)).strftime("%Y-%m-%d")
+    for old in _archives(state_dir):
+        match = _ARCHIVE_RE.match(old.name)
+        if match and match.group(1) < cutoff:
+            try:
+                old.unlink()
+            except OSError:
+                pass
+    return dest
+
+
 def _append_journal(state_dir: Path, row: dict[str, Any]) -> None:
-    path = state_dir / "reflector" / "reflections.jsonl"
+    path = _journal_path(state_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+    try:
+        _rotate_journal(state_dir)
+    except Exception as exc:  # the append succeeded; a rotation problem is reported, not hidden
+        print(f"reflector: journal rotation failed: {exc!r}", file=sys.stderr)
+
+
+def reflection_files(state_dir: Path | str, *, archives: int = _ARCHIVE_READ_FILES) -> list[Path]:
+    """The newest ``archives`` rotated journals (oldest first) followed by the live journal."""
+    files = _archives(state_dir)[-max(0, archives):] if archives else []
+    live = _journal_path(state_dir)
+    if live.is_file():
+        files.append(live)
+    return files
+
+
+def iter_reflection_rows(state_dir: Path | str, byte_needles: tuple[bytes, ...] = (), *, archives: int = _ARCHIVE_READ_FILES):
+    """Rows across :func:`reflection_files`, oldest first; the rotation-aware
+    read every consumer of the journal should use (#1178)."""
+    for path in reflection_files(state_dir, archives=archives):
+        yield from _iter_jsonl(path, byte_needles)
 
 
 def _journal_tail(state_dir: Path) -> list[dict[str, Any]]:
-    return _read_jsonl(state_dir / "reflector" / "reflections.jsonl")[-_JOURNAL_TAIL:]
+    return list(iter_reflection_rows(state_dir))[-_JOURNAL_TAIL:]
 
 
 def _completed_cycles(rows: list[dict[str, Any]], watermark: str) -> list[dict[str, Any]]:
@@ -271,7 +365,7 @@ def run_reflector(
     }
     skipped_ids = {
         str(row.get("cycle_id") or "")
-        for row in _read_jsonl(state_dir / "reflector" / "reflections.jsonl")
+        for row in iter_reflection_rows(state_dir, (b"skipped_pruned",))
         if row.get("status") == "skipped_pruned"
     }
     # A previously skipped cycle is eligible again when its retained plain or
@@ -333,15 +427,27 @@ def mark_reflection_consumed(
 
     Matches by exact recommendation ``detail`` (or matching demand identity ``demand_id``),
     or falls back to entry ``summary`` if detail is not provided.
-    Writes atomically via a temporary file with fsync and os.replace.
+    Writes atomically via a temporary file with fsync and os.replace. Since
+    #1178 a row that has rotated into ``reflector/archive/`` is marked there
+    (the live file first, then the newest archives).
     """
-    p = Path(state_dir) / "reflector" / "reflections.jsonl"
-    if not p.is_file():
-        p = Path(state_dir) / "reflections.jsonl"
-    if not p.is_file():
-        return False
+    candidates = [_journal_path(state_dir), Path(state_dir) / "reflections.jsonl"]
+    candidates += list(reversed(_archives(state_dir)))[:_ARCHIVE_READ_FILES]
+    for p in candidates:
+        if p.is_file() and _mark_in_file(p, recommendation_detail, demand_id, cycle_id, summary):
+            return True
+    return False
+
+
+def _mark_in_file(p: Path, recommendation_detail: str, demand_id: str, cycle_id: str, summary: str) -> bool:
+    """:func:`mark_reflection_consumed` over one journal file (plain or ``.gz``)."""
+    is_gz = p.name.endswith(".gz")
     try:
-        lines = p.read_text(encoding="utf-8").splitlines()
+        if is_gz:
+            with gzip.open(p, "rt", encoding="utf-8") as fh:
+                lines = fh.read().splitlines()
+        else:
+            lines = p.read_text(encoding="utf-8").splitlines()
     except Exception:
         return False
 
@@ -408,10 +514,16 @@ def mark_reflection_consumed(
         p.parent.mkdir(parents=True, exist_ok=True)
         fd, temporary = tempfile.mkstemp(prefix=".reflections.", dir=str(p.parent))
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write("\n".join(new_lines) + "\n")
-                fh.flush()
-                os.fsync(fh.fileno())
+            payload = "\n".join(new_lines) + "\n"
+            if is_gz:
+                os.close(fd)
+                with gzip.open(temporary, "wt", encoding="utf-8") as fh:
+                    fh.write(payload)
+            else:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    fh.write(payload)
+                    fh.flush()
+                    os.fsync(fh.fileno())
             os.replace(temporary, p)
             return True
         finally:

--- a/nanobot/runtime/skill_eval_harness.py
+++ b/nanobot/runtime/skill_eval_harness.py
@@ -197,6 +197,16 @@ def _rewrite_rows(state_dir: Path, prior: list[dict[str, Any]], current: list[di
     try:
         rows = (prior + current)[-MAX_WEEKLY_RUNS * MAX_CASES :]
         path = _sidecar_path(state_dir)
+        # #1178 Class B: _load_rows returns [] past MAX_SIDECAR_BYTES, so this
+        # rewrite would replace the whole history with ``current``. Skip, say so.
+        from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+        status = rewrite_status(path, max_bytes=MAX_SIDECAR_BYTES, json_object=False)
+        if status not in WRITABLE_STATUSES:
+            import logging
+
+            logging.getLogger(__name__).warning("skill_eval_harness: rows not rewritten, sidecar is %s: %s", status, path)
+            return
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text("".join(json.dumps(r, separators=(",", ":")) + "\n" for r in rows), encoding="utf-8")

--- a/nanobot/runtime/skill_fitness.py
+++ b/nanobot/runtime/skill_fitness.py
@@ -54,6 +54,7 @@ SIDECAR_REL = "skill_fitness/reads.json"  # state_dir-relative path
 
 # Bounded write: never let the reads list grow unboundedly.
 _MAX_READS = 2000
+_SIDECAR_MAX_BYTES = 16 * 1024 * 1024  # _MAX_READS bounds the file (~1 KB/read); see #1178
 
 
 def _utc_now() -> str:
@@ -115,6 +116,17 @@ def _read_sidecar(state_dir: Path) -> dict[str, Any]:
 def _write_sidecar_atomic(state_dir: Path, data: dict[str, Any]) -> None:
     """Atomic bounded write: truncate to _MAX_READS, write via tmp+rename."""
     path = Path(state_dir) / SIDECAR_REL
+    # #1178 Class B: the read that produced ``data`` returns a blank default
+    # on a corrupt/oversize/unreadable file; writing that back would erase the
+    # history. Skip and say so; an absent file is created normally.
+    from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+    status = rewrite_status(path, max_bytes=_SIDECAR_MAX_BYTES)
+    if status not in WRITABLE_STATUSES:
+        import logging
+
+        logging.getLogger(__name__).warning("skill_fitness: write skipped, existing file is %s: %s", status, path)
+        return
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         reads = data.get("reads", [])

--- a/nanobot/runtime/state_access.py
+++ b/nanobot/runtime/state_access.py
@@ -229,6 +229,38 @@ def evidence_status(window: Window) -> str:
     return window.status
 
 
+def rewrite_status(path: str | Path, *, max_bytes: int | None = None, json_object: bool = True) -> str:
+    """Whether a read-modify-write may replace ``path`` (#1178, ADR Class B).
+
+    ``absent`` and ``present`` mean the writer read what is there and may write
+    it back. ``corrupt`` (JSON that does not parse, when ``json_object``),
+    ``oversize`` (past ``max_bytes``), ``permission`` and ``io_error`` mean the
+    read that preceded this write returned a blank default, and writing that
+    default back would erase the file's history — the caller must skip the
+    write and say so. Never raises.
+    """
+    path = Path(path)
+    try:
+        if not path.exists():
+            return "absent"
+        if not path.is_file():
+            return "permission"
+        if max_bytes is not None and path.stat().st_size > max_bytes:
+            return "oversize"
+        if json_object:
+            json.loads(path.read_text(encoding="utf-8"))
+        return "present"
+    except PermissionError:
+        return "permission"
+    except (ValueError, json.JSONDecodeError):
+        return "corrupt"
+    except OSError:
+        return "io_error"
+
+
+WRITABLE_STATUSES = frozenset({"absent", "present"})
+
+
 def _artifact_dirs(state_dir: Path) -> Iterable[Path]:
     root = state_dir / "subagents"
     yield root / "results"

--- a/nanobot/runtime/tech_tree.py
+++ b/nanobot/runtime/tech_tree.py
@@ -286,8 +286,22 @@ def read_portfolio(state_dir: Any) -> dict[str, Any]:
         return _empty_portfolio()
 
 
+_PORTFOLIO_MAX_BYTES = 16 * 1024 * 1024  # same reasoning as evolution_tree._TREE_MAX_BYTES (#1178)
+
+
 def _write_portfolio(state_dir: Any, portfolio: dict[str, Any]) -> None:
     path = _portfolio_path(state_dir)
+    # #1178 Class B: the read that produced ``portfolio`` returns a blank default
+    # on a corrupt/oversize/unreadable file; writing that back would erase the
+    # history. Skip and say so; an absent file is created normally.
+    from nanobot.runtime.state_access import WRITABLE_STATUSES, rewrite_status
+
+    status = rewrite_status(path, max_bytes=_PORTFOLIO_MAX_BYTES)
+    if status not in WRITABLE_STATUSES:
+        import logging
+
+        logging.getLogger(__name__).warning("tech_tree: write skipped, existing file is %s: %s", status, path)
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(portfolio, indent=2, ensure_ascii=False), encoding="utf-8")
 

--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -1173,8 +1173,16 @@ def _prune_last_runs(state_dir: Path, valid_rels: set[str]) -> None:
             return
         if path.stat().st_size > _MAX_READ_BYTES:
             # Past anything a legitimate run sequence could produce; reading it
-            # to filter would defeat the point of the bound.
-            _atomic_write(path, "")
+            # to filter would defeat the point of the bound. #1178: it is left
+            # exactly as it is — the previous `_atomic_write(path, "")` erased
+            # every recorded run on the first oversize read, and demand's own
+            # 2 MB refusal already keeps such a file out of the demand path.
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "validator_harness: last_runs.jsonl is %d bytes (> %d); left untouched, not pruned",
+                path.stat().st_size, _MAX_READ_BYTES,
+            )
             return
         lines = path.read_text(encoding="utf-8").splitlines()
         kept = _select_within_budget(

--- a/tests/test_side_role_cliffs.py
+++ b/tests/test_side_role_cliffs.py
@@ -1,0 +1,262 @@
+"""#1178: side-role size cliffs and read-blank-then-write-back sidecars.
+
+Live on the host 2026-09-02: ``reflector/reflections.jsonl`` was 738,050 B with
+no rotation (it crossed the curator's old 512 KiB bail-out around 2026-08-29,
+#1183); ``knowledge_lift.compute_knowledge_digest`` skipped it and the 77,843 B
+``lessons.yaml`` outright at 50,000 B, so the "knowledge unchanged" watermark
+ignored every lesson and reflection change; five JSON sidecars and two JSONL
+harness stores rewrote themselves from the blank default a corrupt or oversize
+read returns. Every test here fails against the pre-#1178 tree for the reason
+in its docstring.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from nanobot.runtime import (
+    demand,
+    evolution_tree,
+    heldout,
+    knowledge_curator,
+    knowledge_lift,
+    reflector,
+    skill_eval_harness,
+    skill_fitness,
+    state_access,
+    tech_tree,
+    validator_harness,
+)
+from nanobot.runtime.heldout import microbench
+
+NOW = datetime.now(timezone.utc)
+
+
+def _iso(hours_ago: float = 0) -> str:
+    return (NOW - timedelta(hours=hours_ago)).isoformat().replace("+00:00", "Z")
+
+
+def _row(cycle: str, detail: str, *, status: str = "", hours_ago: float = 1, rec_status: str = "") -> dict:
+    row = {"cycle_id": cycle, "timestamp": _iso(hours_ago), "created_at": _iso(hours_ago), "summary": f"summary for {cycle}",
+           "findings": [], "recommendations": [{"kind": "approach_hint", "detail": detail, "evidence": f"seen in {cycle}"}]}
+    if status:
+        row["status"] = status
+    if rec_status:
+        row["recommendations"][0]["status"] = rec_status
+    return row
+
+
+def _write_archive(state: Path, day: str, rows: list[dict], seq: str = "") -> Path:
+    path = state / "reflector" / "archive" / f"reflections-{day}{seq}.jsonl.gz"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        fh.writelines(json.dumps(r) + "\n" for r in rows)
+    return path
+
+
+def _write_live(state: Path, rows: list[dict]) -> Path:
+    path = state / "reflector" / "reflections.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    return path
+
+
+# ─── rotation ────────────────────────────────────────────────────────────────
+
+def test_journal_rotates_past_512_kib_and_the_tail_reads_across_the_boundary(tmp_path):
+    """Pre-fix: no rotation existed; the file grew without bound and _journal_tail read only the live file."""
+    state = tmp_path / "state"
+    padding = "x" * 2000
+    for i in range(300):  # ~600 KB of rows
+        reflector._append_journal(state, {**_row(f"c{i:03d}", f"hint {i}", hours_ago=300 - i), "pad": padding})
+    archives = reflector._archives(state)
+    assert len(archives) == 1 and archives[0].name.startswith("reflections-") and archives[0].name.endswith(".jsonl.gz")
+    live = state / "reflector" / "reflections.jsonl"
+    assert live.stat().st_size < reflector._MAX_JOURNAL_BYTES
+    with gzip.open(archives[0], "rt", encoding="utf-8") as fh:
+        archived = [json.loads(line) for line in fh if line.strip()]
+    live_rows = [json.loads(line) for line in live.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(archived) + len(live_rows) == 300 and archived[0]["cycle_id"] == "c000"
+    # the tail is the newest 10 rows regardless of which file holds them
+    reflector._append_journal(state, _row("c300", "hint 300", hours_ago=0))
+    tail = reflector._journal_tail(state)
+    assert [r["cycle_id"] for r in tail] == [f"c{i:03d}" for i in range(291, 301)]
+
+
+def test_readers_see_rows_that_live_only_in_the_newest_archives(tmp_path):
+    """Pre-fix: _journal_tail, iter_lessons and demand._reflection_items read the live file only."""
+    state = tmp_path / "state"
+    _write_archive(state, "2026-08-20", [_row("old", "ancient hint", hours_ago=2)])
+    _write_archive(state, "2026-08-30", [_row("mid", "middle hint", hours_ago=2)])
+    _write_archive(state, "2026-09-01", [_row("new", "newest archived hint about scripts/foo.py", hours_ago=2)])
+    _write_live(state, [_row("live", "live hint", hours_ago=1)])
+
+    assert [r["cycle_id"] for r in reflector._journal_tail(state)] == ["mid", "new", "live"], "newest 2 archives + live"
+    assert [p.name for p in reflector.reflection_files(state)][-1] == "reflections.jsonl"
+
+    lessons = list(knowledge_curator.iter_lessons(tmp_path / "workspace", state))
+    assert {entry["cycle_id"] for entry in lessons} == {"mid", "new", "live"}
+
+    items = demand._reflection_items(state, NOW)
+    assert {item["evidence"].split(":")[0] for item in items} == {"cycle mid", "cycle new", "cycle live"}
+    assert any(item["affected_path"] == "scripts/foo.py" for item in items)
+
+
+def test_mark_reflection_consumed_marks_a_row_that_rotated(tmp_path):
+    """Pre-fix: only the live file was searched, so a rotated recommendation could never be consumed."""
+    state = tmp_path / "state"
+    archive = _write_archive(state, "2026-09-01", [_row("arc", "archived hint"), _row("arc2", "other hint")])
+    _write_live(state, [_row("live", "live hint")])
+    assert reflector.mark_reflection_consumed(state, recommendation_detail="archived hint") is True
+    with gzip.open(archive, "rt", encoding="utf-8") as fh:
+        rows = {json.loads(line)["cycle_id"]: json.loads(line) for line in fh if line.strip()}
+    assert rows["arc"]["recommendations"][0]["status"] == "consumed" and rows["arc"]["status"] == "consumed"
+    assert "status" not in rows["arc2"]["recommendations"][0]
+    assert reflector.mark_reflection_consumed(state, recommendation_detail="nowhere") is False
+
+
+def test_archive_reads_are_bounded_to_the_newest_two(tmp_path, monkeypatch):
+    state = tmp_path / "state"
+    for day in ("2026-08-10", "2026-08-20", "2026-08-30"):
+        _write_archive(state, day, [_row(day, f"hint {day}")])
+    _write_live(state, [_row("live", "live")])
+    opened: list[str] = []
+    real_open = gzip.open
+
+    def recording(path, *args, **kwargs):
+        opened.append(Path(path).name)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(gzip, "open", recording)
+    list(reflector.iter_reflection_rows(state))
+    assert opened == ["reflections-2026-08-20.jsonl.gz", "reflections-2026-08-30.jsonl.gz"]
+
+
+def test_promotion_tops_up_a_freshly_rotated_journal_from_the_archive(tmp_path):
+    """Pre-fix: the bounded tail read the live file only; right after a rotation it saw nothing to promote."""
+    state = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    (workspace / "lessons").mkdir(parents=True)
+    _write_archive(state, "2026-09-01", [
+        _row("a1", "Prefer bounded reads over whole-file reads in verification steps"),
+        _row("a2", "Run the targeted test module before committing a script change"),
+    ])
+    _write_live(state, [])
+    assert knowledge_curator.promote_reflector_recommendations_to_v2(workspace, state) == 2
+
+
+# ─── digest ──────────────────────────────────────────────────────────────────
+
+def test_digest_tracks_files_past_50_kb(tmp_path):
+    """Pre-fix: any file over MAX_FILE_BYTES was skipped, so appending to a 700 KB journal changed nothing."""
+    repo = tmp_path / "repo"
+    (repo / "lessons").mkdir(parents=True)
+    (repo / "lessons" / "lessons.yaml").write_text("- id: L1\n  problem: p\n  solution: s\n" * 3000, encoding="utf-8")  # > 50 KB
+    state = tmp_path / "state"
+    _write_live(state, [{**_row(f"c{i}", f"hint {i}"), "pad": "x" * 500} for i in range(200)])  # > 50 KB
+    before = knowledge_lift.compute_knowledge_digest(repo, state)
+    reflector._append_journal(state, _row("new", "a new reflection"))
+    after_reflection = knowledge_lift.compute_knowledge_digest(repo, state)
+    assert after_reflection != before
+    with (repo / "lessons" / "lessons.yaml").open("a", encoding="utf-8") as fh:
+        fh.write("- id: L-new\n  problem: new problem\n  solution: new solution\n")
+    assert knowledge_lift.compute_knowledge_digest(repo, state) != after_reflection
+
+
+# ─── write guards ────────────────────────────────────────────────────────────
+
+def _corrupt(path: Path) -> bytes:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    return path.read_bytes()
+
+
+def test_rewrite_status_names_every_reason(tmp_path):
+    """Pre-fix: no such contract."""
+    path = tmp_path / "x.json"
+    assert state_access.rewrite_status(path) == "absent"
+    path.write_text("{}", encoding="utf-8")
+    assert state_access.rewrite_status(path) == "present"
+    assert state_access.rewrite_status(path, max_bytes=1) == "oversize"
+    path.write_text("{oops", encoding="utf-8")
+    assert state_access.rewrite_status(path) == "corrupt"
+    assert state_access.rewrite_status(path, json_object=False) == "present"
+    assert state_access.rewrite_status(tmp_path) == "permission"
+
+
+def test_corrupt_tree_is_not_overwritten_by_record_node(tmp_path, caplog):
+    """Pre-fix: read_tree returned an empty tree and record_node wrote it back — lineage erased."""
+    state = tmp_path / "state"
+    before = _corrupt(state / "evolution" / "tree.json")
+    with caplog.at_level(logging.WARNING):
+        evolution_tree.record_node(state, sha="abc1", parent_sha=None, branch="main", cycle_id="c-1")
+    assert (state / "evolution" / "tree.json").read_bytes() == before
+    assert any("evolution_tree: write skipped, existing file is corrupt" in r.message for r in caplog.records)
+    fresh = tmp_path / "fresh"
+    evolution_tree.record_node(fresh, sha="abc1", parent_sha=None, branch="main", cycle_id="c-1")
+    assert "abc1" in evolution_tree.read_tree(fresh)["nodes"]
+
+
+def test_corrupt_portfolio_is_not_overwritten(tmp_path, caplog):
+    state = tmp_path / "state"
+    before = _corrupt(state / "tech_tree" / "portfolio.json")
+    with caplog.at_level(logging.WARNING):
+        tech_tree.ensure_seeded(state)
+    assert (state / "tech_tree" / "portfolio.json").read_bytes() == before
+    assert any("tech_tree: write skipped" in r.message for r in caplog.records)
+    tech_tree.ensure_seeded(tmp_path / "fresh")
+    assert (tmp_path / "fresh" / "tech_tree" / "portfolio.json").is_file()
+
+
+def test_corrupt_skill_reads_heldout_results_and_microbench_are_not_overwritten(tmp_path, caplog):
+    state = tmp_path / "state"
+    reads_path = state / skill_fitness.SIDECAR_REL
+    results_path = state / "heldout" / "results.json"
+    bench_path = microbench._microbench_path(state)
+    befores = {p: _corrupt(p) for p in (reads_path, results_path, bench_path)}
+    with caplog.at_level(logging.WARNING):
+        skill_fitness._write_sidecar_atomic(state, {"schema_version": skill_fitness.SCHEMA_VERSION, "reads": []})
+        heldout._save_results(state, {"schema_version": heldout.HELDOUT_SCHEMA, "results": {}})
+        microbench._save_microbench_file(state, {"schema_version": microbench._SCHEMA, "entries": {}})
+    for path, before in befores.items():
+        assert path.read_bytes() == before, path
+    messages = " ".join(r.message for r in caplog.records)
+    assert "skill_fitness: write skipped" in messages and "heldout: write skipped" in messages and "microbench: write skipped" in messages
+    fresh = tmp_path / "fresh"
+    skill_fitness._write_sidecar_atomic(fresh, {"schema_version": skill_fitness.SCHEMA_VERSION, "reads": []})
+    heldout._save_results(fresh, {"schema_version": heldout.HELDOUT_SCHEMA, "results": {}})
+    microbench._save_microbench_file(fresh, {"schema_version": microbench._SCHEMA, "entries": {}})
+    assert (fresh / skill_fitness.SIDECAR_REL).is_file() and (fresh / "heldout" / "results.json").is_file() and microbench._microbench_path(fresh).is_file()
+
+
+def test_oversize_jsonl_stores_are_left_alone_not_truncated(tmp_path, caplog):
+    """Pre-fix: _load_rows / _read_eval_rows returned [] past the cap and the rewrite persisted [];
+    validator_harness._prune_last_runs wrote "" on an oversize file."""
+    state = tmp_path / "state"
+    sidecar = skill_eval_harness._sidecar_path(state)
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    big = (json.dumps({"pad": "x" * 1000}) + "\n") * (skill_eval_harness.MAX_SIDECAR_BYTES // 1000 + 2)
+    sidecar.write_text(big, encoding="utf-8")
+    with caplog.at_level(logging.WARNING):
+        skill_eval_harness._rewrite_rows(state, [], [{"row": 1}])
+    assert sidecar.read_text(encoding="utf-8") == big
+
+    evals = tmp_path / "knowledge_lift" / "evals.jsonl"
+    evals.parent.mkdir()
+    big_evals = (json.dumps({"pad": "y" * 1000}) + "\n") * (knowledge_lift.MAX_FILE_BYTES * 40 // 1000 + 2)
+    evals.write_text(big_evals, encoding="utf-8")
+    knowledge_lift._atomic_write_eval_rows(evals, [{"row": 1}])
+    assert evals.read_text(encoding="utf-8") == big_evals
+
+    last_runs = validator_harness._last_runs_path(state)
+    last_runs.parent.mkdir(parents=True, exist_ok=True)
+    payload = ("z" * 4000 + "\n") * (validator_harness._MAX_READ_BYTES // 4000 + 2)
+    last_runs.write_text(payload, encoding="utf-8")
+    validator_harness._prune_last_runs(state, {"scripts/a.py"})
+    assert last_runs.read_text(encoding="utf-8") == payload, "left exactly as it was, not emptied"
+    messages = " ".join(r.message for r in caplog.records)
+    assert "skill_eval_harness: rows not rewritten" in messages and "knowledge_lift: eval rows not rewritten" in messages
+    assert "last_runs.jsonl is" in messages and "left untouched" in messages


### PR DESCRIPTION
Closes #1178. Parent ADR #1173. Builds on `state_access` (#1174), the Class-A migration (#1175) and #1183.

## What was already fixed elsewhere, and is not repeated here

Two of the issue's rows were closed by other PRs after it was filed; both checked against `origin/main`, not remembered:
- **Strategist history input** (`strategist._read_lines` 256 KB cliff): #1182 moved the read into `strategist_inputs._history_rows` (8 MiB bound, `scorecard/archive/*.jsonl.gz` fallback, newest 400 rows within 7 days, rendered as a sampled trend) and records `inputs_status.scorecard.history_rows` in every `decisions.jsonl` row. The issue's `256_000` magic numbers are now the named `_MAX_JSON_BYTES` / `_MAX_LINES_FILE_BYTES` for the two small files the module still reads itself.
- **Curator promotion 512 KiB bail-out**: #1183 replaced it with the bounded tail read and a logged unreadable path.

## What this PR does

**`reflections.jsonl` rotation (writer side, `reflector._append_journal`).** At 512 KiB the live journal is gzip-archived whole to `state/reflector/archive/reflections-YYYY-MM-DD.jsonl.gz` (a `-N` suffix if the day's name exists), then truncated — archive first, truncate second, so an interruption leaves a duplicate archive, never a lost row; archives older than 90 days are removed. Live today: 738,050 B, no archive — the first run of the reflector after deploy rotates it.

**Rotation-aware reads.** `reflector.reflection_files` / `iter_reflection_rows` return the newest **2** archives (oldest first) plus the live file, and are what every consumer now uses: `_journal_tail` (the reflector's own 10-row prompt tail), `run_reflector`'s skipped-cycle set (needle-prefiltered), `mark_reflection_consumed` — which now searches the live file, then the newest archives, and rewrites a `.gz` atomically when the row lives there (the archive rewrite was simpler than a `consumed_ids` sidecar: the marking code already existed and only needed an opener; no second source of truth) — `knowledge_curator.iter_lessons`, `knowledge_curator.promote_reflector_recommendations_to_v2` (the bounded tail tops up from the newest archive when the live file has fewer than 50 lines, so the cycle right after a rotation still promotes), and `demand._reflection_items` (through `reflector.iter_reflection_rows`; a lazy import that module already had). `reflection_context.build_reflection_hints` is not migrated — its 128 KB live tail is a best-effort hint source and the AC does not list it; stated rather than implied.

**Digest.** `knowledge_lift.compute_knowledge_digest` hashes the newest 128,000 bytes of each knowledge file instead of skipping anything over 50,000 B. On the host both `lessons.yaml` (77,843 B) and `reflections.jsonl` were past that cliff, so the "knowledge unchanged" watermark had been ignoring every lesson and reflection change — the issue named the reflections half; the lessons half was found while writing the test.

**Read-modify-write guards (ADR Class B).** One helper, `state_access.rewrite_status(path, max_bytes=, json_object=)` → `absent | present | corrupt | oversize | permission | io_error`; only `absent`/`present` may be written over. Applied at the single write site of each store, so every caller is covered: `evolution_tree._write_tree`, `tech_tree._write_portfolio`, `skill_fitness._write_sidecar_atomic`, `heldout._save_results` (new, used by `run_heldout`), `microbench._save_microbench_file` (new, used by `measure_cycle`), `skill_eval_harness._rewrite_rows`, `knowledge_lift._atomic_write_eval_rows`. A skipped write logs one `WARNING` naming the store, the status and the path. `validator_harness._prune_last_runs` on an oversize `last_runs.jsonl` now **leaves the file alone** and logs (the issue offered "truncate to the newest 1 MiB of whole lines" as the alternative; leaving it alone loses nothing, and demand's own 2 MB refusal already keeps such a file out of the demand path). The `max_bytes` on the JSON stores are 16 MiB against files that their own entry caps hold to tens of KB — not a new cliff: past it the write is skipped and logged, nothing is emptied, and the reader still returns its default as before.

Per the #1176 lesson, checked before migrating: `_journal_tail`, `iter_lessons` and `_reflection_items` each read the journal on their own call and nothing else scans `reflector/` (`#1040`'s single-scandir invariant concerns `subagents/results`, untouched here); the reads bound the archive count (2 files) before filtering, not after — a freshly rotated live file still yields the newest rows because the archive is read too.

## Tests

`tests/test_side_role_cliffs.py`, 11 tests. Against `origin/main` (be921d5b), `--tb=line` — **11 failed**, each for its own reason:

```
:75  AttributeError: no attribute '_archives'                       # rotation past 512 KiB + tail across the boundary
:97  AssertionError: newest 2 archives + live                       # _journal_tail / iter_lessons / _reflection_items see archive rows
:113 assert False is True                                          # mark_reflection_consumed on a rotated row
:134 AttributeError: no attribute 'iter_reflection_rows'           # only the newest 2 archives are opened (gzip.open recorded)
:148 assert 0 == 2                                                 # promotion right after a rotation
:163 assert 'e3b0c442…' != 'e3b0c442…'                             # digest identical before/after appending to a >50 KB journal (both are the empty hash: every file was skipped)
:180 AttributeError: no attribute 'rewrite_status'
:196 assert b'{\r\n  "sch...' == b'{not json'                      # corrupt tree.json overwritten by record_node
:208 assert b'{\r\n  "sch...' == b'{not json'                      # corrupt portfolio.json overwritten by ensure_seeded
:222 AttributeError: no attribute '_save_results'                  # skill_fitness / heldout / microbench guards
:245 assert '{"row":1}\n' == '{"pad": ...'                         # oversize skill-eval rows replaced by the current run
```

The digest failure at `:163` is the live shape exactly: on `origin/main` the digest of a repo whose `lessons.yaml` and journal are both over 50 KB is the SHA-256 of nothing, before and after any append.

Every affected existing suite stays green unchanged: `test_reflector`, `test_knowledge_curator`, `test_knowledge_lift`, `test_evolution_tree`, `test_tech_tree`, `test_skill_fitness`, `test_heldout`, `test_microbench`, `test_skill_eval_harness`, `test_validator_harness`, `test_state_access`, `test_reflection_context`, `test_curator_staging_pickup`, `test_demand`, `test_strategist*` (581 passed). Full suite on the branch (Windows, `-n 4`): **2881 passed, 18 failed, 17 skipped** — the 18 are the environmental baseline set (`test_autoevolve*` 12, `test_bridge_locking` 3, `test_selfevo_export_security` 2, `test_bridge_cycle_tags` 1). `ruff` clean on every touched file except `demand.py`, whose 7 `E402` findings pre-exist on `origin/main` outside my hunk. Linux CI is authoritative.

Every bullet above was checked with `git diff origin/main...HEAD | grep <claim>` before writing (all non-zero).

## Live verification (operator; the host stays read-only for me)

1. **Rotation.** After deploy, the first `eeebot-reflector.service` run that appends a row rotates the 738,050 B journal: `ls -la state/reflector/archive/` shows `reflections-2026-09-02.jsonl.gz` (or the deploy day's date), and `stat -c %s state/reflector/reflections.jsonl` is small (one to a few rows). Proof: `zcat` of the archive has the row count the live file had (`wc -l` before deploy, quote both). Not-yet-rotated is also a valid state to quote if the reflector has not appended since deploy.
2. **Readers across the boundary.** The next bridge cycle after the rotation still presents reflection demand: `journalctl -u eeepc-self-evolving-subagent-bridge -g "reflection-"` or a `proposed` row with a `reflection-*` demand id within a few cycles. A cycle that marks a reflection consumed after the rotation writes into the archive: `zcat state/reflector/archive/reflections-*.jsonl.gz | grep -c '"status":"consumed"'` grows when the live file has no matching row.
3. **Curator promotion.** The next `eeebot-knowledge-curator.service` run after a rotation: `journalctl -u eeebot-knowledge-curator --since "-1h"` shows no `promote_reflector_recommendations_to_v2: cannot read` line, and `lessons/lessons.yaml` gains `LESS-REF-*` cards if unconsumed approach hints existed in the newest 50 rows (quote the count; zero with no such hints is honest).
4. **Digest.** `state/knowledge_lift/` watermark: two consecutive cycles that append a reflection must show a changed digest (`compute_knowledge_digest` value in the knowledge-lift sidecar/journal); before this PR it was constant because every input was skipped.
5. **Guards.** Nothing to see on a healthy host: `journalctl -g "write skipped, existing file is"` empty. If it is not empty, the named file is the one corrupt/oversize sidecar the guard protected — quote it; that is the mechanism working, and the file should be byte-identical to before the cycle.

## Non-goals

No change to reflector cadence, `_MAX_CYCLES`, LLM calls, `scorecard._MAX_HISTORY_LINES` (400; not binding — the 7-day window held 336 rows at the last check — and different from `benchmark_evidence._MAX_HISTORY_LINES = 3000`, noted here only). `reflection_context` stays on its live tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
