### PR TITLE
fix(runtime): stage loose lesson migration through bridge pickup (#1214)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1814,6 +1814,7 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
         changed_files: list[str] = []
         applied_lesson_ids: list[str] = []
         fact_ids: list[str] = []
+        loose_lesson_ids: list[str] = []
         # Filter unsupported entries before any validation (#1094 tier-2).
         # overlap_flag=True means zero keyword overlap between fact and support_claim;
         # these entries are kept in staging for audit but never committed to main.
@@ -1840,7 +1841,15 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             if str(entry.get('kind') or '') == LESSONS_KIND:
                 path_ok = rel == LESSONS_REL
             elif str(entry.get('kind') or '') == 'loose_lesson':
-                path_ok = rel.startswith('lessons/archive/loose/') and Path(rel).name == rel.rsplit('/', 1)[-1]
+                source_rel = str(entry.get('source_path') or '').replace('\\', '/')
+                path_ok = (
+                    rel.startswith('lessons/archive/loose/')
+                    and Path(rel).name == rel.rsplit('/', 1)[-1]
+                    and Path(rel).name.endswith('.md')
+                    and source_rel.startswith('lessons/')
+                    and Path(source_rel).name == source_rel.rsplit('/', 1)[-1]
+                    and Path(source_rel).name.endswith('.md')
+                )
             else:
                 path_ok = _fact_path(rel) is not None
             if not rel or not path_ok or not slug or Path(slug).name != slug:
@@ -1854,6 +1863,9 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
                 index_rel = str(entry.get('index_rel') or '').replace('\\', '/')
                 if index_rel:
                     snapshot_paths.add(repo_root / index_rel)
+            source_rel = str(entry.get('source_path') or '').replace('\\', '/')
+            if source_rel:
+                snapshot_paths.add(repo_root / source_rel)
         snapshots = {path: path.read_bytes() if path.exists() else None for path in snapshot_paths}
 
         def _rollback_pickup() -> None:
@@ -1896,11 +1908,20 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
                     changed_files.append(rel)
                     fact_ids.append(str(entry.get('lesson_id') or rel))
                 continue
-            fact_ids.append(str(entry.get('lesson_id') or rel))
+            if str(entry.get('kind') or '') == 'loose_lesson':
+                loose_lesson_ids.append(str(entry.get('lesson_id') or rel))
+            else:
+                fact_ids.append(str(entry.get('lesson_id') or rel))
             target = repo_root / rel
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(payload_path.read_bytes())
             changed_files.append(rel)
+            source_rel = str(entry.get('source_path') or '').replace('\\', '/')
+            if source_rel:
+                source = repo_root / source_rel
+                if source.exists():
+                    source.unlink()
+                    changed_files.append(source_rel)
             if action == 'create' and index_line and index_rel:
                 index_path = repo_root / index_rel
                 index_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1926,7 +1947,8 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             return 0
         n_facts = sum(1 for f in changed_files if f.startswith(('memory/facts/', 'docs/facts/')))
         n_cards = len(applied_lesson_ids)
-        commit_msg = f'curator: promote {n_facts} fact(s) and {n_cards} lesson card(s) from staging (#1001, #1209)'
+        n_loose = len(loose_lesson_ids)
+        commit_msg = f'curator: promote {n_facts} fact(s), {n_cards} lesson card(s), and {n_loose} loose lesson(s) from staging (#1001, #1209)'
         pre_sha = _sp_pick.run(git + ['rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
         add_r = _sp_pick.run(git + ['add'] + changed_files, capture_output=True, text=True)
         if add_r.returncode != 0:
@@ -1943,7 +1965,7 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
         # (never forced) push: a fast-forward also carries any earlier commit
         # left on local main (e.g. a bridge lesson commit whose own push
         # failed); a non-fast-forward means the remote moved and is rejected.
-        all_ids = fact_ids + applied_lesson_ids
+        all_ids = fact_ids + applied_lesson_ids + loose_lesson_ids
         remote_r = _sp_pick.run(git + ['remote', 'get-url', 'origin'], capture_output=True, text=True)
         if remote_r.returncode != 0:
             push_error = 'no origin remote configured'
@@ -1977,11 +1999,15 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             state_dir, applied_lesson_ids, 'promoted',
             f'pushed to origin/main as {new_sha[:12]}', LESSONS_REL,
         )
-        print(
-            f'bridge: staged pickup: pushed {n_facts} fact(s) and {n_cards} lesson card(s) '
-            f'to origin/main {new_sha[:12]} (#1209)'
+        record_pickup_outcome(
+            state_dir, loose_lesson_ids, 'promoted',
+            f'pushed to origin/main as {new_sha[:12]}', 'lessons/archive/loose',
         )
-        return n_facts + n_cards
+        print(
+            f'bridge: staged pickup: pushed {n_facts} fact(s), {n_cards} lesson card(s), '
+            f'and {n_loose} loose lesson(s) to origin/main {new_sha[:12]} (#1209)'
+        )
+        return n_facts + n_cards + n_loose
     except Exception as _exc:
         print(f'bridge: staged pickup: unexpected error ({_exc}); staging retained for retry')
         return 0

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1839,6 +1839,8 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
             slug = str(entry.get('payload_file') or '')
             if str(entry.get('kind') or '') == LESSONS_KIND:
                 path_ok = rel == LESSONS_REL
+            elif str(entry.get('kind') or '') == 'loose_lesson':
+                path_ok = rel.startswith('lessons/archive/loose/') and Path(rel).name == rel.rsplit('/', 1)[-1]
             else:
                 path_ok = _fact_path(rel) is not None
             if not rel or not path_ok or not slug or Path(slug).name != slug:

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -1842,13 +1842,17 @@ def _pickup_staged_promotions(repo_root: 'Path', state_dir: 'Path') -> int:
                 path_ok = rel == LESSONS_REL
             elif str(entry.get('kind') or '') == 'loose_lesson':
                 source_rel = str(entry.get('source_path') or '').replace('\\', '/')
+                rel_parts = Path(rel).parts
+                source_parts = Path(source_rel).parts
                 path_ok = (
                     rel.startswith('lessons/archive/loose/')
-                    and Path(rel).name == rel.rsplit('/', 1)[-1]
-                    and Path(rel).name.endswith('.md')
+                    and rel_parts[:3] == ('lessons', 'archive', 'loose')
+                    and len(rel_parts) == 4
+                    and rel_parts[3].endswith('.md')
                     and source_rel.startswith('lessons/')
-                    and Path(source_rel).name == source_rel.rsplit('/', 1)[-1]
-                    and Path(source_rel).name.endswith('.md')
+                    and source_parts[:1] == ('lessons',)
+                    and len(source_parts) == 2
+                    and source_parts[1].endswith('.md')
                 )
             else:
                 path_ok = _fact_path(rel) is not None

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -36,7 +36,6 @@ import inspect
 import json
 import os
 import re
-import shutil
 import tempfile
 import time
 from datetime import datetime, timezone

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -713,7 +713,7 @@ def _stage_promotions(
                 os.unlink(tmp)
             except FileNotFoundError:
                 pass
-        manifest_entries.append({
+        entry = {
             "path": rel,
             "action": action,
             "payload_file": slug,
@@ -728,7 +728,12 @@ def _stage_promotions(
             "support_claim": str(item.get("support_claim") or "")[:500],
             "verification_status": "unsupported" if item.get("overlap_flag", False) else "supported",
             "overlap_flag": bool(item.get("overlap_flag", False)),
-        })
+        }
+        if item.get("kind"):
+            entry["kind"] = str(item["kind"])
+        if item.get("source_path"):
+            entry["source_path"] = str(item["source_path"]).replace("\\", "/")
+        manifest_entries.append(entry)
     _append_manifest_entries(staged_dir, manifest_entries)
     return manifest_entries
 
@@ -1357,11 +1362,12 @@ def run_curation(
 
 
 def migrate_loose_lessons(workspace: Path, state_dir: Path | None = None) -> dict[str, Any]:
-    """Stage loose-note migrations for bridge pickup; never write the checkout.
+    """Stage the legacy loose-note migration for bridge pickup (#1214).
 
-    The legacy direct-write behavior is intentionally replaced by the existing
-    #1209 manifest protocol. ``state_dir`` is required so an undurable
-    migration cannot be mistaken for a successful one.
+    This preserves the old deterministic behavior — one fact per unique note
+    body, an index line for newly-created facts, and every source note moved to
+    ``lessons/archive/loose`` — without writing the workspace checkout. The
+    existing #1209 staging manifest is the only durable handoff.
     """
     workspace, state_dir = Path(workspace), Path(state_dir) if state_dir is not None else None
     if state_dir is None:
@@ -1369,61 +1375,67 @@ def migrate_loose_lessons(workspace: Path, state_dir: Path | None = None) -> dic
     loose = sorted((workspace / "lessons").glob("*.md"))
     if not loose:
         return {"ok": True, "migrated": 0, "facts_created": 0, "staged": []}
-    archive = Path("lessons/archive/loose")
-    items: list[dict[str, Any]] = []
-    seen_names: set[str] = set()
+
+    groups: dict[str, list[tuple[Path, str]]] = {}
     for path in loose:
         try:
             content = path.read_text(encoding="utf-8").strip()
         except Exception:
-            continue
-        if not content or path.name in seen_names:
-            continue
-        seen_names.add(path.name)
+            return {"ok": False, "migrated": 0, "facts_created": 0, "error": f"could not read {path.name}"}
+        key = re.sub(r"\W+", " ", content.lower()).strip()
+        if key:
+            groups.setdefault(key, []).append((path, content))
+
+    items: list[dict[str, Any]] = []
+    planned_facts: set[str] = set()
+    for paths in groups.values():
+        first_path, first_content = paths[0]
+        slug = re.sub(r"[^a-z0-9]+", "-", first_path.stem.lower()).strip("-")[:60] or "lesson"
+        target = workspace / "memory" / "facts" / f"{slug}.md"
+        if not target.exists() and str(target) not in planned_facts:
+            rel = f"memory/facts/{slug}.md"
+            items.append({
+                "path": rel,
+                "action": "create",
+                "content": f"# {first_path.stem}\n\n{first_content}\n",
+                "lesson_id": first_path.stem,
+                "index_line": f"- [{first_path.stem}]({rel})",
+                "index_rel": "memory/index.md",
+            })
+            planned_facts.add(str(target))
+
+    for path in loose:
+        try:
+            content = path.read_text(encoding="utf-8").strip()
+        except Exception:
+            return {"ok": False, "migrated": 0, "facts_created": 0, "error": f"could not read {path.name}"}
         items.append({
-            "path": str(archive / path.name).replace("\\", "/"),
-            "action": "create",
+            "path": f"lessons/archive/loose/{path.name}",
+            "source_path": f"lessons/{path.name}",
+            "action": "move",
+            "kind": "loose_lesson",
             "content": content + "\n",
             "lesson_id": path.stem,
         })
-    if len(items) != len(loose):
-        return {"ok": False, "migrated": 0, "facts_created": 0, "error": "one or more loose notes could not be staged"}
-    staged_dir = Path(state_dir) / "curator" / _STAGED_DIR
-    staged_dir.mkdir(parents=True, exist_ok=True)
-    manifest_entries: list[dict[str, Any]] = []
-    for item in items:
-        rel = item["path"]
-        slug = rel.replace("/", "__")
-        payload_path = staged_dir / slug
-        fd, temporary = tempfile.mkstemp(prefix=".stg.", dir=str(staged_dir))
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(item["content"])
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(temporary, payload_path)
-        finally:
-            try:
-                os.unlink(temporary)
-            except FileNotFoundError:
-                pass
-        manifest_entries.append({
-            "path": rel,
-            "action": "create",
-            "payload_file": slug,
-            "kind": "loose_lesson",
-            "lesson_id": item["lesson_id"],
-            "index_line": "",
-            "index_rel": "",
-            "related": "",
-            "unknown_related": [],
-            "evidence": [],
-            "support_claim": "",
-            "verification_status": "supported",
-            "overlap_flag": False,
-        })
-    _append_manifest_entries(staged_dir, manifest_entries)
-    return {"ok": True, "migrated": len(items), "facts_created": 0, "staged": [e["path"] for e in manifest_entries]}
+
+    try:
+        staged = _stage_promotions(state_dir, items)
+    except Exception as exc:
+        return {"ok": False, "migrated": 0, "facts_created": 0, "error": f"staging failed: {exc}"}
+    for entry in staged:
+        _write_decision(
+            state_dir,
+            str(entry.get("lesson_id") or entry.get("path") or ""),
+            "staged",
+            "loose lesson migration staged for bridge pickup",
+            str(entry.get("path") or ""),
+        )
+    return {
+        "ok": True,
+        "migrated": len(loose),
+        "facts_created": sum(1 for item in items if item.get("kind") != "loose_lesson"),
+        "staged": [str(entry.get("path") or "") for entry in staged],
+    }
 
 
 def main() -> int:

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -24,9 +24,12 @@ Safe write protocol (#1001, #1209):
   records ``pickup_deferred`` and keeps the item in staging. A write that was
   discarded is never on record as a success.
 
-``migrate_loose_lessons`` is an operator-only utility — run it only while the
-bridge timer is stopped; it writes directly into the workspace checkout and the
-operator must commit and push the result, or the next cycle start discards it.
+``migrate_loose_lessons`` is an operator-triggered utility that stages through
+the same protocol (#1214): it writes the staging manifest only, and the bridge's
+cycle-start pickup commits and pushes the result. Leave the bridge timer
+RUNNING when invoking it — the pickup is what applies the migration, so
+stopping the timer leaves the staged batch unapplied. It supersedes the earlier
+direct-checkout write, which the next cycle's ``git reset --hard`` discarded.
 """
 from __future__ import annotations
 

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -1357,39 +1357,73 @@ def run_curation(
 
 
 def migrate_loose_lessons(workspace: Path, state_dir: Path | None = None) -> dict[str, Any]:
-    """Deterministically consolidate duplicate loose notes and archive originals."""
-    workspace = Path(workspace)
+    """Stage loose-note migrations for bridge pickup; never write the checkout.
+
+    The legacy direct-write behavior is intentionally replaced by the existing
+    #1209 manifest protocol. ``state_dir`` is required so an undurable
+    migration cannot be mistaken for a successful one.
+    """
+    workspace, state_dir = Path(workspace), Path(state_dir) if state_dir is not None else None
+    if state_dir is None:
+        return {"ok": False, "migrated": 0, "facts_created": 0, "error": "state_dir is required for staging"}
     loose = sorted((workspace / "lessons").glob("*.md"))
-    archive = workspace / "lessons" / "archive" / "loose"
-    groups: dict[str, list[Path]] = {}
+    if not loose:
+        return {"ok": True, "migrated": 0, "facts_created": 0, "staged": []}
+    archive = Path("lessons/archive/loose")
+    items: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
     for path in loose:
         try:
-            text = path.read_text(encoding="utf-8").strip()
+            content = path.read_text(encoding="utf-8").strip()
         except Exception:
             continue
-        key = re.sub(r"\W+", " ", text.lower()).strip()
-        groups.setdefault(key, []).append(path)
-    created = 0
-    for key, paths in groups.items():
-        if not key:
+        if not content or path.name in seen_names:
             continue
-        slug = re.sub(r"[^a-z0-9]+", "-", paths[0].stem.lower()).strip("-")[:60] or "lesson"
-        target = workspace / "memory" / "facts" / f"{slug}.md"
-        if not target.exists():
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(f"# {paths[0].stem}\n\n{paths[0].read_text(encoding='utf-8').strip()}\n", encoding="utf-8")
-            with (workspace / "memory" / "index.md").open("a", encoding="utf-8") as fh:
-                fh.write(f"\n- [{paths[0].stem}](memory/facts/{slug}.md)\n")
-            created += 1
+        seen_names.add(path.name)
+        items.append({
+            "path": str(archive / path.name).replace("\\", "/"),
+            "action": "create",
+            "content": content + "\n",
+            "lesson_id": path.stem,
+        })
+    if len(items) != len(loose):
+        return {"ok": False, "migrated": 0, "facts_created": 0, "error": "one or more loose notes could not be staged"}
+    staged_dir = Path(state_dir) / "curator" / _STAGED_DIR
+    staged_dir.mkdir(parents=True, exist_ok=True)
+    manifest_entries: list[dict[str, Any]] = []
+    for item in items:
+        rel = item["path"]
+        slug = rel.replace("/", "__")
+        payload_path = staged_dir / slug
+        fd, temporary = tempfile.mkstemp(prefix=".stg.", dir=str(staged_dir))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(item["content"])
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(temporary, payload_path)
+        finally:
             try:
-                from nanobot.runtime.lessons_rotation import rotate_index_file
-                rotate_index_file(workspace / "memory" / "index.md")
-            except Exception:
+                os.unlink(temporary)
+            except FileNotFoundError:
                 pass
-        for path in paths:
-            archive.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(path), str(archive / path.name))
-    return {"migrated": len(loose), "facts_created": created}
+        manifest_entries.append({
+            "path": rel,
+            "action": "create",
+            "payload_file": slug,
+            "kind": "loose_lesson",
+            "lesson_id": item["lesson_id"],
+            "index_line": "",
+            "index_rel": "",
+            "related": "",
+            "unknown_related": [],
+            "evidence": [],
+            "support_claim": "",
+            "verification_status": "supported",
+            "overlap_flag": False,
+        })
+    _append_manifest_entries(staged_dir, manifest_entries)
+    return {"ok": True, "migrated": len(items), "facts_created": 0, "staged": [e["path"] for e in manifest_entries]}
 
 
 def main() -> int:

--- a/tests/test_issue_1214_loose_lesson_staging.py
+++ b/tests/test_issue_1214_loose_lesson_staging.py
@@ -1,0 +1,79 @@
+"""#1214: loose lesson migration uses the durable #1209 staging path."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from nanobot.runtime.bridge import _pickup_staged_promotions
+from nanobot.runtime.demand import classify_change_tier
+from nanobot.runtime.knowledge_curator import load_staged_manifest, migrate_loose_lessons
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _repo_with_loose_notes(tmp_path: Path) -> tuple[Path, Path]:
+    origin = tmp_path / "origin.git"
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True)
+    _git(repo, "config", "user.email", "test@test")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "lessons").mkdir()
+    (repo / "memory").mkdir()
+    (repo / "memory" / "index.md").write_text("# Index\n", encoding="utf-8")
+    (repo / "lessons" / "lessons.yaml").write_text("lessons: []\n", encoding="utf-8")
+    (repo / "lessons" / "alpha.md").write_text("A durable insight\n", encoding="utf-8")
+    (repo / "lessons" / "beta.md").write_text("A durable insight\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "seed loose lessons")
+    _git(repo, "remote", "add", "origin", str(origin))
+    _git(repo, "push", "-u", "origin", "main")
+    return repo, origin
+
+
+def _cycle_start_reset(repo: Path) -> None:
+    _git(repo, "reset", "--hard")
+    _git(repo, "clean", "-fd")
+    _git(repo, "checkout", "main")
+
+
+def test_staged_loose_migration_survives_cycle_reset_and_is_idempotent(tmp_path: Path) -> None:
+    repo, _origin = _repo_with_loose_notes(tmp_path)
+    state = tmp_path / "state"
+
+    result = migrate_loose_lessons(repo, state)
+
+    assert result["ok"] is True
+    assert result["migrated"] == 2
+    assert result["facts_created"] == 1
+    manifest = load_staged_manifest(state)
+    assert len(manifest) == 3
+    assert sum(1 for entry in manifest if entry.get("kind") == "loose_lesson") == 2
+    assert sum(1 for entry in manifest if entry.get("kind") != "loose_lesson") == 1
+    assert _git(repo, "status", "--porcelain") == ""
+    assert (repo / "lessons" / "alpha.md").exists()
+
+    _cycle_start_reset(repo)
+    assert len(load_staged_manifest(state)) == 3
+    assert _pickup_staged_promotions(repo, state) == 3
+
+    assert _git(repo, "show", "origin/main:lessons/archive/loose/alpha.md") == "A durable insight"
+    assert _git(repo, "show", "origin/main:lessons/archive/loose/beta.md") == "A durable insight"
+    assert _git(repo, "show", "origin/main:memory/facts/alpha.md").startswith("# alpha")
+    assert load_staged_manifest(state) == []
+
+    second = migrate_loose_lessons(repo, state)
+    assert second == {"ok": True, "migrated": 0, "facts_created": 0, "staged": []}
+    assert load_staged_manifest(state) == []
+
+
+def test_loose_lesson_batch_is_doc_only_but_does_not_change_budget_classifier() -> None:
+    paths = [f"lessons/archive/loose/note-{index}.md" for index in range(37)]
+    assert classify_change_tier(paths) == "doc-only"

--- a/tests/test_issue_1214_loose_lesson_staging.py
+++ b/tests/test_issue_1214_loose_lesson_staging.py
@@ -77,3 +77,21 @@ def test_staged_loose_migration_survives_cycle_reset_and_is_idempotent(tmp_path:
 def test_loose_lesson_batch_is_doc_only_but_does_not_change_budget_classifier() -> None:
     paths = [f"lessons/archive/loose/note-{index}.md" for index in range(37)]
     assert classify_change_tier(paths) == "doc-only"
+
+
+def test_pickup_rejects_traversal_in_loose_lesson_manifest(tmp_path: Path) -> None:
+    repo, _origin = _repo_with_loose_notes(tmp_path)
+    state = tmp_path / "state"
+    staged = state / "curator" / "staged"
+    staged.mkdir(parents=True)
+    (staged / "payload.md").write_text("unsafe\n", encoding="utf-8")
+    (staged / "manifest.json").write_text(
+        '[{"path":"lessons/archive/loose/../escaped.md",'
+        '"source_path":"lessons/alpha.md","kind":"loose_lesson",'
+        '"action":"move","payload_file":"payload.md"}]',
+        encoding="utf-8",
+    )
+
+    assert _pickup_staged_promotions(repo, state) == 0
+    assert load_staged_manifest(state)[0]["path"].endswith("../escaped.md")
+    assert not (repo / "lessons" / "escaped.md").exists()

--- a/tests/test_knowledge_curator.py
+++ b/tests/test_knowledge_curator.py
@@ -214,7 +214,7 @@ def test_sanitary_migration_archives_loose_notes(tmp_path):
     result = migrate_loose_lessons(tmp_path, state)
     assert result["ok"] is True
     assert result["migrated"] == 2
-    assert result["facts_created"] == 0
+    assert result["facts_created"] == 1
     assert all((state / "curator/staged" / e["payload_file"]).exists() for e in load_staged_manifest(state))
     assert (tmp_path / "lessons/a.md").exists()
     assert not (tmp_path / "lessons/archive/loose").exists()

--- a/tests/test_knowledge_curator.py
+++ b/tests/test_knowledge_curator.py
@@ -210,11 +210,14 @@ def test_sanitary_migration_archives_loose_notes(tmp_path):
     (tmp_path / "lessons").mkdir()
     (tmp_path / "lessons/a.md").write_text("A durable insight", encoding="utf-8")
     (tmp_path / "lessons/b.md").write_text("A durable insight", encoding="utf-8")
-    result = migrate_loose_lessons(tmp_path)
-    assert result["facts_created"] == 1
-    assert not (tmp_path / "lessons/a.md").exists()
-    assert (tmp_path / "lessons/archive/loose/a.md").exists()
-    assert (tmp_path / "memory/facts/a.md").exists()
+    state = tmp_path / "state"
+    result = migrate_loose_lessons(tmp_path, state)
+    assert result["ok"] is True
+    assert result["migrated"] == 2
+    assert result["facts_created"] == 0
+    assert all((state / "curator/staged" / e["payload_file"]).exists() for e in load_staged_manifest(state))
+    assert (tmp_path / "lessons/a.md").exists()
+    assert not (tmp_path / "lessons/archive/loose").exists()
 
 
 def test_staging_is_idempotent(tmp_path):


### PR DESCRIPTION
## Summary

Route `migrate_loose_lessons` through the existing #1209 curator staging manifest and cycle-start pickup instead of writing directly into the shared checkout.

The migration preserves the legacy deterministic behavior:

- loose notes with identical normalized bodies produce one `memory/facts/<slug>.md` fact and one index entry;
- every source `lessons/*.md` note is staged as a move to `lessons/archive/loose/<name>.md`;
- the bridge applies the fact/index changes and source removals in one commit, pushes `origin/main`, and records promotion only after the push;
- staged data remains available across the cycle-start reset and a repeated migration after pickup is a no-op.

## Design

- Reuses the existing #1209 `_stage_promotions`, `manifest.json`, payload files, `_pickup_staged_promotions`, push, retention, and decision-record protocol.
- Adds only the manifest metadata needed for this migration: `kind: loose_lesson` and a validated `source_path`.
- The pickup accepts only exact one-level `.md` source/destination paths under `lessons/` and `lessons/archive/loose/`; traversal components are rejected.
- Curator-fact rescue (`rescue/curator-*`) is untouched and out of scope.

## Regression evidence

The new reset-survival/idempotency test was run against `origin/main` first and failed before the fix:

```text
FAILED tests/test_issue_1214_loose_lesson_staging.py::test_staged_loose_migration_survives_cycle_reset_and_is_idempotent
E       KeyError: 'ok'
```

The failure is expected: origin/main's `migrate_loose_lessons` returned the legacy result shape and directly wrote the checkout, so the staged migration contract was absent.

Final focused validation:

```text
25 passed  # staging, curator, and #1209 durability tests
3 passed   # #1214 migration tests, including traversal rejection
```

## Doc-only budget check

The migration's archive paths are under `lessons/`, so `classify_change_tier` continues to classify a batch of 37 such paths as `doc-only`. The classifier was not changed. The existing post-merge 24-hour budget guard therefore remains the governing behavior; no new cap or budget exception was added. The 37-file migration is intentionally not silently reclassified as code-bearing.

## Validation

- Full local pytest: `2900 passed, 18 failed, 17 skipped, 11 warnings` on Windows. The 18 failures are the established Windows baseline: temporary test repositories attempt to push a `master` ref without a commit, and Windows-specific `fcntl`/tag behavior differs. No failures are in the changed migration/staging tests.
- `git diff --check`: passed.
- Opus review: **OK**, including path traversal, reset survival, idempotency, source deletion, duplicate-body semantics, and scope.

## Live verification (operator-owned)

After deployment and a bridge cycle, verify against the remote repository, not the working tree:

1. `git show origin/main:lessons/archive/loose/<known-note>.md` succeeds.
2. `git ls-tree origin/main lessons/ | grep -c '\.md$'` decreases from the baseline 37.
3. Confirm the resulting pickup commit is on `origin/main`, and inspect `curator/decisions.jsonl` for `staged` followed by `promoted` only after the push.
4. Confirm no `rescue/curator-*` curator facts were included.

The working-tree presence of an archive file is not evidence; the remote `git show` is the pass condition.

Closes #1214
