### PR TITLE
fix(demand): make doc-only budget deferrals observable (#1108)

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -149,8 +149,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-
-logger = logging.getLogger(__name__)
 import os
 import re
 import subprocess
@@ -159,6 +157,8 @@ from pathlib import Path
 from typing import Any
 
 from nanobot.runtime.state_access import Window, evidence_status, ledger_window
+
+logger = logging.getLogger(__name__)
 
 ENABLED_ENV = "SELFEVO_DEMAND_DRIVEN_ENABLED"
 
@@ -2845,11 +2845,13 @@ def collect_demand(
             )
 
         post_doc_guard: list[dict[str, str]] = []
+        doc_only_deferred = 0
         for item in result:
             k = item.get("kind", "")
             affected = item.get("affected_path", "")
             if doc_budget_exceeded and predict_item_change_tier(item) == "doc-only":
                 # Deferral only: leave completion/exhaustion state untouched.
+                doc_only_deferred += 1
                 continue
             # Preserve #1090's reflection steering and extend the same bounded
             # notice to every surviving lane under the reached budget.
@@ -2877,6 +2879,17 @@ def collect_demand(
                     item["summary"] = f"{summary} {steering_note}".strip()
             post_doc_guard.append(item)
         result = _apply_futile_surfaces(state_dir, post_doc_guard)
+        from nanobot.runtime.cycle_ledger import append_event
+
+        append_event(state_dir, {
+            "phase": "doc_only_budget",
+            "doc_only_deferred": doc_only_deferred,
+            "doc_only_integrations_24h": doc_count_24h,
+            "doc_only_budget_24h": doc_budget,
+            "ledger_blind": ledger_blind,
+            "doc_budget_exceeded": doc_budget_exceeded,
+            "items_considered": len(result) + doc_only_deferred,
+        })
 
         # #815: best-effort, operator-visible V1-vs-V2 split of what's
         # actually presented — never affects the returned list. Opt-in

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -3279,6 +3279,61 @@ class TestIssue1090DocGuard:
         assert demand.collect_demand(state_dir, None) == []
         assert json.loads(exhausted.read_text(encoding="utf-8")) == before
 
+    def test_doc_only_deferrals_are_recorded_with_budget_state(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_priority = demand._make_item(
+            "priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md"
+        )
+        code_priority = demand._make_item(
+            "priority", "Priority 2 — scripts/worker.py", "Improve scripts/worker.py"
+        )
+        monkeypatch.setattr(demand, "_priority_items", lambda *args, **kwargs: [doc_priority, code_priority])
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: 5)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+
+        items = demand.collect_demand(state_dir, None)
+
+        assert [item["id"] for item in items] == [code_priority["id"]]
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        assert ledger_path.is_file()
+        ledger_text = ledger_path.read_text(encoding="utf-8")
+        records = [json.loads(line) for line in ledger_text.splitlines() if line.strip()]
+        records = [event for event in records if event.get("phase") == "doc_only_budget"]
+        record = records[-1]
+        assert record["phase"] == "doc_only_budget"
+        assert record["doc_only_deferred"] == 1
+        assert record["doc_only_integrations_24h"] == 5
+        assert record["doc_only_budget_24h"] == 5
+        assert record["ledger_blind"] is False
+        assert record["doc_budget_exceeded"] is True
+        assert record["items_considered"] == 2
+        assert record["ts"]
+
+    def test_ledger_blind_budget_deferral_is_recorded_as_distinct_cause(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_item = demand._make_item(
+            "priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md"
+        )
+        monkeypatch.setattr(demand, "_priority_items", lambda *args, **kwargs: [doc_item])
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: 0)
+        blind_rows = demand.LedgerRows()
+        blind_rows.status = "unavailable"
+        blind_rows.notes = ("test",)
+        monkeypatch.setattr(demand, "_load_ledger_rows", lambda *args, **kwargs: blind_rows)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+
+        assert demand.collect_demand(state_dir, None) == []
+        ledger_path = state_dir / "ledger" / "cycles.jsonl"
+        assert ledger_path.is_file()
+        ledger_text = ledger_path.read_text(encoding="utf-8")
+        records = [json.loads(line) for line in ledger_text.splitlines() if line.strip()]
+        records = [event for event in records if event.get("phase") == "doc_only_budget"]
+        assert records[-1]["doc_only_deferred"] == 1
+        assert records[-1]["doc_only_integrations_24h"] == 0
+        assert records[-1]["doc_only_budget_24h"] == 5
+        assert records[-1]["ledger_blind"] is True
+        assert records[-1]["doc_budget_exceeded"] is True
+
     def test_doc_budget_count_and_prediction_use_shared_classifier(self, tmp_path, monkeypatch):
         state_dir = _state_dir(tmp_path)
         ledger_dir = state_dir / "ledger"


### PR DESCRIPTION
## Summary

Make the existing #1108 doc-only budget guard observable without changing its behavior.

Each `collect_demand` pass now appends one `phase: doc_only_budget` event to the existing cycle ledger with:

- `doc_only_deferred`: number of doc-only demand items skipped this cycle;
- `doc_only_integrations_24h`: observed rolling count at selection time;
- `doc_only_budget_24h`: configured budget;
- `ledger_blind`: whether unavailable ledger evidence, rather than a real over-budget count, triggered suppression;
- `doc_budget_exceeded`: effective guard state;
- `items_considered`: count before deferral.

The event uses the existing best-effort `cycle_ledger.append_event` surface; no new state file, scan, read, size check, classifier, lifecycle transition, or counter mutation was added.

## Red-state evidence

A temporary regression test was run against `origin/main` before the fix. The guard skipped the doc-only item, but the expected ledger event was absent:

```text
2 failed, 173 passed in 31.16s
FAILED ...test_doc_only_deferrals_are_recorded_with_budget_state
FAILED ...test_ledger_blind_budget_deferral_is_recorded_as_distinct_cause
```

The same tests pass on this branch.

## Deliberately unchanged

- Deferral remains a selection-time `continue`.
- No lifecycle, dedup, exhaustion, or #1038 lane behavior changes.
- Default budget `N=5` and reporting key `value.doc_only_integrations_24h` unchanged.
- Shared `classify_change_tier` / `predict_item_change_tier` classifier unchanged.
- No forced live over-budget condition; no host writes, rollout, or live-store mutation.

## Validation

- Focused new regression tests: `2 passed`.
- Full pytest: pending; Windows baseline is the exact LIST supplied in #1108.
- Ruff: passed on changed runtime/test files.
- `git diff --check`: passed.

## Live verification

Deployment and the natural 24-hour live observation remain operator-owned. The durable ledger event is intended to answer both a real over-budget deferral and a `ledger_blind` deferral without conflating them.

Closes #1108
