### PR TITLE
fix(1209): make curator writes durable — stage the reflector mint, push the pickup, record what survived

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1761,30 +1761,46 @@ async def _main_impl():
 
 
 def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
-    """Integrate any curator-staged fact promotions into main as one commit. (#1001)
+    """Integrate curator-staged promotions into main as one commit AND push it. (#1001, #1209)
 
     Called at a safe cycle-start boundary: bridge lock held, HEAD on clean main.
-    Reads ``state_dir/curator/staged/manifest.json``, copies payload files into
-    the repo checkout, appends index lines, validates paths via
-    ``_validate_mutation_surfaces`` (the script-surface gate — NOT
+    Reads ``state_dir/curator/staged/manifest.json``, copies fact payloads into
+    the repo checkout, appends index lines, merges staged reflector v2 lesson
+    cards into ``lessons/lessons.yaml`` (``kind == LESSONS_KIND``), validates
+    paths via ``_validate_mutation_surfaces`` (the script-surface gate — NOT
     ``_classify_mutation_surface``, which would incorrectly deny
     ``memory/facts/release-promotion-metadata.md`` via the 'promotion' token
-    match in ``_is_runtime_deny``), commits on main, then clears staging only
-    after commit succeeds.
+    match in ``_is_runtime_deny``), commits on main, pushes to ``origin/main``
+    (a plain, never-forced push), then clears staging only after the push.
 
-    Idempotent: if the payload file is missing but the manifest entry remains,
-    the entry is skipped (already applied from a prior retry).
+    The push is what makes the commit durable (#1209): the cycle branch is cut
+    from ``origin/main`` and the integration step runs ``checkout -B main
+    <origin base>``, so a commit left on local ``main`` only is orphaned two
+    minutes later — on the host six of seven pickup commits were dangling
+    (#986) while the journal said "committed N fact(s) on main". If the push is
+    rejected (or there is no ``origin``), the commit is dropped with
+    ``reset --hard <pre-commit sha>``, staging is retained for the next cycle,
+    and every item is recorded ``pickup_deferred`` in ``decisions.jsonl``;
+    on success every item is recorded ``promoted`` with the pushed sha.
 
-    Returns the number of facts committed (0 = nothing to do).
+    Idempotent: if a payload file is missing but the manifest entry remains,
+    the entry is skipped (already applied from a prior retry); a manifest whose
+    entries are all already applied is cleared without a commit.
+
+    Returns the number of facts plus lesson cards pushed (0 = nothing to do).
     Fail-open: any unexpected error is printed and 0 is returned so the normal
     cycle is never blocked by a pickup failure.
     """
     import subprocess as _sp_pick
     try:
         from nanobot.runtime.knowledge_curator import (
+            LESSONS_KIND,
+            LESSONS_REL,
             _fact_path,
+            apply_staged_lesson_cards,
             clear_staged_manifest,
             load_staged_manifest,
+            record_pickup_outcome,
         )
     except Exception as _e:
         print(f'bridge: staged pickup: import failed ({_e}); skipping')
@@ -1796,6 +1812,8 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
         staged_dir = state_dir / 'curator' / 'staged'
         git = _git_cmd(repo_root)
         changed_files: list[str] = []
+        applied_lesson_ids: list[str] = []
+        fact_ids: list[str] = []
         # Filter unsupported entries before any validation (#1094 tier-2).
         # overlap_flag=True means zero keyword overlap between fact and support_claim;
         # these entries are kept in staging for audit but never committed to main.
@@ -1819,7 +1837,11 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
         for entry in entries:
             rel = str(entry.get('path') or '').replace('\\', '/')
             slug = str(entry.get('payload_file') or '')
-            if not rel or _fact_path(rel) is None or not slug or Path(slug).name != slug:
+            if str(entry.get('kind') or '') == LESSONS_KIND:
+                path_ok = rel == LESSONS_REL
+            else:
+                path_ok = _fact_path(rel) is not None
+            if not rel or not path_ok or not slug or Path(slug).name != slug:
                 print(f'bridge: staged pickup: invalid manifest entry; staging retained: {entry!r}')
                 return 0
         snapshot_paths: set[Path] = set()
@@ -1852,11 +1874,27 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             if not rel or not slug:
                 continue
             payload_path = staged_dir / slug
+            if str(entry.get('kind') or '') == LESSONS_KIND:
+                # #1209: reflector v2 cards are merged into the checkout's store
+                # here, at the boundary, instead of being written by the curator
+                # into a working tree the next reset --hard discards.
+                if not payload_path.is_file():
+                    continue  # payload already consumed by a prior pickup
+                _applied = apply_staged_lesson_cards(
+                    repo_root, json.loads(payload_path.read_text(encoding='utf-8')),
+                )
+                if _applied:
+                    applied_lesson_ids.extend(_applied)
+                    if rel not in changed_files:
+                        changed_files.append(rel)
+                continue
             if not payload_path.is_file():
                 # Already applied on a prior retry — skip but count as applied.
                 if (repo_root / rel).exists():
                     changed_files.append(rel)
+                    fact_ids.append(str(entry.get('lesson_id') or rel))
                 continue
+            fact_ids.append(str(entry.get('lesson_id') or rel))
             target = repo_root / rel
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(payload_path.read_bytes())
@@ -1871,6 +1909,11 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
                     if index_rel not in changed_files:
                         changed_files.append(index_rel)
         if not changed_files:
+            # Every entry was already applied (retry after a pickup that
+            # committed but whose clear did not run, or cards already present).
+            # Clear it so the manifest does not re-run as a no-op every cycle.
+            clear_staged_manifest(state_dir, retain_overlap_flag=True)
+            print('bridge: staged pickup: nothing to apply; staging cleared')
             return 0
         # Validate via _validate_mutation_surfaces (script-surface gate only).
         # memory/facts/* paths are allowed; no _is_runtime_deny applied here.
@@ -1880,7 +1923,9 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             print(f'bridge: staged pickup: surface violation(s) — aborting pickup, staging retained: {violations}')
             return 0
         n_facts = sum(1 for f in changed_files if f.startswith(('memory/facts/', 'docs/facts/')))
-        commit_msg = f'curator: promote {n_facts} fact(s) from staging (#1001)'
+        n_cards = len(applied_lesson_ids)
+        commit_msg = f'curator: promote {n_facts} fact(s) and {n_cards} lesson card(s) from staging (#1001, #1209)'
+        pre_sha = _sp_pick.run(git + ['rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
         add_r = _sp_pick.run(git + ['add'] + changed_files, capture_output=True, text=True)
         if add_r.returncode != 0:
             _rollback_pickup()
@@ -1892,11 +1937,49 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             _rollback_pickup()
             print(f'bridge: staged pickup: git commit failed: {commit_r.stderr[:200]}')
             return 0
-        # Clear staging only after the commit is durable.
+        # #1209: the commit is durable only once origin/main carries it. A plain
+        # (never forced) push: a fast-forward also carries any earlier commit
+        # left on local main (e.g. a bridge lesson commit whose own push
+        # failed); a non-fast-forward means the remote moved and is rejected.
+        all_ids = fact_ids + applied_lesson_ids
+        remote_r = _sp_pick.run(git + ['remote', 'get-url', 'origin'], capture_output=True, text=True)
+        if remote_r.returncode != 0:
+            push_error = 'no origin remote configured'
+        else:
+            push_r = _sp_pick.run(git + ['push', 'origin', 'main'], capture_output=True, text=True)
+            push_error = '' if push_r.returncode == 0 else (
+                (push_r.stderr or push_r.stdout).strip().splitlines()[-1:] or [f'exit {push_r.returncode}']
+            )[0][:200]
+        if push_error:
+            if pre_sha:
+                _sp_pick.run(git + ['reset', '--hard', pre_sha], capture_output=True)
+            else:
+                _rollback_pickup()
+            print(
+                f'bridge: staged pickup: push to origin/main failed ({push_error}); '
+                f'commit dropped, staging retained for retry (#1209)'
+            )
+            record_pickup_outcome(
+                state_dir, all_ids, 'pickup_deferred',
+                f'push to origin/main failed: {push_error}',
+            )
+            return 0
+        new_sha = _sp_pick.run(git + ['rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
+        # Clear staging only after the commit is on origin/main.
         # Preserve unsupported entries (overlap_flag=True) for audit (#1094).
         clear_staged_manifest(state_dir, retain_overlap_flag=True)
-        print(f'bridge: staged pickup: committed {n_facts} fact(s) on main')
-        return n_facts
+        record_pickup_outcome(
+            state_dir, fact_ids, 'promoted', f'pushed to origin/main as {new_sha[:12]}',
+        )
+        record_pickup_outcome(
+            state_dir, applied_lesson_ids, 'promoted',
+            f'pushed to origin/main as {new_sha[:12]}', LESSONS_REL,
+        )
+        print(
+            f'bridge: staged pickup: pushed {n_facts} fact(s) and {n_cards} lesson card(s) '
+            f'to origin/main {new_sha[:12]} (#1209)'
+        )
+        return n_facts + n_cards
     except Exception as _exc:
         print(f'bridge: staged pickup: unexpected error ({_exc}); staging retained for retry')
         return 0

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -4,16 +4,29 @@ The curator is deliberately a small adapter around the existing LLM and git
 boundaries. It never deletes files, rewrites an index, or advances its
 watermark before promotions are durably staged.
 
-Safe write protocol (#1001):
+Safe write protocol (#1001, #1209):
 - ``run_curation`` writes promoted facts to ``state/curator/staged/`` only;
-  the repo checkout is NEVER touched by the curator process.
+  the repo checkout is NEVER touched by the curator process. The reflector
+  v2 mint (``promote_reflector_recommendations_to_v2``) stages its cards the
+  same way — it used to write ``lessons/lessons.yaml`` straight into the
+  working tree, where the next cycle's ``git reset --hard`` erased it within
+  minutes (#1209: measured lifetime 2 min 45 s on the host).
 - The bridge picks up staged promotions at a safe cycle-start boundary
-  (clean main, lock held) via ``_pickup_staged_promotions``.
+  (clean main, lock held) via ``_pickup_staged_promotions``, commits them on
+  ``main`` and PUSHES to ``origin/main`` before the cycle branch is cut from
+  ``origin/main``. A commit that stays on local ``main`` only is orphaned by
+  the integration step's ``checkout -B main <origin base>`` (#986: six of
+  seven pickup commits dangling), so the push is what makes it durable.
 - Watermark advances only after the staging manifest is durably written;
   a staging failure leaves the watermark unchanged so the lesson is retried.
+- ``decisions.jsonl`` records ``staged`` when the curator stages an item and
+  ``promoted`` only when the bridge has pushed it; a pickup whose push fails
+  records ``pickup_deferred`` and keeps the item in staging. A write that was
+  discarded is never on record as a success.
 
 ``migrate_loose_lessons`` is an operator-only utility — run it only while the
-bridge timer is stopped; it writes directly into the workspace checkout.
+bridge timer is stopped; it writes directly into the workspace checkout and the
+operator must commit and push the result, or the next cycle start discards it.
 """
 from __future__ import annotations
 
@@ -46,11 +59,20 @@ MAX_WRITES_DEFAULT = 3
 MAX_LESSONS_DEFAULT = 40
 MAX_INPUT_CHARS = 48_000
 MAX_OUTPUT_CHARS = 30_000
-_DECISIONS = {"promoted", "promoted_unsupported", "duplicate", "unimportant", "rejected"}
+_DECISIONS = {
+    "staged", "staged_unsupported", "promoted", "pickup_deferred",
+    "duplicate", "unimportant", "rejected",
+}
 _ALLOWED_FACT_PREFIXES = ("memory/facts/", "docs/facts/")
 
 # Staging directory name under state_dir/curator/.
 _STAGED_DIR = "staged"
+# Reflector v2 lesson cards travel through the same staging manifest (#1209):
+# one entry of this kind, targeting the lessons store, whose payload is a JSON
+# list of cards the bridge merges into the checkout at pickup time.
+LESSONS_REL = "lessons/lessons.yaml"
+LESSONS_KIND = "lessons_v2"
+_LESSONS_PAYLOAD_SLUG = "lessons__lessons.yaml.cards.json"
 
 # Evidence resolution constants (#1094).
 _LEDGER_TAIL_LINES = 200  # bounded ledger tail read for cycle-id resolution
@@ -695,6 +717,8 @@ def _stage_promotions(
             "path": rel,
             "action": action,
             "payload_file": slug,
+            # #1209: the pickup records the durable outcome against this id.
+            "lesson_id": str(item.get("lesson_id") or ""),
             "index_line": index_line,
             "related": related_hint(item),
             "unknown_related": list(item.get("unknown_related") or []),
@@ -705,7 +729,13 @@ def _stage_promotions(
             "verification_status": "unsupported" if item.get("overlap_flag", False) else "supported",
             "overlap_flag": bool(item.get("overlap_flag", False)),
         })
-    # Write manifest atomically.
+    _append_manifest_entries(staged_dir, manifest_entries)
+    return manifest_entries
+
+
+def _append_manifest_entries(staged_dir: Path, manifest_entries: list[dict[str, Any]]) -> None:
+    """Merge *manifest_entries* into ``manifest.json`` atomically: an entry with
+    the same ``path`` replaces the previous one, new paths are appended."""
     existing_manifest = staged_dir / "manifest.json"
     prev: list[dict[str, Any]] = []
     try:
@@ -714,7 +744,6 @@ def _stage_promotions(
             prev = []
     except Exception:
         prev = []
-    # Merge: replace entries with the same path, append new ones.
     path_to_idx = {e["path"]: i for i, e in enumerate(prev)}
     for entry in manifest_entries:
         if entry["path"] in path_to_idx:
@@ -722,7 +751,6 @@ def _stage_promotions(
         else:
             prev.append(entry)
     _atomic_json(existing_manifest, prev)
-    return manifest_entries
 
 
 def load_staged_manifest(state_dir: Path) -> list[dict[str, Any]]:
@@ -916,7 +944,10 @@ def _collect_stage_items(
             "overlap_flag": overlap_flag,
         })
         writes += 1
-        decision_label = "promoted_unsupported" if overlap_flag else "promoted"
+        # #1209: staging is not promotion. ``promoted`` is written by the bridge
+        # pickup once the commit is on origin/main; until then the record says
+        # what actually happened — the item was staged.
+        decision_label = "staged_unsupported" if overlap_flag else "staged"
         decision_reason = reason
         if ev_source and ev_source not in {"ledger_tail", "file", "issue"}:
             decision_reason = f"{reason} (evidence source: {ev_source})"
@@ -1010,17 +1041,11 @@ def promote_reflector_recommendations_to_v2(
             "promote_reflector_recommendations_to_v2: skipped %d unparseable "
             "row(s) in %s", skipped, path,
         )
-    target = Path(workspace) / "lessons" / "lessons.yaml"
-    existing = bounded_load_yaml(target)
-    if not existing and target.exists():
-        try:
-            import yaml
-
-            raw = yaml.safe_load(target.read_text(encoding="utf-8"))
-            existing = raw.get("lessons", []) if isinstance(raw, dict) else raw if isinstance(raw, list) else []
-        except Exception:
-            existing = []
+    # Read-only baseline: the checkout's current store decides ids and
+    # duplicates, but nothing below writes to it (#1209).
+    existing = _load_lessons_list(Path(workspace) / LESSONS_REL)
     count = 0
+    minted: list[dict[str, Any]] = []
     for row in reversed(rows):
         if count >= max_items or not isinstance(row, dict):
             break
@@ -1060,22 +1085,137 @@ def promote_reflector_recommendations_to_v2(
                     f"curator-lesson: rejected reflector recommendation for {card_id}"
                 )
                 continue
-            duplicate = find_duplicate(card["problem"], existing)
-            if duplicate is not None:
-                from nanobot.runtime.lesson_v2 import solution_is_meaningful
-                if not solution_is_meaningful(duplicate.get("problem"), duplicate.get("solution")):
-                    duplicate["solution"] = card["solution"]
-                duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
-                duplicate["last_seen"] = card["last_seen"]
-            else:
-                existing.insert(0, card)
+            # Merge into the in-memory baseline only, so the next card sees this
+            # one's id; the checkout is written by the bridge at pickup (#1209).
+            if _merge_card_into(existing, card) is None:
+                continue
+            minted.append(card)
             count += 1
     if count:
-        # Fill lateral related links mechanically before writing (#1095).
-        from nanobot.runtime.lesson_v2 import fill_related_links
+        _stage_lesson_cards(state_dir, minted)
+        for card in minted:
+            _write_decision(
+                state_dir, str(card["id"]), "staged",
+                "reflector recommendation staged for bridge pickup (#1209)", LESSONS_REL,
+            )
+    return count
+
+
+def _load_lessons_list(target: Path) -> list[dict[str, Any]]:
+    """The v2 lessons store as a list — bounded read first, plain YAML fallback."""
+    existing = bounded_load_yaml(target)
+    if not existing and target.exists():
+        try:
+            import yaml
+
+            raw = yaml.safe_load(target.read_text(encoding="utf-8"))
+            existing = raw.get("lessons", []) if isinstance(raw, dict) else raw if isinstance(raw, list) else []
+        except Exception:
+            existing = []
+    return [entry for entry in existing if isinstance(entry, dict)]
+
+
+def _merge_card_into(existing: list[dict[str, Any]], card: dict[str, Any]) -> str | None:
+    """Merge one minted card into *existing* in place.
+
+    Returns ``"inserted"`` (new card, newest-first), ``"folded"`` (a near-
+    duplicate absorbed it: seen_count/last_seen advance and a filler solution is
+    upgraded in place, #1106) or ``None`` when the card's id is already present
+    — the idempotent case a retried pickup relies on. One implementation for
+    stage time (in-memory baseline) and pickup time (the checkout).
+    """
+    card_id = str(card.get("id") or "")
+    if card_id and any(str(entry.get("id") or "") == card_id for entry in existing):
+        return None
+    duplicate = find_duplicate(str(card.get("problem") or ""), existing)
+    if duplicate is not None:
+        from nanobot.runtime.lesson_v2 import solution_is_meaningful
+        if not solution_is_meaningful(duplicate.get("problem"), duplicate.get("solution")):
+            duplicate["solution"] = card.get("solution")
+        duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
+        duplicate["last_seen"] = card.get("last_seen")
+        return "folded"
+    existing.insert(0, card)
+    return "inserted"
+
+
+def _stage_lesson_cards(state_dir: Path, cards: list[dict[str, Any]]) -> dict[str, Any]:
+    """Stage reflector v2 cards for the bridge pickup (#1209).
+
+    One payload file per staging dir holds the pending cards (merged by id with
+    whatever a previous, not yet picked-up run staged); one manifest entry of
+    kind :data:`LESSONS_KIND` points at it. Atomic like the fact payloads.
+    """
+    staged_dir = Path(state_dir) / "curator" / _STAGED_DIR
+    staged_dir.mkdir(parents=True, exist_ok=True)
+    payload_path = staged_dir / _LESSONS_PAYLOAD_SLUG
+    pending: list[dict[str, Any]] = []
+    try:
+        loaded = json.loads(payload_path.read_text(encoding="utf-8"))
+        pending = [c for c in (loaded.get("cards") if isinstance(loaded, dict) else loaded) or [] if isinstance(c, dict)]
+    except Exception:
+        pending = []
+    by_id = {str(c.get("id") or ""): i for i, c in enumerate(pending)}
+    for card in cards:
+        cid = str(card.get("id") or "")
+        if cid in by_id:
+            pending[by_id[cid]] = card
+        else:
+            pending.append(card)
+    _atomic_json(payload_path, {"schema": "curator-staged-lessons-v1", "cards": pending})
+    entry = {
+        "path": LESSONS_REL,
+        "kind": LESSONS_KIND,
+        "action": "merge",
+        "payload_file": _LESSONS_PAYLOAD_SLUG,
+        "lesson_id": "",
+        "lesson_ids": [str(c.get("id") or "") for c in pending],
+        "index_line": "",
+        "related": "",
+        "unknown_related": [],
+        "index_rel": "",
+        "evidence": sorted({str(e) for c in pending for e in (c.get("evidence") or [])}),
+        "support_claim": "",
+        "verification_status": "supported",
+        "overlap_flag": False,
+    }
+    _append_manifest_entries(staged_dir, [entry])
+    return entry
+
+
+def apply_staged_lesson_cards(repo_root: Path, payload: Any) -> list[str]:
+    """Merge staged v2 cards into ``<repo_root>/lessons/lessons.yaml`` (#1209).
+
+    Called by the bridge pickup with the checkout on clean ``main``. Returns
+    the ids that changed the store (inserted or folded); an empty list means
+    every card was already present and the file was left untouched. The
+    caller commits and pushes; this function only edits the working tree.
+    """
+    cards = payload.get("cards") if isinstance(payload, dict) else payload
+    cards = [c for c in (cards or []) if isinstance(c, dict) and c.get("id")]
+    if not cards:
+        return []
+    target = Path(repo_root) / LESSONS_REL
+    existing = _load_lessons_list(target)
+    applied: list[str] = []
+    for card in cards:
+        if _merge_card_into(existing, card) is not None:
+            applied.append(str(card["id"]))
+    if applied:
         existing, _unknown = fill_related_links(existing)
         atomic_write_yaml(target, {"lessons": existing})
-    return count
+    return applied
+
+
+def record_pickup_outcome(
+    state_dir: Path, lesson_ids: Iterable[str], decision: str, reason: str, target: str = "",
+) -> None:
+    """Append one ``decisions.jsonl`` row per id for what the bridge pickup did
+    (#1209): ``promoted`` once the commit is on ``origin/main``,
+    ``pickup_deferred`` when the push failed and the item stays in staging."""
+    for lesson_id in lesson_ids:
+        if lesson_id:
+            _write_decision(Path(state_dir), str(lesson_id), decision, reason, target)
 
 
 def _parse_output_with_diag(

--- a/tests/test_curator_staging_pickup.py
+++ b/tests/test_curator_staging_pickup.py
@@ -13,14 +13,22 @@ import pytest
 # ---------------------------------------------------------------------------
 
 def _init_git_repo(path: Path) -> None:
-    """Create a minimal git repo at path with one commit on main."""
+    """Create a minimal git repo at path with one commit on main, tracking a bare origin.
+
+    #1209: the pickup pushes to ``origin/main`` (that push is what makes the
+    commit durable), so the fixture carries the instance repo's shape.
+    """
     path.mkdir(parents=True, exist_ok=True)
+    origin = path.parent / f"{path.name}-origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], capture_output=True)
     subprocess.run(["git", "init", "-b", "main", str(path)], capture_output=True)
     subprocess.run(["git", "-C", str(path), "config", "user.email", "test@test"], capture_output=True)
     subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], capture_output=True)
     (path / "README.md").write_text("init\n")
     subprocess.run(["git", "-C", str(path), "add", "README.md"], capture_output=True)
     subprocess.run(["git", "-C", str(path), "commit", "-m", "init"], capture_output=True)
+    subprocess.run(["git", "-C", str(path), "remote", "add", "origin", str(origin)], capture_output=True)
+    subprocess.run(["git", "-C", str(path), "push", "-u", "origin", "main"], capture_output=True)
 
 
 def _write_manifest(state_dir: Path, entries: list[dict]) -> None:

--- a/tests/test_issue_1138_lesson_ids.py
+++ b/tests/test_issue_1138_lesson_ids.py
@@ -6,6 +6,20 @@ import yaml
 from nanobot.runtime.knowledge_curator import promote_reflector_recommendations_to_v2
 
 
+def _materialize_staged_lessons(workspace: Path, state_dir: Path) -> None:
+    """#1209: the mint stages its cards; apply them the way the bridge pickup does."""
+    from nanobot.runtime.knowledge_curator import (
+        _STAGED_DIR,
+        LESSONS_KIND,
+        apply_staged_lesson_cards,
+        load_staged_manifest,
+    )
+    for entry in load_staged_manifest(state_dir):
+        if entry.get("kind") == LESSONS_KIND:
+            payload_path = state_dir / "curator" / _STAGED_DIR / entry["payload_file"]
+            apply_staged_lesson_cards(workspace, json.loads(payload_path.read_text(encoding="utf-8")))
+
+
 def test_promote_reflector_recommendations_grants_unique_ids(tmp_path: Path):
     workspace = tmp_path / "workspace"
     state_dir = tmp_path / "state"
@@ -35,6 +49,7 @@ def test_promote_reflector_recommendations_grants_unique_ids(tmp_path: Path):
 
     promoted = promote_reflector_recommendations_to_v2(workspace=workspace, state_dir=state_dir, max_items=10)
     assert promoted == 2
+    _materialize_staged_lessons(workspace, state_dir)  # #1209: cards are staged, the pickup writes them
 
     lessons_yaml = lessons_dir / "lessons.yaml"
     assert lessons_yaml.exists()

--- a/tests/test_issue_1138_lesson_ids_guard.py
+++ b/tests/test_issue_1138_lesson_ids_guard.py
@@ -6,6 +6,20 @@ import yaml
 from nanobot.runtime.knowledge_curator import promote_reflector_recommendations_to_v2
 
 
+def _materialize_staged_lessons(workspace: Path, state_dir: Path) -> None:
+    """#1209: the mint stages its cards; apply them the way the bridge pickup does."""
+    from nanobot.runtime.knowledge_curator import (
+        _STAGED_DIR,
+        LESSONS_KIND,
+        apply_staged_lesson_cards,
+        load_staged_manifest,
+    )
+    for entry in load_staged_manifest(state_dir):
+        if entry.get("kind") == LESSONS_KIND:
+            payload_path = state_dir / "curator" / _STAGED_DIR / entry["payload_file"]
+            apply_staged_lesson_cards(workspace, json.loads(payload_path.read_text(encoding="utf-8")))
+
+
 def test_promote_reflector_avoids_existing_ids(tmp_path: Path):
     workspace = tmp_path / "workspace"
     state_dir = tmp_path / "state"
@@ -45,6 +59,7 @@ def test_promote_reflector_avoids_existing_ids(tmp_path: Path):
 
     promoted = promote_reflector_recommendations_to_v2(workspace=workspace, state_dir=state_dir, max_items=10)
     assert promoted == 1
+    _materialize_staged_lessons(workspace, state_dir)  # #1209: cards are staged, the pickup writes them
 
     data = yaml.safe_load(lessons_yaml.read_text(encoding="utf-8"))
     lessons = data.get("lessons", [])

--- a/tests/test_issue_1209_durable_curator_writes.py
+++ b/tests/test_issue_1209_durable_curator_writes.py
@@ -1,0 +1,304 @@
+"""#1209: curator writes must survive the cycle-start reset and the integration base reset.
+
+Measured on the host 2026-09-02: the reflector v2 mint wrote ``lessons/lessons.yaml``
+into the instance working tree at 06:19:00 MSK; the next bridge run's
+``_restore_to_main`` (``git reset --hard && git clean -fd``) erased it at
+06:21:45.97 MSK. Staged facts died one step later: the pickup commit landed on
+local ``main``, the cycle branch was cut from ``origin/main``, and the integration
+step's ``checkout -B main <origin base>`` orphaned it — six of seven pickup
+commits dangling (#986) while the journal said "committed N fact(s) on main".
+
+The simulations below mirror the bridge's own git sequence, not a stand-in:
+``_cycle_start_reset`` is ``_restore_to_main``; ``_cycle_integration`` is
+``_setup_cycle_branch`` (branch from ``origin/main``) followed by
+``_integrate_cycle_to_main`` (``checkout -B main origin/main``, ``--no-ff`` merge,
+push). Durability is asserted with ``git show origin/main:<path>`` only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import yaml
+
+from nanobot.runtime.bridge import _pickup_staged_promotions
+from nanobot.runtime.knowledge_curator import (
+    _STAGED_DIR,
+    load_staged_manifest,
+    promote_reflector_recommendations_to_v2,
+    run_curation,
+)
+
+# Spelled out rather than imported so this file still collects against a tree
+# that predates the fix and fails on its assertions, not at import time.
+LESSONS_KIND = "lessons_v2"
+LESSONS_REL = "lessons/lessons.yaml"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> str:
+    proc = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def _init_repo_with_origin(tmp_path: Path) -> tuple[Path, Path]:
+    """A checkout on ``main`` tracking a bare ``origin`` — the instance repo's shape."""
+    repo, origin = tmp_path / "repo", tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], capture_output=True, check=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo)], capture_output=True, check=True)
+    _git(repo, "config", "user.email", "test@test")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "lessons").mkdir()
+    (repo / "memory").mkdir()
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    (repo / "lessons" / "lessons.yaml").write_text("lessons: []\n", encoding="utf-8")
+    (repo / "memory" / "index.md").write_text("# Index\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "-u", "origin", "main")
+    return repo, origin
+
+
+def _cycle_start_reset(repo: Path) -> None:
+    """bridge._restore_to_main: what runs at the start of every cycle."""
+    _git(repo, "reset", "--hard")
+    _git(repo, "clean", "-fd")
+    _git(repo, "checkout", "main")
+
+
+def _cycle_integration(repo: Path, name: str) -> None:
+    """bridge._setup_cycle_branch + _integrate_cycle_to_main, minus the gate."""
+    _git(repo, "fetch", "origin", "main")
+    _git(repo, "checkout", "-B", f"selfevo/cycle-{name}", "origin/main")
+    (repo / f"{name}.txt").write_text(f"{name}\n", encoding="utf-8")
+    _git(repo, "add", f"{name}.txt")
+    _git(repo, "commit", "-m", f"cycle {name}")
+    _git(repo, "checkout", "-B", "main", "origin/main")
+    _git(repo, "merge", "--no-ff", f"selfevo/cycle-{name}", "-m", f"merge: integrate {name}")
+    _git(repo, "push", "origin", "main")
+
+
+def _origin_main_show(repo: Path, rel: str) -> str | None:
+    _git(repo, "fetch", "origin", "main")
+    proc = subprocess.run(["git", "-C", str(repo), "show", f"origin/main:{rel}"], capture_output=True, text=True)
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _reflection(state: Path, detail: str, cycle_id: str = "cycle-1209abcdef00") -> None:
+    reflector = state / "reflector"
+    reflector.mkdir(parents=True, exist_ok=True)
+    (reflector / "reflections.jsonl").write_text(json.dumps({
+        "cycle_id": cycle_id,
+        "summary": "Reflector found an unbounded parser read on a growing journal",
+        "recommendations": [{"kind": "approach_hint", "detail": detail}],
+    }) + "\n", encoding="utf-8")
+
+
+def _stage_fact(state: Path, name: str = "durable-fact", lesson_id: str = "L-1209") -> None:
+    staged = state / "curator" / _STAGED_DIR
+    staged.mkdir(parents=True, exist_ok=True)
+    slug = f"memory__facts__{name}.md"
+    (staged / slug).write_text(f"# {name}\n\nA fact that must reach origin/main.\n", encoding="utf-8")
+    (staged / "manifest.json").write_text(json.dumps([{
+        "path": f"memory/facts/{name}.md", "action": "create", "payload_file": slug,
+        "lesson_id": lesson_id, "index_line": f"- [{name}](memory/facts/{name}.md)",
+        "index_rel": "memory/index.md",
+    }]), encoding="utf-8")
+
+
+def _decisions(state: Path) -> list[dict]:
+    path = state / "curator" / "decisions.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# 1. The mint survives the reset that killed it live
+# ---------------------------------------------------------------------------
+
+def test_reflector_mint_survives_cycle_start_reset_and_two_integrations(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    state = tmp_path / "state"
+    _reflection(state, "Read a bounded tail of the journal instead of the whole file")
+
+    assert promote_reflector_recommendations_to_v2(repo, state, max_items=2) == 1
+    # The curator never touches the checkout now; the card waits in staging.
+    assert _git(repo, "status", "--porcelain") == ""
+    assert [e["kind"] for e in load_staged_manifest(state) if e.get("kind")] == [LESSONS_KIND]
+
+    _cycle_start_reset(repo)  # 06:21:45.97 MSK — the moment the live card died
+    assert _pickup_staged_promotions(repo, state) == 1
+    _cycle_integration(repo, "a")  # checkout -B main origin/main + merge + push
+    _cycle_start_reset(repo)
+    _cycle_integration(repo, "b")
+
+    on_origin = _origin_main_show(repo, LESSONS_REL)
+    assert on_origin is not None
+    cards = yaml.safe_load(on_origin)["lessons"]
+    assert len(cards) == 1
+    assert cards[0]["id"].startswith("LESS-REF-1209abcdef00")
+    assert cards[0]["solution"] == "Read a bounded tail of the journal instead of the whole file"
+    assert cards[0]["tags"] == ["reflector"]
+    assert load_staged_manifest(state) == []
+
+    # Selection logic is untouched (#1209 non-goal): a recommendation still in
+    # the newest rows re-folds into its card on the next run (#1138 suffixes the
+    # id, find_duplicate matches the problem), so the next pickup bumps
+    # seen_count on origin/main instead of minting a second card.
+    assert promote_reflector_recommendations_to_v2(repo, state, max_items=2) == 1
+    _cycle_start_reset(repo)
+    assert _pickup_staged_promotions(repo, state) == 1
+    cards = yaml.safe_load(_origin_main_show(repo, LESSONS_REL) or "")["lessons"]
+    assert len(cards) == 1
+    assert cards[0]["seen_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. A staged fact survives the integration step that orphaned six of seven
+# ---------------------------------------------------------------------------
+
+def test_pickup_commit_survives_integration_base_reset(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    state = tmp_path / "state"
+    _stage_fact(state)
+
+    assert _pickup_staged_promotions(repo, state) == 1
+    _cycle_integration(repo, "a")  # the step that dropped 409c5c29 on the host
+    _cycle_start_reset(repo)
+    _cycle_integration(repo, "b")
+
+    assert _origin_main_show(repo, "memory/facts/durable-fact.md") is not None
+    index = _origin_main_show(repo, "memory/index.md") or ""
+    assert "- [durable-fact](memory/facts/durable-fact.md)" in index
+    assert _git(repo, "log", "--oneline", "origin/main").count("curator: promote") == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. The record says what survived: staged -> promoted, never promoted early
+# ---------------------------------------------------------------------------
+
+def test_decisions_record_staged_then_promoted_with_the_pushed_sha(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    state = tmp_path / "state"
+    _reflection(state, "Prefer the bounded tail reader over a whole-file read")
+
+    promote_reflector_recommendations_to_v2(repo, state, max_items=2)
+    rows = _decisions(state)
+    assert rows, "staging must leave a decision row"
+    assert {r["decision"] for r in rows} == {"staged"}
+    assert rows[0]["lesson_id"].startswith("LESS-REF-")
+    assert rows[0]["target_file"] == LESSONS_REL
+
+    _cycle_start_reset(repo)
+    assert _pickup_staged_promotions(repo, state) == 1
+    promoted = [r for r in _decisions(state) if r["decision"] == "promoted"]
+    assert [r["lesson_id"] for r in promoted] == [rows[0]["lesson_id"]]
+    pushed_sha = _git(repo, "rev-parse", "origin/main")
+    assert promoted[0]["reason"] == f"pushed to origin/main as {pushed_sha[:12]}"
+
+
+def test_run_curation_records_staged_not_promoted(tmp_path: Path) -> None:
+    """The LLM-curated facts follow the same rule: ``promoted`` is the bridge's word."""
+    workspace = tmp_path / "workspace"
+    (workspace / "lessons").mkdir(parents=True)
+    (workspace / "lessons" / "lessons.yaml").write_text(
+        "- id: L1\n  title: insight L1\n  approach: use L1\n  evidence: ['#1209']\n", encoding="utf-8",
+    )
+    state = tmp_path / "state"
+
+    def llm(messages, model):
+        return json.dumps([{
+            "action": "create", "path": "memory/facts/novel.md", "content": "novel durable fact",
+            "lesson_id": "L1", "reason": "new", "evidence": ["#1209"], "support_claim": "novel durable fact",
+        }])
+
+    result = run_curation(workspace, state, llm=llm)
+    assert result["ok"] and result["writes"] == 1
+    assert {r["decision"] for r in _decisions(state)} == {"staged"}
+    assert load_staged_manifest(state)[0]["lesson_id"] == "L1"
+
+
+# ---------------------------------------------------------------------------
+# 4. A write that cannot be made durable is not reported as success
+# ---------------------------------------------------------------------------
+
+def test_push_failure_drops_the_commit_keeps_staging_and_records_deferral(tmp_path: Path) -> None:
+    repo, origin = _init_repo_with_origin(tmp_path)
+    state = tmp_path / "state"
+    _stage_fact(state)
+    _git(repo, "remote", "set-url", "origin", str(tmp_path / "gone.git"))  # origin unreachable
+    before = _git(repo, "rev-parse", "HEAD")
+
+    assert _pickup_staged_promotions(repo, state) == 0
+
+    assert _git(repo, "rev-parse", "HEAD") == before, "the undurable commit must be dropped"
+    assert _git(repo, "status", "--porcelain") == ""
+    assert not (repo / "memory" / "facts" / "durable-fact.md").exists()
+    assert len(load_staged_manifest(state)) == 1, "staging is retained for the next cycle"
+    rows = _decisions(state)
+    assert [r["decision"] for r in rows] == ["pickup_deferred"]
+    assert rows[0]["lesson_id"] == "L-1209"
+    assert rows[0]["reason"].startswith("push to origin/main failed:")
+
+    # Restore the remote: the retry on the next cycle boundary succeeds.
+    _git(repo, "remote", "set-url", "origin", str(origin))
+    assert _pickup_staged_promotions(repo, state) == 1
+    assert _origin_main_show(repo, "memory/facts/durable-fact.md") is not None
+    assert [r["decision"] for r in _decisions(state)] == ["pickup_deferred", "promoted"]
+
+
+def test_no_origin_remote_is_not_durable(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-b", "main", str(repo)], capture_output=True, check=True)
+    _git(repo, "config", "user.email", "test@test")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    state = tmp_path / "state"
+    _stage_fact(state)
+    before = _git(repo, "rev-parse", "HEAD")
+
+    assert _pickup_staged_promotions(repo, state) == 0
+    assert _git(repo, "rev-parse", "HEAD") == before
+    assert len(load_staged_manifest(state)) == 1
+    assert [r["decision"] for r in _decisions(state)] == ["pickup_deferred"]
+    assert "no origin remote" in _decisions(state)[0]["reason"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Pickup-time merge is idempotent and folds duplicates like the mint did
+# ---------------------------------------------------------------------------
+
+def test_pickup_applies_cards_idempotently_and_folds_a_filler_duplicate(tmp_path: Path) -> None:
+    repo, _origin = _init_repo_with_origin(tmp_path)
+    (repo / "lessons" / "lessons.yaml").write_text(yaml.safe_dump({"lessons": [{
+        "id": "LESS-000000000000-0000-0000-0000-000000000000",
+        "problem": "Node missing",
+        "solution": "Apply the reflected error pattern.",
+        "seen_count": 1,
+        "last_seen": "old-date",
+    }]}), encoding="utf-8")
+    _git(repo, "commit", "-am", "filler card")
+    _git(repo, "push", "origin", "main")
+    state = tmp_path / "state"
+    reflector = state / "reflector"
+    reflector.mkdir(parents=True)
+    (reflector / "reflections.jsonl").write_text(json.dumps({
+        "cycle_id": "cycle-fold000000001", "summary": "Node missing",
+        "recommendations": [{"kind": "error_pattern", "detail": "Run apt-get update to fix missing package listings."}],
+    }) + "\n", encoding="utf-8")
+
+    assert promote_reflector_recommendations_to_v2(repo, state) == 1
+    assert _pickup_staged_promotions(repo, state) == 1
+    cards = yaml.safe_load(_origin_main_show(repo, LESSONS_REL))["lessons"]
+    assert len(cards) == 1
+    assert cards[0]["solution"] == "Run apt-get update to fix missing package listings."
+    assert cards[0]["seen_count"] == 2
+    assert load_staged_manifest(state) == []

--- a/tests/test_knowledge_curator.py
+++ b/tests/test_knowledge_curator.py
@@ -69,7 +69,7 @@ def test_tail_expired_cycle_resolves_from_action_index_and_records_source(tmp_pa
 
     assert result["ok"] and result["writes"] == 1
     row = json.loads((state / "curator/decisions.jsonl").read_text(encoding="utf-8").splitlines()[0])
-    assert row["decision"] == "promoted"
+    assert row["decision"] == "staged"  # #1209: ``promoted`` is written by the bridge after the push
     assert "evidence source: action_index" in row["reason"]
 
 
@@ -140,9 +140,9 @@ def test_curator_stages_promotions_not_workspace(tmp_path):
     assert len(manifest) == 1
     assert manifest[0]["path"] == "memory/facts/novel.md"
     assert manifest[0]["action"] == "create"
-    # Decisions sidecar records promoted + duplicate
+    # Decisions sidecar records staged + duplicate (#1209: promoted only after the bridge pushes)
     rows = [json.loads(x) for x in (state / "curator/decisions.jsonl").read_text().splitlines()]
-    assert {r["decision"] for r in rows} == {"promoted", "duplicate"}
+    assert {r["decision"] for r in rows} == {"staged", "duplicate"}
 
 
 def test_watermark_skips_prior_and_failure_does_not_advance(tmp_path):

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -10,7 +10,23 @@ import yaml
 
 from nanobot.runtime.bridge import _write_structured_lesson, build_task
 from nanobot.runtime.knowledge_curator import promote_reflector_recommendations_to_v2
-from nanobot.runtime.lesson_v2 import (
+
+
+def _materialize_staged_lessons(workspace: Path, state_dir: Path) -> None:
+    """#1209: the mint stages its cards; apply them the way the bridge pickup does."""
+    from nanobot.runtime.knowledge_curator import (
+        _STAGED_DIR,
+        LESSONS_KIND,
+        apply_staged_lesson_cards,
+        load_staged_manifest,
+    )
+    for entry in load_staged_manifest(state_dir):
+        if entry.get("kind") == LESSONS_KIND:
+            payload_path = state_dir / "curator" / _STAGED_DIR / entry["payload_file"]
+            apply_staged_lesson_cards(workspace, json.loads(payload_path.read_text(encoding="utf-8")))
+
+
+from nanobot.runtime.lesson_v2 import (  # noqa: E402
     bounded_load_yaml,
     find_duplicate,
     keyword_jaccard,
@@ -125,6 +141,7 @@ def test_curator_promotes_reflector_delta(tmp_path: Path) -> None:
     old_time = time.time() - 10
     os.utime(state / "reflections.jsonl", (old_time, old_time))
     assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    _materialize_staged_lessons(workspace, state.parent.parent)
     lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
     assert validate_lesson_for_mint(lessons["lessons"][0])
     assert lessons["lessons"][0]["solution"] == "Use bounded parser reads incrementally for large files"
@@ -174,6 +191,7 @@ def test_curator_folds_duplicate_and_upgrades_meaningless_solution(tmp_path: Pat
     }), encoding="utf-8")
 
     count = promote_reflector_recommendations_to_v2(tmp_path, state_dir)
+    _materialize_staged_lessons(tmp_path, state_dir)
 
     with target.open(encoding="utf-8") as f:
         doc = yaml.safe_load(f)
@@ -229,6 +247,7 @@ def test_curator_promotes_from_log_larger_than_the_old_size_cap(tmp_path: Path) 
     assert size > 512 * 1024, size
 
     assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    _materialize_staged_lessons(workspace, state.parent.parent)
     lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
     assert lessons["lessons"][0]["solution"] == "Read a bounded tail instead of the whole file"
 
@@ -257,6 +276,7 @@ def test_curator_skips_unparseable_row_instead_of_abandoning_the_file(tmp_path: 
     )
 
     assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    _materialize_staged_lessons(workspace, state.parent.parent)
     lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
     assert lessons["lessons"][0]["solution"] == "Skip the unparseable row and keep the rest"
 


### PR DESCRIPTION
Closes #1209. Refs #986, #1171, #1183 (reopened).

## What was wrong, measured

Two curator outputs, two ways to die inside one bridge cycle (host, 2026-09-02, release `44605ba2`):

| output | written by | where it landed | what erased it | measured |
|---|---|---|---|---|
| reflector v2 lesson cards | `promote_reflector_recommendations_to_v2` | `lessons/lessons.yaml` in the instance **working tree**, uncommitted | next cycle's `_restore_to_main` → `git reset --hard && git clean -fd` (`bridge.py:1146`) | written 06:19:00 MSK (78,129 B, 2 new cards), gone 06:21:45.97 MSK; ledger `started cycle-a13ef1c84568` 03:21:45 UTC is the same second |
| staged facts | `_pickup_staged_promotions` | a commit on **local `main`** | cycle branch cut from `origin/main` (`bridge.py:641/648`), integration `checkout -B main <origin base>` (`:745`) | 6 of 7 pickup commits dangling (`git fsck`), `memory/facts` 9 files vs 23 `promoted` decisions, journal said "committed 3 fact(s) on main" |

Both were recorded as success by the component that wrote them. The four `LESS-REF` cards that exist got in by accident (`0b086859`, a cycle's auto-commit sweep on 2026-08-29).

## What this PR does

**1. Route the write durably — staging, then a pushed pickup.** Chosen over "make the raw write survive the reset" because the module already defines that protocol for facts and because the reset is the cycle's isolation guarantee (non-goal). The curator never touches the checkout now.

- `promote_reflector_recommendations_to_v2` computes its cards against a read-only baseline of the checkout's store and stages them: payload `state/curator/staged/lessons__lessons.yaml.cards.json`, one manifest entry with `kind: lessons_v2` targeting `lessons/lessons.yaml` (`_stage_lesson_cards`). The `atomic_write_yaml(target, …)` in the mint is gone. Selection logic untouched (#1209 non-goal; #1183's fix is intact).
- The pickup merges staged cards into the checkout's store at the boundary (`apply_staged_lesson_cards`), using the same `_merge_card_into` the mint uses in memory — insert newest-first, or fold a near-duplicate with the #1106 filler upgrade, idempotent on an existing id.
- `_pickup_staged_promotions` **pushes** its commit: `git push origin main`, plain, never forced. A fast-forward also carries a bridge lesson commit whose own push had failed; a non-fast-forward is rejected. If the push is rejected or there is no `origin` remote, the commit is dropped with `git reset --hard <pre-commit sha>`, the tree is clean again for `_setup_cycle_branch`, and staging is retained for the next cycle.
- A manifest whose entries are all already applied is cleared instead of re-running as a no-op every cycle.

**2. Audit of every other side-role writer.** Method: `host/eeepc/systemd/*.service` `ExecStart` lines name six side units (`action_index`, `knowledge_curator`, `reflector`, `skill_candidate_mining` + `skill_eval_harness`, `strategist`, `validator_harness`); every write primitive (`write_text`, `write_bytes`, `open(..., "w"|"a")`, `os.replace`, `shutil.move/copy`, `unlink`) was grepped across the 17 runtime modules those units reach, and each target root classified.

| writer | runs from | target | durable? | action |
|---|---|---|---|---|
| `knowledge_curator.promote_reflector_recommendations_to_v2` | curator unit, 00:00 MSK | `lessons/lessons.yaml` working tree | **no** — reset | fixed: staged |
| `bridge._pickup_staged_promotions` | bridge cycle start | commit on local `main` | **no** — orphaned | fixed: pushed |
| `knowledge_curator.run_curation` → `_stage_promotions` | curator unit | `state/curator/staged/` | state, n/a | unchanged |
| `knowledge_curator.migrate_loose_lessons` | operator-only, never run on the host (37 loose notes remain) | working tree | **no** unless the operator commits | docstring now says so; unchanged |
| `bridge._write_structured_lesson` / `_write_structured_error` | bridge, after integration | `lessons/lessons.yaml`, `lessons/errors.yaml` | yes — own `git add` + `commit` + push (`bridge.py:3594–3620`) | none |
| bridge in-cycle subagent writes, `memory_archiver` (`bridge.py:3295`), `lessons_rotation` (called from the lesson writers, `:4438/:4561`) | on the cycle branch / inside the committed path | yes — auto-commit sweep + integration | none |
| `reflector`, `strategist`, `strategist_inputs`, `action_index`, `skill_candidate_mining`, `skill_eval_harness`, `skill_fitness`, `knowledge_lift`, `validator_harness`, `goal_review`, `hypothesis_backlog` | side units | `state_dir` only | n/a | none |
| `system_map.update_system_map` | `llm_proposer.maybe_propose` (`llm_proposer.py:2696`), called by the bridge at `bridge.py:2073` — on clean `main`, **before** `_setup_cycle_branch` (`:2576`) | `docs/SYSTEM_MAP.md` working tree | **would not be** — same class as the mint (reset at the next cycle start, or a `dirty_tree` setup failure) | dormant on the host: the instance's own `scripts/generate_system_map.py` owns the file, so `_map_has_foreign_generator` returns early; `state/system_map/watermark.json` last written 2026-07-14 14:42 UTC, `dirty_tree` rows in the ledger (live + 51 archives): 0. Not changed here; flagged as a follow-up — if the foreign generator ever disappears this writer wakes up on the wrong side of the branch. |

So the two paths fixed here are the only non-durable writers that write today; one more is dormant and named above.

**3. A discarded write is not a success.** `decisions.jsonl` vocabulary:

- curator: `staged` / `staged_unsupported` at staging time (was `promoted` / `promoted_unsupported`);
- pickup: `promoted` per fact id and per card id, reason `pushed to origin/main as <sha12>` — written only after the push returned 0;
- pickup: `pickup_deferred` with the push error when the commit was dropped.

Fact manifest entries now carry `lesson_id` so the pickup can record against the same id the curator used. `_DECISIONS` lists the new labels. Grep for the `"promoted"` string across `nanobot/` and `scripts/` finds only this PR's two writer sites in `bridge.py`; nothing reads it, and the ops dashboard does not read `decisions.jsonl` (`gh search code`).

## Tests — fail against `origin/main`, quoted

`tests/test_issue_1209_durable_curator_writes.py` builds a checkout tracking a bare `origin` and replays the bridge's own git sequence: `_cycle_start_reset` = `_restore_to_main`; `_cycle_integration` = `_setup_cycle_branch` (branch from `origin/main`) + `_integrate_cycle_to_main` (`checkout -B main origin/main`, `--no-ff` merge, push). Durability is asserted only through `git show origin/main:<path>`.

Run against a clean `git archive origin/main` tree (`ad288ad5`) with only this file added — 7 failed:

```
test_reflector_mint_survives_cycle_start_reset_and_two_integrations
>       assert _git(repo, "status", "--porcelain") == ""
E       AssertionError: assert 'M lessons/lessons.yaml' == ''          (the mint wrote the working tree)

test_pickup_commit_survives_integration_base_reset
>       assert _origin_main_show(repo, "memory/facts/durable-fact.md") is not None
E       AssertionError: assert None is not None                          (pickup commit orphaned)

test_decisions_record_staged_then_promoted_with_the_pushed_sha
E       AssertionError: staging must leave a decision row                (mint recorded nothing)

test_run_curation_records_staged_not_promoted
E       AssertionError: assert {'promoted'} == {'staged'}               (recorded as success at staging)

test_push_failure_drops_the_commit_keeps_staging_and_records_deferral
E       AssertionError: assert 1 == 0                                    (unpushable commit reported as 1)

test_no_origin_remote_is_not_durable
E       AssertionError: assert 1 == 0

test_pickup_applies_cards_idempotently_and_folds_a_filler_duplicate
E       AssertionError: assert 0 == 1                                    (no lessons kind in pickup)
```

With the fix: 7 passed. Existing tests adapted, not weakened: `test_curator_staging_pickup.py` fixture now tracks a bare origin (the pickup's contract includes the push); `test_lesson_v2.py`, `test_issue_1138_lesson_ids*.py` apply the staged payload with `apply_staged_lesson_cards` before asserting on the store (helper `_materialize_staged_lessons`); `test_knowledge_curator.py` expects `staged`.

**Full pytest, Windows:** `18 failed, 2889 passed, 17 skipped in 373 s` (`-n 4`). Baseline 18 failed / 2870 passed; the 18 are the known Windows-only set (`test_autoevolve*` symlinks/tar, `test_selfevo_export_security`, `test_bridge_locking` fcntl, `test_bridge_cycle_tags`), none in the touched files. Linux CI is authoritative.

## Behaviour visible on the host after deploy

- Journal at cycle start: `bridge: staged pickup: pushed N fact(s) and M lesson card(s) to origin/main <sha12> (#1209)` replaces `committed N fact(s) on main`; on failure `push to origin/main failed (…); commit dropped, staging retained for retry (#1209)`.
- A repeated recommendation still in the newest 50 reflector rows re-folds on the next run (#1138 suffixes the id, `find_duplicate` matches the problem), so a daily pickup commit that only bumps `seen_count` is expected; that is the pre-existing selection semantics made durable, bounded by `max_items=2`. Not changed here (non-goal).
- The two `overlap_flag` entries currently in the host's `staged/manifest.json` are still skipped and retained, as before.

## Live verification (operator, per the issue)

After the first curator run post-deploy (00:00 MSK) and the following bridge cycle start:

1. journal line `staged pickup: pushed … lesson card(s) to origin/main <sha>`;
2. `git -C <instance> show origin/main:lessons/lessons.yaml | grep -o 'LESS-REF-[0-9a-f-]*'` shows a new id with `first_seen` = deploy day;
3. quote that id and the `started` timestamps of the next two cycles from the ledger, then re-run step 2 — the card must still be there;
4. `state/curator/decisions.jsonl` has a `promoted` row for that id whose reason names the sha from step 1.

A working-tree reading does not count.
