### PR TITLE
fix(runtime): cool recent duplicate-failure demands before LLM selection (#1211)

### DIFF
--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -1134,6 +1134,62 @@ def _write_rotation(state_dir: Path, data: dict[str, Any]) -> None:
     os.replace(tmp_path, path)
 
 
+def _failure_suppress_hours() -> float:
+    try:
+        return float(os.environ.get("SUBAGENT_BRIDGE_FAILURE_SUPPRESS_HOURS", "24").strip() or "24")
+    except ValueError:
+        return 24.0
+
+
+def _recent_duplicate_failure_demand_ids(state_dir: Path) -> set[str]:
+    """Return demand ids with a recent ``recent_duplicate_failure`` outcome.
+
+    This is selection-time cost avoidance only. It deliberately reads the
+    recorded demand id from the proposed/outcome cycle chain and ignores the
+    other duplicate reasons: ``already_done`` is completion bookkeeping and
+    ``existence_index_duplicate`` is a separate semantic suppression. Any
+    unreadable ledger is treated as no evidence so demand remains selectable.
+    """
+    try:
+        suppress_hours = _failure_suppress_hours()
+        rows = _load_ledger_rows(
+            state_dir,
+            days=max(_LEDGER_HORIZON_DAYS, int(suppress_hours / 24) + 1),
+        )
+        demand_by_cycle = {
+            str(row.get("cycle_id") or "").strip(): str(row.get("demand_id") or "").strip()
+            for row in rows
+            if row.get("phase") == "proposed"
+            and str(row.get("cycle_id") or "").strip()
+            and str(row.get("demand_id") or "").strip()
+        }
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=suppress_hours)
+        latest_by_demand: dict[str, tuple[datetime, dict[str, Any]]] = {}
+        for row in rows:
+            if row.get("phase") != "outcome":
+                continue
+            demand_id = str(row.get("demand_id") or "").strip() or demand_by_cycle.get(
+                str(row.get("cycle_id") or "").strip(), ""
+            )
+            if not demand_id:
+                continue
+            ts = _parse_ts(row.get("ts"))
+            if ts is None:
+                continue
+            previous = latest_by_demand.get(demand_id)
+            if previous is None or ts > previous[0]:
+                latest_by_demand[demand_id] = (ts, row)
+        return {
+            demand_id
+            for demand_id, (ts, row) in latest_by_demand.items()
+            if ts >= cutoff
+            and str(row.get("outcome") or "").strip().lower() == "skipped-duplicate"
+            and str(row.get("reason") or "").strip() == "recent_duplicate_failure"
+        }
+    except Exception:
+        return set()
+
+
 def _select_assigned_demand(
     state_dir: Path, demand_items: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -1175,8 +1231,12 @@ def _select_assigned_demand(
 
         current_ids = {str(item["id"]) for item in valid_items}
         served = {k: v for k, v in served.items() if k in current_ids}
+        cooled_ids = _recent_duplicate_failure_demand_ids(state_dir)
+        eligible = [item for item in valid_items if str(item["id"]) not in cooled_ids]
+        if not eligible:
+            return []
 
-        unserved = [item for item in valid_items if str(item["id"]) not in served]
+        unserved = [item for item in eligible if str(item["id"]) not in served]
         if unserved:
             selected = unserved[0]
         else:
@@ -1186,7 +1246,7 @@ def _select_assigned_demand(
 
             # min() keeps the FIRST minimal element on ties, matching the
             # "tie-break: first in list order" spec.
-            selected = min(valid_items, key=_served_ts_key)
+            selected = min(eligible, key=_served_ts_key)
 
         served[str(selected["id"])] = datetime.now(timezone.utc).isoformat()
         _write_rotation(state_dir, {"schema_version": _ROTATION_SCHEMA, "served": served})
@@ -2734,6 +2794,11 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
             rotated_items = _select_assigned_demand(state_dir, demand_items)
             assigned = rotated_items is not demand_items
             demand_items = rotated_items
+            if not demand_items:
+                # A demand-level cooldown exhausted the eligible selection for
+                # this invocation. Do not build context or pay for a proposal;
+                # the existing bridge-level suppression remains the backstop.
+                return None
 
         context = build_context(
             state_dir,

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2798,6 +2798,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
                 # A demand-level cooldown exhausted the eligible selection for
                 # this invocation. Do not build context or pay for a proposal;
                 # the existing bridge-level suppression remains the backstop.
+                _record_proposer_reject(state_dir, "all_cooled")
                 return None
 
         context = build_context(

--- a/tests/test_llm_proposer_rotation.py
+++ b/tests/test_llm_proposer_rotation.py
@@ -12,11 +12,12 @@ design rationale.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from nanobot.runtime import demand, llm_proposer
+from nanobot.runtime import cycle_ledger, demand, llm_proposer
 from tests.test_llm_proposer import (
     DEMAND_ENV,
     ENV_VAR,
@@ -53,6 +54,25 @@ def _write_rotation(state_dir: Path, served: dict) -> None:
     path.write_text(
         json.dumps({"schema_version": "demand-rotation-v1", "served": served}),
         encoding="utf-8",
+    )
+
+
+def _append_recent_duplicate_failure(
+    state_dir: Path,
+    demand_id: str,
+    *,
+    cycle_id: str = "cycle-failed",
+    reason: str = "recent_duplicate_failure",
+    age_hours: float = 1,
+) -> None:
+    ts = (datetime.now(timezone.utc) - timedelta(hours=age_hours)).isoformat().replace("+00:00", "Z")
+    cycle_ledger.append_event(
+        state_dir,
+        {"phase": "proposed", "cycle_id": cycle_id, "demand_id": demand_id, "ts": ts},
+    )
+    cycle_ledger.append_event(
+        state_dir,
+        {"phase": "outcome", "cycle_id": cycle_id, "outcome": "skipped-duplicate", "reason": reason, "ts": ts},
     )
 
 
@@ -140,6 +160,86 @@ class TestSelectAssignedDemand:
     def test_empty_input_returns_input_unchanged(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         assert llm_proposer._select_assigned_demand(state_dir, []) == []
+
+    def test_recent_duplicate_failure_cools_demand_before_selection(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setenv("SUBAGENT_BRIDGE_FAILURE_SUPPRESS_HOURS", "24")
+        item = _item("defect", "defect-cooled", "repair import resolution")
+        _append_recent_duplicate_failure(state_dir, item["id"], age_hours=1)
+
+        assert llm_proposer._select_assigned_demand(state_dir, [item]) == []
+
+    def test_recent_duplicate_failure_cooldown_expires(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setenv("SUBAGENT_BRIDGE_FAILURE_SUPPRESS_HOURS", "24")
+        item = _item("defect", "defect-retryable", "repair import resolution")
+        _append_recent_duplicate_failure(state_dir, item["id"], age_hours=25)
+        _write_rotation(state_dir, {item["id"]: "2026-09-01T00:00:00+00:00"})
+
+        assert llm_proposer._select_assigned_demand(state_dir, [item]) == [item]
+        assert item["id"] in _read_rotation(state_dir)["served"]
+
+    def test_newer_non_failure_outcome_ends_cooldown(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        item = _item("defect", "defect-retried", "repair import resolution")
+        _append_recent_duplicate_failure(state_dir, item["id"], cycle_id="cycle-old", age_hours=1)
+        ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "proposed", "cycle_id": "cycle-new", "demand_id": item["id"], "ts": ts},
+        )
+        cycle_ledger.append_event(
+            state_dir,
+            {"phase": "outcome", "cycle_id": "cycle-new", "outcome": "partial", "reason": "transient", "ts": ts},
+        )
+
+        assert llm_proposer._select_assigned_demand(state_dir, [item]) == [item]
+
+    def test_other_duplicate_reasons_do_not_cool_demand(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        already_done = _item("priority", "priority-existing", "existing work")
+        existence_duplicate = _item("priority", "priority-indexed", "indexed work")
+        _append_recent_duplicate_failure(
+            state_dir, already_done["id"], reason="already_done", age_hours=1,
+        )
+        _append_recent_duplicate_failure(
+            state_dir, existence_duplicate["id"], reason="existence_index_duplicate", age_hours=1,
+        )
+
+        assert llm_proposer._select_assigned_demand(
+            state_dir, [already_done, existence_duplicate]
+        ) == [already_done]
+
+    def test_noncooled_demand_wins_over_cooled_demand(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        cooled = _item("defect", "defect-cooled", "repair import resolution")
+        available = _item("defect", "defect-available", "repair parser")
+        _append_recent_duplicate_failure(state_dir, cooled["id"], age_hours=1)
+
+        assert llm_proposer._select_assigned_demand(
+            state_dir, [cooled, available]
+        ) == [available]
+
+    def test_cooldown_evidence_failure_fails_open(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        item = _item("defect", "defect-unreadable", "repair import resolution")
+        monkeypatch.setattr(llm_proposer, "_load_ledger_rows", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("unreadable")))
+
+        assert llm_proposer._select_assigned_demand(state_dir, [item]) == [item]
+
+    def test_maybe_propose_makes_no_llm_call_when_all_demands_are_cooled(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        monkeypatch.setenv(ENV_VAR, "1")
+        monkeypatch.setenv(DEMAND_ENV, "1")
+        item = _item("defect", "defect-cooled", "repair import resolution")
+        _append_recent_duplicate_failure(state_dir, item["id"], age_hours=1)
+        monkeypatch.setattr(demand, "collect_demand", lambda *_args, **_kwargs: [item])
+        calls = []
+        monkeypatch.setattr(llm_proposer, "propose", lambda *args, **kwargs: calls.append(1))
+        monkeypatch.setattr(llm_proposer, "should_propose", lambda *_args, **_kwargs: True)
+
+        assert llm_proposer.maybe_propose(state_dir, None) is None
+        assert calls == []
 
 
 # ─── maybe_propose integration: rotation + assigned wording + noop advance ──

--- a/tests/test_llm_proposer_rotation.py
+++ b/tests/test_llm_proposer_rotation.py
@@ -240,6 +240,10 @@ class TestSelectAssignedDemand:
 
         assert llm_proposer.maybe_propose(state_dir, None) is None
         assert calls == []
+        assert any(
+            row.get("phase") == "proposer_reject" and row.get("reason") == "all_cooled"
+            for row in llm_proposer._load_ledger_rows(state_dir)
+        )
 
 
 # ─── maybe_propose integration: rotation + assigned wording + noop advance ──


### PR DESCRIPTION
## Summary

Adds a demand-level cooldown at `_select_assigned_demand`, before `build_context` and proposal generation. A demand is temporarily ineligible when its latest linked terminal outcome is `skipped-duplicate` with reason `recent_duplicate_failure` and its timestamp is within the existing `SUBAGENT_BRIDGE_FAILURE_SUPPRESS_HOURS` window (default 24 hours). When every current demand is cooled, `maybe_propose` records `proposer_reject: all_cooled` and returns without an LLM call.

This is cost avoidance, not a suppression-policy change. The existing bridge-level `_recent_failure_match` remains unchanged as the correctness backstop.

## Scope boundaries

- Addresses only `recent_duplicate_failure` (baseline: 266 of 611 suppressed duplicate outcomes).
- Does not address `already_done` (163): that is completion bookkeeping and may mark `[Done]`.
- Does not address `existence_index_duplicate` (182): that is separate existence-index semantic suppression and remains unchanged.
- Does not weaken or modify the bridge matcher or add a new size cap.

## Design and reuse

- Demand ids are linked from recorded `proposed.demand_id` rows to their cycle's recorded `outcome`; no historical id is re-derived.
- The latest outcome per demand id wins. A newer non-`recent_duplicate_failure` outcome clears the cooldown, so a transient failure does not permanently starve a demand.
- The existing suppression window is reused through the same environment variable and default (24h); the ledger read horizon is at least the existing three-day horizon and expands for a longer configured window.
- Existing `demand/rotation.json` timestamps are retained for cooled items. Once eligible again, a demand resumes its prior rotation position rather than jumping ahead as never-served.
- Ledger read errors and malformed timestamps fail open: the demand remains selectable.

## Regression evidence

The new tests were run against `origin/main` before implementation. The primary test failed as expected:

```text
FAILED tests/test_llm_proposer_rotation.py::TestSelectAssignedDemand::test_recent_duplicate_failure_cools_demand_before_selection
E       AssertionError: assert [{'affected_p...defect', ...}] == []
E       Left contains one more item: {'affected_path': '', 'evidence': '', 'id': 'defect-cooled', 'kind': 'defect', ...}
```

The final focused suite passes:

```text
227 passed  # llm proposer + rotation tests
402 passed  # proposer rotation + proposer + demand tests
```

## Validation

- Full local pytest: `2890 passed, 18 failed, 17 skipped, 11 warnings` on Windows. The 18 failures are the established Windows baseline: local temporary repositories push `master` without a created commit, Windows lacks `fcntl` for bridge lock tests, and Windows tag-permission behavior differs. No failures are in the changed files or related proposer/demand tests.
- `ruff check nanobot/runtime/llm_proposer.py tests/test_llm_proposer_rotation.py`: passed.
- `git diff --check`: passed.
- Opus review: **OK**, no remaining findings after fixing selection fallback, rotation-history retention, and all-cooled observability.

## Live verification (operator-owned)

Baseline to watch: `recent_duplicate_failure` currently accounts for 266 of 611 `skipped-duplicate` terminal outcomes, with 15 of 96 terminal outcomes suppressed in the last 24 hours.

After deployment, measure the same counts over a comparable window and inspect the demand-linked sequence. Success is not merely a lower total `skipped-duplicate` count, because `already_done` and `existence_index_duplicate` are intentionally untouched. The proving signal is:

1. A demand with a recent `recent_duplicate_failure` terminal outcome is absent from the selected/assigned demand set during the 24-hour window, and no proposal-generation LLM call is recorded for that demand.
2. The same demand becomes eligible after the configured window (or after a newer non-failure outcome), and can then be selected normally.
3. Compare `recent_duplicate_failure` counts and proposal-call volume, not the aggregate duplicate count. A reduction in the 266 count and fewer proposal calls for those cooled demand ids is evidence; a drop in all duplicate reasons is not proof.
4. Confirm `already_done` and `existence_index_duplicate` counts remain separately reported rather than being reclassified.

The cooldown has a starvation risk: a transient gate failure can justify retrying sooner than 24 hours. To distinguish correct suppression from starvation, inspect the per-demand `proposed`/`outcome` chain, `demand/rotation.json`, the `all_cooled`/idle records, and whether the demand reappears after the 24-hour boundary or a newer non-failure outcome. A demand that remains absent after that boundary indicates starvation or stale evidence rather than correct cooldown.
