### PR TITLE
fix(runtime): read rotated reflection archives for hints (#1207)

### DIFF
--- a/nanobot/runtime/reflection_context.py
+++ b/nanobot/runtime/reflection_context.py
@@ -1,6 +1,7 @@
 """Bounded, steering-only hints from the reflector journal (#1008, #1089)."""
 from __future__ import annotations
 
+import gzip
 import json
 import re
 from datetime import datetime, timedelta, timezone
@@ -119,9 +120,40 @@ def build_reflection_hints(
         task_words = _words(f"{task_title} {target_path}")
         if not task_words:
             return []
-        path = Path(state_dir) / "reflector" / "reflections.jsonl"
+        from nanobot.runtime import reflector
+
+        # Establish the journal order first (oldest archive to newest live
+        # file), then take one bounded tail from that ordered stream. Reading
+        # newest-to-oldest while spending the existing byte budget preserves
+        # the same newest-record semantics after a rotation without reading an
+        # entire archive into memory.
+        paths = reflector.reflection_files(state_dir)
+        tail_chunks: list[list[str]] = []
+        remaining = _MAX_TAIL_BYTES
+        for path in reversed(paths):
+            if remaining <= 0:
+                break
+            try:
+                opener = gzip.open if path.name.endswith(".gz") else open
+                with opener(path, "rb") as fh:  # type: ignore[call-arg]
+                    fh.seek(0, 2)
+                    size = fh.tell()
+                    take = min(size, remaining)
+                    fh.seek(max(0, size - take))
+                    data = fh.read(take)
+                lines = data.decode("utf-8", errors="replace").splitlines()
+                if size > take and lines:
+                    lines = lines[1:]
+                tail_chunks.append(lines)
+                remaining -= take
+            except Exception:
+                continue
+        tail_lines: list[str] = []
+        for chunk in reversed(tail_chunks):
+            tail_lines.extend(chunk)
+
         candidates: list[tuple[int, str, str]] = []
-        for line in reversed(_tail_lines(path)):
+        for line in reversed(tail_lines):
             try:
                 row = json.loads(line)
             except Exception:

--- a/tests/test_reflection_context.py
+++ b/tests/test_reflection_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,6 +24,30 @@ def test_selects_recent_relevant_bounded_hints(tmp_path: Path) -> None:
     hints = build_reflection_hints(tmp_path, "fix timeout bridge", now=datetime.now(timezone.utc))
     assert hints == ["new timeout approach", "other timeout error"]
     assert len(hints) <= 3 and all(len(x) <= 200 for x in hints)
+
+
+def test_reads_matching_hint_from_rotated_archive(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    ts = now.isoformat().replace("+00:00", "Z")
+    archive_row = _row("preserve archive import resolution", kind="approach_hint")
+    archive_row.update({"ts": ts, "task_title": "Fix import resolution", "target_path": "scripts/verify_imports.py"})
+    archive = tmp_path / "reflector/archive/reflections-2026-09-02.jsonl.gz"
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(archive, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps(archive_row) + "\n")
+    _write(
+        tmp_path / "reflector/reflections.jsonl",
+        [_row("unrelated live hint", kind="approach_hint"), _row("another live hint", kind="error_pattern")],
+    )
+
+    hints = build_reflection_hints(
+        tmp_path,
+        "Fix import resolution",
+        "scripts/verify_imports.py",
+        now=now,
+    )
+
+    assert "preserve archive import resolution" in hints
 
 
 def test_missing_corrupt_and_expired_are_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`build_reflection_hints` now reads the existing rotation-aware ordered journal paths from `reflector.reflection_files`, including the newest rotated gzip archives and the live journal. It preserves the existing 128 KiB byte-tail budget, 7-day TTL, matching/ranking, three-hint bound, and fail-open behavior. The reflector rotation threshold and writer are unchanged.

The implementation establishes file order before applying the byte bound: it reads newest-to-oldest across the ordered archive/live paths, spends the existing byte budget, removes a partial leading line when a file is sliced, then restores chronological order before the existing newest-first candidate scan.

## Inputs and design

- Reused `nanobot.runtime.reflector.reflection_files`, which returns the newest rotated archives oldest-first followed by the live journal.
- `gzip.open(..., "rb")` reads archive bytes; `open(..., "rb")` reads the live file.
- The existing `_MAX_TAIL_BYTES = 128_000` remains the only byte bound in this reader; no new cap or rotation flag was added.
- The existing 7-day timestamp filter and 3-hint output cap remain unchanged.
- `compute_knowledge_digest` in `nanobot/runtime/knowledge_lift.py` remains live-tail-based. This change intentionally does not alter its digest contract; its bounded digest changes on live reflector appends, and the weekly knowledge-evaluation cap remains the control on that churn.

## Regression evidence

The new test was run against `origin/main` before the implementation:

```text
FAILED tests/test_reflection_context.py::test_reads_matching_hint_from_rotated_archive
E       AssertionError: assert 'preserve archive import resolution' in []
```

After the implementation:

```text
8 passed in 0.76s
35 passed in 2.81s  # reflection_context + knowledge_curator + knowledge_lift
```

## Validation

- Focused reflection-context tests: `8 passed`.
- Related rotation-reader tests: `35 passed` across `tests/test_reflection_context.py`, `tests/test_knowledge_curator.py`, and `tests/test_knowledge_lift.py`.
- Full pytest: `2883 passed, 18 failed, 17 skipped, 11 warnings` on Windows. This matches the known Windows baseline category (18 platform failures); the failures are unrelated to this two-file change. Representative baseline failures include local temporary-repository pushes using `master` (`src refspec master does not match any`) and Windows-only bridge lock/tag expectations (`fcntl` unavailable). The run completed in 17m24s.
- `ruff check nanobot/runtime/reflection_context.py tests/test_reflection_context.py`: passed.
- `git diff --check`: passed.

## Reader audit

Grep of runtime readers outside `reflector.py`:

- `nanobot/runtime/reflection_context.py`: **rotation-aware in this change** via `reflector.reflection_files`.
- `nanobot/runtime/demand.py`: **rotation-aware**, via `reflector.reflection_files` / `reflector.iter_reflection_rows`.
- `nanobot/runtime/knowledge_curator.py`: **rotation-aware** for curation reads via `_reflection_lines` / `_reflection_tail_lines`; its path discovery strings and legacy fallback paths are not journal-window reads.
- `nanobot/runtime/knowledge_lift.py`: `compute_knowledge_digest` is **not a journal-row window read**; it intentionally hashes the bounded live tail only, as stated above.

The remaining `reflections.jsonl` references in `reflector.py` are the journal writer/path and its own rotation-aware readers, excluded from this audit as requested.

## Live verification (operator-owned)

Please verify immediately after the next rotation, not hours later:

1. Record UTC and MSK timestamps and the live journal byte size immediately after truncation.
2. Count rows available in the newest rotated archive plus the live file.
3. Inspect the first post-rotation `llm-proposed-improvement` request payload whose task matches an archive row. Its `lessons_context.reflection_hints` must be non-empty, demonstrating that the request sees archive+live rather than only the newly refilled live file.
4. Record rows seen versus rows available. The proof is that a matching archive row is visible immediately after rotation; the prior failure observed only 20 of 687 rows (3%) and could return zero hints for matching tasks.

This defect self-heals as the live journal refills, so a sample taken hours after rotation may look healthy. That is the trap, not evidence that the defect was absent.

## Changed files

- `nanobot/runtime/reflection_context.py`
- `tests/test_reflection_context.py`

Closes #1207
