### PR TITLE
feat(curator): reflector recommendations earn a card on recurrence, not on sight (#1171)

### DIFF
--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -52,7 +52,9 @@ from nanobot.runtime.lesson_v2 import (
     fill_related_links,
     find_duplicate,
     inline_related_slugs,
+    keyword_set,
     related_hint,
+    set_jaccard,
     validate_lesson_for_mint,
 )
 from nanobot.runtime.model_registry import resolve_model
@@ -336,21 +338,6 @@ def _reflection_lines(live: Path):
                 yield from fh
         except OSError:
             continue
-
-
-def _reflection_tail_lines(live: Path, max_lines: int) -> list[str]:
-    """The last ``max_lines`` journal lines across the newest archive and the
-    live file — a freshly rotated live journal is nearly empty (#1178)."""
-    lines = _bounded_tail_lines(live, max_lines)
-    if len(lines) < max_lines:
-        for archive in reversed(_reflection_archives(live, newest=1)):
-            try:
-                with gzip.open(archive, "rt", encoding="utf-8") as fh:
-                    older = fh.read().splitlines()
-            except OSError:
-                continue
-            lines = older[-(max_lines - len(lines)):] + lines if older else lines
-    return lines
 
 
 def _bounded_tail_lines(path: Path, max_lines: int) -> list[str]:
@@ -977,14 +964,174 @@ def _collect_stage_items(
 # Newest reflector rows considered for promotion. The tail read that finds
 # them is bounded by _MAX_LEDGER_TAIL_BYTES, which is a window into the end of
 # the file, not a limit on how large the log may grow (#1183).
-_REFLECTOR_TAIL_ROWS = 50
 _REFLECTOR_MAX_AGE_SECONDS = 90 * 86400
+
+# ─── #1171: recurrence earns a card ──────────────────────────────────────────
+#
+# The reflector journal receives ~120 rows/day carrying ~70 promotable
+# `approach_hint` items (live store 2026-08-27..09-02: 502 items in 738 rows).
+# Almost all are task-specific one-offs — 448 of the 502 are lexical
+# singletons at the threshold below — and those already reach the proposer
+# through `build_reflection_hints`. The ~21 that recur across independent
+# cycles are the general lessons ("configure a LiteLLM fallback for the model
+# group", "commit early in the turn budget", "emit the skipped verdict as soon
+# as inspection shows the feature exists"). So a recommendation earns a card
+# on RECURRENCE, folds into an existing card when one already says the same
+# thing, and otherwise waits in a bounded pool. Minting everything would copy
+# the journal into the lesson base at ~70 cards/day, unread past the
+# proposer's 200-card scan.
+#
+# _REFLECTOR_FOLD_THRESHOLD was calibrated on ONE week of ONE loop's output
+# (the store above, 2026-09-03): every cluster at 0.35 was a coherent theme
+# when read by eye; 0.30 gave 34 clusters, 0.40 gave 15, still coherent. It
+# is a dial nobody can see the shoulder of unless the near-miss band below it
+# is counted, so each run records how many items landed in
+# [_REFLECTOR_NEAR_MISS_FLOOR, _REFLECTOR_FOLD_THRESHOLD) against their best
+# match. Same-day-only recurrences (an incident echo — seven cycles failing
+# the same way one afternoon is one event, not a lesson learned twice) are
+# not minted while _REFLECTOR_MIN_DAYS is 2 and are counted separately.
+_REFLECTOR_FOLD_THRESHOLD = 0.35
+_REFLECTOR_NEAR_MISS_FLOOR = 0.25
+_REFLECTOR_MIN_CYCLES = 2
+_REFLECTOR_MIN_DAYS = 2
+_REFLECTOR_MAX_ROWS_PER_RUN = 600  # ≈5 days of journal; the 738-row backlog clears in two nightly runs
+_REFLECTOR_POOL_MAX = 400
+_REFLECTOR_POOL_MAX_AGE_DAYS = 14  # every recurrence in the calibration store spanned ≤ 4 days
+_REFLECTOR_POOL_SLUG = "reflector_pool.json"
+_REFLECTOR_POOL_SCHEMA = "curator-reflector-pool-v1"
+_REFLECTOR_CARD_EVIDENCE_CAP = 8
+_REFLECTOR_KINDS = frozenset({"error_pattern", "approach_hint"})
+
+
+def _reflector_pool_path(state_dir: Path) -> Path:
+    return Path(state_dir) / "curator" / _REFLECTOR_POOL_SLUG
+
+
+def load_reflector_pool(state_dir: Path) -> dict[str, Any]:
+    """The mint's sidecar: cursor, waiting clusters, last-run counts. Missing
+    or corrupt → a fresh pool (the cursor restarts from the oldest readable
+    row, which is idempotent: folds by id, pool cycles are a set)."""
+    raw = _safe_json(_reflector_pool_path(state_dir), None)
+    if not isinstance(raw, dict) or raw.get("schema") != _REFLECTOR_POOL_SCHEMA:
+        return {"schema": _REFLECTOR_POOL_SCHEMA, "cursor": "", "clusters": [], "last_run": {}, "last_staged_at": ""}
+    raw.setdefault("cursor", "")
+    raw["clusters"] = [c for c in (raw.get("clusters") or []) if isinstance(c, dict) and c.get("detail")]
+    raw.setdefault("last_run", {})
+    raw.setdefault("last_staged_at", "")
+    return raw
+
+
+def _reflector_rows_after(path: Path, cursor: str, limit: int) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Rows across the newest archives and the live journal whose ``timestamp``
+    is after ``cursor``, oldest first, at most ``limit`` (#1171 cursor). Rows
+    without a timestamp are always new — the cursor cannot place them."""
+    counts = {"rows_read": 0, "rows_after_cursor": 0, "unparseable": 0}
+    rows: list[dict[str, Any]] = []
+    for line in _reflection_lines(path):
+        if not line.strip():
+            continue
+        counts["rows_read"] += 1
+        try:
+            row = json.loads(line)
+        except ValueError:
+            counts["unparseable"] += 1
+            continue
+        if not isinstance(row, dict):
+            continue
+        ts = str(row.get("timestamp") or "")
+        if ts and cursor and ts <= cursor:
+            continue
+        counts["rows_after_cursor"] += 1
+        if len(rows) < limit:
+            rows.append(row)
+    return rows, counts
+
+
+def _reflector_card(
+    *, card_id: str, detail: str, problem: str, cycles: list[str], days: list[str],
+    first_seen: str, last_seen: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 2, "id": card_id,
+        "title": detail[:200],
+        # problem = what was observed (the item's `evidence`), solution = the
+        # recommendation. The pre-#1171 mint put the cycle NARRATIVE here
+        # ("Added a doctest suite to tests/…"), and `find_duplicate` compares
+        # `problem`, so two recommendations from one cycle folded into each
+        # other and the second one's solution was discarded (179 of 502 items
+        # in the live store were such same-row siblings).
+        "problem": problem[:400],
+        "solution": detail[:500],
+        "tags": ["reflector"], "severity": "medium",
+        "seen_count": max(1, len(cycles)),
+        "first_seen": first_seen, "last_seen": last_seen,
+        "evidence": list(cycles[:_REFLECTOR_CARD_EVIDENCE_CAP]),
+        # How many calendar days the recurrence spans — 1 means an incident
+        # echo (#1171); recorded so raising _REFLECTOR_MIN_DAYS/_MIN_CYCLES
+        # later is a decision on data.
+        "distinct_days": max(1, len(days)),
+    }
+
+
+def _new_card_id(existing_ids: set[str], first_cycle: str, detail: str) -> str:
+    import hashlib
+
+    base_id = f"LESS-REF-{(first_cycle or 'unknown')[-12:]}"
+    digest = hashlib.sha1(detail.encode("utf-8")).hexdigest()[:4]
+    card_id = f"{base_id}-{digest}"
+    idx = 0
+    while card_id in existing_ids:  # #1138: never reuse an id already in the store
+        card_id = f"{base_id}-{digest}{idx}"
+        idx += 1
+    return card_id
+
+
+def _prune_pool(clusters: list[dict[str, Any]], newest_ts: str) -> int:
+    """Drop clusters idle past _REFLECTOR_POOL_MAX_AGE_DAYS, then the oldest
+    beyond _REFLECTOR_POOL_MAX. Returns the number evicted."""
+    before = len(clusters)
+    cutoff = ""
+    try:
+        ref = datetime.fromisoformat(newest_ts.replace("Z", "+00:00")) if newest_ts else datetime.now(timezone.utc)
+        cutoff = (ref.timestamp() - _REFLECTOR_POOL_MAX_AGE_DAYS * 86400)
+        clusters[:] = [
+            c for c in clusters
+            if not c.get("last_seen")
+            or datetime.fromisoformat(str(c["last_seen"]).replace("Z", "+00:00")).timestamp() >= cutoff
+        ]
+    except (ValueError, TypeError):
+        pass
+    if len(clusters) > _REFLECTOR_POOL_MAX:
+        clusters.sort(key=lambda c: str(c.get("last_seen") or ""), reverse=True)
+        del clusters[_REFLECTOR_POOL_MAX:]
+    return before - len(clusters)
 
 
 def promote_reflector_recommendations_to_v2(
-    workspace: Path, state_dir: Path, *, max_items: int = 2,
+    workspace: Path, state_dir: Path, *, max_items: int = 5,
 ) -> int:
-    """Promote bounded reflector error/approach deltas into v2 lessons."""
+    """Stage v2 lesson cards from reflector recommendations that RECUR (#1171).
+
+    For every promotable item (``kind`` in :data:`_REFLECTOR_KINDS`, non-empty
+    ``detail``) after the sidecar cursor:
+
+    1. **Fold** into an existing v2 card whose solution says the same thing
+       (keyword Jaccard ≥ :data:`_REFLECTOR_FOLD_THRESHOLD`) or whose problem
+       matches (:func:`find_duplicate`): ``seen_count``/``last_seen``/evidence
+       advance, a filler solution is upgraded (#1106), a narrative ``problem``
+       written by the pre-#1171 mint is repaired when the item is the card's
+       own origin. Folds never grow the base and are not capped.
+    2. Else **pool**: join the cluster it matches or start one. A cluster
+       **graduates** to a new card once it holds ≥ :data:`_REFLECTOR_MIN_CYCLES`
+       distinct cycles across ≥ :data:`_REFLECTOR_MIN_DAYS` distinct days —
+       at most ``max_items`` new cards per run (a valve, not a rate).
+
+    Cards are staged for the bridge pickup (#1209); the cursor and pool are
+    written only after staging succeeded. Returns the number of cards staged
+    (folds + new). Per-stage counts land in the sidecar's ``last_run`` and one
+    stdout line, so zero staged with candidates is distinguishable from an
+    idle run (#1216).
+    """
     state_dir = Path(state_dir)
     candidates = [
         state_dir / "reflector" / "reflections.jsonl",
@@ -999,26 +1146,18 @@ def promote_reflector_recommendations_to_v2(
             path = matches[0]
         else:
             return 0
+    pool = load_reflector_pool(state_dir)
     try:
         stat = path.stat()
         # The staleness guard stays. A reflector log untouched for 90 days
         # describes a loop that stopped running, and promoting from it would
         # mint lessons about a dead past. It is a claim about freshness, and it
-        # un-trips by itself the moment the loop writes again — unlike the size
-        # cap removed below, which an append-only file could only trip once.
+        # un-trips by itself the moment the loop writes again — unlike the
+        # 512 KiB size cap #1183 removed, which an append-only file could only
+        # trip once and which silently switched this path off for four days.
         if time.time() - stat.st_mtime > _REFLECTOR_MAX_AGE_SECONDS:
             return 0
-        # #1183: this used to also `return 0` when the file exceeded 512 KiB.
-        # `reflections.jsonl` is append-only with no rotation, so it crossed
-        # that line once — on the host around 2026-08-29, at 699,393 bytes —
-        # and could never come back: the v2 reflector mint path was off
-        # permanently, and silently, because `return 0` is exactly what a
-        # healthy run with nothing to promote returns. The cap also defended
-        # nothing, since the read has always been bounded to the newest
-        # _REFLECTOR_TAIL_ROWS rows; it rejected the file to avoid a cost the
-        # next line never paid. Use the module's existing bounded tail reader
-        # instead, so cost follows the tail window and not the total size.
-        lines = _reflection_tail_lines(path, _REFLECTOR_TAIL_ROWS)
+        rows, counts = _reflector_rows_after(path, str(pool.get("cursor") or ""), _REFLECTOR_MAX_ROWS_PER_RUN)
     except OSError:
         # Unreadable is not the same as "nothing to promote" (#1183). Both
         # still return 0 — the caller counts promotions — but the reason is
@@ -1030,82 +1169,174 @@ def promote_reflector_recommendations_to_v2(
             "no promotions attempted (unreadable, not empty)", path,
         )
         return 0
-    rows = []
-    skipped = 0
-    for line in lines:
-        if not line.strip():
-            continue
-        try:
-            rows.append(json.loads(line))
-        except ValueError:
-            # One malformed row previously aborted the whole promotion, and in
-            # an append-only log that too would have been permanent (#1183).
-            skipped += 1
-    if skipped:
+    if counts["unparseable"]:
         import logging as _logging
 
         _logging.getLogger(__name__).warning(
             "promote_reflector_recommendations_to_v2: skipped %d unparseable "
-            "row(s) in %s", skipped, path,
+            "row(s) in %s", counts["unparseable"], path,
         )
+    stats: dict[str, Any] = dict(counts)
+    stats.update({
+        "rows_processed": len(rows), "items": 0, "folded": 0, "repaired": 0,
+        "pooled_new": 0, "pooled_recurrence": 0, "same_day_only_waiting": 0,
+        "graduated": 0, "deferred_by_cap": 0, "near_misses": 0, "rejected": 0,
+    })
+
     # Read-only baseline: the checkout's current store decides ids and
     # duplicates, but nothing below writes to it (#1209).
     existing = _load_lessons_list(Path(workspace) / LESSONS_REL)
-    count = 0
+    existing_ids = {str(e.get("id")) for e in existing if e.get("id")}
+    card_words: dict[int, frozenset[str]] = {
+        id(e): keyword_set(e.get("solution")) for e in existing if isinstance(e.get("solution"), str)
+    }
+    clusters: list[dict[str, Any]] = pool["clusters"]
+    for cluster in clusters:
+        cluster["_words"] = keyword_set(cluster.get("detail"))
+
     minted: list[dict[str, Any]] = []
-    for row in reversed(rows):
-        if count >= max_items or not isinstance(row, dict):
-            break
-        for item in row.get("recommendations", []):
-            if count >= max_items or not isinstance(item, dict) or item.get("kind") not in {"error_pattern", "approach_hint"}:
+    new_cards = 0
+    today = datetime.now(timezone.utc).date().isoformat()
+    newest_ts = str(pool.get("cursor") or "")
+    for row in rows:
+        cycle_id = str(row.get("cycle_id") or "reflector")
+        ts = str(row.get("timestamp") or "")
+        if ts > newest_ts:
+            newest_ts = ts
+        day = ts[:10] if len(ts) >= 10 else today
+        for item in row.get("recommendations") or []:
+            if not isinstance(item, dict) or item.get("kind") not in _REFLECTOR_KINDS:
                 continue
             detail = str(item.get("detail") or "").strip()
             if not detail:
                 continue
+            stats["items"] += 1
+            problem = str(item.get("evidence") or row.get("summary") or f"Reflected issue: {detail[:60]}").strip()
+            words = keyword_set(detail)
 
-            existing_ids = {lesson_entry.get("id") for lesson_entry in existing if isinstance(lesson_entry, dict) and lesson_entry.get("id")}
-            base_id = f"LESS-REF-{row.get('cycle_id', 'unknown')[-12:]}"
-
-            import hashlib
-            digest = hashlib.sha1(detail.encode('utf-8')).hexdigest()[:4]
-            card_id = f"{base_id}-{digest}"
-
-            idx = 0
-            while card_id in existing_ids:
-                card_id = f"{base_id}-{digest}{idx}"
-                idx += 1
-
-            problem = str(
-                row.get("summary")
-                or f"Reflected issue: {detail[:60]}"
-            ).strip()
-            card = {"schema_version": 2, "id": card_id,
-
-                    "title": detail[:200], "problem": problem[:400],
-                    "solution": detail[:500],
-                    "tags": ["reflector"], "severity": "medium", "seen_count": 1,
-                    "first_seen": datetime.now(timezone.utc).date().isoformat(),
-                    "last_seen": datetime.now(timezone.utc).date().isoformat(),
-                    "evidence": [str(row.get("cycle_id") or "reflector")]}
-            if not validate_lesson_for_mint(card):
-                print(
-                    f"curator-lesson: rejected reflector recommendation for {card_id}"
+            # 1) fold into an existing card
+            best_card, best_score = None, 0.0
+            for entry in existing:
+                score = set_jaccard(words, card_words.get(id(entry), frozenset()))
+                if score > best_score:
+                    best_card, best_score = entry, score
+            by_problem = find_duplicate(problem, existing)
+            if by_problem is not None or best_score >= _REFLECTOR_FOLD_THRESHOLD:
+                card = _reflector_card(
+                    card_id=_new_card_id(existing_ids, cycle_id, detail), detail=detail, problem=problem,
+                    cycles=[cycle_id], days=[day], first_seen=day, last_seen=day,
                 )
+                if not validate_lesson_for_mint(card):
+                    stats["rejected"] += 1
+                    continue
+                target = by_problem if by_problem is not None else best_card
+                before_problem = target.get("problem") if target is not None else None
+                if _merge_card_into(existing, card) is None:
+                    continue
+                if target is not None:
+                    if target.get("problem") != before_problem:
+                        stats["repaired"] += 1
+                    card_words[id(target)] = keyword_set(target.get("solution"))  # a filler solution may have been upgraded
+                stats["folded"] += 1
+                existing_ids.add(card["id"])
+                minted.append(card)
                 continue
-            # Merge into the in-memory baseline only, so the next card sees this
-            # one's id; the checkout is written by the bridge at pickup (#1209).
-            if _merge_card_into(existing, card) is None:
+
+            # 2) pool: join a cluster or start one
+            best_cluster, best_cluster_score = None, 0.0
+            for cluster in clusters:
+                score = set_jaccard(words, cluster["_words"])
+                if score > best_cluster_score:
+                    best_cluster, best_cluster_score = cluster, score
+            if best_cluster is None or best_cluster_score < _REFLECTOR_FOLD_THRESHOLD:
+                if max(best_score, best_cluster_score) >= _REFLECTOR_NEAR_MISS_FLOOR:
+                    stats["near_misses"] += 1
+                clusters.append({
+                    "detail": detail, "problem": problem, "kind": item.get("kind"),
+                    "cycles": [cycle_id], "days": [day],
+                    "first_seen": ts or day, "last_seen": ts or day, "_words": words,
+                })
+                stats["pooled_new"] += 1
                 continue
-            minted.append(card)
-            count += 1
-    if count:
+            cluster = best_cluster
+            if cycle_id not in cluster["cycles"]:
+                cluster["cycles"].append(cycle_id)
+            if day not in cluster["days"]:
+                cluster["days"].append(day)
+            cluster["last_seen"] = ts or day
+            stats["pooled_recurrence"] += 1
+
+    # 3) graduate: every cluster that now recurs across enough cycles AND days,
+    # most-recurrent first, up to the per-run cap. Evaluated over the whole
+    # pool (not only clusters touched this run) so a cluster deferred by the
+    # cap, or waiting on a second day, graduates on a later run without needing
+    # another matching item to arrive.
+    ready = [
+        c for c in clusters
+        if len(c.get("cycles") or []) >= _REFLECTOR_MIN_CYCLES and len(c.get("days") or []) >= _REFLECTOR_MIN_DAYS
+    ]
+    stats["same_day_only_waiting"] = sum(
+        1 for c in clusters
+        if len(c.get("cycles") or []) >= _REFLECTOR_MIN_CYCLES and len(c.get("days") or []) < _REFLECTOR_MIN_DAYS
+    )
+    ready.sort(key=lambda c: (-len(c["cycles"]), str(c.get("first_seen") or "")))
+    for cluster in ready:
+        if new_cards >= max(0, int(max_items)):
+            stats["deferred_by_cap"] += 1  # stays in the pool for the next run
+            continue
+        last_day = str(cluster.get("last_seen") or today)[:10]
+        card = _reflector_card(
+            card_id=_new_card_id(existing_ids, cluster["cycles"][0], cluster["detail"]),
+            detail=str(cluster["detail"]), problem=str(cluster.get("problem") or f"Reflected issue: {cluster['detail'][:60]}"),
+            cycles=list(cluster["cycles"]), days=list(cluster["days"]),
+            first_seen=str(cluster.get("first_seen") or last_day)[:10], last_seen=last_day,
+        )
+        if not validate_lesson_for_mint(card):
+            stats["rejected"] += 1
+            clusters.remove(cluster)
+            continue
+        # Merge into the in-memory baseline only, so the next card sees this
+        # one's id; the checkout is written by the bridge at pickup (#1209).
+        if _merge_card_into(existing, card) is None:
+            clusters.remove(cluster)
+            continue
+        card_words[id(card)] = cluster["_words"]
+        existing_ids.add(card["id"])
+        minted.append(card)
+        clusters.remove(cluster)
+        new_cards += 1
+        stats["graduated"] += 1
+
+    if minted:
         _stage_lesson_cards(state_dir, minted)
         for card in minted:
             _write_decision(
                 state_dir, str(card["id"]), "staged",
                 "reflector recommendation staged for bridge pickup (#1209)", LESSONS_REL,
             )
-    return count
+        pool["last_staged_at"] = _now()
+    stats["staged"] = len(minted)
+    stats["evicted"] = _prune_pool(clusters, newest_ts)
+    for cluster in clusters:
+        cluster.pop("_words", None)
+    stats["pool_size"] = len(clusters)
+    stats["at"] = _now()
+    # Cursor and pool advance only after staging succeeded (above); a crash
+    # before this write re-processes the same rows next run, which is
+    # idempotent (folds by id, pool cycles are a set, staged payload merges by id).
+    pool["cursor"] = newest_ts
+    pool["last_run"] = stats
+    _atomic_json(_reflector_pool_path(state_dir), pool)
+    print(
+        "curator-reflector: "
+        + " ".join(f"{k}={stats[k]}" for k in (
+            "rows_read", "rows_processed", "items", "folded", "repaired", "pooled_new",
+            "pooled_recurrence", "same_day_only_waiting", "graduated", "deferred_by_cap",
+            "near_misses", "rejected", "staged", "pool_size",
+        ))
+        + f" cursor={newest_ts or '-'}"
+    )
+    return len(minted)
 
 
 def _load_lessons_list(target: Path) -> list[dict[str, Any]]:
@@ -1134,16 +1365,61 @@ def _merge_card_into(existing: list[dict[str, Any]], card: dict[str, Any]) -> st
     card_id = str(card.get("id") or "")
     if card_id and any(str(entry.get("id") or "") == card_id for entry in existing):
         return None
-    duplicate = find_duplicate(str(card.get("problem") or ""), existing)
+    duplicate = _fold_target(existing, card)
     if duplicate is not None:
         from nanobot.runtime.lesson_v2 import solution_is_meaningful
         if not solution_is_meaningful(duplicate.get("problem"), duplicate.get("solution")):
             duplicate["solution"] = card.get("solution")
-        duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + 1
+        incoming_cycles = [str(e) for e in (card.get("evidence") or []) if e]
+        known_cycles = [str(e) for e in (duplicate.get("evidence") or []) if e]
+        new_cycles = [c for c in incoming_cycles if c not in known_cycles]
+        # #1171: the incoming card is the same recommendation seen in cycles
+        # this card already counts (typically its own origin item re-read
+        # after a cursor reset) — repair, do not re-count.
+        same_origin = bool(incoming_cycles) and bool(known_cycles) and not new_cycles
+        if same_origin:
+            if (
+                card.get("problem") and duplicate.get("problem") != card.get("problem")
+                and set_jaccard(keyword_set(card.get("solution")), keyword_set(duplicate.get("solution"))) >= 0.8
+            ):
+                # The pre-#1171 mint stored the cycle narrative as `problem`;
+                # the origin item carries the observation it should have had.
+                duplicate["problem"] = card["problem"]
+        else:
+            increment = len(new_cycles) if incoming_cycles and known_cycles else int(card.get("seen_count") or 1)
+            duplicate["seen_count"] = int(duplicate.get("seen_count") or 1) + max(1, increment)
+            if new_cycles:
+                duplicate["evidence"] = (known_cycles + new_cycles)[:_REFLECTOR_CARD_EVIDENCE_CAP]
+            if card.get("distinct_days") or duplicate.get("distinct_days"):
+                duplicate["distinct_days"] = max(
+                    int(duplicate.get("distinct_days") or 1), int(card.get("distinct_days") or 1),
+                )
         duplicate["last_seen"] = card.get("last_seen")
         return "folded"
     existing.insert(0, card)
     return "inserted"
+
+
+def _fold_target(existing: list[dict[str, Any]], card: dict[str, Any]) -> dict[str, Any] | None:
+    """The card an incoming card folds into, or ``None`` (#1171). Same problem
+    (:func:`find_duplicate`: hash or Jaccard ≥ 0.8) first; else the entry whose
+    solution says the same thing (keyword Jaccard ≥
+    :data:`_REFLECTOR_FOLD_THRESHOLD`), best match. One rule for stage time
+    and pickup time, so the pickup agrees with the curator's decision."""
+    duplicate = find_duplicate(str(card.get("problem") or ""), existing)
+    if duplicate is not None:
+        return duplicate
+    words = keyword_set(card.get("solution"))
+    if not words:
+        return None
+    best, best_score = None, 0.0
+    for entry in existing:
+        if not isinstance(entry, dict) or not isinstance(entry.get("solution"), str):
+            continue
+        score = set_jaccard(words, keyword_set(entry["solution"]))
+        if score > best_score:
+            best, best_score = entry, score
+    return best if best_score >= _REFLECTOR_FOLD_THRESHOLD else None
 
 
 def _stage_lesson_cards(state_dir: Path, cards: list[dict[str, Any]]) -> dict[str, Any]:
@@ -1288,7 +1564,7 @@ def run_curation(
 ) -> dict[str, Any]:
     """Run one fail-open curator pass. Writes staged dir only — never the workspace. (#1001)"""
     workspace, state_dir = Path(workspace), Path(state_dir)
-    promote_reflector_recommendations_to_v2(workspace, state_dir, max_items=2)
+    promote_reflector_recommendations_to_v2(workspace, state_dir, max_items=5)
     malformed_diagnostic_written = False
     wm_path = state_dir / "curator" / "watermark.json"
     old = _safe_json(wm_path, {})

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -1044,7 +1044,10 @@ def _reflector_rows_after(path: Path, cursor: str, limit: int) -> tuple[list[dic
         if ts and cursor and ts <= cursor:
             continue
         counts["rows_after_cursor"] += 1
-        if len(rows) < limit:
+        # The cursor is the last processed timestamp and rows at or before it
+        # are skipped, so rows sharing one timestamp must never be split across
+        # runs: past the limit, keep taking rows that tie with the last one.
+        if len(rows) < limit or (rows and ts and ts == str(rows[-1].get("timestamp") or "")):
             rows.append(row)
     return rows, counts
 
@@ -1323,10 +1326,15 @@ def promote_reflector_recommendations_to_v2(
             continue
         # Merge into the in-memory baseline only, so the next card sees this
         # one's id; the checkout is written by the bridge at pickup (#1209).
+        target = _fold_target(existing, card)  # a card graduated earlier this run may absorb it
         if _merge_card_into(existing, card) is None:
             clusters.remove(cluster)
             continue
-        card_words[id(card)] = cluster["_words"]
+        if target is not None:
+            card_words[id(target)] = _fold_words(target)
+            problem_index.pop(id(target), None)
+        else:
+            card_words[id(card)] = cluster["_words"]
         existing_ids.add(card["id"])
         minted.append(card)
         clusters.remove(cluster)
@@ -1352,7 +1360,17 @@ def promote_reflector_recommendations_to_v2(
     # idempotent (folds by id, pool cycles are a set, staged payload merges by id).
     pool["cursor"] = newest_ts
     pool["last_run"] = stats
-    _atomic_json(_reflector_pool_path(state_dir), pool)
+    try:
+        _atomic_json(_reflector_pool_path(state_dir), pool)
+    except OSError as exc:
+        # The cards are staged; a lost sidecar only re-processes these rows
+        # next run. The curator pass must not die here (fail-open).
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "promote_reflector_recommendations_to_v2: cannot write %s: %s",
+            _reflector_pool_path(state_dir), exc,
+        )
     print(
         "curator-reflector: "
         + " ".join(f"{k}={stats[k]}" for k in (
@@ -1609,7 +1627,14 @@ def run_curation(
 ) -> dict[str, Any]:
     """Run one fail-open curator pass. Writes staged dir only — never the workspace. (#1001)"""
     workspace, state_dir = Path(workspace), Path(state_dir)
-    promote_reflector_recommendations_to_v2(workspace, state_dir, max_items=5)
+    try:
+        promote_reflector_recommendations_to_v2(workspace, state_dir, max_items=5)
+    except Exception as exc:  # the mint must not take the fact-curation pass down with it
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "promote_reflector_recommendations_to_v2 failed; fact curation continues: %r", exc,
+        )
     malformed_diagnostic_written = False
     wm_path = state_dir / "curator" / "watermark.json"
     old = _safe_json(wm_path, {})

--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -53,8 +53,10 @@ from nanobot.runtime.lesson_v2 import (
     find_duplicate,
     inline_related_slugs,
     keyword_set,
+    problem_hash,
     related_hint,
     set_jaccard,
+    solution_is_meaningful,
     validate_lesson_for_mint,
 )
 from nanobot.runtime.model_registry import resolve_model
@@ -1188,8 +1190,31 @@ def promote_reflector_recommendations_to_v2(
     existing = _load_lessons_list(Path(workspace) / LESSONS_REL)
     existing_ids = {str(e.get("id")) for e in existing if e.get("id")}
     card_words: dict[int, frozenset[str]] = {
-        id(e): keyword_set(e.get("solution")) for e in existing if isinstance(e.get("solution"), str)
+        id(e): _fold_words(e) for e in existing
     }
+    # Per-entry problem hash + keyword set, computed once: find_duplicate
+    # re-normalizes every entry for every call, and on the 502-item backfill
+    # that was 86% of the run (145k normalizations). Same rule as
+    # find_duplicate — hash equality or Jaccard ≥ 0.8, first entry in order.
+    problem_index: dict[int, tuple[str, frozenset[str]]] = {}
+
+    def _problem_key(entry: dict[str, Any]) -> tuple[str, frozenset[str]]:
+        key = problem_index.get(id(entry))
+        if key is None:
+            text = entry.get("problem") or entry.get("hypothesis") or entry.get("title")
+            key = (problem_hash(text), keyword_set(text))
+            problem_index[id(entry)] = key
+        return key
+
+    def _by_problem(text: str) -> dict[str, Any] | None:
+        digest = problem_hash(text)
+        text_words = keyword_set(text)
+        for entry in existing:
+            entry_hash, entry_words = _problem_key(entry)
+            if (digest and entry_hash == digest) or set_jaccard(text_words, entry_words) >= 0.8:
+                return entry
+        return None
+
     clusters: list[dict[str, Any]] = pool["clusters"]
     for cluster in clusters:
         cluster["_words"] = keyword_set(cluster.get("detail"))
@@ -1220,7 +1245,7 @@ def promote_reflector_recommendations_to_v2(
                 score = set_jaccard(words, card_words.get(id(entry), frozenset()))
                 if score > best_score:
                     best_card, best_score = entry, score
-            by_problem = find_duplicate(problem, existing)
+            by_problem = _by_problem(problem)
             if by_problem is not None or best_score >= _REFLECTOR_FOLD_THRESHOLD:
                 card = _reflector_card(
                     card_id=_new_card_id(existing_ids, cycle_id, detail), detail=detail, problem=problem,
@@ -1236,7 +1261,8 @@ def promote_reflector_recommendations_to_v2(
                 if target is not None:
                     if target.get("problem") != before_problem:
                         stats["repaired"] += 1
-                    card_words[id(target)] = keyword_set(target.get("solution"))  # a filler solution may have been upgraded
+                    card_words[id(target)] = _fold_words(target)  # a filler solution may have been upgraded
+                    problem_index.pop(id(target), None)  # and a narrative problem repaired
                 stats["folded"] += 1
                 existing_ids.add(card["id"])
                 minted.append(card)
@@ -1367,8 +1393,15 @@ def _merge_card_into(existing: list[dict[str, Any]], card: dict[str, Any]) -> st
         return None
     duplicate = _fold_target(existing, card)
     if duplicate is not None:
-        from nanobot.runtime.lesson_v2 import solution_is_meaningful
         if not solution_is_meaningful(duplicate.get("problem"), duplicate.get("solution")):
+            # #1106: a filler solution is upgraded in place. The 2026-08-29 mint
+            # also stored the recommendation itself as `problem`; when that is
+            # what the incoming solution matched, the observation replaces it.
+            if (
+                card.get("problem")
+                and set_jaccard(keyword_set(duplicate.get("problem")), keyword_set(card.get("solution"))) >= 0.8
+            ):
+                duplicate["problem"] = card["problem"]
             duplicate["solution"] = card.get("solution")
         incoming_cycles = [str(e) for e in (card.get("evidence") or []) if e]
         known_cycles = [str(e) for e in (duplicate.get("evidence") or []) if e]
@@ -1414,12 +1447,24 @@ def _fold_target(existing: list[dict[str, Any]], card: dict[str, Any]) -> dict[s
         return None
     best, best_score = None, 0.0
     for entry in existing:
-        if not isinstance(entry, dict) or not isinstance(entry.get("solution"), str):
+        if not isinstance(entry, dict):
             continue
-        score = set_jaccard(words, keyword_set(entry["solution"]))
+        score = set_jaccard(words, _fold_words(entry))
         if score > best_score:
             best, best_score = entry, score
     return best if best_score >= _REFLECTOR_FOLD_THRESHOLD else None
+
+
+def _fold_words(entry: dict[str, Any]) -> frozenset[str]:
+    """The text an incoming solution is compared against: the entry's solution,
+    or — when that solution is filler ("Apply the reflected approach hint.",
+    the 2026-08-29 mint) — its ``problem``, where that mint stored the
+    recommendation itself. Otherwise those four cards can never be reached by
+    the recommendation that would upgrade them."""
+    solution = entry.get("solution")
+    if isinstance(solution, str) and solution_is_meaningful(entry.get("problem"), solution):
+        return keyword_set(solution)
+    return keyword_set(entry.get("problem"))
 
 
 def _stage_lesson_cards(state_dir: Path, cards: list[dict[str, Any]]) -> dict[str, Any]:

--- a/nanobot/runtime/lesson_v2.py
+++ b/nanobot/runtime/lesson_v2.py
@@ -115,10 +115,20 @@ def problem_hash(text: Any) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest() if normalized else ""
 
 
-def keyword_jaccard(first: Any, second: Any) -> float:
-    left = set(_WORD_RE.findall(normalize_problem(first)))
-    right = set(_WORD_RE.findall(normalize_problem(second)))
+def keyword_set(text: Any) -> frozenset[str]:
+    """The normalized keyword set :func:`keyword_jaccard` compares — exposed so
+    a caller comparing one text against many can normalize each text once
+    (#1171: the reflector mint compares every recommendation against every
+    card and pool entry; two regex passes per pair would dominate the run)."""
+    return frozenset(_WORD_RE.findall(normalize_problem(text)))
+
+
+def set_jaccard(left: frozenset[str], right: frozenset[str]) -> float:
     return len(left & right) / len(left | right) if left and right else 0.0
+
+
+def keyword_jaccard(first: Any, second: Any) -> float:
+    return set_jaccard(keyword_set(first), keyword_set(second))
 
 
 def find_duplicate(problem: Any, entries: list[dict[str, Any]], threshold: float = 0.8) -> dict[str, Any] | None:

--- a/tests/test_issue_1138_lesson_ids.py
+++ b/tests/test_issue_1138_lesson_ids.py
@@ -30,22 +30,25 @@ def test_promote_reflector_recommendations_grants_unique_ids(tmp_path: Path):
     reflector_dir = state_dir / "reflector"
     reflector_dir.mkdir(parents=True)
 
-    # One cycle with MULTIPLE recommendations
-    row = {
-        "cycle_id": "cycle-abcdef123456",
-        "recommendations": [
-            {
-                "kind": "error_pattern",
-                "detail": "The system fails to allocate memory during the large array initialization.",
-            },
-            {
-                "kind": "approach_hint",
-                "detail": "A null reference exception occurs inside the secondary API endpoint parser.",
-            }
-        ]
-    }
+    # One cycle with MULTIPLE recommendations — repeated by a second cycle on
+    # another day, since #1171 mints on recurrence. Ids derive from the FIRST
+    # cycle that made each recommendation.
+    recommendations = [
+        {
+            "kind": "error_pattern",
+            "detail": "The system fails to allocate memory during the large array initialization.",
+        },
+        {
+            "kind": "approach_hint",
+            "detail": "A null reference exception occurs inside the secondary API endpoint parser.",
+        }
+    ]
+    rows = [
+        {"cycle_id": "cycle-abcdef123456", "timestamp": "2026-09-01T10:00:00Z", "recommendations": recommendations},
+        {"cycle_id": "cycle-abcdef123457", "timestamp": "2026-09-02T10:00:00Z", "recommendations": recommendations},
+    ]
 
-    (reflector_dir / "reflections.jsonl").write_text(json.dumps(row) + "\n", encoding="utf-8")
+    (reflector_dir / "reflections.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
 
     promoted = promote_reflector_recommendations_to_v2(workspace=workspace, state_dir=state_dir, max_items=10)
     assert promoted == 2

--- a/tests/test_issue_1138_lesson_ids_guard.py
+++ b/tests/test_issue_1138_lesson_ids_guard.py
@@ -45,17 +45,15 @@ def test_promote_reflector_avoids_existing_ids(tmp_path: Path):
     reflector_dir = state_dir / "reflector"
     reflector_dir.mkdir(parents=True)
 
-    row = {
-        "cycle_id": "cycle-abcdef123456",
-        "recommendations": [
-            {
-                "kind": "error_pattern",
-                "detail": "Completely new problem",
-            }
-        ]
-    }
+    # Two cycles on two days (#1171 mints on recurrence); the id derives from
+    # the first one, whose base collides with the pre-existing card above.
+    recommendations = [{"kind": "error_pattern", "detail": "Completely new problem"}]
+    rows = [
+        {"cycle_id": "cycle-abcdef123456", "timestamp": "2026-09-01T10:00:00Z", "recommendations": recommendations},
+        {"cycle_id": "cycle-abcdef123457", "timestamp": "2026-09-02T10:00:00Z", "recommendations": recommendations},
+    ]
 
-    (reflector_dir / "reflections.jsonl").write_text(json.dumps(row) + "\n", encoding="utf-8")
+    (reflector_dir / "reflections.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
 
     promoted = promote_reflector_recommendations_to_v2(workspace=workspace, state_dir=state_dir, max_items=10)
     assert promoted == 1

--- a/tests/test_issue_1171_reflector_mint_recurrence.py
+++ b/tests/test_issue_1171_reflector_mint_recurrence.py
@@ -209,6 +209,30 @@ def test_narrative_problem_is_repaired_from_the_cards_own_origin_item(tmp_path: 
     assert card["evidence"] == ["cycle-4f03664182da"]
 
 
+def test_2026_08_29_filler_card_is_reached_through_its_problem_and_repaired(tmp_path: Path) -> None:
+    """The four surviving 08-29 cards store the recommendation as ``problem``
+    with the filler ``solution`` — no recommendation could match them on
+    solution text, so #1106's upgrade path was unreachable for them. The
+    recurrence of that recommendation upgrades the solution and puts the
+    observation where the problem belongs."""
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path, [_card("LESS-REF-5b349fbfddd0", "Apply the reflected approach hint.", OTHER,
+                                            evidence=["cycle-5b349fbfddd0"])])
+    _write_live(state, [
+        _row("cycle-5b349fbfddd0", "2026-08-29T10:00:00Z", (OTHER, "AGENTS.md gained a section with no structural test")),
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (OTHER, "another AGENTS.md section landed untested")),
+    ])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 2
+    assert load_reflector_pool(state)["last_run"]["folded"] == 2
+    _apply(workspace, state)
+    [card] = _lessons(workspace)
+    assert card["id"] == "LESS-REF-5b349fbfddd0"
+    assert card["solution"] == OTHER
+    assert card["problem"] == "AGENTS.md gained a section with no structural test"
+    assert card["seen_count"] == 2 and card["evidence"] == ["cycle-5b349fbfddd0", "cycle-aaaaaaaaaaa1"]
+
+
 def test_filler_solution_on_an_old_card_is_upgraded_by_a_matching_problem(tmp_path: Path) -> None:
     """#1106's upgrade path, now reached through the shared fold rule."""
     state = tmp_path / "state"

--- a/tests/test_issue_1171_reflector_mint_recurrence.py
+++ b/tests/test_issue_1171_reflector_mint_recurrence.py
@@ -1,0 +1,407 @@
+"""#1171: the reflector mint earns a card on recurrence, folds on agreement,
+and walks the journal with a cursor instead of a 50-row window.
+
+Live store 2026-08-27..09-02: 738 rows, 502 promotable items, all
+``approach_hint``; 448 of the 502 were lexical singletons at Jaccard 0.35 and
+the ~21 clusters that recurred across cycles were the general lessons. The
+pre-#1171 mint staged the first two items of the newest 50 rows once a day,
+folded on ``summary`` (the cycle narrative — 179 same-row siblings folded into
+each other and lost their solution) and wrote that narrative as the card's
+``problem``.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nanobot.runtime import knowledge_curator as kc
+from nanobot.runtime.knowledge_curator import (
+    _LESSONS_PAYLOAD_SLUG,
+    _STAGED_DIR,
+    LESSONS_REL,
+    apply_staged_lesson_cards,
+    load_reflector_pool,
+    promote_reflector_recommendations_to_v2,
+)
+
+DETAIL = "Configure a fallback model group for the local model in LiteLLM so server crashes fail over automatically."
+DETAIL_PARAPHRASE = "Define fallback routes for the local model group in the LiteLLM configuration so crashes fail over."
+OTHER = "Register newly added AGENTS.md sections in tests/test_agents_structure.py so standing instructions stay covered."
+
+
+def _row(cycle: str, ts: str, *recs: tuple[str, str], summary: str = "", kind: str = "approach_hint") -> dict:
+    return {
+        "cycle_id": cycle, "timestamp": ts,
+        "summary": summary or f"The agent did a number of things in {cycle}",
+        "recommendations": [{"kind": kind, "detail": detail, "evidence": evidence} for detail, evidence in recs],
+    }
+
+
+def _write_live(state: Path, rows: list[dict]) -> Path:
+    path = state / "reflector" / "reflections.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    return path
+
+
+def _write_archive(state: Path, day: str, rows: list[dict]) -> Path:
+    path = state / "reflector" / "archive" / f"reflections-{day}.jsonl.gz"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        fh.writelines(json.dumps(r) + "\n" for r in rows)
+    return path
+
+
+def _workspace(tmp_path: Path, cards: list[dict] | None = None) -> Path:
+    workspace = tmp_path / "workspace"
+    target = workspace / LESSONS_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if cards is not None:
+        target.write_text(yaml.safe_dump({"lessons": cards}, sort_keys=False), encoding="utf-8")
+    return workspace
+
+
+def _staged_cards(state: Path) -> list[dict]:
+    payload = state / "curator" / _STAGED_DIR / _LESSONS_PAYLOAD_SLUG
+    if not payload.exists():
+        return []
+    return json.loads(payload.read_text(encoding="utf-8"))["cards"]
+
+
+def _apply(workspace: Path, state: Path) -> list[str]:
+    payload = state / "curator" / _STAGED_DIR / _LESSONS_PAYLOAD_SLUG
+    return apply_staged_lesson_cards(workspace, json.loads(payload.read_text(encoding="utf-8")))
+
+
+def _lessons(workspace: Path) -> list[dict]:
+    return yaml.safe_load((workspace / LESSONS_REL).read_text(encoding="utf-8"))["lessons"]
+
+
+def _card(card_id: str, solution: str, problem: str, *, seen: int = 1, evidence: list[str] | None = None) -> dict:
+    return {
+        "schema_version": 2, "id": card_id, "title": solution[:200], "problem": problem, "solution": solution,
+        "tags": ["reflector"], "severity": "medium", "seen_count": seen,
+        "first_seen": "2026-08-29", "last_seen": "2026-08-29", "evidence": evidence or [],
+    }
+
+
+# ─── the rule ────────────────────────────────────────────────────────────────
+
+
+def test_first_sighting_waits_in_the_pool_and_is_not_minted(tmp_path: Path) -> None:
+    """Pre-#1171 this staged one card from one sighting (and would have staged
+    ~70 a day at the live rate)."""
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [_row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "LiteLLM returned 502 for three calls"))])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 0
+
+    assert _staged_cards(state) == []
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["items"] == 1 and pool["last_run"]["pooled_new"] == 1 and pool["last_run"]["staged"] == 0
+    assert [c["cycles"] for c in pool["clusters"]] == [["cycle-aaaaaaaaaaa1"]]
+
+
+def test_two_cycles_on_two_days_graduate_one_card_with_the_observation_as_problem(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "LiteLLM returned 502 for three calls")),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-02T11:00:00Z", (DETAIL_PARAPHRASE, "The model server dropped the connection twice")),
+    ])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+
+    [card] = _staged_cards(state)
+    assert card["id"].startswith("LESS-REF-aaaaaaaaaaa1-")
+    assert card["solution"] == DETAIL
+    assert card["problem"] == "LiteLLM returned 502 for three calls", "problem is the observation, not the cycle narrative"
+    assert card["seen_count"] == 2
+    assert card["evidence"] == ["cycle-aaaaaaaaaaa1", "cycle-bbbbbbbbbbb2"]
+    assert card["distinct_days"] == 2
+    assert card["first_seen"] == "2026-09-01" and card["last_seen"] == "2026-09-02"
+    pool = load_reflector_pool(state)
+    assert pool["clusters"] == [] and pool["last_run"]["graduated"] == 1
+    assert pool["last_staged_at"]
+
+
+def test_same_day_recurrence_is_an_incident_echo_and_waits(tmp_path: Path) -> None:
+    """Seven cycles failing the same way in one afternoon is one event. It is
+    counted, visible, and not minted until a second day confirms it."""
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row(f"cycle-{i:012d}", f"2026-09-01T1{i}:00:00Z", (DETAIL, f"502 number {i}")) for i in range(3)
+    ])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 0
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["same_day_only_waiting"] == 1
+    [cluster] = pool["clusters"]
+    assert len(cluster["cycles"]) == 3 and cluster["days"] == ["2026-09-01"]
+
+    _write_live(state, [
+        _row(f"cycle-{i:012d}", f"2026-09-01T1{i}:00:00Z", (DETAIL, f"502 number {i}")) for i in range(3)
+    ] + [_row("cycle-nextday00000", "2026-09-02T09:00:00Z", (DETAIL_PARAPHRASE, "502 again the next morning"))])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    [card] = _staged_cards(state)
+    assert card["seen_count"] == 4 and card["distinct_days"] == 2
+
+
+def test_same_row_siblings_are_separate_lessons_not_folded_into_each_other(tmp_path: Path) -> None:
+    """The pre-#1171 fold key was ``summary``: two recommendations from one
+    cycle shared it, so the second folded into the first and its solution was
+    discarded (179 of 502 live items)."""
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z",
+             (DETAIL, "502s during the run"), (OTHER, "AGENTS.md gained a section without a test"),
+             summary="One narrative shared by both recommendations"),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z",
+             (DETAIL, "502s again"), (OTHER, "another AGENTS.md section without a test"),
+             summary="One narrative shared by both recommendations"),
+    ])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 2
+    assert sorted(c["solution"] for c in _staged_cards(state)) == sorted([DETAIL, OTHER])
+
+
+def test_recurrence_that_agrees_with_an_existing_card_folds_and_is_not_capped(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path, [_card("LESS-REF-000000000000-0000", DETAIL, "502s seen before", evidence=["cycle-000000000000"])])
+    _write_live(state, [_row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL_PARAPHRASE, "502s seen again"))])
+
+    # max_items=0: no NEW card may be minted; the fold still goes through.
+    assert promote_reflector_recommendations_to_v2(workspace, state, max_items=0) == 1
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["folded"] == 1 and pool["last_run"]["graduated"] == 0 and pool["clusters"] == []
+
+    assert _apply(workspace, state) == [_staged_cards(state)[0]["id"]]
+    [card] = _lessons(workspace)
+    assert card["id"] == "LESS-REF-000000000000-0000", "folded, not inserted"
+    assert card["seen_count"] == 2
+    assert card["evidence"] == ["cycle-000000000000", "cycle-aaaaaaaaaaa1"]
+    assert card["last_seen"] == "2026-09-01"
+
+
+def test_narrative_problem_is_repaired_from_the_cards_own_origin_item(tmp_path: Path) -> None:
+    """Two cards on origin/main (2026-09-02) carry the cycle narrative as
+    ``problem``. Their origin items are still in the store; re-reading them
+    repairs the problem in place and does not re-count the sighting."""
+    narrative = "Added a doctest suite to tests/test_jsonl_stream_filter.py validating docstring examples"
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path, [_card("LESS-REF-4f03664182da-0d35", DETAIL, narrative, evidence=["cycle-4f03664182da"])])
+    _write_live(state, [_row("cycle-4f03664182da", "2026-09-02T03:00:00Z", (DETAIL, "LiteLLM returned 502 for three calls"), summary=narrative)])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    assert load_reflector_pool(state)["last_run"]["repaired"] == 1
+    _apply(workspace, state)
+    [card] = _lessons(workspace)
+    assert card["problem"] == "LiteLLM returned 502 for three calls"
+    assert card["seen_count"] == 1, "the origin item is not a second sighting"
+    assert card["evidence"] == ["cycle-4f03664182da"]
+
+
+def test_filler_solution_on_an_old_card_is_upgraded_by_a_matching_problem(tmp_path: Path) -> None:
+    """#1106's upgrade path, now reached through the shared fold rule."""
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path, [{
+        "id": "LESS-REF-c871bf9abe41", "problem": "Node missing from the inventory file",
+        "solution": "Apply the reflected approach hint.", "seen_count": 1, "last_seen": "2026-08-29",
+    }])
+    _write_live(state, [_row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z",
+                             ("Run apt-get update before installing so the inventory is current.", "Node missing from the inventory file"))])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    _apply(workspace, state)
+    [card] = _lessons(workspace)
+    assert card["solution"] == "Run apt-get update before installing so the inventory is current."
+    assert card["seen_count"] == 2
+
+
+# ─── cursor ──────────────────────────────────────────────────────────────────
+
+
+def test_cursor_advances_and_rows_are_not_reprocessed(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    rows = [_row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s"))]
+    _write_live(state, rows)
+    promote_reflector_recommendations_to_v2(workspace, state)
+    assert load_reflector_pool(state)["cursor"] == "2026-09-01T10:00:00Z"
+
+    promote_reflector_recommendations_to_v2(workspace, state)
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["rows_read"] == 1 and pool["last_run"]["rows_processed"] == 0
+    assert [c["cycles"] for c in pool["clusters"]] == [["cycle-aaaaaaaaaaa1"]]
+
+    rows.append(_row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z", (DETAIL, "502s again")))
+    _write_live(state, rows)
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    assert load_reflector_pool(state)["cursor"] == "2026-09-02T10:00:00Z"
+
+
+def test_recurrence_across_an_archive_and_the_live_journal_is_seen(tmp_path: Path) -> None:
+    """The 50-row window saw ~10 hours; an item outside it was never
+    evaluated and after rotation never could be."""
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_archive(state, "2026-09-01", [
+        _row(f"cycle-{i:012d}", f"2026-08-31T{i % 24:02d}:00:00Z", (f"Unrelated one-off advice number {i} about a script.", f"evidence {i}"))
+        for i in range(80)
+    ] + [_row("cycle-aaaaaaaaaaa1", "2026-09-01T00:30:00Z", (DETAIL, "502s"))])
+    _write_live(state, [_row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z", (DETAIL_PARAPHRASE, "502s again"))])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    [card] = _staged_cards(state)
+    assert card["evidence"] == ["cycle-aaaaaaaaaaa1", "cycle-bbbbbbbbbbb2"]
+    assert load_reflector_pool(state)["last_run"]["rows_read"] == 82
+
+
+def test_rows_per_run_cap_carries_the_remainder_to_the_next_run(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(kc, "_REFLECTOR_MAX_ROWS_PER_RUN", 1)
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s")),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z", (DETAIL, "502s again")),
+    ])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 0
+    pool = load_reflector_pool(state)
+    assert pool["cursor"] == "2026-09-01T10:00:00Z"
+    assert pool["last_run"]["rows_after_cursor"] == 2 and pool["last_run"]["rows_processed"] == 1
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    assert load_reflector_pool(state)["cursor"] == "2026-09-02T10:00:00Z"
+
+
+def test_new_card_cap_defers_graduation_and_the_next_run_finishes_it_without_new_rows(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s"), (OTHER, "section without test")),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z", (DETAIL, "502s again"), (OTHER, "another section")),
+    ])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state, max_items=1) == 1
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["graduated"] == 1 and pool["last_run"]["deferred_by_cap"] == 1
+    assert len(pool["clusters"]) == 1
+
+    assert promote_reflector_recommendations_to_v2(workspace, state, max_items=1) == 1
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["rows_processed"] == 0 and pool["last_run"]["graduated"] == 1
+    assert pool["clusters"] == []
+    assert sorted(c["solution"] for c in _staged_cards(state)) == sorted([DETAIL, OTHER])
+
+
+# ─── instrumentation ─────────────────────────────────────────────────────────
+
+
+def test_near_misses_below_the_fold_threshold_are_counted(tmp_path: Path) -> None:
+    """Jaccard 4/12 = 0.33 against the existing card: inside [0.25, 0.35)."""
+    state = tmp_path / "state"
+    existing = "alpha beta gamma delta epsilon zeta eta theta"
+    workspace = _workspace(tmp_path, [_card("LESS-REF-000000000000-0000", existing, "an observation")])
+    _write_live(state, [_row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z",
+                             ("alpha beta gamma delta iota kappa lambda omicron", "another observation"))])
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 0
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["near_misses"] == 1 and pool["last_run"]["pooled_new"] == 1 and pool["last_run"]["folded"] == 0
+
+
+def test_run_counts_distinguish_candidates_from_an_idle_run(tmp_path: Path, capsys) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [_row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s"))])
+    promote_reflector_recommendations_to_v2(workspace, state)
+    busy = load_reflector_pool(state)["last_run"]
+    line = capsys.readouterr().out
+    assert "curator-reflector: " in line and "items=1" in line and "staged=0" in line
+
+    promote_reflector_recommendations_to_v2(workspace, state)
+    idle = load_reflector_pool(state)["last_run"]
+    assert (busy["items"], busy["staged"]) == (1, 0)
+    assert (idle["items"], idle["staged"]) == (0, 0)
+
+
+def test_pool_is_bounded_and_stale_clusters_are_evicted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(kc, "_REFLECTOR_POOL_MAX", 2)
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row("cycle-000000000001", "2026-08-01T10:00:00Z", ("Archive the stale inventory snapshot before rotating the journal.", "e1")),
+        _row("cycle-000000000002", "2026-09-01T10:00:00Z", ("Pin the pytest version so the collection phase stays deterministic.", "e2")),
+        _row("cycle-000000000003", "2026-09-01T11:00:00Z", ("Validate YAML configuration keys against the schema at load time.", "e3")),
+        _row("cycle-000000000004", "2026-09-01T12:00:00Z", ("Squash fixup commits locally before pushing the branch for review.", "e4")),
+    ])
+
+    promote_reflector_recommendations_to_v2(workspace, state)
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["pooled_new"] == 4
+    assert pool["last_run"]["evicted"] == 2  # one past 14 days, one over the size bound
+    assert [c["cycles"][0] for c in pool["clusters"]] == ["cycle-000000000004", "cycle-000000000003"]
+
+
+def test_error_rows_unparseable_lines_and_other_kinds_are_skipped(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    path = _write_live(state, [
+        {"cycle_id": "cycle-err", "timestamp": "2026-09-01T09:00:00Z", "status": "error", "recommendations": []},
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s")),
+        _row("cycle-ccccccccccc3", "2026-09-01T10:30:00Z", ("Change the task instructions to name the target.", "x"), kind="instruction_change"),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z", (DETAIL, "502s again")),
+    ])
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('{"cycle_id": "cycle-truncated", "recommendations": [\n')
+
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["unparseable"] == 1 and pool["last_run"]["items"] == 2
+
+
+def test_corrupt_pool_sidecar_restarts_from_the_oldest_row(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    (state / "curator").mkdir(parents=True)
+    (state / "curator" / "reflector_pool.json").write_text("{not json", encoding="utf-8")
+    _write_live(state, [
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s")),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-02T10:00:00Z", (DETAIL, "502s again")),
+    ])
+    assert promote_reflector_recommendations_to_v2(workspace, state) == 1
+
+
+# ─── pickup uses the same rule ───────────────────────────────────────────────
+
+
+def test_pickup_folds_a_staged_card_into_a_card_that_arrived_meanwhile(tmp_path: Path) -> None:
+    """The checkout may have gained a card since staging; the pickup applies
+    the same fold rule as the curator instead of inserting a near-duplicate."""
+    workspace = _workspace(tmp_path, [_card("LESS-REF-000000000000-0000", DETAIL, "502s before", evidence=["cycle-000000000000"])])
+    staged = _card("LESS-REF-aaaaaaaaaaa1-1234", DETAIL_PARAPHRASE, "502s again", seen=2,
+                   evidence=["cycle-aaaaaaaaaaa1", "cycle-bbbbbbbbbbb2"])
+    staged["distinct_days"] = 2
+
+    assert apply_staged_lesson_cards(workspace, {"cards": [staged]}) == ["LESS-REF-aaaaaaaaaaa1-1234"]
+    [card] = _lessons(workspace)
+    assert card["id"] == "LESS-REF-000000000000-0000"
+    assert card["seen_count"] == 3
+    assert card["evidence"] == ["cycle-000000000000", "cycle-aaaaaaaaaaa1", "cycle-bbbbbbbbbbb2"]
+    assert card["distinct_days"] == 2
+
+
+@pytest.mark.parametrize("threshold", [kc._REFLECTOR_FOLD_THRESHOLD])
+def test_fold_threshold_is_a_named_constant_with_its_calibration_on_record(threshold: float) -> None:
+    assert threshold == 0.35
+    source = Path(kc.__file__).read_text(encoding="utf-8")
+    assert "calibrated on ONE week of ONE loop" in source

--- a/tests/test_issue_1171_reflector_mint_recurrence.py
+++ b/tests/test_issue_1171_reflector_mint_recurrence.py
@@ -307,6 +307,24 @@ def test_rows_per_run_cap_carries_the_remainder_to_the_next_run(tmp_path: Path, 
     assert load_reflector_pool(state)["cursor"] == "2026-09-02T10:00:00Z"
 
 
+def test_rows_sharing_the_boundary_timestamp_are_never_split_across_runs(tmp_path: Path, monkeypatch) -> None:
+    """Rows at or before the cursor are skipped, so a tie at the row cap would
+    lose the rows past it forever; the run takes the whole tie instead."""
+    monkeypatch.setattr(kc, "_REFLECTOR_MAX_ROWS_PER_RUN", 1)
+    state = tmp_path / "state"
+    workspace = _workspace(tmp_path)
+    _write_live(state, [
+        _row("cycle-aaaaaaaaaaa1", "2026-09-01T10:00:00Z", (DETAIL, "502s")),
+        _row("cycle-bbbbbbbbbbb2", "2026-09-01T10:00:00Z", (OTHER, "untested section")),
+        _row("cycle-ccccccccccc3", "2026-09-02T10:00:00Z", (DETAIL, "502s again")),
+    ])
+
+    promote_reflector_recommendations_to_v2(workspace, state)
+    pool = load_reflector_pool(state)
+    assert pool["last_run"]["rows_processed"] == 2 and pool["cursor"] == "2026-09-01T10:00:00Z"
+    assert sorted(c["cycles"][0] for c in pool["clusters"]) == ["cycle-aaaaaaaaaaa1", "cycle-bbbbbbbbbbb2"]
+
+
 def test_new_card_cap_defers_graduation_and_the_next_run_finishes_it_without_new_rows(tmp_path: Path) -> None:
     state = tmp_path / "state"
     workspace = _workspace(tmp_path)

--- a/tests/test_issue_1209_durable_curator_writes.py
+++ b/tests/test_issue_1209_durable_curator_writes.py
@@ -90,13 +90,25 @@ def _origin_main_show(repo: Path, rel: str) -> str | None:
 
 
 def _reflection(state: Path, detail: str, cycle_id: str = "cycle-1209abcdef00") -> None:
+    """Two cycles on two days recommending the same thing — since #1171 a
+    recommendation earns a card on recurrence, not on first sight."""
     reflector = state / "reflector"
     reflector.mkdir(parents=True, exist_ok=True)
-    (reflector / "reflections.jsonl").write_text(json.dumps({
-        "cycle_id": cycle_id,
-        "summary": "Reflector found an unbounded parser read on a growing journal",
-        "recommendations": [{"kind": "approach_hint", "detail": detail}],
-    }) + "\n", encoding="utf-8")
+    rows = [
+        {
+            "cycle_id": cycle_id, "timestamp": "2026-09-01T10:00:00Z",
+            "summary": "Reflector found an unbounded parser read on a growing journal",
+            "recommendations": [{"kind": "approach_hint", "detail": detail, "evidence": "The parser read the whole journal"}],
+        },
+        {
+            "cycle_id": cycle_id[:-2] + "01", "timestamp": "2026-09-02T10:00:00Z",
+            "summary": "Reflector found the same unbounded read in a second script",
+            "recommendations": [{"kind": "approach_hint", "detail": detail, "evidence": "The parser read the whole journal again"}],
+        },
+    ]
+    (reflector / "reflections.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8",
+    )
 
 
 def _stage_fact(state: Path, name: str = "durable-fact", lesson_id: str = "L-1209") -> None:
@@ -145,15 +157,14 @@ def test_reflector_mint_survives_cycle_start_reset_and_two_integrations(tmp_path
     assert cards[0]["id"].startswith("LESS-REF-1209abcdef00")
     assert cards[0]["solution"] == "Read a bounded tail of the journal instead of the whole file"
     assert cards[0]["tags"] == ["reflector"]
+    assert cards[0]["seen_count"] == 2  # #1171: one card for the two cycles that recommended it
     assert load_staged_manifest(state) == []
 
-    # Selection logic is untouched (#1209 non-goal): a recommendation still in
-    # the newest rows re-folds into its card on the next run (#1138 suffixes the
-    # id, find_duplicate matches the problem), so the next pickup bumps
-    # seen_count on origin/main instead of minting a second card.
-    assert promote_reflector_recommendations_to_v2(repo, state, max_items=2) == 1
+    # #1171: the cursor has moved past both rows, so the next run has nothing
+    # new to stage and the pickup finds nothing — the store is not re-counted.
+    assert promote_reflector_recommendations_to_v2(repo, state, max_items=2) == 0
     _cycle_start_reset(repo)
-    assert _pickup_staged_promotions(repo, state) == 1
+    assert _pickup_staged_promotions(repo, state) == 0
     cards = yaml.safe_load(_origin_main_show(repo, LESSONS_REL) or "")["lessons"]
     assert len(cards) == 1
     assert cards[0]["seen_count"] == 2

--- a/tests/test_lesson_v2.py
+++ b/tests/test_lesson_v2.py
@@ -131,12 +131,22 @@ def test_curator_promotes_reflector_delta(tmp_path: Path) -> None:
     state = tmp_path / "state" / "reflector"
     workspace.mkdir()
     state.mkdir(parents=True)
-    (state / "reflections.jsonl").write_text(json.dumps({
-        "cycle_id": "cycle-reflect",
-        "timestamp": "2026-08-31T12:00:00Z",
-        "summary": "Reflector found an inefficient parser path",
-        "recommendations": [{"kind": "approach_hint", "detail": "Use bounded parser reads incrementally for large files"}],
-    }) + "\n", encoding="utf-8")
+    # #1171: a recommendation earns a card on recurrence — two cycles, two days.
+    rows = [
+        {
+            "cycle_id": "cycle-reflect",
+            "timestamp": "2026-08-31T12:00:00Z",
+            "summary": "Reflector found an inefficient parser path",
+            "recommendations": [{"kind": "approach_hint", "detail": "Use bounded parser reads incrementally for large files"}],
+        },
+        {
+            "cycle_id": "cycle-reflect2",
+            "timestamp": "2026-09-01T12:00:00Z",
+            "summary": "Reflector found the parser path again",
+            "recommendations": [{"kind": "approach_hint", "detail": "Use bounded parser reads incrementally for large files"}],
+        },
+    ]
+    (state / "reflections.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
     import os
     old_time = time.time() - 10
     os.utime(state / "reflections.jsonl", (old_time, old_time))
@@ -204,7 +214,7 @@ def test_curator_folds_duplicate_and_upgrades_meaningless_solution(tmp_path: Pat
     assert cards[0]["seen_count"] == 2
 
 
-def _write_reflections_over(path: Path, min_bytes: int, tail_row: dict[str, object]) -> int:
+def _write_reflections_over(path: Path, min_bytes: int, tail_row: dict[str, object] | list[dict[str, object]]) -> int:
     """Write padding rows until *path* exceeds *min_bytes*, then *tail_row* last.
 
     Padding rows carry no ``recommendations``, so nothing but *tail_row* is
@@ -212,12 +222,21 @@ def _write_reflections_over(path: Path, min_bytes: int, tail_row: dict[str, obje
     """
     filler = "x" * 800
     written = 0
+    index = 0
+    tail_rows = tail_row if isinstance(tail_row, list) else [tail_row]
     with path.open("w", encoding="utf-8") as handle:
         while written <= min_bytes:
-            line = json.dumps({"cycle_id": f"cycle-pad-{written}", "summary": filler}) + "\n"
+            # Timestamped like real journal rows so the #1171 cursor can advance
+            # through the padding (a run reads a bounded number of rows).
+            line = json.dumps({
+                "cycle_id": f"cycle-pad-{written}", "summary": filler,
+                "timestamp": f"2026-08-01T00:00:{index % 60:02d}.{index // 60:06d}Z",
+            }) + "\n"
             handle.write(line)
             written += len(line)
-        handle.write(json.dumps(tail_row) + "\n")
+            index += 1
+        for row in tail_rows:
+            handle.write(json.dumps(row) + "\n")
     return path.stat().st_size
 
 
@@ -236,17 +255,36 @@ def test_curator_promotes_from_log_larger_than_the_old_size_cap(tmp_path: Path) 
     size = _write_reflections_over(
         state / "reflections.jsonl",
         512 * 1024,
-        {
-            "cycle_id": "cycle-oversize",
-            "summary": "Reflector found an unbounded read on a growing log",
-            "recommendations": [
-                {"kind": "approach_hint", "detail": "Read a bounded tail instead of the whole file"}
-            ],
-        },
+        [
+            {
+                "cycle_id": "cycle-oversize",
+                "timestamp": "2026-09-01T12:00:00Z",
+                "summary": "Reflector found an unbounded read on a growing log",
+                "recommendations": [
+                    {"kind": "approach_hint", "detail": "Read a bounded tail instead of the whole file"}
+                ],
+            },
+            {
+                "cycle_id": "cycle-oversize2",
+                "timestamp": "2026-09-02T12:00:00Z",
+                "summary": "Reflector found the unbounded read again",
+                "recommendations": [
+                    {"kind": "approach_hint", "detail": "Read a bounded tail instead of the whole file"}
+                ],
+            },
+        ],
     )
     assert size > 512 * 1024, size
 
-    assert promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2) == 1
+    # #1171: a run reads a bounded number of rows after its cursor and carries
+    # the rest over, so a file this size takes two runs to reach its tail —
+    # but it is read, where the old size cap returned 0 forever.
+    staged = 0
+    for _ in range(4):
+        staged += promote_reflector_recommendations_to_v2(workspace, state.parent.parent, max_items=2)
+        if staged:
+            break
+    assert staged == 1
     _materialize_staged_lessons(workspace, state.parent.parent)
     lessons = yaml.safe_load((workspace / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
     assert lessons["lessons"][0]["solution"] == "Read a bounded tail instead of the whole file"
@@ -263,10 +301,20 @@ def test_curator_skips_unparseable_row_instead_of_abandoning_the_file(tmp_path: 
     workspace.mkdir()
     state.mkdir(parents=True)
     (state / "reflections.jsonl").write_text(
-        '{"cycle_id": "cycle-truncated", "recommendations": [\n'
-        + json.dumps({
+        json.dumps({
             "cycle_id": "cycle-good",
+            "timestamp": "2026-09-01T12:00:00Z",
             "summary": "Reflector found a parser that aborts on one bad row",
+            "recommendations": [
+                {"kind": "error_pattern", "detail": "Skip the unparseable row and keep the rest"}
+            ],
+        })
+        + "\n"
+        + '{"cycle_id": "cycle-truncated", "recommendations": [\n'
+        + json.dumps({
+            "cycle_id": "cycle-good2",
+            "timestamp": "2026-09-02T12:00:00Z",
+            "summary": "Reflector found the aborting parser again",
             "recommendations": [
                 {"kind": "error_pattern", "detail": "Skip the unparseable row and keep the rest"}
             ],

--- a/tests/test_side_role_cliffs.py
+++ b/tests/test_side_role_cliffs.py
@@ -136,7 +136,9 @@ def test_archive_reads_are_bounded_to_the_newest_two(tmp_path, monkeypatch):
 
 
 def test_promotion_tops_up_a_freshly_rotated_journal_from_the_archive(tmp_path):
-    """Pre-fix: the bounded tail read the live file only; right after a rotation it saw nothing to promote."""
+    """Pre-fix: the bounded tail read the live file only; right after a rotation it saw nothing to promote.
+    Since #1171 the mint reads every row after its cursor across the archives, and a first-seen
+    recommendation waits in the pool rather than minting — so the archive read is observed there."""
     state = tmp_path / "state"
     workspace = tmp_path / "workspace"
     (workspace / "lessons").mkdir(parents=True)
@@ -145,7 +147,10 @@ def test_promotion_tops_up_a_freshly_rotated_journal_from_the_archive(tmp_path):
         _row("a2", "Run the targeted test module before committing a script change"),
     ])
     _write_live(state, [])
-    assert knowledge_curator.promote_reflector_recommendations_to_v2(workspace, state) == 2
+    assert knowledge_curator.promote_reflector_recommendations_to_v2(workspace, state) == 0
+    pool = knowledge_curator.load_reflector_pool(state)
+    assert pool["last_run"]["rows_read"] == 2 and pool["last_run"]["items"] == 2
+    assert sorted(c["cycles"][0] for c in pool["clusters"]) == ["a1", "a2"]
 
 
 # ─── digest ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1171. Design agreed on the issue (comment 5516742216 and the reply); this PR is that design.

## What changes

`promote_reflector_recommendations_to_v2` (`knowledge_curator.py`) — **a reflector recommendation earns a card on recurrence, folds on agreement, otherwise waits.**

- **Cursor replaces the window.** A timestamp watermark in `state/curator/reflector_pool.json`; each run reads every row after it across the newest two archives plus the live journal (`_reflector_rows_after`), at most `_REFLECTOR_MAX_ROWS_PER_RUN = 600` rows, and carries the remainder over. `_REFLECTOR_TAIL_ROWS` and `_reflection_tail_lines` are gone.
- **Fold first, uncapped.** An item folds into an existing card whose solution says the same thing (keyword Jaccard ≥ `_REFLECTOR_FOLD_THRESHOLD = 0.35`) or whose problem matches (`find_duplicate` rule, hash or ≥ 0.8). Folds advance `seen_count`/`last_seen`/`evidence` and never grow the base. A card whose solution is filler is matched through its `problem` (`_fold_words`) — that is where the 2026-08-29 mint stored the recommendation — and upgraded (#1106).
- **Pool, then graduate.** Otherwise the item joins the pool cluster it matches or starts one. A cluster graduates to a new card when it spans **≥ 2 distinct cycles AND ≥ 2 distinct days** (`_REFLECTOR_MIN_CYCLES`, `_REFLECTOR_MIN_DAYS`); graduation is evaluated over the whole pool after each run, most-recurrent first, so a cluster deferred by the cap or waiting on a second day graduates later without another matching item. Pool bounded to 400 clusters / 14 days (`_prune_pool`).
- **Cap is a valve.** `max_items = 5` new cards per run (was 2, and it counted folds).
- **Card fields.** `problem` = the item's `evidence` (the observation), `solution` = `detail`, `title` = `detail[:200]`, `seen_count` = distinct cycles, `evidence` = cycle ids (cap 8), `distinct_days` recorded per card.
- **Repair in place: yes.** When a re-read item is a card's own origin (its cycle already in the card's `evidence`, solution match ≥ 0.8), the card's narrative `problem` is replaced by the observation and `seen_count` is **not** incremented. On the live store this repairs `LESS-REF-4f03664182da-0d35` and `LESS-REF-16436c7d5b3a-4c67` (problem becomes "Tool execution after write_file 8v84c3XW6 produced TypeError…" / "Analysis during test writing noted: 'The script has a duplic…") and upgrades all four 08-29 filler cards, on the first backfill run, via the normal pickup.
- **Same rule at pickup.** `_merge_card_into` (used by `apply_staged_lesson_cards`) folds through `_fold_target`, so the bridge agrees with the curator's decision.
- **Signal.** `last_run` in the sidecar and one `curator-reflector:` stdout line carry `rows_read, rows_processed, items, folded, repaired, pooled_new, pooled_recurrence, same_day_only_waiting, graduated, deferred_by_cap, near_misses, rejected, staged, pool_size, cursor`; `last_staged_at` is kept. Near-misses = items whose best match fell in `[_REFLECTOR_NEAR_MISS_FLOOR = 0.25, 0.35)`. Feeds #1216; does not decide its cadence question.
- `lesson_v2.keyword_set` / `set_jaccard`: normalize a text once per run; `keyword_jaccard` is unchanged in behaviour.

## Pre-change failure (origin/main `e6c8e9ef`)

Three-assertion repro (`um-scratch/1171/test_repro_1171.py`, old API only), verbatim:

```
E       AssertionError: a single sighting minted a card
E       assert 1 == 0
E        +  where 1 = promote_reflector_recommendations_to_v2(...)
E       AssertionError: assert 'One narrativ...commendations' == 'LiteLLM retu...r three calls'
E         - LiteLLM returned 502 for three calls
E         + One narrative shared by both recommendations
E       AssertionError: assert ['Configure a...tay covered.'] == ['Configure a...tay covered.']
E         At index 1 diff: 'Configure a fallback model group ...' != 'Register newly added AGENTS.md sections ...'
E         Left contains 2 more items
3 failed in 1.73s
```

One sighting minted; the card's problem was the cycle narrative; two same-row recommendations produced four staged cards (each folded into the other's narrative). Same repro on this branch: `3 passed`.

## The live store through this code (read-only copy, 738 rows / 502 items, store from `origin/main` of the instance repo, 110 entries / 6 v2)

| run | ms (here) | rows | items | folded | repaired | pooled_new | same-day waiting | graduated | deferred | near-misses | staged |
|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 | 412 | 600 | 432 | 5 | 4 | 400 | 9 | 5 | 1 | 85 | 10 |
| 2 | 240 | 138 | 70 | 2 | 2 | 63 | 11 | 4 | 0 | 11 | 6 |
| 3 | 120 | 0 | 0 | 0 | 0 | 0 | 9 | 0 | 0 | 0 | 0 |

Result: 6 v2 cards → 15 (9 graduated, 6 repaired in place, 0 rejected). Top cards: LiteLLM fallback (seen 4, 2 days), commit-early-in-turn-budget (3, 2 days), document out-of-scope pre-existing failures (3, 3 days), pytest-not-unittest, loop-breaker pivot, chained git exec. **9 clusters wait as same-day-only** — the 7-cycle LiteLLM echo of 2026-09-01 among them; with days not gated they would have been 21 cards (the design comment's number). 96 of 502 items were near-misses in `[0.25, 0.35)` — 19%; that is the shoulder you asked to see, and it says the threshold is not obviously too high or too low without a second week. Pool reached its 400 bound during run 2 (singletons from 08-27/28 evicted by size before by age).

**Cost per run.** Backfill run: 0.41 s here (was 2.5 s before caching the per-entry problem keys — `find_duplicate` re-normalized every entry per item, 86% of the run); the Atom N550 is ~10–15× slower → **~4–6 s once, split over two nightly runs by the 600-row cap**. Steady state (~120 rows, ~70 items/day against ~120 cards + 400 pool): 0.24 s here → **~3 s/day on the host**. Memory: sidecar ~250 KB at the bound. No LLM, no embeddings.

## Tests

`tests/test_issue_1171_reflector_mint_recurrence.py` — 20 tests: first sighting waits; two cycles/two days graduate with the observation as problem; same-day recurrence waits and is counted; same-row siblings stay separate lessons; fold is uncapped (`max_items=0`); narrative problem repaired from the origin item without re-counting; 08-29 filler card reached through its problem and repaired; cursor advances / rows not reprocessed; recurrence across archive + live; rows-per-run cap carries over; new-card cap defers and the next run finishes without new rows; near-misses counted; run counts distinguish candidates from idle; pool bounded and stale clusters evicted; error/unparseable/other-kind rows skipped; corrupt sidecar restarts; pickup folds into a card that arrived meanwhile; threshold constant and calibration note on record.

Adapted (fixtures that minted from one sighting now recur it across two cycles on two days; the durability/id assertions are unchanged): `test_issue_1209_durable_curator_writes.py`, `test_issue_1138_lesson_ids.py`, `test_issue_1138_lesson_ids_guard.py`, `test_lesson_v2.py` (padding rows now timestamped so the cursor can advance through them), `test_side_role_cliffs.py` (archive read now observed in the pool).

## Review pass (cavecrew-reviewer, applied)

- Rows sharing the boundary timestamp are never split across runs (the cursor skips `ts <= cursor`, so a tie at the 600-row cap would have lost the rows past it). Real journal timestamps are microsecond-unique; closed anyway, tested.
- A graduation that folds into a card minted earlier in the same run refreshes that card's fold caches (within-run staleness only — the caches are per-run locals).
- The sidecar write is fail-open (cards are already staged; a lost sidecar re-processes the rows, idempotently), and `run_curation` now wraps the mint so an exception there cannot take the fact-curation pass down — a pre-existing exposure, logged as a warning rather than swallowed silently.

## Full pytest (Windows, `-n auto`, this branch `83ea0305`)

**18 failed, 2920 passed, 17 skipped.** The 18: `test_autoevolve*` (12, symlink/tar), `test_bridge_locking` (3, flock), `test_selfevo_export_security` (2, `master` refspec), `test_bridge_cycle_tags::test_fail_open_tag_failure_never_breaks_a_green_cycle` (fails on origin/main, per your note). None touch the curator or lesson modules. Absolute counts as asked; reconcile against your baseline.

## Least-certain claim

**The pool bound (400) bites before the age bound (14 d) at the live rate**: ~67 singletons/day fill it in six days, so a recommendation first seen on day 1 and repeated on day 8 is evicted before it can recur. Every recurrence in the calibration week spanned ≤ 4 days, so it held there, but that is one week. `evicted` is in the run counts; if it is non-zero while `same_day_only_waiting`/`graduated` stay flat, raise `_REFLECTOR_POOL_MAX` — cost is linear in it (~0.5 ms per 100 clusters per item here).

Also on record: 0.35 / K=2 from one week of one loop (comment block above the constants); `error_pattern` is never a recommendation kind in the reflector's own prompt (it is a *finding* kind), so `_REFLECTOR_KINDS` effectively means `approach_hint` — left as is, not widened.

## Live verification (yours)

After deploy and the first 00:00 MSK run: `state/curator/reflector_pool.json` `last_run` with `items > 0`, `graduated + folded > 0`, `cursor` at the newest row; after the next bridge pickup, `git show origin/main:lessons/lessons.yaml` carries new `LESS-REF-*` cards with `distinct_days: 2`, `seen_count ≥ 2`, `problem` an observation, and the two 09-02 cards with their problems replaced. Do not hand-write a card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
