### PR TITLE
fix(existence_index): retire the hypothesis corpus; readers stop reading state/research; state-path writer registry (#1219)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -4753,134 +4753,13 @@ def _write_structured_error(
         return False
 
 
-
-def _active_backlog_is_empty(memory_text: str) -> bool:
-    """Return True if ## Active backlog section has no undone Priority blocks."""
-    import re as _re
-    # Extract Active backlog section (between BACKLOG_START and BACKLOG_END comments, or between headers)
-    section_match = _re.search(
-        r'## Active backlog.*?(?=\n## |\Z)',
-        memory_text,
-        _re.DOTALL,
-    )
-    if not section_match:
-        return True  # no active section → treat as empty
-    section = section_match.group(0)
-    # Check for any Priority block NOT marked Done
-    undone = _re.findall(r'###\s+Priority\s+\d+:(?!.*\[Done\])', section)
-    return len(undone) == 0
-
-
-def _auto_seed_backlog_from_research(
-    repo_root: Path,
-    memory_text: str,
-    memory_path: Path,
-) -> bool:
-    """If Active backlog is empty, add 2 new priorities from state/research/feed.json.
-
-    Returns True if MEMORY.md was updated.
-    """
-    import json as _json
-    import re as _re
-
-    if not _active_backlog_is_empty(memory_text):
-        return False
-
-    # Find research/feed.json — state root is ../state relative to repo
-    # Convention: repo at .../eeebot-self-evolving, state at .../state
-    state_root = repo_root.parent / 'state'
-    feed_path = state_root / 'research' / 'feed.json'
-    if not feed_path.exists():
-        return False
-
-    try:
-        feed = _json.loads(feed_path.read_text(encoding='utf-8'))
-    except Exception:
-        feed = {}
-
-    # Support both list-at-root and {entries: [...]} formats
-    if isinstance(feed, list):
-        entries = feed
-    else:
-        entries = feed.get('entries') if isinstance(feed.get('entries'), list) else []
-
-    # Fallback: if feed.json has no entries, try hypotheses.json
-    if not entries:
-        hyp_path = state_root / 'research' / 'hypotheses.json'
-        if hyp_path.exists():
-            try:
-                hyp_data = _json.loads(hyp_path.read_text(encoding='utf-8'))
-                if isinstance(hyp_data, list):
-                    # Each element is {cycle_id, candidates:[{title, acceptance}]}
-                    for hyp_entry in hyp_data[:5]:
-                        cands = hyp_entry.get('candidates') or []
-                        for c in cands:
-                            title = str(c.get('title') or '').strip()
-                            acceptance = str(c.get('acceptance') or '').strip()
-                            if title and title not in memory_text:
-                                entries.append({'title': title, 'acceptance': acceptance})
-                        if len(entries) >= 5:
-                            break
-            except Exception:
-                pass
-
-    if not entries:
-        return False
-
-    # Find next priority number
-    existing_nums = [int(m) for m in _re.findall(r'###\s+Priority\s+(\d+):', memory_text)]
-    next_num = max(existing_nums, default=8) + 1
-
-    new_blocks: list[str] = []
-    added = 0
-    for entry in entries:
-        if added >= 2:
-            break
-        title = str(entry.get('title') or entry.get('hypothesis') or '').strip()
-        if not title or title in memory_text:
-            continue
-        # Skip tasks that _task_already_done would immediately reject
-        if _task_already_done(title, repo_root):
-            print(f'bridge-memory: skipping already-done feed entry: {title[:60]}')
-            continue
-        acceptance = str(entry.get('acceptance') or entry.get('action') or '').strip()
-        instructions = acceptance or f'Research candidate from synthesize cycle: {title}'
-        block = (
-            f'### Priority {next_num}: {title}\n'
-            f'{instructions}\n'
-            f'Test: verify the change runs without errors.\n'
-            f'Commit: git add <file> && git commit -m "feat: {title[:50]}"\n'
-        )
-        new_blocks.append(block)
-        next_num += 1
-        added += 1
-
-    if not new_blocks:
-        return False
-
-    # Insert new blocks before BACKLOG_END comment (or before ## Completed)
-    insertion = '\n'.join(new_blocks)
-    if '<!-- BACKLOG_END -->' in memory_text:
-        updated = memory_text.replace(
-            '<!-- BACKLOG_END -->',
-            insertion + '\n<!-- BACKLOG_END -->',
-            1,
-        )
-    elif '## Completed' in memory_text:
-        updated = memory_text.replace(
-            '## Completed',
-            insertion + '\n---\n\n## Completed',
-            1,
-        )
-    else:
-        updated = memory_text.rstrip() + '\n\n' + insertion
-
-    if updated == memory_text:
-        return False
-
-    memory_path.write_text(updated, encoding='utf-8')
-    print(f'bridge-memory: auto-seeded {added} priorities from research/feed.json')
-    return True
+# #1219: ``_auto_seed_backlog_from_research`` (and its only caller-side
+# helper ``_active_backlog_is_empty``) (seed two MEMORY.md priorities
+# from ``state/research/feed.json`` when the Active backlog is empty) was
+# removed. Its input had no writer since ``cycle_planning`` was deleted (#924)
+# and froze on 2026-08-22 with two entries; it fired twice in the repository's
+# history (2760a525 2026-06-24, 1520d8e7 2026-06-22) and never in the 70 days
+# since. The demand lanes, not the research feed, drive the loop now.
 
 
 def _move_priority_to_completed(
@@ -5007,21 +4886,9 @@ def _try_mark_backlog_done(
         capture_output=True, text=True,
     )
     committed = result.returncode == 0
-
-    # Auto-seed: if Active backlog is now empty, add new priorities from research feed
-    if committed:
-        try:
-            fresh_text = memory_path.read_text(encoding='utf-8')
-            seeded = _auto_seed_backlog_from_research(repo_root, fresh_text, memory_path)
-            if seeded:
-                _sp.run(_git + ['add', 'memory/MEMORY.md'], capture_output=True)
-                _sp.run(
-                    _git + ['commit', '-m', 'chore: auto-seed backlog from research/feed.json (backlog empty)'],
-                    capture_output=True,
-                )
-        except Exception:
-            pass  # never block on auto-seed failure
-
+    # #1219: the auto-seed of MEMORY.md priorities from state/research/feed.json
+    # that used to follow here is gone with its writer-less input (see
+    # _move_priority_to_completed's neighbour comment above).
     return committed
 
 

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -1643,25 +1643,10 @@ def _hypothesis_items(
             seen.add(title)
             evidence = str(entry.get("evidence") or entry.get("metric") or entry.get("data_to_collect") or entry.get("insight_criterion") or entry.get("acceptance") or "")
             items.append(_make_item("hypothesis", title, evidence))
-
-        research = _read_json(Path(state_dir) / "research" / "hypotheses.json", None)
-        if isinstance(research, list):
-            for snapshot in research[:50]:
-                if not isinstance(snapshot, dict):
-                    continue
-                for cand in snapshot.get("candidates") or []:
-                    if not isinstance(cand, dict):
-                        continue
-                    if not _is_active(cand):
-                        continue
-                    title = str(cand.get("title") or cand.get("hypothesis") or "").strip()
-                    if not title or title in seen:
-                        continue
-                    if not _hypothesis_has_evidence(cand, selfevo_repo):
-                        continue
-                    seen.add(title)
-                    evidence = str(cand.get("evidence") or cand.get("metric") or cand.get("acceptance") or "")
-                    items.append(_make_item("hypothesis", title, evidence))
+        # #1219: ``research/hypotheses.json`` is no longer a source here. Its
+        # writer (``cycle_planning._write_research_feed``) was deleted with the
+        # planner (#924) and the file froze on 2026-08-22; durable + backlog
+        # above are the live hypothesis sources.
 
         # #878: at most ONE active hypothesis experiment at a time. If a
         # hypothesis already has an unanswered in-flight serving cycle

--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -566,8 +566,10 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
     ``ledger_titles_unchanged``, ``ledger_titles_not_integrated``,
     ``ledger_titles_deactivated`` (#1215), ``hypotheses_deactivated``
     (#1219 — the retired corpus; non-zero only until its documents are
-    gone). On any unexpected failure, returns a dict with an ``"error"`` key
-    instead of raising — callers must fail open.
+    gone), ``retirement_skipped`` (list of kinds whose builder raised this
+    pass, so their documents were left as they were). On any unexpected
+    failure, returns a dict with an ``"error"`` key instead of raising —
+    callers must fail open.
     """
     state_dir = Path(state_dir)
     selfevo_repo = Path(selfevo_repo)
@@ -580,30 +582,39 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
         "ledger_titles_not_integrated": 0,
         "ledger_titles_deactivated": 0,
         "hypotheses_deactivated": 0,
+        "retirement_skipped": [],  # kinds whose builder raised this pass (#1219)
     }
     try:
         con = _open_db(state_dir)
     except Exception as exc:
         return {"error": str(exc)}
     try:
-        evidence: dict[str, set[str]] = {kind: set() for kind, _ in _CORPORA}
+        # A kind with no builder retires completely (evidence = ∅). A kind
+        # whose builder RAISED is different: its evidence is unknown, not
+        # empty, so retirement is skipped for that kind this pass and the skip
+        # is reported — a transient read error must not retire a live corpus.
+        evidence: dict[str, set[str] | None] = {kind: set() for kind, _ in _CORPORA}
         try:
             built, evidence["script"] = _reindex_scripts(con, selfevo_repo)
             counts.update(built)
         except Exception:
-            pass
+            evidence["script"] = None
         try:
             built, evidence["ledger_title"] = _reindex_ledger_titles(con, state_dir, selfevo_repo)
             counts.update(built)
         except Exception:
-            pass
+            evidence["ledger_title"] = None
         # Retire whatever no builder re-derived this pass — for EVERY kind,
         # including ``hypothesis``, which has no builder any more.
         for kind, prefix in _CORPORA:
+            seen = evidence[kind]
+            if seen is None:
+                counts["retirement_skipped"].append(kind)
+                continue
             try:
-                counts[f"{prefix}_deactivated"] = _deactivate_missing(con, kind, evidence[kind])
+                counts[f"{prefix}_deactivated"] = _deactivate_missing(con, kind, seen)
             except Exception:
-                pass
+                counts["retirement_skipped"].append(kind)
         con.commit()
     except Exception as exc:
         counts["error"] = str(exc)

--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -250,10 +250,6 @@ def _fts_replace(con: sqlite3.Connection, kind: str, path: str, text: str) -> No
     )
 
 
-def _fts_remove(con: sqlite3.Connection, kind: str, path: str) -> None:
-    con.execute("DELETE FROM docs_fts WHERE kind = ? AND path = ?", (kind, path))
-
-
 def _upsert_document(con: sqlite3.Connection, kind: str, path: str, text: str) -> bool:
     """Insert/update one document. Returns True if content actually changed
     (i.e. FTS/content work was done), False if the hash was unchanged
@@ -283,16 +279,27 @@ def _deactivate_missing(con: sqlite3.Connection, kind: str, seen_paths: set[str]
     rows = con.execute(
         "SELECT path FROM documents WHERE kind = ? AND active = 1", (kind,),
     ).fetchall()
-    deactivated = 0
-    for (path,) in rows:
-        if path in seen_paths:
-            continue
+    retire = [path for (path,) in rows if path not in seen_paths]
+    if not retire:
+        return 0
+    # Batched (#1219): ``docs_fts`` has no index on ``path`` — a per-row
+    # ``DELETE ... WHERE path = ?`` scans the whole FTS table each time, and
+    # retiring the 6,935 hypothesis documents row by row took 11 s on a
+    # desktop, minutes on the host, inside the bridge's dedup gate. One
+    # statement per kind when the whole kind retires, else IN-list chunks.
+    if len(retire) == len(rows):
+        con.execute("UPDATE documents SET active = 0 WHERE kind = ? AND active = 1", (kind,))
+        con.execute("DELETE FROM docs_fts WHERE kind = ?", (kind,))
+        return len(retire)
+    chunk = 400  # well under SQLite's default 999 bound-parameter limit
+    for start in range(0, len(retire), chunk):
+        paths = retire[start:start + chunk]
+        marks = ",".join("?" * len(paths))
         con.execute(
-            "UPDATE documents SET active = 0 WHERE kind = ? AND path = ?", (kind, path),
+            f"UPDATE documents SET active = 0 WHERE kind = ? AND path IN ({marks})", (kind, *paths),
         )
-        _fts_remove(con, kind, path)
-        deactivated += 1
-    return deactivated
+        con.execute(f"DELETE FROM docs_fts WHERE kind = ? AND path IN ({marks})", (kind, *paths))
+    return len(retire)
 
 
 # ─── corpus builders ────────────────────────────────────────────────────────

--- a/nanobot/runtime/existence_index.py
+++ b/nanobot/runtime/existence_index.py
@@ -26,8 +26,10 @@ a busy timeout so a concurrent reindex/read never deadlocks the loop:
   boilerplate docstring line) is stored once.
 - ``documents(kind TEXT, path TEXT, hash TEXT, active INTEGER DEFAULT 1,
   UNIQUE(kind, path))`` — ``kind`` is one of ``script``, ``ledger_title``,
-  ``hypothesis``. ``active=0`` marks a soft-deleted document (e.g. a script
-  file that no longer exists) without losing history.
+  or the retired ``hypothesis`` (#1219; rows stay, inactive). ``active=0``
+  marks a soft-deleted document (a script file that no longer exists, an
+  attempt that is no longer evidence, a corpus that is no longer built)
+  without losing history.
 - ``docs_fts`` — an FTS5 virtual table ``(kind UNINDEXED, path, text,
   tokenize='porter unicode61')`` mirroring the ACTIVE documents only. Kept in
   sync explicitly on every upsert/deactivate (delete-then-insert on change) —
@@ -55,9 +57,21 @@ Indexed corpus (built by :func:`reindex`)
   asserts an attempt, not an artifact, and indexing it let the first refusal
   of a subject suppress every later one. Documents that no longer qualify
   are deactivated on reindex, like deleted scripts.
-- **hypotheses**: titles from ``<state_dir>/hypotheses/backlog.json``
-  (``entries[].task_title``) and ``<state_dir>/research/hypotheses.json``
-  (``[].candidates[].title``). Both optional; each fails open independently.
+- **hypotheses** — RETIRED (#1219). Titles from ``hypotheses/backlog.json``
+  and the writer-less ``research/hypotheses.json`` used to be indexed here. A
+  hypothesis is a statement of something not yet done, so its title is never
+  evidence that an artifact exists; the corpus was never consulted by the
+  gate and only displaced documents that are. Existing rows are deactivated
+  by the retirement contract below; nothing is indexed under this kind.
+
+Retirement contract (:data:`_CORPORA`, #1219)
+----------------------------------------------
+Each corpus builder returns the set of document paths it re-derived from a
+living source in this pass, and :func:`reindex` deactivates every other
+active document of that kind — for every kind ever held, including one that
+no longer has a builder. Retirement is therefore a property of the index,
+not of each builder: a source whose writer disappears retires with it
+instead of leaving its documents active forever.
 
 Matching (:func:`find_similar` / :func:`find_duplicate_script`)
 -----------------------------------------------------------------
@@ -82,8 +96,10 @@ or a test-suite-for-X title) is NEVER flagged against a ``scripts/``/
 that overlap is guaranteed and meaningless; writing tests for existing code
 is new work. Such a proposal may only be flagged against another test
 artifact (a ``tests/`` path) or a prior ``ledger_title`` attempt that is
-itself test-for the same subject. ``hypothesis`` hits remain informational
-only (future proposer-context use, not wired into the gate in #750).
+itself test-for the same subject. (``hypothesis`` hits were "informational
+only" from #750 until #1219 retired the corpus — never wired into the gate,
+but present in the BM25 top-k the gate reads, where they displaced the
+documents it can act on.)
 
 Kill switch
 -----------
@@ -307,8 +323,11 @@ def _script_display_text(py_path: Path) -> str:
     return f"{name} {docline}".strip()
 
 
-def _reindex_scripts(con: sqlite3.Connection, selfevo_repo: Path) -> dict[str, int]:
-    counts = {"scripts_indexed": 0, "scripts_unchanged": 0, "scripts_deactivated": 0}
+def _reindex_scripts(con: sqlite3.Connection, selfevo_repo: Path) -> tuple[dict[str, int], set[str]]:
+    """Index the script corpus. Returns ``(counts, evidence)`` where
+    ``evidence`` is the set of repo-relative paths that exist right now —
+    :func:`reindex` retires every other active ``script`` document."""
+    counts = {"scripts_indexed": 0, "scripts_unchanged": 0}
     seen: set[str] = set()
     for subdir in _SCRIPT_SUBDIRS:
         d = selfevo_repo / subdir
@@ -343,11 +362,7 @@ def _reindex_scripts(con: sqlite3.Connection, selfevo_repo: Path) -> dict[str, i
                 counts["scripts_indexed"] += 1
             else:
                 counts["scripts_unchanged"] += 1
-    try:
-        counts["scripts_deactivated"] = _deactivate_missing(con, "script", seen)
-    except Exception:
-        pass
-    return counts
+    return counts, seen
 
 
 def _origin_main_paths(selfevo_repo: Path) -> set[str] | None:
@@ -405,8 +420,10 @@ def _result_entries(state_dir: Path) -> list[tuple[Path, float]]:
 
 def _reindex_ledger_titles(
     con: sqlite3.Connection, state_dir: Path, selfevo_repo: Path | None = None,
-) -> dict[str, int]:
+) -> tuple[dict[str, int], set[str]]:
     """Index the titles of past attempts that PRODUCED something (#1215).
+    Returns ``(counts, evidence)``; :func:`reindex` retires every active
+    ``ledger_title`` document not in ``evidence`` (#1219 contract).
 
     A ``ledger_title`` document is evidence that an artifact exists only
     when the attempt behind it integrated — its result carries
@@ -497,68 +514,40 @@ def _reindex_ledger_titles(
             counts["ledger_titles_indexed"] += 1
         else:
             counts["ledger_titles_unchanged"] += 1
-    try:
-        counts["ledger_titles_deactivated"] = _deactivate_missing(con, "ledger_title", evidence_ids)
-    except Exception:
-        pass
-    return counts
+    return counts, evidence_ids
 
 
-def _reindex_hypotheses(con: sqlite3.Connection, state_dir: Path) -> dict[str, int]:
-    counts = {"hypotheses_indexed": 0, "hypotheses_unchanged": 0}
-
-    backlog_path = state_dir / "hypotheses" / "backlog.json"
-    if backlog_path.is_file():
-        try:
-            data = json.loads(backlog_path.read_text(encoding="utf-8"))
-        except Exception:
-            data = None
-        entries = (data or {}).get("entries") if isinstance(data, dict) else None
-        for idx, entry in enumerate(entries or []):
-            if not isinstance(entry, dict):
-                continue
-            title = str(entry.get("task_title") or "").strip()
-            if not title:
-                continue
-            doc_path = f"hyp-backlog-{entry.get('task_id') or idx}"
-            try:
-                changed = _upsert_document(con, "hypothesis", doc_path, title)
-            except Exception:
-                continue
-            if changed:
-                counts["hypotheses_indexed"] += 1
-            else:
-                counts["hypotheses_unchanged"] += 1
-
-    research_path = state_dir / "research" / "hypotheses.json"
-    if research_path.is_file():
-        try:
-            data = json.loads(research_path.read_text(encoding="utf-8"))
-        except Exception:
-            data = None
-        if isinstance(data, list):
-            for hyp_idx, hyp_entry in enumerate(data[:50]):
-                if not isinstance(hyp_entry, dict):
-                    continue
-                cycle_id = hyp_entry.get("cycle_id") or hyp_idx
-                candidates = hyp_entry.get("candidates") or []
-                for cand_idx, cand in enumerate(candidates):
-                    if not isinstance(cand, dict):
-                        continue
-                    title = str(cand.get("title") or "").strip()
-                    if not title:
-                        continue
-                    doc_path = f"hyp-research-{cycle_id}-{cand_idx}"
-                    try:
-                        changed = _upsert_document(con, "hypothesis", doc_path, title)
-                    except Exception:
-                        continue
-                    if changed:
-                        counts["hypotheses_indexed"] += 1
-                    else:
-                        counts["hypotheses_unchanged"] += 1
-
-    return counts
+# ─── retirement contract (#1219) ─────────────────────────────────────────────
+#
+# Every kind the index has ever held, with the builder that produces its
+# evidence this pass — or ``None`` for a kind that is no longer built. A
+# builder returns ``(counts, evidence)``: ``evidence`` is the set of document
+# paths it re-derived from a living source, and :func:`reindex` deactivates
+# every other active document of that kind. A kind with no builder therefore
+# retires completely on the next reindex.
+#
+# Why a contract and not a per-builder rule: retirement used to live inside
+# each builder, so a builder without one (``hypothesis``) had no retirement
+# path, and a source whose writer was deleted (``state/research/``, #924)
+# left every document it had ever produced active — 6,214 ``hyp-research-*``
+# documents, 98.4% matching nothing on the host, 71% of the index.
+#
+# ``hypothesis`` is retired, not rebuilt: a hypothesis is by definition a
+# statement of something NOT yet done, so a hypothesis title is never
+# evidence that an artifact exists — the backlog half exactly as much as the
+# frozen research half. The corpus also had no consumer (never
+# ``duplicate_suspect``, filtered out of ``related_scripts``) and only took
+# BM25 slots from documents the gate can act on: on 400 recent proposals it
+# pushed a real script duplicate out of the gate's top-5 ten times and cost
+# the proposer 536 reuse hints. Non-goal: "has this already been PROPOSED?"
+# is a legitimate question, and a different one from "does this EXIST?" — if
+# it is wanted it needs its own mechanism, not this index with a hypothesis
+# corpus.
+_CORPORA: tuple[tuple[str, str], ...] = (
+    ("script", "scripts"),
+    ("ledger_title", "ledger_titles"),
+    ("hypothesis", "hypotheses"),
+)
 
 
 def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
@@ -568,9 +557,10 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
     logging: ``scripts_indexed``, ``scripts_unchanged``,
     ``scripts_deactivated``, ``ledger_titles_indexed``,
     ``ledger_titles_unchanged``, ``ledger_titles_not_integrated``,
-    ``ledger_titles_deactivated`` (#1215), ``hypotheses_indexed``,
-    ``hypotheses_unchanged``. On any unexpected failure, returns a dict with
-    an ``"error"`` key instead of raising — callers must fail open.
+    ``ledger_titles_deactivated`` (#1215), ``hypotheses_deactivated``
+    (#1219 — the retired corpus; non-zero only until its documents are
+    gone). On any unexpected failure, returns a dict with an ``"error"`` key
+    instead of raising — callers must fail open.
     """
     state_dir = Path(state_dir)
     selfevo_repo = Path(selfevo_repo)
@@ -582,26 +572,31 @@ def reindex(state_dir: Path, selfevo_repo: Path) -> dict[str, Any]:
         "ledger_titles_unchanged": 0,
         "ledger_titles_not_integrated": 0,
         "ledger_titles_deactivated": 0,
-        "hypotheses_indexed": 0,
-        "hypotheses_unchanged": 0,
+        "hypotheses_deactivated": 0,
     }
     try:
         con = _open_db(state_dir)
     except Exception as exc:
         return {"error": str(exc)}
     try:
+        evidence: dict[str, set[str]] = {kind: set() for kind, _ in _CORPORA}
         try:
-            counts.update(_reindex_scripts(con, selfevo_repo))
+            built, evidence["script"] = _reindex_scripts(con, selfevo_repo)
+            counts.update(built)
         except Exception:
             pass
         try:
-            counts.update(_reindex_ledger_titles(con, state_dir, selfevo_repo))
+            built, evidence["ledger_title"] = _reindex_ledger_titles(con, state_dir, selfevo_repo)
+            counts.update(built)
         except Exception:
             pass
-        try:
-            counts.update(_reindex_hypotheses(con, state_dir))
-        except Exception:
-            pass
+        # Retire whatever no builder re-derived this pass — for EVERY kind,
+        # including ``hypothesis``, which has no builder any more.
+        for kind, prefix in _CORPORA:
+            try:
+                counts[f"{prefix}_deactivated"] = _deactivate_missing(con, kind, evidence[kind])
+            except Exception:
+                pass
         con.commit()
     except Exception as exc:
         counts["error"] = str(exc)

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -2,15 +2,23 @@
 
 The deterministic planner (retired in #739) used to be the only reader of
 ``state_dir/hypotheses/backlog.json`` (written every self-evolving cycle by
-``nanobot.runtime.coordinator``/``cycle_persist._build_hypothesis_backlog_snapshot``)
-and ``state_dir/research/hypotheses.json`` (an append-only cycle-snapshot log
-written by ``cycle_planning._write_research_feed``). With the planner off,
-nothing on the live path read either file — the "hypothesis -> priority"
-chain existed only on paper. This module gives the LLM proposer
-(``nanobot.runtime.llm_proposer``) a bounded, fail-open read of both files as
-candidate ``serves: hypothesis <id>`` targets, plus a small lifecycle
-(active -> answered/stale) so the context doesn't re-offer resolved or
-abandoned candidates forever.
+``nanobot.runtime.coordinator``/``cycle_persist._build_hypothesis_backlog_snapshot``).
+With the planner off, nothing on the live path read it — the "hypothesis ->
+priority" chain existed only on paper. This module gives the LLM proposer
+(``nanobot.runtime.llm_proposer``) a bounded, fail-open read of that file
+(plus the strategist's ``hypotheses/durable.json``) as candidate
+``serves: hypothesis <id>`` targets, plus a small lifecycle (active ->
+answered/stale) so the context doesn't re-offer resolved or abandoned
+candidates forever.
+
+Sources (#1219): ``durable.json`` and ``backlog.json`` only. #751 also read
+``state_dir/research/hypotheses.json`` as a secondary source; its writer,
+``cycle_planning._write_research_feed``, was deleted with the planner module
+(#916/#923, recorded in #924) and the file froze on 2026-08-22 holding two
+distinct titles, both already ``stale`` in the lifecycle — so the source was
+removed rather than left to serve a frozen file forever. #751's intent, the
+hypothesis -> priority chain, is served from ``backlog.json`` as #751 itself
+specified; this is the deliberate resolution, not a revert.
 
 Design note — why lifecycle state is NOT stored inside ``backlog.json``
 itself (a deviation from the most literal reading of #751's brief): that
@@ -29,9 +37,8 @@ without fighting the existing writer's overwrite semantics.
 
 Everything here is fail-open: a missing/corrupt file, or any unexpected
 shape, degrades to "no candidates" / "no lifecycle change" rather than
-raising. Nothing here ever touches ``backlog.json`` or
-``research/hypotheses.json`` themselves — both remain owned by their
-existing writers.
+raising. Nothing here ever touches ``backlog.json`` or ``durable.json``
+themselves — both remain owned by their existing writers.
 
 #878 (closing the hypothesis -> experiment -> verdict loop): ``reconcile``
 now also computes a harness-MEASURED verdict (:mod:`hypothesis_verdict`) the
@@ -151,35 +158,6 @@ def _backlog_candidates(state_dir: Path) -> list[dict[str, str]]:
     return out
 
 
-def _research_candidates(state_dir: Path) -> list[dict[str, str]]:
-    """Secondary source: ``research/hypotheses.json`` — an append-only list
-    of cycle snapshots (``cycle_planning._write_research_feed``'s shape),
-    each with a ``candidates`` list of ``{title, hypothesis, acceptance}``."""
-    data = _read_json(Path(state_dir) / "research" / "hypotheses.json", None)
-    if not isinstance(data, list):
-        return []
-    out: list[dict[str, str]] = []
-    seen: set[str] = set()
-    for snapshot in data:
-        if not isinstance(snapshot, dict):
-            continue
-        candidates = snapshot.get("candidates")
-        if not isinstance(candidates, list):
-            continue
-        for cand in candidates:
-            if not isinstance(cand, dict):
-                continue
-            title = str(cand.get("title") or cand.get("hypothesis") or "").strip()
-            if not title:
-                continue
-            key = f"slug-{_slug(title)}"
-            if key in seen:
-                continue
-            seen.add(key)
-            out.append({"key": key, "title": title, "source": "research"})
-    return out
-
-
 def _durable_candidates(state_dir: Path) -> list[dict[str, str]]:
     data = _read_json(Path(state_dir) / "hypotheses" / "durable.json", None)
     entries = data.get("entries") if isinstance(data, dict) else []
@@ -196,7 +174,7 @@ def _durable_candidates(state_dir: Path) -> list[dict[str, str]]:
 def _all_candidates(state_dir: Path) -> list[dict[str, str]]:
     seen: set[str] = set()
     out: list[dict[str, str]] = []
-    for cand in _durable_candidates(state_dir) + _backlog_candidates(state_dir) + _research_candidates(state_dir):
+    for cand in _durable_candidates(state_dir) + _backlog_candidates(state_dir):
         if cand["key"] in seen:
             continue
         seen.add(cand["key"])
@@ -446,7 +424,7 @@ def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
 
 
 def top_candidates(state_dir: Path, n: int = TOP_N) -> list[dict[str, str]]:
-    """Top ``n`` still-``active`` candidates, backlog-order then research-
+    """Top ``n`` still-``active`` candidates, durable-order then backlog-
     order, reconciling lifecycle state first. Fail-open: returns ``[]`` on
     any error."""
     try:

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -2,7 +2,8 @@
 
 The deterministic planner (retired in #739) used to be the only reader of
 ``state_dir/hypotheses/backlog.json`` (written every self-evolving cycle by
-``nanobot.runtime.coordinator``/``cycle_persist._build_hypothesis_backlog_snapshot``).
+``backlog_snapshot.write_backlog_snapshot``; the original writer,
+``cycle_persist._build_hypothesis_backlog_snapshot``, went with the planner in #923).
 With the planner off, nothing on the live path read it — the "hypothesis ->
 priority" chain existed only on paper. This module gives the LLM proposer
 (``nanobot.runtime.llm_proposer``) a bounded, fail-open read of that file

--- a/nanobot/runtime/state_paths.py
+++ b/nanobot/runtime/state_paths.py
@@ -1,0 +1,137 @@
+"""Who writes each ``<state_dir>/<segment>`` that the runtime reads (#1219).
+
+``state/research/`` was read by five code paths for twelve days after its
+only writer, ``cycle_planning._write_research_feed``, was deleted with the
+planner module (#916/#923, recorded in #924). Nothing noticed: a frozen input
+reads as healthy to every check, and ``scorecard._FEEDS`` is a hand-listed
+tuple of five paths that cannot see a sixth. The failure mode is a reader
+whose writer is gone — so this module declares, for every state subpath the
+runtime reads, the writer(s) that own it, and ``tests/test_state_path_writers.py``
+checks two things:
+
+1. **Every read segment has an entry.** The test scans ``nanobot/`` for the
+   greppable read forms (``state_dir / "<segment>"``, ``state_root /
+   '<segment>'``, ``STATE_DIR / '<segment>'``) and fails naming the readers of
+   any segment missing here. The scan is a floor — three of ``_FEEDS``'s five paths reach state
+   through other forms — so this registry may list more than the scan finds.
+2. **Every declared writer still exists.** This is the load-bearing half:
+   ``"nanobot.runtime.cycle_planning:_write_research_feed"`` stops resolving
+   the moment that module is deleted, which is exactly #924's case, and it
+   does not depend on finding every reader. A ref is resolved to a real module
+   attribute; a non-empty string is not enough.
+
+Reference forms (each verified by the test):
+
+- ``"<module>:<attribute>"`` — importable Python writer.
+- ``"repo:<path>"`` — a file in THIS repository that is the writer or the
+  operator procedure (a host libexec script, a runbook for an operator-written
+  file). The path must exist.
+- ``"orphan:#<issue>"`` — a reader whose writer is gone or unknown, declared
+  and tracked. Not an exemption: the test requires the issue to be listed in
+  :data:`ORPHAN_ISSUES` with a one-line reason, and the PR that adds one must
+  say so. Resolving the issue means replacing the entry with the real writer
+  or removing the reader so the segment leaves the scan.
+
+Granularity is the first path segment, so a directory with one live file and
+one orphaned file (``control_plane/``) is declared by its live writer and the
+orphaned read is recorded in the issue; see #1222.
+"""
+from __future__ import annotations
+
+STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
+    "action_index": (
+        "nanobot.runtime.action_index:build_action_index",
+        "nanobot.observability.llm_telemetry:record_llm_prompt",
+    ),
+    # apply.ok is written by the operator (runbook), read by the bridge gate.
+    "approvals": ("repo:docs/EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md",),
+    # doctor probes completed/completed.json; nothing has ever written it —
+    # the live file is demand/completed.json.
+    "completed": ("orphan:#1222",),
+    # current_summary.json froze 2026-08-22 02:00 with the deleted planner;
+    # stale_execution_repair.json has no in-repo writer either.
+    "control_plane": ("orphan:#1222",),
+    "credits": ("orphan:#1222",),  # latest.json frozen 2026-08-22 02:00
+    "curator": (
+        "nanobot.runtime.knowledge_curator:_write_decision",
+        "nanobot.runtime.knowledge_curator:_stage_promotions",
+        "nanobot.runtime.knowledge_curator:_stage_lesson_cards",
+        "nanobot.runtime.knowledge_curator:_append_manifest_entries",
+        "nanobot.runtime.knowledge_curator:promote_reflector_recommendations_to_v2",
+    ),
+    "demand": (
+        "nanobot.runtime.demand:_write_json",
+        "nanobot.runtime.demand:mark_skill_retired",
+        "nanobot.runtime.demand:record_escalation",
+        "nanobot.runtime.goal_gap_futility:_save",
+    ),
+    # derived_priorities.json is live (goal_review); goal_text.json is the
+    # operator's canon; registry.json / active.json / cycle_archive.json froze
+    # 2026-08-22 02:00 with the deleted planner — see #1222.
+    "goals": (
+        "nanobot.runtime.goal_review:_write_derived_priorities",
+        "repo:host/eeepc/scripts/deploy_release.sh",  # seeds goals/goal_text.json, the operator's canon
+        "orphan:#1222",
+    ),
+    "heldout": (
+        "nanobot.runtime.heldout:_save_results",
+        "nanobot.runtime.heldout.microbench:_save_microbench_file",
+    ),
+    # backlog.json and lifecycle.json are live; durable.json is written daily
+    # by something outside this repository — identify it (#1222).
+    "hypotheses": (
+        "nanobot.runtime.backlog_snapshot:write_backlog_snapshot",
+        "nanobot.runtime.hypothesis_backlog:_save_lifecycle",
+        "nanobot.runtime.hypothesis_backlog:append_hypotheses",
+        "orphan:#1222",
+    ),
+    "improvements": ("nanobot.runtime.llm_proposer:write_request",),
+    "ledger": ("nanobot.runtime.cycle_ledger:append_event",),
+    "llm_calls": (
+        "nanobot.observability.llm_telemetry:record_llm_call",
+        "nanobot.observability.llm_telemetry:record_llm_prompt",
+    ),
+    "outbox": ("orphan:#1222",),  # report.index.json frozen 2026-08-22 02:00
+    "promotions": (
+        "nanobot.runtime.bridge:_record_runtime_slice_candidate",
+        "nanobot.runtime.promotions_rotation:rotate_promotions",
+    ),
+    "reflector": (
+        "nanobot.runtime.reflector:_append_journal",
+        "nanobot.runtime.reflector:_save_watermark",
+    ),
+    # evolution-*.json (the read target) last written 2026-08-21; proof-*.json
+    # in the same directory is live and written outside nanobot/.
+    "reports": ("orphan:#1222",),
+    "scorecard": ("nanobot.runtime.scorecard:compute_scorecard",),
+    "self_evolution": (
+        "nanobot.runtime.autoevolve:write_guarded_evolution_state",
+        "nanobot.runtime.autoevolve:write_noop_export_status",
+    ),
+    # knowledge_curator's nested-layout fallback (``<state_dir>/state/reflector``)
+    # — an alias of the reflector journal, not a directory of its own.
+    "state": (
+        "nanobot.runtime.reflector:_append_journal",
+    ),
+    "strategist": (
+        "nanobot.runtime.strategist:_write_advisories",
+        "nanobot.runtime.strategist:save_watermark",
+        "nanobot.runtime.strategist:_record_decision",
+    ),
+    "subagent_bridge": ("nanobot.runtime.bridge:_main_impl_body",),  # handled_<id>.txt markers
+    "subagents": (
+        "nanobot.runtime.llm_proposer:write_request",
+        "nanobot.runtime.bridge:_write_bridge_completed_result",
+        "repo:scripts/cleanup_subagent_queue.py",  # results/requests -> archive/
+    ),
+}
+
+# Every ``orphan:#N`` reference must name an issue listed here, with the
+# one-line reason the orphan is being carried rather than fixed in place.
+ORPHAN_ISSUES: dict[str, str] = {
+    "#1222": (
+        "readers of state written by the planner deleted in #916/#923 "
+        "(credits, outbox, control_plane, goals/registry, reports/evolution-*), "
+        "plus durable.json's out-of-repo writer and doctor's completed/ probe"
+    ),
+}

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -380,19 +380,20 @@ class TestHypothesisDemand:
         )
         assert demand.collect_demand(state_dir, None) == []
 
-    def test_research_candidate_with_metric_qualifies(self, tmp_path):
+    def test_research_candidate_is_no_longer_a_source_but_the_same_backlog_entry_is(self, tmp_path):
+        """#1219: ``research/hypotheses.json`` has had no writer since #924 and is
+        ignored; the identical candidate reaching the lane through the live
+        ``backlog.json`` still qualifies (the #751 chain is intact)."""
         state_dir = _state_dir(tmp_path)
         research_dir = state_dir / "research"
         research_dir.mkdir(parents=True)
+        candidate = {"title": "Trim ledger rotation cost", "metric": "rotation p95 800ms"}
         (research_dir / "hypotheses.json").write_text(
-            json.dumps(
-                [{
-                    "cycle_id": "c1",
-                    "candidates": [{"title": "Trim ledger rotation cost", "metric": "rotation p95 800ms"}],
-                }]
-            ),
-            encoding="utf-8",
+            json.dumps([{"cycle_id": "c1", "candidates": [candidate]}]), encoding="utf-8",
         )
+        assert [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"] == []
+
+        self._write_backlog(state_dir, [{"task_title": candidate["title"], "metric": candidate["metric"]}])
         hyps = [i for i in demand.collect_demand(state_dir, None) if i["kind"] == "hypothesis"]
         assert len(hyps) == 1
 

--- a/tests/test_existence_index.py
+++ b/tests/test_existence_index.py
@@ -403,18 +403,20 @@ class TestOtherCorpora:
         hits = ei.find_similar(state_dir, "memory tracker", limit=5)
         assert any(h["kind"] == "ledger_title" and h["path"] == "req-1" for h in hits)
 
-    def test_hypothesis_backlog_and_research_indexed(self, tmp_path):
+    def test_hypothesis_files_are_not_indexed(self, tmp_path):
+        """#1219: a hypothesis is a statement of something not yet done — its
+        title is never evidence that an artifact exists. Neither the live
+        ``hypotheses/backlog.json`` nor the writer-less
+        ``research/hypotheses.json`` produces documents any more."""
         state_dir = tmp_path / "state"
         repo = tmp_path / "repo"
         repo.mkdir()
-
         hyp_dir = state_dir / "hypotheses"
         hyp_dir.mkdir(parents=True)
         (hyp_dir / "backlog.json").write_text(
             json.dumps({"entries": [{"task_id": "t1", "task_title": "improve disk benchmarking"}]}),
             encoding="utf-8",
         )
-
         research_dir = state_dir / "research"
         research_dir.mkdir(parents=True)
         (research_dir / "hypotheses.json").write_text(
@@ -423,13 +425,123 @@ class TestOtherCorpora:
         )
 
         counts = ei.reindex(state_dir, repo)
-        assert counts["hypotheses_indexed"] == 2
 
-        hits_backlog = ei.find_similar(state_dir, "disk benchmarking", limit=5)
-        assert any(h["kind"] == "hypothesis" for h in hits_backlog)
+        assert "hypotheses_indexed" not in counts
+        assert counts["hypotheses_deactivated"] == 0
+        assert ei.find_similar(state_dir, "disk benchmarking", limit=5) == []
+        assert ei.find_similar(state_dir, "cpu governor watcher", limit=5) == []
+        con = sqlite3.connect(str(ei._index_path(state_dir)))
+        try:
+            assert con.execute("SELECT count(*) FROM documents WHERE kind = 'hypothesis'").fetchone()[0] == 0
+        finally:
+            con.close()
 
-        hits_research = ei.find_similar(state_dir, "cpu governor watcher", limit=5)
-        assert any(h["kind"] == "hypothesis" for h in hits_research)
+
+# ─── #1219: retirement is the index's contract, not each builder's ──────────
+
+
+def _active_by_kind(state_dir: Path) -> dict[str, int]:
+    con = sqlite3.connect(str(ei._index_path(state_dir)))
+    try:
+        rows = con.execute(
+            "SELECT kind, count(*) FROM documents WHERE active = 1 GROUP BY kind",
+        ).fetchall()
+        fts = con.execute("SELECT count(*) FROM docs_fts").fetchone()[0]
+    finally:
+        con.close()
+    out = {kind: n for kind, n in rows}
+    out["_fts_rows"] = fts
+    return out
+
+
+class TestRetirementContract:
+    def _poisoned_index(self, tmp_path: Path) -> tuple[Path, Path]:
+        """An index in the live host's shape: hypothesis documents minted by
+        the pre-#1219 builder from research snapshots that no file holds any
+        more, plus backlog hypotheses, plus a real script."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        _write_script(repo, "scripts/track_memory.py", "track memory usage over time.")
+        con = ei._open_db(state_dir)
+        try:
+            for i in range(6):
+                ei._upsert_document(con, "hypothesis", f"hyp-research-cycle-{i:012d}-0", f"research candidate number {i} about memory")
+            ei._upsert_document(con, "hypothesis", "hyp-backlog-t1", "improve disk benchmarking for memory")
+            con.commit()
+        finally:
+            con.close()
+        return state_dir, repo
+
+    def test_first_reindex_retires_every_hypothesis_document(self, tmp_path):
+        state_dir, repo = self._poisoned_index(tmp_path)
+        before = _active_by_kind(state_dir)
+        assert before["hypothesis"] == 7 and before["_fts_rows"] == 7
+
+        counts = ei.reindex(state_dir, repo)
+
+        after = _active_by_kind(state_dir)
+        assert counts["hypotheses_deactivated"] == 7
+        assert "hypothesis" not in after
+        assert after["script"] == 1 and after["_fts_rows"] == 1
+        # Rows stay (history), inactive.
+        con = sqlite3.connect(str(ei._index_path(state_dir)))
+        try:
+            assert con.execute("SELECT count(*) FROM documents WHERE kind = 'hypothesis' AND active = 0").fetchone()[0] == 7
+        finally:
+            con.close()
+
+    def test_second_reindex_is_a_no_op(self, tmp_path):
+        state_dir, repo = self._poisoned_index(tmp_path)
+        ei.reindex(state_dir, repo)
+        counts = ei.reindex(state_dir, repo)
+        assert counts["hypotheses_deactivated"] == 0
+        assert counts["scripts_deactivated"] == 0 and counts["ledger_titles_deactivated"] == 0
+
+    def test_retired_documents_no_longer_take_gate_slots(self, tmp_path):
+        """The measured harm: hypothesis docs held 36% of the gate's top-5
+        slots on 400 live proposals and pushed a real script duplicate out of
+        the top-5 ten times. With the corpus retired the script is found."""
+        state_dir, repo = self._poisoned_index(tmp_path)
+        # Pre-retirement the query's top-5 is all hypothesis text (7 docs,
+        # limit 5, every one mentions "memory").
+        hits = ei.find_similar(state_dir, "monitor RAM and memory usage", limit=5)
+        assert hits and all(h["kind"] == "hypothesis" for h in hits)
+        assert ei.find_duplicate_script(state_dir, repo, "monitor RAM and memory usage") == "scripts/track_memory.py"
+        hits = ei.find_similar(state_dir, "monitor RAM and memory usage", limit=5)
+        assert [h["kind"] for h in hits] == ["script"]
+
+    def test_every_kind_is_retired_by_the_same_rule(self, tmp_path):
+        """A deleted script, a refused attempt and a hypothesis all leave the
+        active set the same way — through :data:`_CORPORA`, not a rule inside
+        their builder."""
+        state_dir = tmp_path / "state"
+        repo = tmp_path / "repo"
+        gone = _write_script(repo, "scripts/gone_soon.py", "a script about to be deleted.")
+        results = state_dir / "subagents" / "results"
+        results.mkdir(parents=True)
+        (results / "result-req-refused.json").write_text(json.dumps({
+            "request_id": "req-refused", "backlog_title": "Create unit tests for gone soon script",
+            "rollback": {"integrated": False},
+        }), encoding="utf-8")
+        con = ei._open_db(state_dir)
+        try:
+            ei._upsert_document(con, "ledger_title", "req-refused", "Create unit tests for gone soon script")
+            ei._upsert_document(con, "hypothesis", "hyp-research-x-0", "some hypothesis about gone soon")
+            con.commit()
+        finally:
+            con.close()
+        first = ei.reindex(state_dir, repo)
+        # The refused attempt is not evidence (#1218) and the hypothesis has no
+        # builder (#1219): both retire on the first pass; the script stays.
+        assert (first["scripts_deactivated"], first["ledger_titles_deactivated"], first["hypotheses_deactivated"]) == (0, 1, 1)
+        assert _active_by_kind(state_dir) == {"script": 1, "_fts_rows": 1}
+        gone.unlink()
+
+        second = ei.reindex(state_dir, repo)
+
+        assert (second["scripts_deactivated"], second["ledger_titles_deactivated"], second["hypotheses_deactivated"]) == (1, 0, 0)
+        assert _active_by_kind(state_dir) == {"_fts_rows": 0}
+        assert [kind for kind, _ in ei._CORPORA] == ["script", "ledger_title", "hypothesis"]
 
 
 # ─── #840: related_scripts (relevance ranking for the proposer inventory) ──

--- a/tests/test_existence_index.py
+++ b/tests/test_existence_index.py
@@ -510,6 +510,24 @@ class TestRetirementContract:
         hits = ei.find_similar(state_dir, "monitor RAM and memory usage", limit=5)
         assert [h["kind"] for h in hits] == ["script"]
 
+    def test_a_builder_that_raises_skips_retirement_for_its_kind(self, tmp_path, monkeypatch):
+        """Unknown evidence is not empty evidence: a transient read error in one
+        builder must not retire that corpus. The skip is reported, and the
+        other kinds still retire normally."""
+        state_dir, repo = self._poisoned_index(tmp_path)
+        ei.reindex(state_dir, repo)  # scripts indexed, hypotheses retired
+        assert _active_by_kind(state_dir) == {"script": 1, "_fts_rows": 1}
+
+        def _boom(con, selfevo_repo):
+            raise OSError("scripts/ unreadable")
+
+        monkeypatch.setattr(ei, "_reindex_scripts", _boom)
+        counts = ei.reindex(state_dir, repo)
+
+        assert counts["retirement_skipped"] == ["script"]
+        assert counts["scripts_deactivated"] == 0
+        assert _active_by_kind(state_dir) == {"script": 1, "_fts_rows": 1}, "the live script corpus survived the failed pass"
+
     def test_every_kind_is_retired_by_the_same_rule(self, tmp_path):
         """A deleted script, a refused attempt and a hypothesis all leave the
         active set the same way — through :data:`_CORPORA`, not a rule inside

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -2,8 +2,8 @@
 
 Covers reading candidates from the primary source
 (``hypotheses/backlog.json``, ``cycle_persist._build_hypothesis_backlog_snapshot``'s
-shape) and the secondary source (``research/hypotheses.json``,
-``cycle_planning._write_research_feed``'s append-only shape), the bounded
+shape) and the strategist's ``durable.json``, that the writer-less
+``research/hypotheses.json`` is no longer a source (#1219), the bounded
 ``context_section`` rendering, and the lifecycle reconciliation
 (active -> answered/stale), including that unknown fields in a lifecycle
 entry survive a rewrite.
@@ -102,46 +102,47 @@ class TestPrimarySource:
         assert candidates == [{"key": "hypothesis-h1", "title": "Valid title", "source": "backlog"}]
 
 
-class TestSecondarySource:
-    def test_research_hypotheses_used_when_no_backlog(self, tmp_path):
+class TestResearchFeedIsNotASource:
+    """#1219: ``research/hypotheses.json`` lost its writer when the planner
+    module was deleted (#924) and froze on 2026-08-22. #751's intent — the
+    hypothesis -> priority chain — is served from ``backlog.json`` (as #751
+    itself specified) and the strategist's ``durable.json``; the frozen file
+    is ignored even when present, and candidates never come from it."""
+
+    def test_research_file_alone_yields_no_candidates(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_research(
             state_dir,
-            [
-                {
-                    "date": "2026-07-01",
-                    "cycle_id": "cycle-a",
-                    "candidates": [{"title": "Research candidate one", "acceptance": "..."}],
-                }
-            ],
+            [{"date": "2026-07-01", "cycle_id": "cycle-a", "candidates": [{"title": "Research candidate one"}]}],
         )
+        assert hypothesis_backlog.top_candidates(state_dir) == []
 
-        candidates = hypothesis_backlog.top_candidates(state_dir)
-        assert len(candidates) == 1
-        assert candidates[0]["title"] == "Research candidate one"
-        assert candidates[0]["key"].startswith("slug-")
-        assert candidates[0]["source"] == "research"
-
-    def test_backlog_takes_precedence_and_dedups_by_key(self, tmp_path):
+    def test_backlog_and_durable_serve_the_chain_without_research(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Primary title"}])
+        (state_dir / "hypotheses" / "durable.json").write_text(
+            json.dumps({"entries": [{"hypothesis_id": "hypothesis-d1", "task_title": "Durable title"}]}),
+            encoding="utf-8",
+        )
         _write_research(
             state_dir,
-            [{"date": "2026-07-01", "cycle_id": "cycle-a", "candidates": [{"title": "Secondary title"}]}],
+            [{"date": "2026-07-01", "cycle_id": "cycle-a", "candidates": [{"title": "Frozen research title"}]}],
         )
 
         candidates = hypothesis_backlog.top_candidates(state_dir)
-        titles = [c["title"] for c in candidates]
-        assert "Primary title" in titles
-        assert "Secondary title" in titles
-        assert titles[0] == "Primary title"
 
-    def test_corrupt_research_file_is_omitted(self, tmp_path):
+        assert [(c["title"], c["source"]) for c in candidates] == [
+            ("Durable title", "durable"), ("Primary title", "backlog"),
+        ]
+        assert not any(c["source"] == "research" for c in candidates)
+
+    def test_corrupt_research_file_is_irrelevant(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         research_dir = state_dir / "research"
         research_dir.mkdir(parents=True)
         (research_dir / "hypotheses.json").write_text("not json", encoding="utf-8")
-        assert hypothesis_backlog.top_candidates(state_dir) == []
+        _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Primary title"}])
+        assert [c["title"] for c in hypothesis_backlog.top_candidates(state_dir)] == ["Primary title"]
 
 
 class TestLifecycleReconciliation:

--- a/tests/test_state_path_writers.py
+++ b/tests/test_state_path_writers.py
@@ -1,0 +1,155 @@
+"""#1219: a state path with readers and no writer must fail a test.
+
+``state/research/`` had five readers for twelve days after its only writer was
+deleted (#924). :mod:`nanobot.runtime.state_paths` declares the writer(s) of
+every ``<state_dir>/<segment>`` the runtime reads; this module checks that the
+declaration covers every read the scan can see and that every declared writer
+still exists. The second check is the one that fires when a writer module is
+deleted — it does not depend on the scan finding every reader.
+"""
+from __future__ import annotations
+
+import importlib
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import state_paths
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "nanobot"
+
+# The greppable read forms. A floor, not a census: ``usage``, ``host_metrics``
+# and ``validator_harness_parent`` reach state through other spellings and are
+# not caught here — the registry may (and does) list more than this finds.
+_READ_RE = re.compile(r"""\b(?:state_dir|state_root|STATE_DIR|state)\s*/\s*['"]([A-Za-z_]+)['"]""")
+
+
+def scan_read_segments(package: Path = PACKAGE) -> dict[str, set[str]]:
+    """First path segment -> files (relative to the package's parent) that read under it."""
+    root = package.parent
+    readers: dict[str, set[str]] = defaultdict(set)
+    for path in package.rglob("*.py"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for match in _READ_RE.finditer(text):
+            readers[match.group(1)].add(path.relative_to(root).as_posix())
+    return dict(readers)
+
+
+def resolve_writer(ref: str, *, root: Path = ROOT, orphan_issues: dict[str, str] | None = None) -> str | None:
+    """Return None when ``ref`` names something that exists, else the reason it does not."""
+    orphan_issues = state_paths.ORPHAN_ISSUES if orphan_issues is None else orphan_issues
+    if ref.startswith("repo:"):
+        rel = ref[len("repo:"):]
+        return None if (root / rel).exists() else f"{ref}: no such file in the repository"
+    if ref.startswith("orphan:"):
+        issue = ref[len("orphan:"):]
+        return None if issue in orphan_issues else f"{ref}: issue not listed in ORPHAN_ISSUES"
+    module_name, sep, attr = ref.partition(":")
+    if not sep or not attr:
+        return f"{ref!r}: expected '<module>:<attribute>', 'repo:<path>' or 'orphan:#<issue>'"
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # ImportError, or a module that fails at import
+        return f"{ref}: module does not import ({exc.__class__.__name__})"
+    if not hasattr(module, attr):
+        return f"{ref}: module has no attribute {attr!r}"
+    return None
+
+
+def unwritten_segments(readers: dict[str, set[str]], registry: dict[str, tuple[str, ...]]) -> list[str]:
+    """Human-readable line per read segment that declares no writer."""
+    problems = []
+    for segment in sorted(readers):
+        writers = registry.get(segment)
+        if not writers:
+            files = ", ".join(sorted(readers[segment]))
+            problems.append(f"state/{segment} is read by {files} and has no declared writer")
+    return problems
+
+
+# ─── the live registry ───────────────────────────────────────────────────────
+
+
+def test_every_read_segment_declares_a_writer() -> None:
+    readers = scan_read_segments()
+    assert readers, "the scan found no state reads at all — the regex is broken, not the tree"
+    assert unwritten_segments(readers, state_paths.STATE_PATH_WRITERS) == []
+
+
+def test_every_declared_writer_still_exists() -> None:
+    """The load-bearing half: a deleted writer module fails here even if the
+    reader scan never saw its readers."""
+    failures = [
+        f"state/{segment}: {reason}"
+        for segment, writers in sorted(state_paths.STATE_PATH_WRITERS.items())
+        for ref in writers
+        if (reason := resolve_writer(ref)) is not None
+    ]
+    assert failures == []
+
+
+def test_registry_entries_are_non_empty_and_orphan_issues_are_explained() -> None:
+    for segment, writers in state_paths.STATE_PATH_WRITERS.items():
+        assert writers, f"state/{segment}: empty writer tuple is a silent exemption"
+    for issue, reason in state_paths.ORPHAN_ISSUES.items():
+        assert issue.startswith("#") and issue[1:].isdigit(), issue
+        assert len(reason.split()) >= 4, f"{issue}: give the reason, not a label"
+    used = {ref[len("orphan:"):] for w in state_paths.STATE_PATH_WRITERS.values() for ref in w if ref.startswith("orphan:")}
+    assert used <= set(state_paths.ORPHAN_ISSUES)
+    assert set(state_paths.ORPHAN_ISSUES) <= used, "an ORPHAN_ISSUES entry nothing references is stale"
+
+
+def test_research_is_no_longer_read_anywhere() -> None:
+    """The #1219 case itself: the frozen directory has left the read set."""
+    assert "research" not in scan_read_segments()
+
+
+# ─── the checker, against the failure it exists for ─────────────────────────
+
+
+def test_the_deleted_planner_writer_would_fail_resolution() -> None:
+    """#924's case: the module that wrote state/research/ no longer exists."""
+    reason = resolve_writer("nanobot.runtime.cycle_planning:_write_research_feed")
+    assert reason is not None and "does not import" in reason
+
+
+def test_a_stale_attribute_on_a_live_module_fails_resolution() -> None:
+    reason = resolve_writer("nanobot.runtime.existence_index:_reindex_hypotheses")
+    assert reason is not None and "no attribute" in reason
+    assert resolve_writer("nanobot.runtime.existence_index:reindex") is None
+
+
+def test_unknown_reference_forms_and_untracked_orphans_are_rejected() -> None:
+    assert "expected" in (resolve_writer("just a string") or "")
+    assert "not listed" in (resolve_writer("orphan:#99999") or "")
+    assert "no such file" in (resolve_writer("repo:docs/does-not-exist.md") or "")
+
+
+def test_a_reader_with_no_declared_writer_is_named_with_its_files(tmp_path: Path) -> None:
+    """A synthetic tree in the shape #1219 found: readers survive, the writer
+    entry is gone. The failure message names the segment and every reader."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "a.py").write_text('feed = state_dir / "research" / "feed.json"\n', encoding="utf-8")
+    (pkg / "b.py").write_text("hyps = state_root / 'research' / 'hypotheses.json'\n", encoding="utf-8")
+    (pkg / "c.py").write_text('rows = state_dir / "ledger" / "cycles.jsonl"\n', encoding="utf-8")
+
+    readers = {seg: {Path(f).name for f in files} for seg, files in
+               ((s, {str(p) for p in fs}) for s, fs in scan_read_segments(pkg).items())}
+    assert set(readers) == {"research", "ledger"}
+    assert readers["research"] == {"a.py", "b.py"}
+
+    problems = unwritten_segments(scan_read_segments(pkg), {"ledger": ("nanobot.runtime.cycle_ledger:append_event",)})
+    assert len(problems) == 1
+    assert problems[0].startswith("state/research is read by ")
+    assert "a.py" in problems[0] and "b.py" in problems[0] and "no declared writer" in problems[0]
+
+
+@pytest.mark.parametrize("segment", ["ledger", "reflector", "subagents", "curator"])
+def test_hot_directories_are_declared_by_real_writers_not_orphans(segment: str) -> None:
+    writers = state_paths.STATE_PATH_WRITERS[segment]
+    assert not any(ref.startswith("orphan:") for ref in writers)
+    assert all(resolve_writer(ref) is None for ref in writers)


### PR DESCRIPTION
Closes #1219. Design agreed on the issue (comment 5517570157 and the reply); follow-up findings filed as #1222.

## Decision, recorded

**`state/research/` does not get a writer back; its readers stop.** The files were outputs of the deterministic planner (`cycle_planning._write_research_feed`), retired in #739 and deleted in #916/#923 (#924). The duty — hypotheses reach the proposer as `serves:` candidates — is owned by `backlog_snapshot.write_backlog_snapshot` (`hypotheses/backlog.json`, every cycle). **#751's intent is served from `backlog.json`, deliberately**: #751's own text names that file as the reader's source; `research/` was the tertiary source in every reader, held 2 distinct titles both already `stale` in the lifecycle, and contributed zero live candidates. Pinned by `TestResearchFeedIsNotASource` and the demand test.

Readers removed: `existence_index` (with the corpus, below), `hypothesis_backlog._research_candidates`, the `demand.py` research block, `bridge._auto_seed_backlog_from_research` (+ its only helper `_active_backlog_is_empty`). The seeder fired **twice in the repository's history — `2760a525` 2026-06-24 and `1520d8e7` 2026-06-22 — and never in the 70 days since**; its input froze with two entries. Nothing reads `state/research/` any more (`test_research_is_no_longer_read_anywhere`).

## The `hypothesis` corpus is retired, whole

A hypothesis is a statement of something not yet done; its title is never evidence an artifact exists — the backlog half exactly as much as the frozen research half. The corpus also had no consumer: a `hypothesis` hit is never `duplicate_suspect`, `related_scripts` filters it out, and the proposer gets hypotheses directly from `backlog.json`. Its only effect was crowding the BM25 top-k the gate reads. On the 400 newest live proposals against the live index copy: 36% of gate top-5 slots, a real script duplicate pushed out of the top-5 in **10** proposals, **536** proposer reuse hints lost; with only the 721 backlog docs kept: 11 and 458.

**Refusals against a `hyp-research-*` document: 0 of 186** dedup rows, ledger plus every archive — the issue's "if zero, say so" case. The corpus did not over-suppress; it defeated the gate and starved the proposer.

**Non-goal, on record** (in `_CORPORA`'s comment): "has this already been PROPOSED?" is a legitimate question and a different one from "does this EXIST?". If it is wanted it needs its own mechanism with its own semantics — not the existence index with a hypothesis corpus.

## Retirement is now the index's contract

Every corpus builder returns `(counts, evidence)` — the paths it re-derived from a living source this pass — and `reindex` deactivates every other active document of that kind for every kind in `_CORPORA = (script, ledger_title, hypothesis)`, including a kind with no builder (evidence = ∅). Retirement used to live inside each builder, so a builder without one had no retirement path and a source whose writer vanished left its documents active forever. Counts: `<kind>_deactivated` for all three; `hypotheses_indexed/unchanged` are gone.

`_deactivate_missing` is batched: `docs_fts` has no index on `path`, so the per-row delete scanned the table each time — retiring 6,935 rows took **11 s** on a desktop (minutes on the Atom, inside the bridge's gate). Now one statement per fully-retired kind, IN-list chunks of 400 otherwise: **1.3 s** here, ~15 s once on the host.

## The acceptance number — live index copy, new `reindex`, instance repo at HEAD

| | before | after first reindex | second reindex |
|---|---|---|---|
| `hyp-research-*` active | **6,214** | **0** | 0 |
| `hypothesis` active | 6,935 | 0 | 0 |
| `script` active | 346 | 347 (clone HEAD has one more script) | 347 |
| `docs_fts` rows | 7,761 | 347 | 347 |
| `hypotheses_deactivated` | | 6,935 | 0 |

The copy has no `subagents/` results, so its 480 ledger titles retired too (`ledger_titles_deactivated: 480`); that is an artifact of the copy, not a prediction for the host, where results are present. Rows stay in `documents` with `active = 0`. Host confirmation post-deploy is yours.

## Pre-change failure (origin/main `877f86e2`), verbatim

Old-API repro (`um-scratch/1219/test_repro_1219.py`):

```
E       AssertionError: a research candidate title became an active existence document
E       assert 1 == 0
E       AssertionError: 6 hypothesis documents stayed active with no source; reindex counts={'scripts_indexed': 0, ...
E       assert 6 == 0
2 failed in 1.51s
```

Same repro on this branch: `2 passed`.

## Detection: a reader with no writer fails a test

`nanobot/runtime/state_paths.py` — `STATE_PATH_WRITERS: {segment: (writer refs)}`; `tests/test_state_path_writers.py` — 12 tests:

- **Load-bearing half:** every declared writer resolves to a real module attribute (`importlib` + `getattr`) or an existing repo file; a non-empty string is not enough. `nanobot.runtime.cycle_planning:_write_research_feed` fails it today (tested) — #924's case, independent of whether the reader scan sees anything.
- Coverage half: the scan of `state_dir / "x"` / `state_root / 'x'` / `STATE_DIR / 'x'` (24 segments today) must be ⊆ the registry, else the failure names the segment and every reader (tested on a synthetic tree in #1219's shape). The scan is a floor, as you found; the registry may list more.
- `orphan:#<issue>` is a **declared, tracked** orphan, not an exemption: the test requires the issue to be listed in `ORPHAN_ISSUES` with its reason, rejects an issue nothing references, and hot directories (`ledger`, `reflector`, `subagents`, `curator`) are asserted to have real writers.

Relation to #1216: a different layer (static, test-time, "does a writer exist"), not a runtime signal. `scorecard._FEEDS` and its predicate are untouched.

### What the registry found — #1222

Mapping the 24 segments to writers found more writer-less reads than `research/`, all measured read-only on the host:

| read path | live mtime | |
|---|---|---|
| `credits/latest.json`, `outbox/{latest,report.index}.json`, `control_plane/current_summary.json`, `goals/{registry,active,cycle_archive}.json` | **2026-08-22 02:00** — the same instant as `research/*` | same deleted writer |
| `reports/evolution-*.json` | last 2026-08-21 23:00 | writer gone; `proof-*.json` alongside is live, written outside `nanobot/` |
| `hypotheses/durable.json` | 2026-09-02 03:00, daily | a writer exists **outside this repository** — not the strategist code here, which appends to `backlog.json` |
| `completed/completed.json` (doctor probe) | directory does not exist | nothing has ever written it |

Registered as `orphan:#1222` and not widened into this change; the PR touches none of those readers. `cycle_persist.py` is also gone (#923) — the docstrings that credited it now name `backlog_snapshot.write_backlog_snapshot`.

## Full pytest (Windows, `-n auto`, this branch `7e584bad`)

**18 failed, 2951 passed, 17 skipped.** The 18 by file: `test_autoevolve` 5, `test_autoevolve_commit` 3, `test_autoevolve_guards` 1, `test_autoevolve_remote_target` 1, `test_autoevolve_state` 2, `test_bridge_locking` 3, `test_selfevo_export_security` 2, `test_bridge_cycle_tags` 1 — the itemised baseline set. None touch the changed modules. Absolute counts as asked.

## Review pass (cavecrew-reviewer, applied)

One finding, and it was my own least-certain claim: a builder that *raises* mid-pass left its `evidence` at `∅`, which the contract reads as "retire everything of this kind" — an unreadable `scripts/` would have retired the live script corpus for a pass. Fixed: a raising builder's evidence is **unknown, not empty**; retirement for that kind is skipped that pass and reported as `retirement_skipped: ["script"]` (tested: the live corpus survives the failed pass, the other kinds still retire).

## Least-certain claim

**The registry's writer mapping is mine, from greps and the host's mtimes.** The test guards against *deleted* writers (the ref stops resolving) and *undeclared* readers (the scan), not against a *misattributed* one: a function that exists but does not actually write that directory passes. `subagent_bridge: bridge._main_impl_body` and `state: reflector._append_journal` (the nested-layout alias) are the two entries where I am least sure the named symbol is the real writer rather than the nearest one. If either is wrong the registry is still louder than the five-path `_FEEDS` it sits beside, but say so and I will correct the entry.

## Live verification (yours)

After deploy, the first bridge cycle's dedup gate triggers `reindex`: `hypotheses_deactivated: 6935` once in the journal, then 0; `sqlite3 index.sqlite "select count(*) from documents where path like 'hyp-research-%' and active=1"` → **0**; `select count(*) from docs_fts` ≈ 346 + active ledger titles (480 today). Nothing on the host is touched by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
