### PR TITLE
fix(existence_index): a refused proposal's title is not evidence the thing exists (#1215)

### DIFF
--- a/nanobot/runtime/cycle_ledger.py
+++ b/nanobot/runtime/cycle_ledger.py
@@ -307,6 +307,46 @@ def read_events(state_dir: Path) -> list[dict]:
     return rows
 
 
+def successful_cycle_ids(state_dir: Path) -> set[str]:
+    """Return the ``cycle_id`` of every terminal row with ``outcome: success``,
+    read ACROSS the rotation: every ``cycles-YYYY-MM-DD.jsonl.gz`` archive
+    plus the active file. Best-effort — never raises; an unreadable archive
+    or malformed line is skipped (#1215).
+
+    Unlike :func:`read_events`, this answers a question that is NOT
+    same-day: "did the cycle behind this result artifact ever integrate?"
+    Result artifacts outlive the day they were written (they migrate to
+    ``subagents/archive/`` and stay readable for hundreds of cycles), so a
+    reader that opened only the active file would call every integrated
+    attempt older than today "never integrated" (#1178/#1207: rotation
+    narrows every reader that only opens the live file).
+    """
+    ids: set[str] = set()
+
+    def _collect(lines) -> None:
+        for line in lines:
+            with contextlib.suppress(Exception):
+                row = json.loads(line)
+                if (
+                    isinstance(row, dict)
+                    and row.get("phase") == "outcome"
+                    and row.get("outcome") == "success"
+                    and row.get("cycle_id")
+                ):
+                    ids.add(str(row["cycle_id"]))
+
+    ledger_dir = _ledger_dir(state_dir)
+    with contextlib.suppress(Exception):
+        for gz_path in sorted(ledger_dir.glob("cycles-*.jsonl.gz")):
+            with contextlib.suppress(Exception):
+                with gzip.open(gz_path, "rt", encoding="utf-8") as fh:
+                    _collect(fh)
+    with contextlib.suppress(Exception):
+        with open(ledger_dir / _LEDGER_FILENAME, encoding="utf-8") as fh:
+            _collect(fh)
+    return ids
+
+
 def record_explore_started(state_dir: Path, cycle_id: str, candidates_count: int, declared_measurement: str) -> None:
     append_event(state_dir, {
         'phase': 'explore_started',

--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -42,12 +42,19 @@ Indexed corpus (built by :func:`reindex`)
   into spaces, plus the first line of the module docstring (``ast``,
   best-effort; falls back to the first ``#`` comment line if the file
   doesn't parse). ``path`` = the path relative to ``selfevo_repo``.
-- **ledger_titles**: titles of past subagent attempts, read from
-  ``<state_dir>/subagents/results/*.json`` (bounded to the 500
-  most-recently-modified files — this is the durable, title-bearing record;
+- **ledger_titles**: titles of past subagent attempts that PRODUCED
+  something, read from ``<state_dir>/subagents/results/*.json`` plus the
+  ``result-*.json`` files of ``<state_dir>/subagents/archive/`` (results
+  migrate there within the hour, #1176; bounded to the 500 most-recently-
+  modified files across both — this is the durable, title-bearing record;
   ``cycles.jsonl`` itself never carries ``task_title``, only cycle/phase
-  bookkeeping, so the results directory is the actual source of past
-  proposal titles). ``path`` = the request id.
+  bookkeeping). ``path`` = the request id. Since #1215 a title is indexed
+  only when its attempt integrated (``rollback.integrated``, or the ledger's
+  ``outcome: success`` for results predating the rollback record) or its
+  ``target_path`` exists on ``origin/main`` — a refused proposal's title
+  asserts an attempt, not an artifact, and indexing it let the first refusal
+  of a subject suppress every later one. Documents that no longer qualify
+  are deactivated on reindex, like deleted scripts.
 - **hypotheses**: titles from ``<state_dir>/hypotheses/backlog.json``
   (``entries[].task_title``) and ``<state_dir>/research/hypotheses.json``
   (``[].candidates[].title``). Both optional; each fails open independently.
@@ -102,6 +109,7 @@ import json
 import os
 import re
 import sqlite3
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -342,20 +350,99 @@ def _reindex_scripts(con: sqlite3.Connection, selfevo_repo: Path) -> dict[str, i
     return counts
 
 
-def _reindex_ledger_titles(con: sqlite3.Connection, state_dir: Path) -> dict[str, int]:
-    counts = {"ledger_titles_indexed": 0, "ledger_titles_unchanged": 0}
-    results_dir = state_dir / "subagents" / "results"
-    if not results_dir.is_dir():
-        return counts
+def _origin_main_paths(selfevo_repo: Path) -> set[str] | None:
+    """Return every path in the tree of ``origin/main`` (``git ls-tree``), or
+    ``None`` when that cannot be determined (no git, no remote-tracking ref,
+    timeout). Callers fall back to the working tree on ``None``."""
     try:
-        entries = [p for p in results_dir.glob("*.json") if p.is_file()]
+        proc = subprocess.run(
+            [
+                "git", "-c", f"safe.directory={selfevo_repo}", "-C", str(selfevo_repo),
+                "ls-tree", "-r", "--name-only", "origin/main",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
     except Exception:
-        return counts
-    try:
-        entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    except Exception:
-        pass
-    for entry in entries[:_MAX_LEDGER_RESULTS]:
+        return None
+    if proc.returncode != 0:
+        return None
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def _result_entries(state_dir: Path) -> list[tuple[Path, float]]:
+    """Newest-first ``(path, mtime)`` of result artifacts across the live
+    ``subagents/results/`` and the flat ``subagents/archive/``, bounded to
+    :data:`_MAX_LEDGER_RESULTS` AFTER sorting (bounding an unsorted listing
+    would pick an arbitrary slice of the archive's thousands of files).
+
+    Results migrate out of ``results/`` within the hour (#1176), so the live
+    directory alone holds only the last few attempts; the archive keeps the
+    original filenames (``result-<id>.json`` next to ``request-<id>.json``),
+    so only ``result-`` files are taken from it.
+    """
+    subagents = state_dir / "subagents"
+    stamped: list[tuple[float, Path]] = []
+    for directory, prefix in ((subagents / "results", ""), (subagents / "archive", "result-")):
+        try:
+            if not directory.is_dir():
+                continue
+            with os.scandir(str(directory)) as it:
+                for entry in it:
+                    if not entry.name.endswith(".json"):
+                        continue
+                    if prefix and not entry.name.startswith(prefix):
+                        continue
+                    try:
+                        if entry.is_file():
+                            stamped.append((entry.stat().st_mtime, Path(entry.path)))
+                    except Exception:
+                        continue
+        except Exception:
+            continue
+    stamped.sort(key=lambda x: (x[0], x[1].name), reverse=True)
+    return [(path, mtime) for mtime, path in stamped[:_MAX_LEDGER_RESULTS]]
+
+
+def _reindex_ledger_titles(
+    con: sqlite3.Connection, state_dir: Path, selfevo_repo: Path | None = None,
+) -> dict[str, int]:
+    """Index the titles of past attempts that PRODUCED something (#1215).
+
+    A ``ledger_title`` document is evidence that an artifact exists only
+    when the attempt behind it integrated — its result carries
+    ``rollback.integrated: true`` (written in the same step as the ledger's
+    ``outcome: success`` row; the ledger is consulted for results that
+    predate the rollback record) — or when the attempt's own ``target_path``
+    now exists on ``origin/main`` (it arrived some other way; the artifact is
+    real regardless of who shipped it). A refused/blocked/no-commit attempt
+    asserts only that an attempt happened; indexing its title let the first
+    refusal of a subject seed every later one (live: 75 of 83 ``ledger_title``
+    suppressions matched an attempt that produced nothing, and
+    ``tests/test_verify_and_proof.py`` was refused 4 times as a duplicate of
+    a file never created).
+
+    Retirement: every active ``ledger_title`` document whose attempt is not
+    re-verified as evidence in this pass is deactivated (same
+    :func:`_deactivate_missing` mechanism the ``script`` corpus uses for
+    deleted files). That heals an already-poisoned index on the first
+    reindex after deploy, and treats an attempt that can no longer be found
+    in ``results/``/``archive/`` as unknown rather than as proof — an
+    integrated artifact stays covered by the ``script`` corpus, since the
+    file exists. A document is reactivated if its attempt later integrates.
+    """
+    counts = {
+        "ledger_titles_indexed": 0,
+        "ledger_titles_unchanged": 0,
+        "ledger_titles_not_integrated": 0,
+        "ledger_titles_deactivated": 0,
+    }
+    seen_ids: set[str] = set()
+    evidence_ids: set[str] = set()
+    success_cycles: set[str] | None = None  # lazy: only for rollback-less results
+    main_paths: set[str] | None = None  # lazy: only for a non-integrated attempt with a target
+    main_paths_resolved = False
+
+    for entry, _mtime in _result_entries(state_dir):
         try:
             data = json.loads(entry.read_text(encoding="utf-8"))
         except Exception:
@@ -366,6 +453,42 @@ def _reindex_ledger_titles(con: sqlite3.Connection, state_dir: Path) -> dict[str
         if not title:
             continue
         request_id = str(data.get("request_id") or entry.stem)
+        if request_id in seen_ids:
+            continue  # newest copy wins (results/ and archive/ may both hold it)
+        seen_ids.add(request_id)
+
+        rollback = data.get("rollback")
+        if isinstance(rollback, dict) and "integrated" in rollback:
+            integrated = bool(rollback.get("integrated"))
+        else:
+            if success_cycles is None:
+                try:
+                    from nanobot.runtime.cycle_ledger import successful_cycle_ids
+                    success_cycles = successful_cycle_ids(state_dir)
+                except Exception:
+                    success_cycles = set()
+            cycle_id = str(data.get("cycle_id") or "")
+            integrated = bool(cycle_id) and cycle_id in (success_cycles or set())
+
+        is_evidence = integrated
+        if not is_evidence and selfevo_repo is not None:
+            target = str(data.get("target_path") or "").strip().replace("\\", "/")
+            if target:
+                if not main_paths_resolved:
+                    main_paths = _origin_main_paths(selfevo_repo)
+                    main_paths_resolved = True
+                if main_paths is not None:
+                    is_evidence = target in main_paths
+                else:
+                    try:
+                        is_evidence = (selfevo_repo / target).is_file()
+                    except Exception:
+                        is_evidence = False
+
+        if not is_evidence:
+            counts["ledger_titles_not_integrated"] += 1
+            continue
+        evidence_ids.add(request_id)
         try:
             changed = _upsert_document(con, "ledger_title", request_id, title)
         except Exception:
@@ -374,6 +497,10 @@ def _reindex_ledger_titles(con: sqlite3.Connection, state_dir: Path) -> dict[str
             counts["ledger_titles_indexed"] += 1
         else:
             counts["ledger_titles_unchanged"] += 1
+    try:
+        counts["ledger_titles_deactivated"] = _deactivate_missing(con, "ledger_title", evidence_ids)
+    except Exception:
+        pass
     return counts
 
 
@@ -440,7 +567,8 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
     Returns a counts dict (all keys always present, 0 if nothing to do) for
     logging: ``scripts_indexed``, ``scripts_unchanged``,
     ``scripts_deactivated``, ``ledger_titles_indexed``,
-    ``ledger_titles_unchanged``, ``hypotheses_indexed``,
+    ``ledger_titles_unchanged``, ``ledger_titles_not_integrated``,
+    ``ledger_titles_deactivated`` (#1215), ``hypotheses_indexed``,
     ``hypotheses_unchanged``. On any unexpected failure, returns a dict with
     an ``"error"`` key instead of raising — callers must fail open.
     """
@@ -452,6 +580,8 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
         "scripts_deactivated": 0,
         "ledger_titles_indexed": 0,
         "ledger_titles_unchanged": 0,
+        "ledger_titles_not_integrated": 0,
+        "ledger_titles_deactivated": 0,
         "hypotheses_indexed": 0,
         "hypotheses_unchanged": 0,
     }
@@ -465,7 +595,7 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
         except Exception:
             pass
         try:
-            counts.update(_reindex_ledger_titles(con, state_dir))
+            counts.update(_reindex_ledger_titles(con, state_dir, selfevo_repo))
         except Exception:
             pass
         try:

--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -357,7 +357,7 @@ def _origin_main_paths(selfevo_repo: Path) -> set[str] | None:
     try:
         proc = subprocess.run(
             [
-                "git", "-c", f"safe.directory={selfevo_repo}", "-C", str(selfevo_repo),
+                "git", "-c", f"safe.directory={Path(selfevo_repo).as_posix()}", "-C", str(selfevo_repo),
                 "ls-tree", "-r", "--name-only", "origin/main",
             ],
             capture_output=True, text=True, timeout=15,
@@ -436,8 +436,8 @@ def _reindex_ledger_titles(
         "ledger_titles_not_integrated": 0,
         "ledger_titles_deactivated": 0,
     }
-    seen_ids: set[str] = set()
-    evidence_ids: set[str] = set()
+    seen_ids: set[str] = set()  # dedupe: every request_id classified this pass
+    evidence_ids: set[str] = set()  # subset that qualified; everything else is retired below
     success_cycles: set[str] | None = None  # lazy: only for rollback-less results
     main_paths: set[str] | None = None  # lazy: only for a non-integrated attempt with a target
     main_paths_resolved = False

--- a/tests/test_existence_index.py
+++ b/tests/test_existence_index.py
@@ -302,8 +302,13 @@ class TestTestsForXCarveOut:
         state_dir, repo = self._seeded_repo(tmp_path)
         results_dir = state_dir / "subagents" / "results"
         results_dir.mkdir(parents=True)
+        # #1215: the prior attempt must have INTEGRATED for its title to
+        # count as existence evidence — a refused title is not evidence.
         (results_dir / "req-prior.json").write_text(
-            json.dumps({"request_id": "req-prior", "backlog_title": self._TITLE}),
+            json.dumps({
+                "request_id": "req-prior", "backlog_title": self._TITLE,
+                "rollback": {"integrated": True},
+            }),
             encoding="utf-8",
         )
         ei.reindex(state_dir, repo)
@@ -327,7 +332,10 @@ class TestTestsForXCarveOut:
         results_dir = state_dir / "subagents" / "results"
         results_dir.mkdir(parents=True)
         (results_dir / "req-prior.json").write_text(
-            json.dumps({"request_id": "req-prior", "backlog_title": self._TITLE}),
+            json.dumps({
+                "request_id": "req-prior", "backlog_title": self._TITLE,
+                "rollback": {"integrated": True},
+            }),
             encoding="utf-8",
         )
         ei.reindex(state_dir, repo)
@@ -382,7 +390,10 @@ class TestOtherCorpora:
         results_dir = state_dir / "subagents" / "results"
         results_dir.mkdir(parents=True)
         (results_dir / "req-1.json").write_text(
-            json.dumps({"request_id": "req-1", "backlog_title": "add a memory tracker script"}),
+            json.dumps({
+                "request_id": "req-1", "backlog_title": "add a memory tracker script",
+                "rollback": {"integrated": True},
+            }),
             encoding="utf-8",
         )
 
@@ -514,6 +525,309 @@ class TestKillSwitchAndFailOpen:
         repo = tmp_path / "repo"
         repo.mkdir()
         assert ei.find_duplicate_script(state_dir, repo, "", None) is None
+
+
+# ─── bridge integration ─────────────────────────────────────────────────────
+
+
+# ─── #1215: a refused proposal's title is not evidence the thing exists ─────
+
+
+def _write_result(directory: Path, request_id: str, **fields) -> Path:
+    """Write a bridge-shaped result artifact (see
+    ``bridge._write_bridge_completed_result``) under ``directory``."""
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = {"schema_version": "subagent-result-v1", "request_id": request_id}
+    payload.update(fields)
+    path = directory / f"result-{request_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class TestRefusedTitleIsNotExistence:
+    """#1215 live evidence: ``tests/test_verify_and_proof.py`` was never
+    created and never touched by any commit on origin/main, yet the proposal
+    to create it was refused 4 times since 2026-08-16 as a duplicate — of the
+    ``ledger_title`` document minted from its own earlier refusal. A
+    ``ledger_title`` document asserts that an *attempt happened*, not that an
+    *artifact exists*; only an attempt that integrated (or whose target now
+    exists) may suppress a repeat."""
+
+    _TITLE = "Create unit tests for verify_and_proof script"
+    _TARGET = "tests/test_verify_and_proof.py"
+    _REFUSED = {
+        "integrated": False,
+        "reason": "existence_index_duplicate",
+        "main_sha_before": "abc", "main_sha_after": "abc",
+    }
+
+    def _repo(self, tmp_path) -> tuple[Path, Path]:
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        # The subject script exists (the tests would be FOR it); the test
+        # file itself — the proposal's target — is absent.
+        _write_script(repo, "scripts/verify_and_proof.py", "verify cycle claims and record proof.")
+        return state_dir, repo
+
+    def _refused_attempt(self, state_dir: Path, request_id: str = "req-refused", **extra) -> Path:
+        return _write_result(
+            state_dir / "subagents" / "results", request_id,
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            result_status="blocked", status="blocked",
+            cycle_id=f"cycle-{request_id}",
+            rollback=dict(self._REFUSED), **extra,
+        )
+
+    def _active(self, state_dir: Path, request_id: str) -> int | None:
+        con = sqlite3.connect(str(ei._index_path(state_dir)))
+        try:
+            row = con.execute(
+                "SELECT active FROM documents WHERE kind = 'ledger_title' AND path = ?",
+                (request_id,),
+            ).fetchone()
+        finally:
+            con.close()
+        return None if row is None else row[0]
+
+    # ── the failing fixture named in the issue ──────────────────────────────
+
+    def test_refused_attempt_title_does_not_suppress_repeat(self, tmp_path):
+        state_dir, repo = self._repo(tmp_path)
+        self._refused_attempt(state_dir)
+        assert not (repo / self._TARGET).exists()
+
+        ei.reindex(state_dir, repo)
+        matched = ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET)
+
+        assert matched is None, (
+            f"refused attempt {matched!r} was treated as proof the target exists"
+        )
+        # The refused title is not in the active corpus at all.
+        assert self._active(state_dir, "req-refused") in (None, 0)
+
+    def test_refused_attempt_is_not_indexed_and_is_counted(self, tmp_path):
+        state_dir, repo = self._repo(tmp_path)
+        self._refused_attempt(state_dir)
+
+        counts = ei.reindex(state_dir, repo)
+
+        assert counts["ledger_titles_indexed"] == 0
+        assert counts["ledger_titles_not_integrated"] == 1
+        hits = ei.find_similar(state_dir, self._TITLE, target_path=self._TARGET)
+        assert not any(h["kind"] == "ledger_title" for h in hits)
+
+    # ── the rule is FOR this case: an integrated attempt still suppresses ──
+
+    def test_integrated_attempt_still_suppresses_repeat(self, tmp_path):
+        state_dir, repo = self._repo(tmp_path)
+        _write_result(
+            state_dir / "subagents" / "results", "req-shipped",
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            result_status="completed", status="completed", commits_pushed=1,
+            files_changed=[self._TARGET], cycle_id="cycle-shipped",
+            rollback={"integrated": True, "reason": None},
+        )
+
+        ei.reindex(state_dir, repo)
+        matched = ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET)
+
+        assert matched == "req-shipped"
+        assert self._active(state_dir, "req-shipped") == 1
+
+    def test_refused_attempt_whose_target_now_exists_still_suppresses(self, tmp_path):
+        """Rule 1b: the target arrived (e.g. as a side file of another cycle)
+        — the artifact exists, so the title IS evidence even though that
+        particular attempt was refused."""
+        state_dir, repo = self._repo(tmp_path)
+        self._refused_attempt(state_dir)
+        _write_script(repo, self._TARGET, "tests for verify and proof.")
+
+        ei.reindex(state_dir, repo)
+        matched = ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET)
+
+        # The same-path tests/ script hit is deliberately never suspect
+        # (that is _task_already_done_for_path's job), so the suppression
+        # here comes from the ledger_title document — kept because the
+        # target exists.
+        assert matched == "req-refused"
+
+    # ── ledger fallback for results without a rollback record ──────────────
+
+    def test_result_without_rollback_uses_ledger_outcome_success(self, tmp_path):
+        from nanobot.runtime import cycle_ledger
+
+        state_dir, repo = self._repo(tmp_path)
+        _write_result(
+            state_dir / "subagents" / "results", "req-legacy",
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            cycle_id="cycle-legacy",
+        )
+        cycle_ledger.record_cycle_outcome(
+            state_dir, "cycle-legacy", "success", None, [self._TARGET], "cycle/legacy",
+        )
+
+        ei.reindex(state_dir, repo)
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) == "req-legacy"
+
+    def test_result_without_rollback_and_non_success_ledger_row_is_not_evidence(self, tmp_path):
+        from nanobot.runtime import cycle_ledger
+
+        state_dir, repo = self._repo(tmp_path)
+        _write_result(
+            state_dir / "subagents" / "results", "req-legacy",
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            cycle_id="cycle-legacy",
+        )
+        cycle_ledger.record_cycle_outcome(
+            state_dir, "cycle-legacy", "skipped-duplicate", "existence_index_duplicate", [], None,
+        )
+
+        ei.reindex(state_dir, repo)
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) is None
+
+    def test_ledger_success_in_rotated_archive_is_read(self, tmp_path):
+        """The ledger rotates daily into ``cycles-YYYY-MM-DD.jsonl.gz``; an
+        integrated attempt from before today must still count (#1178/#1207:
+        rotation narrows every reader that only opens the active file)."""
+        import gzip
+
+        state_dir, repo = self._repo(tmp_path)
+        _write_result(
+            state_dir / "subagents" / "results", "req-old",
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            cycle_id="cycle-old",
+        )
+        ledger_dir = state_dir / "ledger"
+        ledger_dir.mkdir(parents=True)
+        row = {"phase": "outcome", "cycle_id": "cycle-old", "outcome": "success"}
+        with gzip.open(ledger_dir / "cycles-2026-08-20.jsonl.gz", "wt", encoding="utf-8") as fh:
+            fh.write(json.dumps(row) + "\n")
+
+        ei.reindex(state_dir, repo)
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) == "req-old"
+
+    # ── retirement: the host's already-poisoned index heals on first reindex
+
+    def test_preexisting_refused_title_document_is_retired(self, tmp_path):
+        """The live index already holds ``ledger_title`` documents minted from
+        refused attempts under the old rule. The first reindex after deploy
+        must deactivate them — the result JSON says the attempt never
+        integrated."""
+        state_dir, repo = self._repo(tmp_path)
+        self._refused_attempt(state_dir)
+        con = ei._open_db(state_dir)
+        try:
+            ei._upsert_document(con, "ledger_title", "req-refused", self._TITLE)
+            con.commit()
+        finally:
+            con.close()
+        assert self._active(state_dir, "req-refused") == 1
+
+        counts = ei.reindex(state_dir, repo)
+
+        assert counts["ledger_titles_deactivated"] == 1
+        assert self._active(state_dir, "req-refused") == 0
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) is None
+
+    def test_title_document_with_no_surviving_result_is_retired(self, tmp_path):
+        """Results migrate to ``subagents/archive/`` and the archive is
+        bounded — a document whose attempt can no longer be re-verified as
+        integrated is not evidence of existence either. (An integrated
+        artifact stays covered by the ``script`` corpus: the file exists.)"""
+        state_dir, repo = self._repo(tmp_path)
+        con = ei._open_db(state_dir)
+        try:
+            ei._upsert_document(con, "ledger_title", "req-vanished", self._TITLE)
+            con.commit()
+        finally:
+            con.close()
+
+        counts = ei.reindex(state_dir, repo)
+
+        assert counts["ledger_titles_deactivated"] == 1
+        assert self._active(state_dir, "req-vanished") == 0
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) is None
+
+    def test_retired_document_is_reactivated_if_the_attempt_later_integrates(self, tmp_path):
+        state_dir, repo = self._repo(tmp_path)
+        path = self._refused_attempt(state_dir)
+        ei.reindex(state_dir, repo)
+        assert self._active(state_dir, "req-refused") in (None, 0)
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["rollback"] = {"integrated": True, "reason": None}
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+        ei.reindex(state_dir, repo)
+        assert self._active(state_dir, "req-refused") == 1
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) == "req-refused"
+
+    # ── archive: results migrate out of results/ within the hour (#1176) ───
+
+    def test_integrated_result_in_archive_still_suppresses(self, tmp_path):
+        state_dir, repo = self._repo(tmp_path)
+        _write_result(
+            state_dir / "subagents" / "archive", "req-archived",
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            rollback={"integrated": True},
+        )
+        # A request artifact in the same flat archive dir is not a result.
+        (state_dir / "subagents" / "archive" / "request-req-archived.json").write_text(
+            json.dumps({"request_id": "req-archived", "task_title": self._TITLE}),
+            encoding="utf-8",
+        )
+
+        counts = ei.reindex(state_dir, repo)
+
+        assert counts["ledger_titles_indexed"] == 1
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) == "req-archived"
+
+    def test_same_request_in_results_and_archive_is_classified_once(self, tmp_path):
+        state_dir, repo = self._repo(tmp_path)
+        self._refused_attempt(state_dir)
+        _write_result(
+            state_dir / "subagents" / "archive", "req-refused",
+            backlog_title=self._TITLE, target_path=self._TARGET,
+            rollback=dict(self._REFUSED),
+        )
+
+        counts = ei.reindex(state_dir, repo)
+
+        assert counts["ledger_titles_not_integrated"] == 1
+        assert ei.find_duplicate_script(state_dir, repo, self._TITLE, self._TARGET) is None
+
+    # ── the other direction: the script-match half is untouched ────────────
+
+    def test_existing_script_still_refused_with_refused_title_present(self, tmp_path):
+        """Non-goal guard: a proposal duplicating an EXISTING test file is
+        still refused via the ``script`` corpus, whether or not a refused
+        ``ledger_title`` for the same subject sits alongside."""
+        state_dir, repo = self._repo(tmp_path)
+        # A refused attempt for an UNRELATED subject sits in the corpus too.
+        self._refused_attempt(state_dir)
+        _write_script(repo, "tests/test_lessons_integrity.py", "tests for lessons integrity checks.")
+        ei.reindex(state_dir, repo)
+
+        title = "Create test suite for lessons integrity script"
+        target = "tests/test_lessons_integrity_suite.py"
+        hits = ei.find_similar(state_dir, title, target_path=target)
+        assert any(
+            h["kind"] == "script" and h["path"] == "tests/test_lessons_integrity.py"
+            and h["duplicate_suspect"] for h in hits
+        )
+        assert ei.find_duplicate_script(state_dir, repo, title, target) == "tests/test_lessons_integrity.py"
+
+    def test_existing_ordinary_script_still_refused(self, tmp_path):
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        _write_script(repo, "scripts/track_memory.py", "track memory usage over time.")
+        self._refused_attempt(state_dir)
+        ei.reindex(state_dir, repo)
+
+        matched = ei.find_duplicate_script(
+            state_dir, repo, "Create a script to monitor RAM and memory usage",
+        )
+        assert matched == "scripts/track_memory.py"
 
 
 # ─── bridge integration ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1215.

## Defect

`existence_index` minted a `ledger_title` document from every `subagents/results/*.json` title with no outcome filter and never deactivated one. A `ledger_title` asserts that an *attempt happened*, not that an *artifact exists*, so a proposal was refused as a duplicate of an earlier proposal that was itself refused. Live: 75 of 83 `ledger_title` suppressions matched an attempt that produced nothing; `tests/test_verify_and_proof.py` is absent on `origin/main`, touched by zero commits, and was refused 4 times since 2026-08-16 as a duplicate of it.

## Fix (existence_index.py, `_reindex_ledger_titles`)

- A `ledger_title` is indexed **only** when the attempt behind it is evidence of an artifact:
  - its result carries `rollback.integrated: true` (written in the same bridge step as the ledger's `outcome: success` row), **or**
  - the result predates the rollback record and the ledger has `outcome: success` for its `cycle_id` — new `cycle_ledger.successful_cycle_ids()`, read across every `cycles-*.jsonl.gz` archive plus the active file (rotation would otherwise narrow this reader to today), **or**
  - the attempt's own `target_path` exists on `origin/main` (`git ls-tree -r --name-only origin/main`, one lazy subprocess per reindex and only when a non-integrated attempt names a target; falls back to the working tree when git is unavailable, e.g. the test tmp dirs).
- **Retirement — yes, done.** Every active `ledger_title` not re-verified as evidence in the pass is deactivated via the existing `_deactivate_missing` mechanism the `script` corpus uses for deleted files. Why: the live index already holds the poisoned documents and their result JSONs have migrated out of `results/`; without retirement the fix would apply to new refusals only and the 83 existing seeds would keep refusing. An attempt that can no longer be found in `results/` or `archive/` is treated as unknown, not as proof — an integrated artifact stays covered by the `script` corpus because the file exists. A retired document is reactivated if its attempt later integrates (tested).
- Results are read from `results/` **and** `archive/result-*.json`, newest-first, under the **existing** `_MAX_LEDGER_RESULTS` bound (no new cap). Results migrate to `archive/` within the hour (#1176), so the live dir alone no longer holds the history the retirement rule needs to classify. Same `request_id` in both dirs is classified once (newest copy wins). `request-*.json` files in the flat archive are skipped.
- New reindex counts: `ledger_titles_not_integrated`, `ledger_titles_deactivated`.

## Untouched (non-goals)

`find_similar`, `find_duplicate_script`, the script-match half, `_recent_failure_match`, the #1211 cooldown, `bridge.py`. `git diff origin/main...HEAD` touches three files: `existence_index.py`, `cycle_ledger.py`, `tests/test_existence_index.py`.

## Failing fixture (pre-change, quoted)

`TestRefusedTitleIsNotExistence::test_refused_attempt_title_does_not_suppress_repeat` — a `ledger_title` for a refused attempt at `tests/test_verify_and_proof.py` (`result_status: blocked`, `rollback.integrated: false`, `reason: existence_index_duplicate`), target absent, new proposal for the same subject:

```
>       assert matched is None, (
            f"refused attempt {matched!r} was treated as proof the target exists"
        )
E       AssertionError: refused attempt 'req-refused' was treated as proof the target exists
E       assert 'req-refused' is None

tests\test_existence_index.py:602: AssertionError
9 failed, 5 passed, 36 deselected in 2.77s
```

The 5 that passed pre-change are the other-direction guards (integrated still suppresses, existing script still refused).

## Both directions tested

| direction | test |
|---|---|
| refused title, target absent → **not** suppressed | `test_refused_attempt_title_does_not_suppress_repeat`, `test_refused_attempt_is_not_indexed_and_is_counted` |
| integrated attempt → **still** suppressed | `test_integrated_attempt_still_suppresses_repeat` |
| refused title but target now exists → still suppressed | `test_refused_attempt_whose_target_now_exists_still_suppresses` |
| rollback-less result + ledger success / non-success | `test_result_without_rollback_uses_ledger_outcome_success`, `test_result_without_rollback_and_non_success_ledger_row_is_not_evidence` |
| ledger success only in a rotated `.gz` | `test_ledger_success_in_rotated_archive_is_read` |
| pre-existing poisoned document retired on first reindex | `test_preexisting_refused_title_document_is_retired`, `test_title_document_with_no_surviving_result_is_retired`, `test_retired_document_is_reactivated_if_the_attempt_later_integrates` |
| archive read; request files ignored; dedupe by request_id | `test_integrated_result_in_archive_still_suppresses`, `test_same_request_in_results_and_archive_is_classified_once` |
| script-match half unchanged | `test_existing_script_still_refused_with_refused_title_present`, `test_existing_ordinary_script_still_refused` (+ the existing #757/#798 tests) |

Three existing fixtures that seeded a bare `{"request_id","backlog_title"}` result now mark the attempt `rollback.integrated: true` — they assert that a prior title suppresses, which under the new rule requires the attempt to have integrated.

## Full pytest (Windows, `-n auto`)

| | failed | passed |
|---|---|---|
| origin/main `ee8925a4` | 18 | 2897 |
| this branch | 18 | 2911 |

Identical failing set (autoevolve symlink/tar, bridge flock, `master` refspec — Windows environment classes). +14 = the new tests.

## Live verification (yours, post-deploy)

First reindex after deploy should log a non-zero `ledger_titles_deactivated`. Then: one of the stuck targets (`test_verify_and_proof`, `test_summarize_failure_reasons`, `test_prevent_repeat_failures`, `test_analyze_repeat_failures`) reaches a non-suppressed outcome, or `existence_index_duplicate` for test-for proposals drops from ~4/day over the 14-day window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
