### PR TITLE
fix(runtime): resolve the orphaned state reads behind #1222 — goal id from goal_text.json, status surface reads live sources only

### DIFF
--- a/nanobot/runtime/backlog_snapshot.py
+++ b/nanobot/runtime/backlog_snapshot.py
@@ -30,9 +30,10 @@ just means that source contributes zero entries, never an exception):
    candidates). Bounded to the ``_MAX_REQUEST_CANDIDATES`` most recently
    modified files younger than ``_MAX_REQUEST_AGE_DAYS``, both applied in
    the SAME stat pass the sort needs anyway — see ``_recent_request_paths``.
-2. ``state_dir/goals/registry.json`` — ``current_task_id``/``current_task``
-   mark the matching request candidate (if any) as ``selected`` instead of
-   ``backlog``.
+2. ``state_dir/goals/goal_text.json`` — the operator canon's ``goal_id``
+   (#1222; the coordinator's ``registry.json`` froze on 2026-08-22). Its
+   ``current_task_id`` went with the coordinator: the bridge queue is FIFO,
+   nothing pre-selects a task, so every candidate is ``backlog``.
 
 The scoring formulas (``_task_effort_weight``/``_bounded_priority_score``/
 ``_wsjf_components``) are adapted, not imported, from
@@ -148,23 +149,16 @@ def _acceptance_for(task: dict[str, Any], goal_id: str) -> str:
     return f"{title} advances goal {goal_id}" if goal_id else f"{title} is completed"
 
 
-def _current_task_id(state_dir: Path) -> str | None:
-    goals = _read_json(state_dir / "goals" / "registry.json", None)
-    if not isinstance(goals, dict):
-        return None
-    current_task_id = goals.get("current_task_id")
-    if isinstance(current_task_id, str) and current_task_id.strip():
-        return current_task_id.strip()
-    return None
-
-
 def _active_goal_id(state_dir: Path) -> str:
-    goals = _read_json(state_dir / "goals" / "registry.json", None)
-    if isinstance(goals, dict):
-        gid = goals.get("active_goal_id")
-        if isinstance(gid, str) and gid.strip():
-            return gid.strip()
-    return ""
+    """#1222: from the operator's ``goals/goal_text.json`` (see
+    :func:`goal_review.active_goal_id`), not the coordinator's frozen
+    ``registry.json``. Fail-open to ``""``."""
+    try:
+        from nanobot.runtime.goal_review import active_goal_id
+
+        return active_goal_id(state_dir)
+    except Exception:
+        return ""
 
 
 def _last_cycle_id(state_dir: Path) -> str:
@@ -258,7 +252,7 @@ def _handled_request_markers(bridge_state_dir: Path) -> set[str]:
     return handled
 
 
-def _request_candidates(state_dir: Path, *, current_task_id: str | None, goal_id: str) -> list[dict[str, Any]]:
+def _request_candidates(state_dir: Path, *, goal_id: str) -> list[dict[str, Any]]:
     req_dir = state_dir / "subagents" / "requests"
     if not req_dir.is_dir():
         return []
@@ -297,7 +291,10 @@ def _request_candidates(state_dir: Path, *, current_task_id: str | None, goal_id
         if not task_title:
             continue
         seen_ids.add(task_id)
-        selected = bool(current_task_id and task_id == current_task_id)
+        # #1222: nothing pre-selects a queued request any more (the
+        # coordinator's current_task_id is gone); the keys stay for schema
+        # stability, always "backlog".
+        selected = False
         task_for_scoring = {**req, "status": status}
         acceptance = _acceptance_for(req, goal_id)
         evidence = req.get("evidence") or req.get("metric")
@@ -331,8 +328,7 @@ def _request_candidates(state_dir: Path, *, current_task_id: str | None, goal_id
 
 def _build_snapshot(state_dir: Path) -> dict[str, Any] | None:
     goal_id = _active_goal_id(state_dir)
-    current_task_id = _current_task_id(state_dir)
-    entries = _request_candidates(state_dir, current_task_id=current_task_id, goal_id=goal_id)
+    entries = _request_candidates(state_dir, goal_id=goal_id)
 
     selected_entry = next((e for e in entries if e.get("selected")), None)
 

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2040,21 +2040,18 @@ async def _main_impl_body():
     except Exception:
         pass
 
-    outbox = load_json(STATE_DIR / 'outbox' / 'report.index.json') or {}
-    goals = load_json(STATE_DIR / 'goals' / 'registry.json') or {}
-    report_source = (outbox.get('source') or '').strip()
-    # #913: drop the outbox bootstrap dependency — the live goal machinery
-    # maintains goals/registry.json every cycle, so it is now the PRIMARY
-    # source; the outbox's goal_id is kept only as a legacy fallback for
-    # hosts still coasting on a frozen outbox snapshot. report_source is no
-    # longer required (see build_task above) — a fresh/rebuilt state dir
-    # with no outbox/ at all can still bootstrap a cycle as long as a goal
-    # id is resolvable from somewhere.
-    goal_id = (
-        goals.get('active_goal_id')
-        or (outbox.get('goal') or {}).get('goal_id')
-        or ''
-    ).strip()
+    # #1222: the active goal id comes from the operator's goals/goal_text.json.
+    # #913 made goals/registry.json primary and outbox/report.index.json a
+    # fallback; both were written only by the coordinator and froze on
+    # 2026-08-22 when it was deleted (#916/#923) — twelve days of reading a
+    # dead file as the live goal. goal_text.json (seeded by deploy_release.sh)
+    # has carried goal_id all along.
+    from nanobot.runtime.goal_review import active_goal_id as _active_goal_id_from_canon
+
+    goal_id = _active_goal_id_from_canon(STATE_DIR)
+    # build_task's optional "Origin report" line; only the coordinator's
+    # outbox ever supplied one.
+    report_source = ''
 
     if not goal_id:
         print('no_active_goal')
@@ -2216,7 +2213,6 @@ async def _main_impl_body():
                 (load_json(STATE_DIR / 'goals' / 'goal_text.json') or {}).get('text')
                 # Fallback: read from release root (deployed with release)
                 or (load_json(RELEASE_ROOT / 'host' / 'eeepc' / 'etc' / 'goal_text.json') or {}).get('text')
-                or (goals.get('goals') or {}).get(goal_id, {}).get('text')
                 or goal_id
             )
         try:
@@ -2235,9 +2231,11 @@ async def _main_impl_body():
         goal_text = filter_completed_priorities_from_goal_text(
             goal_text, _selfevo_repo_check, state_dir=STATE_DIR
         )
-        subagent_policy = (goals.get('goals') or {}).get(goal_id, {}).get('subagent_policy') or {}
-        profile = FORCE_PROFILE or req.get('profile') or subagent_policy.get('preferred_profile') or 'bounded_execution'
-        budget_class = FORCE_BUDGET or subagent_policy.get('budget_class') or req.get('budget') or 'standard'
+        # #1222: the coordinator's per-goal subagent_policy (preferred_profile /
+        # budget_class in goals/registry.json) went with the coordinator; the
+        # live registry never carried the key, so this was always the default.
+        profile = FORCE_PROFILE or req.get('profile') or 'bounded_execution'
+        budget_class = FORCE_BUDGET or req.get('budget') or 'standard'
         gate_open = approval_open()
         mode_at_start = 'auto' if gate_open else 'strict'
 

--- a/nanobot/runtime/doctor.py
+++ b/nanobot/runtime/doctor.py
@@ -134,7 +134,9 @@ def _check_watermarks(state_dir: Path, now: datetime) -> Check:
 
 def _check_integrity(state_dir: Path) -> Check:
     malformed: dict[str, int] = {}
-    paths = [state_dir / "ledger" / "cycles.jsonl", state_dir / "completed" / "completed.json", state_dir / "demand" / "rotation.json"]
+    # #1222: the completed sidecar lives at demand/completed.json (written by
+    # demand._write_json); completed/completed.json was a path nothing ever wrote.
+    paths = [state_dir / "ledger" / "cycles.jsonl", state_dir / "demand" / "completed.json", state_dir / "demand" / "rotation.json"]
     for results_dir in (state_dir / "subagents" / "results", state_dir / "subagents" / "archive"):
         try:
             for path in results_dir.glob("*.json"):

--- a/nanobot/runtime/goal_review.py
+++ b/nanobot/runtime/goal_review.py
@@ -246,6 +246,27 @@ def read_charter_text(release_root: "Path | None") -> str:
         return ""
 
 
+def active_goal_id(state_dir: "Path | str") -> str:
+    """The active goal's id, from the operator's ``goals/goal_text.json``.
+
+    #1222: the coordinator used to rewrite ``goals/registry.json`` /
+    ``active.json`` every cycle; those files froze on 2026-08-22 when it was
+    deleted (#916/#923) and four readers kept treating them as live. The
+    operator canon — ``goal_text.json``, seeded by ``deploy_release.sh`` —
+    has carried ``goal_id`` all along, so it is the one source now. Returns
+    ``""`` when the file is absent, unreadable or has no id. Fail-open:
+    never raises.
+    """
+    try:
+        data = _read_json(Path(state_dir) / "goals" / "goal_text.json", None)
+    except Exception:
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    goal_id = data.get("goal_id")
+    return goal_id.strip() if isinstance(goal_id, str) else ""
+
+
 # ─── bounded inputs ─────────────────────────────────────────────────────────
 
 

--- a/nanobot/runtime/health.py
+++ b/nanobot/runtime/health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, Callable
 
@@ -12,8 +13,23 @@ from nanobot.runtime.schemas import CycleHealth
 
 _DEFAULT_BRIDGE_SERVICE = "eeepc-self-evolving-subagent-bridge.service"
 _SELFEVO_REPO_DIRNAME = "eeebot-self-evolving"
+# One day without a ledger append means the loop is not running; the same
+# horizon the retired report read used (#1222).
+_LEDGER_STALE_AFTER_SECONDS = 86400
 
 CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _ledger_age_seconds(state_root: Path, *, now: float | None = None) -> float | None:
+    """Seconds since ``ledger/cycles.jsonl`` was last appended to, or ``None``
+    when the ledger is absent/unreadable. The bridge appends one event per
+    cycle (``cycle_ledger.append_event``), so the file's mtime is the loop's
+    heartbeat. Fail-open: never raises."""
+    try:
+        mtime = (state_root / "ledger" / "cycles.jsonl").stat().st_mtime
+    except OSError:
+        return None
+    return max(0.0, (now if now is not None else time.time()) - mtime)
 
 
 def _default_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
@@ -96,8 +112,6 @@ def _recommended_next_action(
         return "inspect_failed_systemd_units"
     if service_status.get("active_state") not in {"active", "inactive", "unknown"}:
         return "inspect_bridge_service_status"
-    if runtime.get("next_hint") and runtime.get("next_hint") != "none":
-        return str(runtime["next_hint"])
     promo_action = promotion_readiness.get("recommended_next_action")
     if promo_action and promotion_readiness.get("state") not in {"absent", "ready"}:
         return str(promo_action)
@@ -121,11 +135,6 @@ def _calculate_severity(
         return "blocked", 2
     
     if service_status.get("active_state") == "failed" or service_status.get("result") not in {"success", "unknown"}:
-        return "blocked", 2
-
-    approval_gate_state = runtime.get("approval_gate_state")
-    next_hint = str(runtime.get("next_hint") or "")
-    if approval_gate_state in {"missing", "expired", "stale"} or "approval gate missing" in next_hint:
         return "blocked", 2
 
     promo_state = promotion_readiness.get("state")
@@ -188,9 +197,15 @@ def build_cycle_health_summary(
 ) -> CycleHealth:
     """Build an operator-friendly health summary from runtime state and systemd."""
     runtime = load_runtime_state_from_root(state_root, source_kind=source_kind)
-    if runtime.get("report_stale") or runtime.get("runtime_state_source") is None:
-        runtime["runtime_state_stale"] = bool(runtime.get("report_stale"))
-        runtime["runtime_state_unavailable"] = runtime.get("runtime_state_source") is None
+    # #1222: liveness comes from the cycle ledger, the file the bridge appends
+    # to every cycle — not from reports/evolution-*.json, which the deleted
+    # coordinator last wrote on 2026-08-22 (so "stale" was a constant).
+    ledger_age = _ledger_age_seconds(state_root)
+    runtime["runtime_state_unavailable"] = ledger_age is None
+    runtime["runtime_state_stale"] = ledger_age is not None and ledger_age > _LEDGER_STALE_AFTER_SECONDS
+    live = runtime.get("live") if isinstance(runtime.get("live"), dict) else {}
+    recent = live.get("recent_outcomes") if isinstance(live.get("recent_outcomes"), list) else []
+    latest_cycle_id = recent[0].get("cycle_id") if recent and isinstance(recent[0], dict) else None
     service_status = read_service_status(service_name, runner=runner)
     failed_units_count = read_failed_units_count(runner=runner)
     promotion_readiness = _promotion_readiness(runtime)
@@ -200,8 +215,8 @@ def build_cycle_health_summary(
         "schema_version": "cycle-health-summary-v2",
         "runtime_state_source": runtime.get("runtime_state_source"),
         "runtime_state_root": runtime.get("runtime_state_root"),
-        "latest_cycle_id": runtime.get("cycle_id"),
-        "latest_report_path": runtime.get("report_path"),
+        "latest_cycle_id": latest_cycle_id,
+        "ledger_age_seconds": ledger_age,
         "latest_subagent_telemetry_id": runtime.get("subagent_telemetry_latest_id"),
         "latest_subagent_telemetry_path": runtime.get("subagent_telemetry_path"),
         "service_status": service_status,
@@ -243,7 +258,8 @@ def format_cycle_health_summary(summary: CycleHealth) -> list[str]:
         f"  Runtime state source: {summary.get('runtime_state_source') or 'unknown'}",
         f"  Runtime state root: {summary.get('runtime_state_root') or 'unknown'}",
         f"  Latest cycle id: {summary.get('latest_cycle_id') or 'unknown'}",
-        f"  Latest report path: {summary.get('latest_report_path') or 'unknown'}",
+        "  Ledger age: "
+        + (f"{summary.get('ledger_age_seconds') / 3600:.1f}h" if isinstance(summary.get('ledger_age_seconds'), (int, float)) else "no ledger"),
         f"  Latest subagent telemetry id: {summary.get('latest_subagent_telemetry_id') or 'unknown'}",
         f"  Latest subagent telemetry path: {summary.get('latest_subagent_telemetry_path') or 'unknown'}",
         "  Service status: "

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -637,9 +637,15 @@ def has_in_flight_experiment(
 
 
 def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) -> int:
-    """Append structured hypothesis entries to state_dir/hypotheses/backlog.json (#999).
+    """Append structured hypothesis entries to ``state_dir/hypotheses/durable.json`` (#999).
 
-    Preserves the existing schema of backlog.json (dict with schema, updated_at, entries).
+    This is the writer of ``durable.json`` — the strategist's daily run
+    (``strategist.run_strategist``) calls it, which is why the file's mtime
+    moves once a day at 00:00 UTC. The docstring used to say ``backlog.json``
+    (the bridge's per-cycle snapshot, a different file) and #1222 spent a
+    row hunting for an out-of-repo writer that was this function all along.
+
+    Preserves the existing schema (dict with schema, updated_at, entries).
     Writes atomically via tempfile + os.replace.
     Returns the number of valid entries actually appended.
     """

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2417,16 +2417,14 @@ def _is_duplicate_proposal(
 
 
 def _active_goal_id(state_dir: Path) -> str:
+    """#1222: from the operator's ``goals/goal_text.json``, not the
+    coordinator's frozen ``registry.json``. Fail-open to ``""``."""
     try:
-        path = Path(state_dir) / "goals" / "registry.json"
-        if not path.is_file():
-            return ""
-        data = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            return str(data.get("active_goal_id") or "")
+        from nanobot.runtime.goal_review import active_goal_id
+
+        return active_goal_id(state_dir)
     except Exception:
-        pass
-    return ""
+        return ""
 
 
 def _display_title(task_title: str) -> str:

--- a/nanobot/runtime/schemas.py
+++ b/nanobot/runtime/schemas.py
@@ -51,7 +51,7 @@ class CycleHealth(TypedDict, total=False):
     runtime_state_source: str | None
     runtime_state_root: str | None
     latest_cycle_id: str | None
-    latest_report_path: str | None
+    ledger_age_seconds: float | None
     latest_subagent_telemetry_id: str | None
     latest_subagent_telemetry_path: str | None
     service_status: dict[str, Any]

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -910,15 +910,15 @@ def _subagent_rollup_snapshot_uncached(
 
 # ─── live status surface (#914) ──────────────────────────────────────────
 #
-# The sections below repoint the operator status/health surface at sources
+# The sections below point the operator status/health surface at sources
 # that the CURRENT (post-coordinator-decommission, #900/#910) loop actually
-# updates every cycle: the goal registry, the cycle ledger, and the
-# scorecard — instead of ``goals/current.json``/``outbox/``/``promotions/``/
-# ``experiments/``/``credits/``, which froze when the coordinator was
-# retired. Every helper here is independently fail-open: a missing or
-# corrupt source file yields ``None``/``[]`` for just that field, never an
-# exception, so one bad artifact can never blank out the rest of the
-# surface (or crash the CLI/health check that reads it).
+# updates: the operator's goal_text.json, the cycle ledger, and the
+# scorecard. #914 introduced them beside the coordinator-era reads
+# (``goals/current.json``/``outbox/``/``credits/``/``reports/evolution-*``);
+# #1222 removed those reads outright. Every helper here is independently
+# fail-open: a missing or corrupt source file yields ``None``/``[]`` for
+# just that field, never an exception, so one bad artifact can never blank
+# out the rest of the surface (or crash the CLI/health check that reads it).
 
 _LIVE_LEDGER_TAIL_LINES = 200
 _LIVE_RECENT_OUTCOMES_LIMIT = 5
@@ -937,6 +937,24 @@ def _live_active_goal_id(state_root: Path) -> str | None:
 
     goal_id = active_goal_id(state_root)
     return goal_id or None
+
+
+def _live_approval_gate_state(state_root: Path, *, now: float | None = None) -> str:
+    """``fresh`` / ``expired`` / ``missing`` from ``approvals/apply.ok``.
+
+    Same file and same rule as ``bridge.approval_open()`` (``expires_at_epoch``
+    in the future). #1222: the coordinator copied this into ``outbox/`` and the
+    status surface read the copy; the copy froze, the file did not. Fail-open
+    to ``missing``.
+    """
+    data = _safe_read_json(state_root / "approvals" / "apply.ok")
+    if not isinstance(data, dict):
+        return "missing"
+    try:
+        expires = int(data.get("expires_at_epoch", 0) or 0)
+    except (TypeError, ValueError):
+        return "missing"
+    return "fresh" if expires > int(now if now is not None else time.time()) else "expired"
 
 
 def _live_recent_outcomes(
@@ -1059,42 +1077,33 @@ def _live_state_snapshot(state_root: Path) -> dict[str, Any] | None:
 
 
 def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace_state") -> dict[str, Any]:
-    """Load canonical runtime state from an explicit state root if present."""
-    reports_dir = state_root / "reports"
-    outbox_dir = state_root / "outbox"
+    """Load canonical runtime state from an explicit state root if present.
+
+    #1222: this surface reads only files something still writes — the
+    operator's ``goals/goal_text.json``, ``promotions/`` (bridge),
+    ``hypotheses/backlog.json`` (bridge), ``subagents/`` telemetry, the host
+    resource sensors and the ``live`` section (ledger + scorecard). The
+    coordinator's per-cycle artifacts — ``reports/evolution-*.json``,
+    ``outbox/``, ``goals/{registry,active,current}.json``, ``credits/`` — froze
+    on 2026-08-22 when it was deleted (#916/#923); #914 labelled them
+    "decommissioned" and #1205 stopped presenting the stale report, but the
+    reads (and ~40 fields derived only from them) stayed. They are gone: a
+    field with no live source is not "unknown", it is not a field.
+    """
     goals_dir = state_root / "goals"
     promotions_dir = state_root / "promotions"
     hypotheses_dir = state_root / "hypotheses"
     subagents_dir = state_root / "subagents"
-    credits_dir = state_root / "credits"
 
-    report_result = latest_file(reports_dir, "evolution-*.json", max_age_s=86400)
-    latest_report = report_result.path or _latest_json_file(reports_dir, "*.json")
-    current_goal_path = goals_dir / "current.json"
-    active_goal_path = goals_dir / "active.json"
-    latest_goal = current_goal_path if current_goal_path.exists() else active_goal_path if active_goal_path.exists() else _latest_json_file(goals_dir, "*.json")
-    if source_kind == "host_control_plane":
-        latest_outbox = (
-            _latest_json_file(outbox_dir, "report.index.json")
-            or _latest_json_file(outbox_dir, "latest.json")
-            or _latest_json_file(outbox_dir, "*.json")
-        )
-    else:
-        latest_outbox = _latest_json_file(outbox_dir, "latest.json") or _latest_json_file(outbox_dir, "*.json")
+    goal_text_path = goals_dir / "goal_text.json"
     latest_promotion = _latest_json_file(promotions_dir, "latest.json") or _latest_json_file(promotions_dir, "*.json")
     latest_hypothesis_backlog = _latest_json_file(hypotheses_dir, "backlog.json") or _latest_json_file(hypotheses_dir, "*.json")
     latest_subagent = _latest_json_file(subagents_dir, "*.json")
-    latest_credits = _latest_json_file(credits_dir, "latest.json") or _latest_json_file(credits_dir, "*.json")
 
-    report_data = _safe_read_json(latest_report) if not report_result.stale else None
-    current_goal_data = _safe_read_json(current_goal_path)
-    active_goal_data = _safe_read_json(active_goal_path)
-    goal_data = current_goal_data or active_goal_data or _safe_read_json(latest_goal)
-    outbox_data = _safe_read_json(latest_outbox)
+    goal_text_data = _safe_read_json(goal_text_path)
     promotion_data = _safe_read_json(latest_promotion)
     hypothesis_backlog_data = _safe_read_json(latest_hypothesis_backlog)
     subagent_data = _safe_read_json(latest_subagent)
-    credits_data = _safe_read_json(latest_credits)
 
     hypothesis_backlog_schema_version = None
     hypothesis_backlog_entry_count = None
@@ -1127,138 +1136,27 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         if scores:
             hypothesis_backlog_best_score = max(scores)
 
-    approval_gate = None
-    explicit_next_hint = None
-    if isinstance(outbox_data, dict):
-        approval_gate = outbox_data.get("approval_gate") or outbox_data.get("approvalGate")
-        if approval_gate is None:
-            capability_gate = outbox_data.get("capability_gate") if isinstance(outbox_data.get("capability_gate"), dict) else None
-            if isinstance(capability_gate, dict):
-                approval_gate = capability_gate.get("approval") if isinstance(capability_gate.get("approval"), dict) else None
-        explicit_next_hint = outbox_data.get("next_hint") or outbox_data.get("nextHint")
-        if explicit_next_hint is None:
-            explicit_next_hint = (
-                ((outbox_data.get("goal") or {}).get("follow_through") or {}).get("blocked_next_step")
-                if isinstance(outbox_data.get("goal"), dict)
-                else None
-            )
-
-    approval_gate_state = None
-    approval_gate_ttl_minutes = None
-    next_hint = explicit_next_hint
-    if isinstance(approval_gate, dict):
-        approval_gate_state = (
-            approval_gate.get("state")
-            or approval_gate.get("status")
-            or approval_gate.get("reason")
-            or ("ok" if approval_gate.get("ok") else None)
-        )
-        approval_gate_ttl_minutes = approval_gate.get("ttl_minutes") or approval_gate.get("ttlMinutes")
-        if next_hint is None:
-            if approval_gate_state in {"fresh", "active", "valid", "ok"}:
-                next_hint = "none"
-            else:
-                next_hint = "refresh approval gate manually"
-    elif approval_gate:
-        approval_gate_state = str(approval_gate)
-        if next_hint is None:
-            next_hint = "refresh approval gate manually"
-    elif next_hint is None:
-        next_hint = "approval gate missing; refresh manually"
-
+    # The operator canon is the only goal source (goal_review.active_goal_id
+    # reads the same file for the bridge, proposer and backlog snapshot).
     active_goal = None
-    if isinstance(goal_data, dict):
-        active_goal = (
-            goal_data.get("active_goal")
-            or goal_data.get("activeGoal")
-            or goal_data.get("active_goal_id")
-            or goal_data.get("activeGoalId")
-            or goal_data.get("goal_id")
-            or goal_data.get("goalId")
-        )
-    if not active_goal and isinstance(report_data, dict):
-        active_goal = (
-            report_data.get("goal_id")
-            or report_data.get("goalId")
-            or ((report_data.get("goal") or {}).get("goal_id") if isinstance(report_data.get("goal"), dict) else None)
-            or ((report_data.get("goal") or {}).get("goalId") if isinstance(report_data.get("goal"), dict) else None)
-        )
+    goal_text = None
+    if isinstance(goal_text_data, dict):
+        goal_id = goal_text_data.get("goal_id")
+        active_goal = goal_id.strip() if isinstance(goal_id, str) and goal_id.strip() else None
+        text = goal_text_data.get("text")
+        goal_text = text if isinstance(text, str) and text.strip() else None
 
-    goal_rotation_reason = None
-    goal_rotation_streak = None
-    goal_rotation_trigger_goal = None
-    goal_rotation_trigger_artifact_paths = None
-    if isinstance(goal_data, dict):
-        goal_rotation_reason = goal_data.get("rotation_reason") or goal_data.get("rotationReason")
-        goal_rotation_streak = goal_data.get("rotation_streak") or goal_data.get("rotationStreak")
-        goal_rotation_trigger_goal = goal_data.get("rotation_trigger_goal") or goal_data.get("rotationTriggerGoal")
-        goal_rotation_trigger_artifact_paths = goal_data.get("rotation_trigger_artifact_paths") or goal_data.get("rotationTriggerArtifactPaths")
-    if goal_rotation_reason is None and isinstance(active_goal_data, dict):
-        goal_rotation_reason = active_goal_data.get("rotation_reason") or active_goal_data.get("rotationReason")
-        goal_rotation_streak = goal_rotation_streak or active_goal_data.get("rotation_streak") or active_goal_data.get("rotationStreak")
-        goal_rotation_trigger_goal = goal_rotation_trigger_goal or active_goal_data.get("rotation_trigger_goal") or active_goal_data.get("rotationTriggerGoal")
-        goal_rotation_trigger_artifact_paths = goal_rotation_trigger_artifact_paths or active_goal_data.get("rotation_trigger_artifact_paths") or active_goal_data.get("rotationTriggerArtifactPaths")
+    # The bounded-apply gate is the operator's approvals/apply.ok (the same
+    # file bridge.approval_open() consults); the coordinator used to copy its
+    # state into outbox/ and this surface read the copy.
+    approval_gate_state = _live_approval_gate_state(state_root)
 
-    current_task_id = None
-    task_counts = None
-    task_reward_signal = None
-    task_plan = None
-    task_history = None
-    task_plan_schema_version = None
-    task_feedback_decision = None
-    task_plan_path = str(current_goal_path) if current_goal_path.exists() else (str(active_goal_path) if active_goal_path.exists() else str(latest_goal) if latest_goal else None)
-    task_history_path = None
-    if isinstance(current_goal_data, dict):
-        task_plan = current_goal_data
-        task_history = current_goal_data
-    if isinstance(task_plan, dict):
-        current_task_id = task_plan.get("current_task_id") or task_plan.get("currentTaskId")
-        task_counts = task_plan.get("task_counts") or task_plan.get("taskCounts")
-        task_reward_signal = task_plan.get("reward_signal") or task_plan.get("rewardSignal")
-        task_plan_schema_version = task_plan.get("schema_version") or task_plan.get("schemaVersion")
-        task_feedback_decision = task_plan.get("feedback_decision") or task_plan.get("feedbackDecision")
-        task_history_path = task_plan.get("history_path") or task_history_path
-    if current_task_id is None and isinstance(task_history, dict):
-        current_task_id = task_history.get("current_task_id") or task_history.get("currentTaskId")
-    if task_counts is None and isinstance(task_history, dict):
-        task_counts = task_history.get("task_counts") or task_history.get("taskCounts")
-    if task_reward_signal is None and isinstance(task_history, dict):
-        task_reward_signal = task_history.get("reward_signal") or task_history.get("rewardSignal")
-    if task_plan_schema_version is None and isinstance(task_history, dict):
-        task_plan_schema_version = task_history.get("schema_version") or task_history.get("schemaVersion")
-    if task_feedback_decision is None and isinstance(task_history, dict):
-        task_feedback_decision = task_history.get("feedback_decision") or task_history.get("feedbackDecision")
-
-    cycle_id = None
-    cycle_started = None
-    cycle_ended = None
-    evidence_ref = None
     promotion_candidate_id = None
     review_status = None
     decision = None
     decision_reason = None
-    runtime_status = None
-    artifact_paths = None
-    follow_through_status = None
-    goal_text = None
-    improvement_score = None
-    subagent_rollup = None
-    subagent_rollup_from_files = None
     selfevo_current_state = None
-    experiment = None
-    experiment_path = None
-    experiment_budget = None
-    experiment_budget_used = None
-    experiment_reward_signal = None
-    experiment_outcome = None
-    experiment_metric_name = None
-    experiment_metric_baseline = None
-    experiment_metric_current = None
-    experiment_metric_frontier = None
-    experiment_complexity_delta = None
-    experiment_simplicity_judgment = None
     promotion_schema_version = None
-    experiment_contract_path = None
     promotion_path = str(latest_promotion) if latest_promotion else None
     promotion_candidate_path = None
     promotion_decision_record = None
@@ -1273,9 +1171,6 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     promotion_recommended_next_action = None
     promotion_governance_packet = None
     promotion_provenance = None
-    credits_balance = None
-    credits_delta = None
-    credits_path = str(latest_credits) if latest_credits else None
     subagent_telemetry_count = None  # deferred to _subagent_rollup_snapshot.telemetry_count
     subagent_telemetry_latest_path = str(latest_subagent) if latest_subagent else None
     subagent_telemetry_latest_status = None
@@ -1294,101 +1189,13 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
     selfevo_current_state_path = state_root / 'self_evolution' / 'current_state.json'
     if selfevo_current_state_path.exists():
         selfevo_current_state = _safe_read_json(selfevo_current_state_path)
-    if isinstance(credits_data, dict):
-        credits_balance = credits_data.get("balance")
-        credits_delta = credits_data.get("delta")
-    if isinstance(report_data, dict):
-        cycle_id = report_data.get("cycle_id") or report_data.get("cycleId")
-        cycle_started = report_data.get("cycle_started_utc") or report_data.get("cycleStartedUtc")
-        cycle_ended = report_data.get("cycle_ended_utc") or report_data.get("cycleEndedUtc")
-        evidence_ref = report_data.get("evidence_ref_id") or report_data.get("evidenceRefId")
-        promotion_candidate_id = report_data.get("promotion_candidate_id") or report_data.get("promotionCandidateId")
-        review_status = report_data.get("review_status") or report_data.get("reviewStatus")
-        decision = report_data.get("decision")
-        runtime_status = (
-            report_data.get("result_status")
-            or report_data.get("resultStatus")
-            or ((report_data.get("result") or {}).get("status") if isinstance(report_data.get("result"), dict) else None)
-            or ((report_data.get("process_reflection") or {}).get("status") if isinstance(report_data.get("process_reflection"), dict) else None)
-            or (outbox_data.get("status") if isinstance(outbox_data, dict) else None)
-        )
-        goal_text = (
-            report_data.get("goal_text")
-            or report_data.get("goalText")
-            or ((report_data.get("goal") or {}).get("text") if isinstance(report_data.get("goal"), dict) else None)
-        )
-        improvement_score = report_data.get("improvement_score") or report_data.get("improvementScore")
-        follow_through = report_data.get("follow_through") if isinstance(report_data.get("follow_through"), dict) else None
-        if isinstance(follow_through, dict):
-            follow_through_status = follow_through.get("status") or follow_through.get("follow_through_status") or follow_through.get("followThroughStatus")
-            artifact_paths = follow_through.get("artifact_paths") or follow_through.get("artifactPaths")
-        if isinstance(outbox_data, dict) and isinstance(outbox_data.get("goal"), dict):
-            outbox_follow_through = ((outbox_data.get("goal") or {}).get("follow_through") or {})
-            if artifact_paths is None:
-                artifact_paths = outbox_follow_through.get("artifact_paths")
-            follow_through_status = follow_through_status or outbox_follow_through.get("status")
-        if goal_text is None and isinstance(outbox_data, dict) and isinstance(outbox_data.get("goal"), dict):
-            goal_text = (outbox_data.get("goal") or {}).get("text")
-        if improvement_score is None and isinstance(outbox_data, dict):
-            improvement_score = outbox_data.get("improvement_score") or outbox_data.get("improvementScore")
-        if subagent_rollup is None and isinstance(outbox_data, dict):
-            subagent_rollup = ((outbox_data.get("goal_context") or {}).get("subagent_rollup")) if isinstance(outbox_data.get("goal_context"), dict) else None
-        if subagent_rollup is None:
-            result_obj = report_data.get("result") if isinstance(report_data.get("result"), dict) else None
-            task_obj = (result_obj or {}).get("task") if isinstance((result_obj or {}).get("task"), dict) else None
-            goal_context = (task_obj or {}).get("goal_context") if isinstance((task_obj or {}).get("goal_context"), dict) else None
-            subagent_rollup = (goal_context or {}).get("subagent_rollup") if isinstance(goal_context, dict) else None
-        subagent_rollup_from_files = _subagent_rollup_snapshot(
-            state_root=state_root,
-            current_task_id=current_task_id,
-            current_task_title=(task_plan.get("current_task") if isinstance(task_plan, dict) else None),
-        )
-        if subagent_rollup is None:
-            subagent_rollup = subagent_rollup_from_files
-        elif isinstance(subagent_rollup_from_files, dict) and (
-            subagent_rollup_from_files.get("result_count")
-            or subagent_rollup.get("state") in {"stale", "missing"}
-        ):
-            subagent_rollup = subagent_rollup_from_files
-        if subagent_telemetry_count is None and isinstance(subagent_rollup, dict):
-            subagent_telemetry_count = subagent_rollup.get("telemetry_count")
-        capability_gate = report_data.get("capability_gate") if isinstance(report_data.get("capability_gate"), dict) else None
-        if approval_gate is None and isinstance(capability_gate, dict):
-            approval_gate = capability_gate.get("approval") if isinstance(capability_gate.get("approval"), dict) else None
-            if isinstance(approval_gate, dict):
-                approval_gate_state = approval_gate.get("reason") or ("ok" if approval_gate.get("ok") else "blocked")
-
-    if subagent_rollup is None:
-        subagent_rollup = _subagent_rollup_snapshot(
-            state_root=state_root,
-            current_task_id=current_task_id,
-        )
+    # Subagent rollup from the telemetry files themselves (live); nothing
+    # pre-selects a task any more, so no current_task_id to correlate on.
+    subagent_rollup = _subagent_rollup_snapshot(state_root=state_root, current_task_id=None)
+    if isinstance(subagent_rollup, dict):
+        subagent_telemetry_count = subagent_rollup.get("telemetry_count")
     if subagent_telemetry_count is None:
-        subagent_telemetry_count = (
-            subagent_rollup.get("telemetry_count")
-            if isinstance(subagent_rollup, dict)
-            else (len(list(subagents_dir.glob("*.json"))) if subagents_dir.exists() else 0)
-        )
-
-    if isinstance(report_data, dict):
-        experiment = report_data.get("experiment") if isinstance(report_data.get("experiment"), dict) else experiment
-    if isinstance(experiment, dict):
-        experiment_path = experiment.get("experiment_path") or experiment.get("experimentPath") or experiment_path
-        experiment_budget = experiment.get("budget") or experiment.get("budgetBudget")
-        experiment_budget_used = experiment.get("budget_used") or experiment.get("budgetUsed")
-        experiment_reward_signal = experiment.get("reward_signal") or experiment.get("rewardSignal")
-        experiment_outcome = experiment.get("outcome")
-        experiment_metric_name = experiment.get("metric_name")
-        experiment_metric_baseline = experiment.get("metric_baseline")
-        experiment_metric_current = experiment.get("metric_current")
-        experiment_metric_frontier = experiment.get("metric_frontier")
-        experiment_complexity_delta = experiment.get("complexity_delta")
-        experiment_simplicity_judgment = experiment.get("simplicity_judgment")
-        experiment_contract_path = experiment.get("contract_path") or experiment.get("contractPath")
-        if experiment_reward_signal is None and isinstance(task_reward_signal, dict):
-            experiment_reward_signal = task_reward_signal
-        if task_feedback_decision is None:
-            task_feedback_decision = experiment.get("feedback_decision") or experiment.get("feedbackDecision")
+        subagent_telemetry_count = len(list(subagents_dir.glob("*.json"))) if subagents_dir.exists() else 0
 
     if isinstance(promotion_data, dict):
         promotion_schema_version = promotion_data.get("schema_version") or promotion_data.get("schemaVersion") or promotion_schema_version
@@ -1409,13 +1216,6 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         promotion_decision_record = promotion_data.get("decision_record") or promotion_data.get("decisionRecord") or promotion_decision_record
         promotion_accepted_record = promotion_data.get("accepted_record") or promotion_data.get("acceptedRecord") or promotion_accepted_record
         promotion_provenance = _promotion_provenance_snapshot(promotion_data)
-    elif isinstance(outbox_data, dict):
-        promotion = outbox_data.get("promotion") if isinstance(outbox_data.get("promotion"), dict) else None
-        if isinstance(promotion, dict):
-            promotion_candidate_path = promotion.get("candidate_path") or promotion.get("candidatePath")
-            promotion_candidate_id = promotion.get("promotion_candidate_id") or promotion.get("promotionCandidateId") or promotion_candidate_id
-            review_status = promotion.get("review_status") or promotion.get("reviewStatus") or review_status
-            decision = promotion.get("decision") or decision
 
     promotion_summary = None
     governance_schema = None
@@ -1576,10 +1376,6 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         "runtime_state_source": source_kind,
         "runtime_state_root": str(state_root),
         "active_goal": active_goal,
-        "cycle_id": cycle_id,
-        "cycle_started_utc": cycle_started,
-        "cycle_ended_utc": cycle_ended,
-        "evidence_ref": evidence_ref,
         "promotion_candidate_id": promotion_candidate_id,
         "review_status": review_status,
         "decision": decision,
@@ -1600,67 +1396,19 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         "promotion_provenance": promotion_provenance,
         "promotion_replay_readiness": promotion_replay_readiness,
         "hypothesis_backlog_schema_version": hypothesis_backlog_schema_version,
-        "runtime_status": runtime_status,
-        "artifact_paths": artifact_paths,
-        "follow_through_status": follow_through_status,
         "goal_text": goal_text,
-        "improvement_score": improvement_score,
+        "goal_path": str(goal_text_path) if goal_text_path.exists() else None,
+        "approval_gate_state": approval_gate_state,
         "subagent_rollup": subagent_rollup,
         "selfevo_current_state": selfevo_current_state,
         "promotion_path": promotion_path,
-        "approval_gate": approval_gate,
-        "approval_gate_state": approval_gate_state,
-        "approval_gate_ttl_minutes": approval_gate_ttl_minutes,
-        "next_hint": next_hint,
-        "goal_rotation_reason": goal_rotation_reason,
-        "goal_rotation_streak": goal_rotation_streak,
-        "goal_rotation_trigger_goal": goal_rotation_trigger_goal,
-        "goal_rotation_trigger_artifact_paths": goal_rotation_trigger_artifact_paths,
-        "task_plan": task_plan,
-        "task_history": task_history,
-        "task_plan_path": task_plan_path,
-        "task_history_path": task_history_path,
         "hypothesis_backlog_path": str(latest_hypothesis_backlog) if latest_hypothesis_backlog else None,
-        "task_plan_schema_version": task_plan_schema_version,
-        "task_feedback_decision": task_feedback_decision,
-        "hypothesis_backlog_schema_version": hypothesis_backlog_schema_version,
         "hypothesis_backlog_entry_count": hypothesis_backlog_entry_count,
         "hypothesis_backlog_selected_id": hypothesis_backlog_selected_id,
         "hypothesis_backlog_selected_title": hypothesis_backlog_selected_title,
         "hypothesis_backlog_best_score": hypothesis_backlog_best_score,
         "hypothesis_backlog_model": hypothesis_backlog_model,
         "hypothesis_backlog_selected_wsjf": hypothesis_backlog_selected_wsjf,
-        "current_task_id": current_task_id,
-        "task_counts": task_counts,
-        "task_reward_signal": task_reward_signal,
-        "task_reward_value": task_reward_signal.get("value") if isinstance(task_reward_signal, dict) else None,
-        "experiment": experiment,
-        "experiment_path": experiment_path,
-        "experiment_budget": experiment_budget,
-        "experiment_budget_used": experiment_budget_used,
-        "experiment_reward_signal": experiment_reward_signal,
-        "experiment_outcome": experiment_outcome,
-        "experiment_metric_name": experiment_metric_name,
-        "experiment_metric_baseline": experiment_metric_baseline,
-        "experiment_metric_current": experiment_metric_current,
-        "experiment_metric_frontier": experiment_metric_frontier,
-        "experiment_complexity_delta": experiment_complexity_delta,
-        "experiment_simplicity_judgment": experiment_simplicity_judgment,
-        "experiment_contract_path": experiment_contract_path,
-        "credits_balance": credits_balance,
-        "credits_delta": credits_delta,
-        "credits_path": credits_path,
-        # #914: these four flags mark data actually loaded from the frozen
-        # coordinator-era artifact directories (outbox/, promotions/,
-        # experiments/, credits/ — see module docstring above
-        # `load_runtime_state_from_root`) so a consumer/renderer can label
-        # it "decommissioned" instead of presenting it as current. True
-        # only when the corresponding file was found AND parsed as a dict
-        # — an absent file is just absent, not an error.
-        "outbox_decommissioned": isinstance(outbox_data, dict),
-        "promotion_decommissioned": isinstance(promotion_data, dict),
-        "experiment_decommissioned": False,
-        "credits_decommissioned": isinstance(credits_data, dict),
         "subagent_telemetry_root": str(subagents_dir) if subagents_dir.exists() else None,
         "subagent_telemetry_count": subagent_telemetry_count,
         "subagent_telemetry_path": subagent_telemetry_latest_path,
@@ -1674,26 +1422,12 @@ def load_runtime_state_from_root(state_root: Path, source_kind: str = "workspace
         "subagent_telemetry_latest_reward_signal": subagent_telemetry_latest_reward_signal,
         "subagent_telemetry_latest_feedback_decision": subagent_telemetry_latest_feedback_decision,
         "host_resources": _host_resource_snapshot(state_root),
-        "report_path": str(latest_report) if latest_report else None,
-        "report_stale": bool(report_result.stale),
-        "report_age_seconds": report_result.age_s,
-        "goal_path": str(active_goal_path) if active_goal_path.exists() else (str(current_goal_path) if current_goal_path.exists() else str(latest_goal) if latest_goal else None),
-        "outbox_path": str(latest_outbox) if latest_outbox else None,
     }
     runtime["capabilities"] = _capability_snapshot(runtime)
     runtime["subagent_correlation"] = _subagent_correlation_snapshot(runtime)
     runtime["operator_boost"] = _safe_runtime_config_operator_boost()
     runtime["governance_coverage"] = _governance_coverage_snapshot(runtime)
     runtime["material_progress"] = _material_progress_snapshot(runtime)
-    runtime["task_boundary"] = {
-        'task_id': runtime.get('current_task_id'),
-        'title': runtime.get('selected_task_title') or runtime.get('current_task'),
-        'selection_source': runtime.get('task_selection_source'),
-        'selected_tasks': runtime.get('selected_tasks'),
-        'mutation_lane': (runtime.get('task_plan') or {}).get('mutation_lane') if isinstance(runtime.get('task_plan'), dict) else None,
-        'budget': runtime.get('selected_hypothesis_execution_spec_budget'),
-        'acceptance': runtime.get('selected_hypothesis_execution_spec_acceptance'),
-    }
     runtime["live"] = _live_state_snapshot(state_root)
     return runtime
 
@@ -1704,19 +1438,15 @@ def load_runtime_state(workspace: Path) -> dict[str, Any]:
     return load_runtime_state_from_root(workspace / "state", source_kind="workspace_state")
 
 
-_DECOMMISSIONED_SUFFIX = " (decommissioned — frozen data)"
-
-
 def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
     """Format the canonical runtime state into stable user-facing lines.
 
-    #914: the `live` section (goal registry, recent ledger outcomes,
-    scorecard metrics/preset) is rendered FIRST — it is what the current
-    loop actually keeps fresh. The legacy coordinator-era sections that
-    follow are unchanged in content, except that their *source* line is
-    suffixed "(decommissioned — frozen data)" when that section's data was
-    actually loaded, so a reader can never mistake a frozen artifact for
-    current state.
+    #914: the `live` section (active goal, recent ledger outcomes, scorecard
+    metrics/preset) is rendered FIRST — it is what the current loop keeps
+    fresh. #1222: the sections that follow read only live sources too
+    (goal_text.json, promotions/, hypotheses/backlog.json, subagents/), so
+    the "(decommissioned — frozen data)" suffix #914 added has nothing left
+    to label and is gone with the frozen reads.
     """
     lines = ["Runtime:"]
 
@@ -1728,12 +1458,6 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
             lines.append(f"  {label}: {compact or 'unknown'}")
         else:
             lines.append(f"  {label}: {value}")
-
-    def _render_source(label: str, value: Any, decommissioned: bool) -> None:
-        if value in (None, ""):
-            lines.append(f"  {label}: unknown")
-        else:
-            lines.append(f"  {label}: {value}{_DECOMMISSIONED_SUFFIX if decommissioned else ''}")
 
     live = runtime.get("live") if isinstance(runtime.get("live"), dict) else None
     lines.append("Live status:")
@@ -1774,22 +1498,10 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
     lines.append("Legacy runtime detail:")
     _render("Runtime state source", runtime.get("runtime_state_source"))
     _render("Runtime state root", runtime.get("runtime_state_root"))
-    _render("Runtime status", runtime.get("runtime_status"))
     _render("Active goal", runtime.get("active_goal"))
     _render("Goal text", runtime.get("goal_text"))
-    _render("Current task", runtime.get("current_task_id"))
-    _render("Task counts", runtime.get("task_counts"))
-    _render("Task reward", runtime.get("task_reward_signal") or runtime.get("task_reward_value"))
-    _render("Experiment outcome", runtime.get("experiment_outcome"))
-    _render("Experiment metric", runtime.get("experiment_metric_name"))
-    _render("Experiment baseline", runtime.get("experiment_metric_baseline"))
-    _render("Experiment current", runtime.get("experiment_metric_current"))
-    _render("Experiment frontier", runtime.get("experiment_metric_frontier"))
-    _render("Experiment contract", runtime.get("experiment_contract_path"))
-    _render_source("Experiment source", runtime.get("experiment_path"), bool(runtime.get("experiment_decommissioned")))
-    _render("Credits balance", runtime.get("credits_balance"))
-    _render("Credits delta", runtime.get("credits_delta"))
-    _render_source("Credits source", runtime.get("credits_path"), bool(runtime.get("credits_decommissioned")))
+    _render("Goal source", runtime.get("goal_path"))
+    _render("Approval gate (apply.ok)", runtime.get("approval_gate_state"))
     _render("Subagent telemetry root", runtime.get("subagent_telemetry_root"))
     _render("Subagent telemetry path", runtime.get("subagent_telemetry_path"))
     _render("Subagent telemetry count", runtime.get("subagent_telemetry_count"))
@@ -1808,17 +1520,7 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
         if runtime.get("subagent_telemetry_latest_feedback_decision"):
             latest_bits.append(f"feedback={runtime.get('subagent_telemetry_latest_feedback_decision')}")
         _render("Subagent telemetry latest", " | ".join(latest_bits))
-    if isinstance(runtime.get("experiment"), dict):
-        experiment = runtime.get("experiment") or {}
-        lines.append(
-            "  Experiment: "
-            f"id={experiment.get('experiment_id')}, budget={experiment.get('budget')}, used={experiment.get('budget_used')}"
-        )
-    _render("Plan source", runtime.get("task_plan_path"))
-    _render("History source", runtime.get("task_history_path"))
     _render("Hypothesis backlog source", runtime.get("hypothesis_backlog_path"))
-    _render("Task plan schema", runtime.get("task_plan_schema_version"))
-    _render("Feedback", runtime.get("task_feedback_decision"))
     _render("Hypothesis backlog schema", runtime.get("hypothesis_backlog_schema_version"))
     _render("Hypothesis backlog model", runtime.get("hypothesis_backlog_model"))
     _render("Hypothesis backlog selected", runtime.get("hypothesis_backlog_selected_id"))
@@ -1826,14 +1528,6 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
     _render("Hypothesis backlog entries", runtime.get("hypothesis_backlog_entry_count"))
     _render("Hypothesis backlog best score", runtime.get("hypothesis_backlog_best_score"))
     _render("Hypothesis backlog WSJF", runtime.get("hypothesis_backlog_selected_wsjf"))
-    if runtime.get("report_stale"):
-        age = runtime.get("report_age_seconds")
-        age_text = f"{age / 86400:.1f} days old" if isinstance(age, (int, float)) else "age unknown"
-        lines.append(f"  Report source: {runtime.get('report_path') or 'unknown'} (frozen — writer retired 2026-08-22; {age_text})")
-    _render("Cycle", runtime.get("cycle_id"))
-    _render("Cycle started", runtime.get("cycle_started_utc"))
-    _render("Cycle ended", runtime.get("cycle_ended_utc"))
-    _render("Evidence", runtime.get("evidence_ref"))
     _render("Promotion candidate", runtime.get("promotion_candidate_id"))
     _render("Promotion review", runtime.get("review_status"))
     _render("Promotion decision", runtime.get("decision"))
@@ -1850,9 +1544,6 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
     _render("Promotion accepted at", runtime.get("promotion_accepted_at"))
     _render("Patch bundle", runtime.get("promotion_patch_bundle_path"))
     _render("Promotion replay readiness", runtime.get("promotion_replay_readiness"))
-    _render("Hypothesis backlog schema", runtime.get("hypothesis_backlog_schema_version"))
-    _render("Follow-through", runtime.get("follow_through_status"))
-    _render("Improvement score", runtime.get("improvement_score"))
 
     if isinstance(runtime.get("subagent_rollup"), dict):
         roll = runtime.get("subagent_rollup") or {}
@@ -1861,28 +1552,5 @@ def format_runtime_state(runtime: dict[str, Any]) -> list[str]:
             f"enabled={roll.get('enabled')}, total={roll.get('count_total')}, done={roll.get('count_done')}, "
             f"queued={roll.get('count_queued')}, stale={roll.get('count_stale')}"
         )
-    if runtime.get("artifact_paths"):
-        artifacts = runtime.get("artifact_paths")
-        if isinstance(artifacts, list):
-            _render("Artifacts", ", ".join(str(item) for item in artifacts))
-        else:
-            _render("Artifacts", artifacts)
-    _render_source("Promotion source", runtime.get("promotion_path"), bool(runtime.get("promotion_decommissioned")))
-    _render("Approval gate", runtime.get("approval_gate"))
-    _render("Gate state", runtime.get("approval_gate_state"))
-    if runtime.get("approval_gate_ttl_minutes") is not None:
-        _render("Gate TTL (min)", runtime.get("approval_gate_ttl_minutes"))
-    _render("Next", runtime.get("next_hint"))
-    _render("Goal rotation reason", runtime.get("goal_rotation_reason"))
-    _render("Goal rotation streak", runtime.get("goal_rotation_streak"))
-    _render("Goal rotation trigger", runtime.get("goal_rotation_trigger_goal"))
-    if runtime.get("goal_rotation_trigger_artifact_paths"):
-        trigger_artifacts = runtime.get("goal_rotation_trigger_artifact_paths")
-        if isinstance(trigger_artifacts, list):
-            _render("Goal rotation artifacts", ", ".join(str(item) for item in trigger_artifacts))
-        else:
-            _render("Goal rotation artifacts", trigger_artifacts)
-    _render("Report source", runtime.get("report_path"))
-    _render("Goal source", runtime.get("goal_path"))
-    _render_source("Outbox source", runtime.get("outbox_path"), bool(runtime.get("outbox_decommissioned")))
+    _render("Promotion source", runtime.get("promotion_path"))
     return lines

--- a/nanobot/runtime/state.py
+++ b/nanobot/runtime/state.py
@@ -925,20 +925,18 @@ _LIVE_RECENT_OUTCOMES_LIMIT = 5
 
 
 def _live_active_goal_id(state_root: Path) -> str | None:
-    """Active goal id from the live goal registry.
+    """Active goal id from the operator canon, ``goals/goal_text.json``.
 
-    ``goals/registry.json`` is rewritten every cycle by the current loop
-    (see ``coordinator._write_goal_registry`` / ``bridge``'s equivalent) —
-    unlike ``goals/current.json``/``active.json``, which stopped updating
-    when the coordinator was decommissioned. Fail-open to ``None``.
+    #914 read ``goals/registry.json`` here believing the current loop
+    rewrote it every cycle; it did not — the coordinator was its only
+    writer and the file froze on 2026-08-22 (#1222). ``goal_text.json``
+    (seeded by ``deploy_release.sh``) carries ``goal_id``. Fail-open to
+    ``None``.
     """
-    data = _safe_read_json(state_root / "goals" / "registry.json")
-    if not isinstance(data, dict):
-        return None
-    goal_id = data.get("active_goal_id")
-    if isinstance(goal_id, str) and goal_id.strip():
-        return goal_id.strip()
-    return None
+    from nanobot.runtime.goal_review import active_goal_id
+
+    goal_id = active_goal_id(state_root)
+    return goal_id or None
 
 
 def _live_recent_outcomes(

--- a/nanobot/runtime/state_paths.py
+++ b/nanobot/runtime/state_paths.py
@@ -45,12 +45,10 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
     ),
     # apply.ok is written by the operator (runbook), read by the bridge gate.
     "approvals": ("repo:docs/EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md",),
-    # doctor probes completed/completed.json; nothing has ever written it —
-    # the live file is demand/completed.json.
-    "completed": ("orphan:#1222",),
-    # current_summary.json froze 2026-08-22 02:00 with the deleted planner;
-    # stale_execution_repair.json has no in-repo writer either.
-    "control_plane": ("orphan:#1222",),
+    # current_summary.json froze 2026-08-22 02:00 with the deleted planner; its
+    # only reader is autoevolve.health_check_release, retired with autoevolve
+    # in #1224. stale_execution_repair.json has no in-repo writer either.
+    "control_plane": ("orphan:#1224",),
     "credits": ("orphan:#1222",),  # latest.json frozen 2026-08-22 02:00
     "curator": (
         "nanobot.runtime.knowledge_curator:_write_decision",
@@ -66,24 +64,26 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
         "nanobot.runtime.goal_gap_futility:_save",
     ),
     # derived_priorities.json is live (goal_review); goal_text.json is the
-    # operator's canon; registry.json / active.json / cycle_archive.json froze
-    # 2026-08-22 02:00 with the deleted planner — see #1222.
+    # operator's canon and, since #1222, the only source of the active goal id
+    # (goal_review.active_goal_id). cycle_archive.json froze 2026-08-22 02:00
+    # with the deleted planner and still feeds the #877 line-switch trigger in
+    # bridge._setup_cycle_branch — restore a writer or retire the trigger: #1225.
     "goals": (
         "nanobot.runtime.goal_review:_write_derived_priorities",
         "repo:host/eeepc/scripts/deploy_release.sh",  # seeds goals/goal_text.json, the operator's canon
-        "orphan:#1222",
+        "orphan:#1225",
     ),
     "heldout": (
         "nanobot.runtime.heldout:_save_results",
         "nanobot.runtime.heldout.microbench:_save_microbench_file",
     ),
-    # backlog.json and lifecycle.json are live; durable.json is written daily
-    # by something outside this repository — identify it (#1222).
+    # backlog.json (bridge, per cycle), lifecycle.json, and durable.json —
+    # written by append_hypotheses from the strategist's daily run (#1222
+    # thought that one came from outside the repo; the docstring lied).
     "hypotheses": (
         "nanobot.runtime.backlog_snapshot:write_backlog_snapshot",
         "nanobot.runtime.hypothesis_backlog:_save_lifecycle",
         "nanobot.runtime.hypothesis_backlog:append_hypotheses",
-        "orphan:#1222",
     ),
     "improvements": ("nanobot.runtime.llm_proposer:write_request",),
     "ledger": ("nanobot.runtime.cycle_ledger:append_event",),
@@ -104,6 +104,9 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
     # in the same directory is live and written outside nanobot/.
     "reports": ("orphan:#1222",),
     "scorecard": ("nanobot.runtime.scorecard:compute_scorecard",),
+    # Writers exist but have not run on the host since 2026-06-20 (no unit or
+    # timer invokes guarded_self_evolve.py; the directory is empty). Resolving
+    # a ref proves the code exists, not that the duty is performed — #1224.
     "self_evolution": (
         "nanobot.runtime.autoevolve:write_guarded_evolution_state",
         "nanobot.runtime.autoevolve:write_noop_export_status",
@@ -131,7 +134,14 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
 ORPHAN_ISSUES: dict[str, str] = {
     "#1222": (
         "readers of state written by the planner deleted in #916/#923 "
-        "(credits, outbox, control_plane, goals/registry, reports/evolution-*), "
-        "plus durable.json's out-of-repo writer and doctor's completed/ probe"
+        "(credits, outbox, reports/evolution-*) in the operator status surface"
+    ),
+    "#1224": (
+        "autoevolve: writers exist, duty not performed since 2026-06-20; "
+        "health_check_release reads frozen control_plane/ and reports/evolution-*"
+    ),
+    "#1225": (
+        "goals/cycle_archive.json feeds the #877 line-switch trigger and has "
+        "had no writer since 2026-08-22; restore a reward writer or retire it"
     ),
 }

--- a/nanobot/runtime/state_paths.py
+++ b/nanobot/runtime/state_paths.py
@@ -49,7 +49,6 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
     # only reader is autoevolve.health_check_release, retired with autoevolve
     # in #1224. stale_execution_repair.json has no in-repo writer either.
     "control_plane": ("orphan:#1224",),
-    "credits": ("orphan:#1222",),  # latest.json frozen 2026-08-22 02:00
     "curator": (
         "nanobot.runtime.knowledge_curator:_write_decision",
         "nanobot.runtime.knowledge_curator:_stage_promotions",
@@ -91,7 +90,6 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
         "nanobot.observability.llm_telemetry:record_llm_call",
         "nanobot.observability.llm_telemetry:record_llm_prompt",
     ),
-    "outbox": ("orphan:#1222",),  # report.index.json frozen 2026-08-22 02:00
     "promotions": (
         "nanobot.runtime.bridge:_record_runtime_slice_candidate",
         "nanobot.runtime.promotions_rotation:rotate_promotions",
@@ -100,9 +98,11 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
         "nanobot.runtime.reflector:_append_journal",
         "nanobot.runtime.reflector:_save_watermark",
     ),
-    # evolution-*.json (the read target) last written 2026-08-21; proof-*.json
-    # in the same directory is live and written outside nanobot/.
-    "reports": ("orphan:#1222",),
+    # evolution-*.json last written 2026-08-21 by the deleted coordinator; its
+    # one remaining reader is autoevolve.health_check_release (#1224). The
+    # status surface stopped reading it in #1222. proof-*.json in the same
+    # directory is live and written outside nanobot/.
+    "reports": ("orphan:#1224",),
     "scorecard": ("nanobot.runtime.scorecard:compute_scorecard",),
     # Writers exist but have not run on the host since 2026-06-20 (no unit or
     # timer invokes guarded_self_evolve.py; the directory is empty). Resolving
@@ -132,10 +132,6 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
 # Every ``orphan:#N`` reference must name an issue listed here, with the
 # one-line reason the orphan is being carried rather than fixed in place.
 ORPHAN_ISSUES: dict[str, str] = {
-    "#1222": (
-        "readers of state written by the planner deleted in #916/#923 "
-        "(credits, outbox, reports/evolution-*) in the operator status surface"
-    ),
     "#1224": (
         "autoevolve: writers exist, duty not performed since 2026-06-20; "
         "health_check_release reads frozen control_plane/ and reports/evolution-*"

--- a/tests/test_backlog_snapshot.py
+++ b/tests/test_backlog_snapshot.py
@@ -25,13 +25,13 @@ def _seed_request(state_dir: Path, request_id: str, **extra) -> None:
     (req_dir / f"{request_id}.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _seed_goal_registry(state_dir: Path, *, active_goal_id: str = "goal-1", current_task_id: str | None = None) -> None:
+def _seed_goal_text(state_dir: Path, *, goal_id: str = "goal-1") -> None:
+    """#1222: the active goal id comes from the operator's goals/goal_text.json
+    (goal_review.active_goal_id), not the coordinator's frozen registry.json."""
     goals_dir = state_dir / "goals"
     goals_dir.mkdir(parents=True, exist_ok=True)
-    payload: dict = {"active_goal_id": active_goal_id}
-    if current_task_id:
-        payload["current_task_id"] = current_task_id
-    (goals_dir / "registry.json").write_text(json.dumps(payload), encoding="utf-8")
+    payload = {"schema_version": "goal-text-v1", "goal_id": goal_id, "text": "test goal"}
+    (goals_dir / "goal_text.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _mark_handled(state_dir: Path, request_id: str) -> None:
@@ -52,7 +52,7 @@ def _mark_handled(state_dir: Path, request_id: str) -> None:
 class TestWriteBacklogSnapshot:
     def test_valid_state_writes_file_and_round_trips_through_reader(self, tmp_path):
         state_dir = tmp_path / "state"
-        _seed_goal_registry(state_dir, current_task_id="req-1")
+        _seed_goal_text(state_dir)
         _seed_request(state_dir, "req-1", acceptance="`pytest -q` passes")
         _seed_request(state_dir, "req-2", evidence="benchmark shows 2x speedup")
 
@@ -75,25 +75,24 @@ class TestWriteBacklogSnapshot:
         assert "Task req-1" in section
         assert "Task req-2" in section
 
-    def test_selected_task_marked_from_current_task_id(self, tmp_path):
+    def test_nothing_is_preselected_every_candidate_is_backlog(self, tmp_path):
+        """#1222: the coordinator's current_task_id (goals/registry.json) is
+        gone; the bridge queue is FIFO, so no candidate is ever ``selected``."""
         state_dir = tmp_path / "state"
-        _seed_goal_registry(state_dir, current_task_id="req-1")
+        _seed_goal_text(state_dir)
         _seed_request(state_dir, "req-1")
         _seed_request(state_dir, "req-2")
 
         write_backlog_snapshot(state_dir, None)
 
         data = json.loads((state_dir / "hypotheses" / "backlog.json").read_text(encoding="utf-8"))
-        assert data["selected_hypothesis_id"] == "req-1"
-        by_id = {e["task_id"]: e for e in data["entries"]}
-        assert by_id["req-1"]["selected"] is True
-        assert by_id["req-1"]["selection_status"] == "selected"
-        assert by_id["req-2"]["selected"] is False
-        assert by_id["req-2"]["selection_status"] == "backlog"
+        assert data["selected_hypothesis_id"] is None
+        assert data["goal_id"] == "goal-1"
+        assert all(e["selected"] is False and e["selection_status"] == "backlog" for e in data["entries"])
 
     def test_no_requests_still_writes_empty_backlog(self, tmp_path):
         state_dir = tmp_path / "state"
-        _seed_goal_registry(state_dir)
+        _seed_goal_text(state_dir)
 
         assert write_backlog_snapshot(state_dir, None) is True
 
@@ -110,11 +109,11 @@ class TestWriteBacklogSnapshot:
         assert data["entries"] == []
         assert data["goal_id"] == ""
 
-    def test_corrupt_registry_does_not_crash_and_still_writes(self, tmp_path):
+    def test_corrupt_goal_text_does_not_crash_and_still_writes(self, tmp_path):
         state_dir = tmp_path / "state"
         goals_dir = state_dir / "goals"
         goals_dir.mkdir(parents=True)
-        (goals_dir / "registry.json").write_text("not json {{{", encoding="utf-8")
+        (goals_dir / "goal_text.json").write_text("not json {{{", encoding="utf-8")
         _seed_request(state_dir, "req-1")
 
         assert write_backlog_snapshot(state_dir, None) is True
@@ -150,7 +149,7 @@ class TestWriteBacklogSnapshot:
 
     def test_repeated_calls_are_idempotent(self, tmp_path):
         state_dir = tmp_path / "state"
-        _seed_goal_registry(state_dir)
+        _seed_goal_text(state_dir)
         _seed_request(state_dir, "req-1")
 
         write_backlog_snapshot(state_dir, None)

--- a/tests/test_bridge_goal_bootstrap.py
+++ b/tests/test_bridge_goal_bootstrap.py
@@ -1,14 +1,13 @@
-"""Tests for #913: drop the outbox bootstrap dependency.
+"""Tests for the bridge's goal bootstrap: the active goal id comes from
+``goals/goal_text.json`` (#1222).
 
-``bridge._main_impl`` used to require BOTH a non-empty
-``outbox/report.index.json:source`` AND a resolvable goal id before running
-any cycle — the only writer of ``outbox/`` was the decommissioned
-coordinator, so a fresh/rebuilt state dir (no ``outbox/`` at all) could never
-start a cycle even with a perfectly valid ``goals/registry.json`` (maintained
-by the live goal machinery). Goal id resolution is now registry-first, with
-the outbox's legacy ``goal.goal_id`` as a fallback only; ``report_source`` is
-no longer part of the gate (see tests/test_bridge_recent_activity_context.py
-for the build_task prompt-line side of this change).
+#913 dropped the outbox bootstrap dependency and made ``goals/registry.json``
+primary — but both files were written only by the coordinator and froze on
+2026-08-22 when it was deleted (#916/#923). The operator canon,
+``goals/goal_text.json`` (seeded by ``deploy_release.sh``), has carried
+``goal_id`` all along; ``goal_review.active_goal_id`` reads it and the bridge
+consults nothing else. A frozen registry or outbox present on the host is
+ignored, and a fresh state dir with only ``goal_text.json`` starts a cycle.
 
 Exercises this through the same seam tests/test_bridge_bulk_skip.py and
 friends already use: ``bridge._main_impl()`` called directly with STATE_DIR/
@@ -32,37 +31,23 @@ def _set_common_paths(monkeypatch, state_dir, base):
     monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
 
 
-class TestGoalIdBootstrapPrecedence:
-    def test_registry_only_no_outbox_dir_runs_normally(self, tmp_path, monkeypatch, capsys):
+def _write_goal_text(state_dir, goal_id: str) -> None:
+    (state_dir / "goals").mkdir(parents=True, exist_ok=True)
+    (state_dir / "goals" / "goal_text.json").write_text(
+        json.dumps({"schema_version": "goal-text-v1", "goal_id": goal_id, "text": "test goal"}),
+        encoding="utf-8",
+    )
+
+
+class TestGoalIdBootstrap:
+    def test_goal_text_only_runs_normally(self, tmp_path, monkeypatch, capsys):
         state_dir = tmp_path / "state"
         state_dir.mkdir()
         _set_common_paths(monkeypatch, state_dir, tmp_path)
 
-        (state_dir / "goals").mkdir(parents=True)
-        (state_dir / "goals" / "registry.json").write_text(
-            json.dumps({"active_goal_id": "goal-registry-only"}), encoding="utf-8",
-        )
-        # No outbox/ directory at all — the fresh-install case #913 fixes.
+        _write_goal_text(state_dir, "goal-canon")
+        # No outbox/, no registry.json — the fresh-install case.
         assert not (state_dir / "outbox").exists()
-
-        result = asyncio.run(bridge._main_impl())
-        assert result == 0
-
-        out = capsys.readouterr().out
-        assert "no_active_goal" not in out
-        assert "already_handled" in out
-
-    def test_outbox_only_legacy_fallback_runs_normally(self, tmp_path, monkeypatch, capsys):
-        state_dir = tmp_path / "state"
-        state_dir.mkdir()
-        _set_common_paths(monkeypatch, state_dir, tmp_path)
-
-        # No goals/registry.json at all — only the legacy outbox goal_id.
-        (state_dir / "outbox").mkdir(parents=True)
-        (state_dir / "outbox" / "report.index.json").write_text(
-            json.dumps({"source": "legacy-report", "goal": {"goal_id": "goal-legacy"}}),
-            encoding="utf-8",
-        )
         assert not (state_dir / "goals" / "registry.json").exists()
 
         result = asyncio.run(bridge._main_impl())
@@ -72,51 +57,79 @@ class TestGoalIdBootstrapPrecedence:
         assert "no_active_goal" not in out
         assert "already_handled" in out
 
-    def test_registry_takes_precedence_over_outbox(self, tmp_path, monkeypatch):
-        """Registry active_goal_id wins even when a (stale) outbox goal_id
-        is also present — registry is now PRIMARY, outbox is fallback only.
-        """
+    def test_frozen_registry_and_outbox_are_not_a_goal_source(self, tmp_path, monkeypatch, capsys):
+        """The coordinator's files may still sit on the host; they are not read."""
         state_dir = tmp_path / "state"
         state_dir.mkdir()
         _set_common_paths(monkeypatch, state_dir, tmp_path)
 
         (state_dir / "goals").mkdir(parents=True)
         (state_dir / "goals" / "registry.json").write_text(
-            json.dumps({"active_goal_id": "goal-fresh"}), encoding="utf-8",
+            json.dumps({"active_goal_id": "goal-frozen"}), encoding="utf-8",
         )
         (state_dir / "outbox").mkdir(parents=True)
         (state_dir / "outbox" / "report.index.json").write_text(
             json.dumps({"source": "stale-report", "goal": {"goal_id": "goal-stale"}}),
             encoding="utf-8",
         )
+        assert not (state_dir / "goals" / "goal_text.json").exists()
 
-        captured_goal_ids = []
-        real_write = bridge.write_backlog_snapshot
-
-        def _spy(state_dir_arg, selfevo_repo_arg):
-            data = bridge.load_json(state_dir_arg / "goals" / "registry.json") or {}
-            captured_goal_ids.append(data.get("active_goal_id"))
-            return real_write(state_dir_arg, selfevo_repo_arg)
-
-        monkeypatch.setattr(bridge, "write_backlog_snapshot", _spy)
-
-        result = asyncio.run(bridge._main_impl())
-        assert result == 0
-        assert captured_goal_ids == ["goal-fresh"]
-
-    def test_neither_present_prints_no_active_goal(self, tmp_path, monkeypatch, capsys):
-        state_dir = tmp_path / "state"
-        state_dir.mkdir()
-        _set_common_paths(monkeypatch, state_dir, tmp_path)
-
-        # Neither goals/registry.json nor outbox/report.index.json exists.
         result = asyncio.run(bridge._main_impl())
         assert result == 0
 
         out = capsys.readouterr().out
         assert "no_active_goal" in out
 
-    def test_neither_present_does_not_crash(self, tmp_path, monkeypatch):
+    def test_goal_text_wins_over_frozen_registry(self, tmp_path, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _set_common_paths(monkeypatch, state_dir, tmp_path)
+
+        _write_goal_text(state_dir, "goal-canon")
+        (state_dir / "goals" / "registry.json").write_text(
+            json.dumps({"active_goal_id": "goal-frozen"}), encoding="utf-8",
+        )
+
+        captured_goal_ids = []
+        real_write = bridge.write_backlog_snapshot
+
+        def _spy(state_dir_arg, selfevo_repo_arg):
+            from nanobot.runtime.goal_review import active_goal_id
+
+            captured_goal_ids.append(active_goal_id(state_dir_arg))
+            return real_write(state_dir_arg, selfevo_repo_arg)
+
+        monkeypatch.setattr(bridge, "write_backlog_snapshot", _spy)
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+        assert captured_goal_ids == ["goal-canon"]
+
+    def test_goal_text_without_id_prints_no_active_goal(self, tmp_path, monkeypatch, capsys):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _set_common_paths(monkeypatch, state_dir, tmp_path)
+
+        (state_dir / "goals").mkdir(parents=True)
+        (state_dir / "goals" / "goal_text.json").write_text(
+            json.dumps({"text": "a goal with no id"}), encoding="utf-8",
+        )
+
+        assert asyncio.run(bridge._main_impl()) == 0
+        assert "no_active_goal" in capsys.readouterr().out
+
+    def test_empty_state_dir_prints_no_active_goal(self, tmp_path, monkeypatch, capsys):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _set_common_paths(monkeypatch, state_dir, tmp_path)
+
+        result = asyncio.run(bridge._main_impl())
+        assert result == 0
+
+        out = capsys.readouterr().out
+        assert "no_active_goal" in out
+
+    def test_empty_state_dir_does_not_crash(self, tmp_path, monkeypatch):
         """No crash even on a completely empty state dir (defense-in-depth,
         redundant with the capsys assertion above but pins the return code
         contract independently of print output)."""
@@ -144,10 +157,7 @@ class TestBacklogSnapshotCalledEveryRun:
         state_dir = tmp_path / "state"
         state_dir.mkdir()
         _set_common_paths(monkeypatch, state_dir, tmp_path)
-        (state_dir / "goals").mkdir(parents=True)
-        (state_dir / "goals" / "registry.json").write_text(
-            json.dumps({"active_goal_id": "goal-1"}), encoding="utf-8",
-        )
+        _write_goal_text(state_dir, "goal-1")
 
         assert asyncio.run(bridge._main_impl()) == 0
 

--- a/tests/test_capability_reporting.py
+++ b/tests/test_capability_reporting.py
@@ -6,12 +6,10 @@ from nanobot.runtime.state import load_runtime_state
 
 def test_runtime_state_exposes_capabilities_snapshot(tmp_path: Path):
     state = tmp_path / 'state'
+    # #1222: the bounded-apply gate is read from approvals/apply.ok (absent
+    # here -> missing), not from the coordinator's frozen outbox copy.
     (state / 'goals').mkdir(parents=True)
-    (state / 'goals' / 'active.json').write_text(json.dumps({'active_goal': 'goal-bootstrap'}), encoding='utf-8')
-    (state / 'reports').mkdir(parents=True)
-    (state / 'reports' / 'evolution-20260422T000000Z.json').write_text(json.dumps({'result_status': 'BLOCK'}), encoding='utf-8')
-    (state / 'outbox').mkdir(parents=True)
-    (state / 'outbox' / 'latest.json').write_text(json.dumps({'approval_gate': {'state': 'missing'}, 'next_hint': 'approval gate missing; refresh manually'}), encoding='utf-8')
+    (state / 'goals' / 'goal_text.json').write_text(json.dumps({'goal_id': 'goal-bootstrap', 'text': 'goal'}), encoding='utf-8')
     (state / 'subagents').mkdir(parents=True)
     (state / 'subagents' / 'sub-1.json').write_text(json.dumps({'goal_id': 'goal-bootstrap', 'cycle_id': 'cycle-1', 'current_task_id': 'record-reward', 'report_path': '/workspace/state/reports/evolution-1.json', 'status': 'ok', 'task_reward_signal': {'value': 1.0}, 'task_feedback_decision': {'mode': 'stable'}}), encoding='utf-8')
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from nanobot.cli.commands import _make_provider, app
 from nanobot.config.schema import Config
-from nanobot.runtime.state import load_runtime_state, load_runtime_state_from_root
+from nanobot.runtime.state import format_runtime_state, load_runtime_state, load_runtime_state_from_root
 from nanobot.providers.litellm_provider import LiteLLMProvider
 from nanobot.providers.openai_codex_provider import _strip_model_prefix
 from nanobot.providers.registry import find_by_model
@@ -494,63 +494,25 @@ def test_load_runtime_state_from_host_control_plane_root(tmp_path):
 
 
 def test_load_runtime_state_reads_host_control_plane_layout(tmp_path):
+    """#1222: the goal comes from the operator's goals/goal_text.json; the
+    coordinator's reports/, outbox/ and registry.json are not read even when
+    present (they froze on the host on 2026-08-22)."""
     state_root = tmp_path / "host-state"
-    reports_dir = state_root / "reports"
     goals_dir = state_root / "goals"
-    outbox_dir = state_root / "outbox"
-    reports_dir.mkdir(parents=True)
     goals_dir.mkdir(parents=True)
-    outbox_dir.mkdir(parents=True)
-    report_path = reports_dir / "evolution-20260415T230020Z.json"
-    report_path.write_text(
-        json.dumps(
-            {
-                "goal": {"goal_id": "goal-44"},
-                "result": {"status": "BLOCK"},
-                "process_reflection": {"status": "BLOCK"},
-                "capability_gate": None,
-            }
-        ),
+    (goals_dir / "goal_text.json").write_text(
+        json.dumps({"schema_version": "goal-text-v1", "goal_id": "goal-44", "text": "Improve prompt clarity"}),
         encoding="utf-8",
     )
-    (goals_dir / "registry.json").write_text(
-        json.dumps(
-            {
-                "active_goal_id": "goal-44",
-                "goals": {"goal-44": {"goal_id": "goal-44", "status": "blocked"}},
-            }
-        ),
-        encoding="utf-8",
+    # Frozen coordinator artifacts that must be ignored.
+    (goals_dir / "registry.json").write_text(json.dumps({"active_goal_id": "goal-frozen"}), encoding="utf-8")
+    (state_root / "outbox").mkdir(parents=True)
+    (state_root / "outbox" / "report.index.json").write_text(
+        json.dumps({"status": "BLOCK", "goal": {"goal_id": "goal-frozen", "text": "frozen"}}), encoding="utf-8",
     )
-    (outbox_dir / "report.index.json").write_text(
-        json.dumps(
-            {
-                "status": "BLOCK",
-                "source": str(report_path),
-                "improvement_score": 32,
-                "goal": {
-                    "goal_id": "goal-44",
-                    "text": "Improve prompt clarity",
-                    "follow_through": {
-                        "status": "blocked_next_action",
-                        "artifact_paths": ["prompts/diagnostics.md"],
-                    },
-                },
-                "goal_context": {
-                    "subagent_rollup": {
-                        "enabled": True,
-                        "count_total": 3,
-                        "count_done": 2,
-                    }
-                },
-                "capability_gate": {"approval": {"ok": False, "reason": "missing"}},
-            }
-        ),
-        encoding="utf-8",
-    )
-    (outbox_dir / "latest_workspace_export.json").write_text(
-        json.dumps({"kind": "workspace_export"}),
-        encoding="utf-8",
+    (state_root / "reports").mkdir(parents=True)
+    (state_root / "reports" / "evolution-20260415T230020Z.json").write_text(
+        json.dumps({"goal": {"goal_id": "goal-frozen"}, "result": {"status": "BLOCK"}}), encoding="utf-8",
     )
 
     runtime = load_runtime_state_from_root(
@@ -558,72 +520,29 @@ def test_load_runtime_state_reads_host_control_plane_layout(tmp_path):
         source_kind="host_control_plane",
     )
 
-    assert runtime["report_path"] == str(report_path)
     assert runtime["active_goal"] == "goal-44"
     assert runtime["goal_text"] == "Improve prompt clarity"
-    assert runtime["runtime_status"] == "BLOCK"
+    assert runtime["goal_path"].endswith("goal_text.json")
+    for retired in ("report_path", "report_stale", "outbox_path", "runtime_status", "approval_gate",
+                    "next_hint", "credits_balance", "cycle_id", "current_task_id", "task_plan"):
+        assert retired not in runtime, retired
+    # The gate is read from approvals/apply.ok now (absent here), not the outbox copy.
     assert runtime["approval_gate_state"] == "missing"
-    assert runtime["artifact_paths"] == ["prompts/diagnostics.md"]
-    assert runtime["follow_through_status"] == "blocked_next_action"
-    assert runtime["improvement_score"] == 32
-    assert runtime["subagent_rollup"]["enabled"] is True
-    assert runtime["outbox_path"].endswith("report.index.json")
 
 
 
 def test_status_can_report_host_control_plane_authority(tmp_path, monkeypatch):
     state_root = tmp_path / "host-state"
-    reports_dir = state_root / "reports"
-    outbox_dir = state_root / "outbox"
     goals_dir = state_root / "goals"
-    reports_dir.mkdir(parents=True)
-    outbox_dir.mkdir(parents=True)
     goals_dir.mkdir(parents=True)
-    report_path = reports_dir / "evolution-20260415T230020Z.json"
-    report_path.write_text(
-        json.dumps(
-            {
-                "goal": {"goal_id": "goal-44"},
-                "process_reflection": {"status": "PASS"},
-                "capability_gate": {"approval": {"ok": True, "reason": "valid"}},
-                "follow_through": {"artifact_paths": ["prompts/diagnostics.md"]},
-            }
-        ),
+    (goals_dir / "goal_text.json").write_text(
+        json.dumps({"schema_version": "goal-text-v1", "goal_id": "goal-44", "text": "Improve prompt clarity"}),
         encoding="utf-8",
     )
-    (outbox_dir / "report.index.json").write_text(
-        json.dumps(
-            {
-                "status": "PASS",
-                "source": str(report_path),
-                "improvement_score": 77,
-                "goal": {
-                    "goal_id": "goal-44",
-                    "text": "Improve prompt clarity",
-                    "follow_through": {
-                        "status": "artifact",
-                        "artifact_paths": ["prompts/diagnostics.md"],
-                    },
-                },
-                "goal_context": {
-                    "subagent_rollup": {
-                        "enabled": True,
-                        "count_total": 3,
-                        "count_done": 2,
-                    }
-                },
-                "capability_gate": {"approval": {"ok": True, "reason": "valid"}},
-            }
-        ),
-        encoding="utf-8",
-    )
-    (goals_dir / "registry.json").write_text(
-        json.dumps(
-            {
-                "active_goal_id": "goal-44",
-                "goals": {"goal-44": {"goal_id": "goal-44", "status": "active"}},
-            }
-        ),
+    # #1222: a frozen outbox on the host is not a status source any more.
+    (state_root / "outbox").mkdir(parents=True)
+    (state_root / "outbox" / "report.index.json").write_text(
+        json.dumps({"status": "PASS", "improvement_score": 77, "capability_gate": {"approval": {"ok": True, "reason": "valid"}}}),
         encoding="utf-8",
     )
 
@@ -651,44 +570,22 @@ def test_status_can_report_host_control_plane_authority(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "Runtime state source: host_control_plane" in result.stdout
     assert f"Runtime state root: {state_root}" in result.stdout
-    assert "Runtime status: PASS" in result.stdout
     assert "Active goal: goal-44" in result.stdout
     assert "Goal text: Improve prompt clarity" in result.stdout
-    assert "Follow-through: artifact" in result.stdout
-    assert "Improvement score: 77" in result.stdout
-    assert "Subagents: enabled=True, total=3, done=2" in result.stdout
-    assert "Artifacts: prompts/diagnostics.md" in result.stdout
-    assert "Gate state: valid" in result.stdout
+    assert "Goal source:" in result.stdout and "goal_text.json" in result.stdout
+    for retired_line in ("Runtime status:", "Improvement score:", "Gate state:", "Outbox source:", "Report source:"):
+        assert retired_line not in result.stdout, retired_line
 
 
 
 def test_status_reports_runtime_surface(tmp_path, monkeypatch):
     workspace = tmp_path / "workspace"
     state_dir = workspace / "state"
-    reports_dir = state_dir / "reports"
     goals_dir = state_dir / "goals"
-    outbox_dir = state_dir / "outbox"
     hypotheses_dir = state_dir / "hypotheses"
-    reports_dir.mkdir(parents=True)
     goals_dir.mkdir(parents=True)
-    outbox_dir.mkdir(parents=True)
     hypotheses_dir.mkdir(parents=True)
 
-    (reports_dir / "evolution-20260412.json").write_text(
-        json.dumps(
-            {
-                "cycle_id": "cycle-123",
-                "cycle_started_utc": "2026-04-12T12:00:00Z",
-                "cycle_ended_utc": "2026-04-12T12:05:00Z",
-                "goal_id": "goal-44e50921129bf475",
-                "evidence_ref_id": "evidence-88",
-                "promotion_candidate_id": "promotion-42",
-                "review_status": "pending",
-                "decision": "pending",
-            }
-        ),
-        encoding="utf-8",
-    )
     (state_dir / "promotions").mkdir(parents=True)
     ((state_dir / "promotions") / "latest.json").write_text(
         json.dumps(
@@ -726,56 +623,8 @@ def test_status_reports_runtime_surface(tmp_path, monkeypatch):
         ),
         encoding="utf-8",
     )
-    (goals_dir / "active.json").write_text(
-        json.dumps({"active_goal": "goal-44e50921129bf475"}),
-        encoding="utf-8",
-    )
-    history_dir = goals_dir / "history"
-    history_dir.mkdir(parents=True)
-    (goals_dir / "current.json").write_text(
-        json.dumps(
-            {
-                "schema_version": "task-plan-v1",
-                "cycle_id": "cycle-123",
-                "goal_id": "goal-44e50921129bf475",
-                "active_goal": "goal-44e50921129bf475",
-                "current_task_id": "record-reward",
-                "task_counts": {"total": 3, "done": 2, "active": 1, "pending": 0},
-                "reward_signal": {
-                    "value": 1.0,
-                    "source": "result_status",
-                    "result_status": "PASS",
-                    "improvement_score": None,
-                },
-                "history_path": str(history_dir / "cycle-cycle-123.json"),
-            }
-        ),
-        encoding="utf-8",
-    )
-    (history_dir / "cycle-cycle-123.json").write_text(
-        json.dumps(
-            {
-                "schema_version": "task-history-v1",
-                "cycle_id": "cycle-123",
-                "current_task_id": "record-reward",
-                "task_counts": {"total": 3, "done": 2, "active": 1, "pending": 0},
-                "reward_signal": {
-                    "value": 1.0,
-                    "source": "result_status",
-                    "result_status": "PASS",
-                    "improvement_score": None,
-                },
-                "recorded_at_utc": "2026-04-12T12:05:00Z",
-            }
-        ),
-        encoding="utf-8",
-    )
-    (outbox_dir / "latest.json").write_text(
-        json.dumps({"approval_gate": {"state": "fresh", "ttl_minutes": 60}}),
-        encoding="utf-8",
-    )
-    (outbox_dir / "20260412-old.json").write_text(
-        json.dumps({"approval_gate": {"state": "stale", "ttl_minutes": 5}}),
+    (goals_dir / "goal_text.json").write_text(
+        json.dumps({"schema_version": "goal-text-v1", "goal_id": "goal-44e50921129bf475", "text": "Ship the thing"}),
         encoding="utf-8",
     )
     (hypotheses_dir / "backlog.json").write_text(
@@ -858,12 +707,8 @@ def test_status_reports_runtime_surface(tmp_path, monkeypatch):
     assert "Runtime:" in result.stdout
     assert "Runtime state source: workspace_state" in result.stdout
     assert f"Runtime state root: {state_dir}" in result.stdout
-    assert "Runtime status: unknown" in result.stdout
     assert "Active goal: goal-44e50921129bf475" in result.stdout
-    assert "Cycle: cycle-123" in result.stdout
-    assert "Cycle started: 2026-04-12T12:00:00Z" in result.stdout
-    assert "Cycle ended: 2026-04-12T12:05:00Z" in result.stdout
-    assert "Evidence: evidence-88" in result.stdout
+    assert "Goal text: Ship the thing" in result.stdout
     assert "Promotion candidate: promotion-42" in result.stdout
     assert "Promotion review: pending" in result.stdout
     assert "Promotion decision: pending" in result.stdout
@@ -878,19 +723,6 @@ def test_status_reports_runtime_surface(tmp_path, monkeypatch):
     assert "Promotion accepted at: 2026-04-12T12:07:00Z" in result.stdout
     assert "Patch bundle: " in result.stdout
     assert "promotion-42.json" in result.stdout
-    assert "Approval gate: state=fresh, ttl_minutes=60" in result.stdout
-    assert "Gate state: fresh" in result.stdout
-    assert "Gate TTL (min): 60" in result.stdout
-    assert "Next: none" in result.stdout
-    assert "Report source:" in result.stdout
-    assert "evolution-20260412.json" in result.stdout
-    assert "Current task: record-reward" in result.stdout
-    assert "Task counts: total=3, done=2, active=1, pending=0" in result.stdout
-    assert "Task reward: value=1.0, source=result_status" in result.stdout
-    assert "Plan source:" in result.stdout
-    assert "current.json" in result.stdout
-    assert "History source:" in result.stdout
-    assert "cycle-cycle-123.json" in result.stdout
     assert "Hypothesis backlog source:" in result.stdout
     assert "backlog.json" in result.stdout
     assert "Hypothesis backlog schema: hypothesis-backlog-v1" in result.stdout
@@ -898,49 +730,42 @@ def test_status_reports_runtime_surface(tmp_path, monkeypatch):
     assert "Hypothesis backlog title: Record cycle reward" in result.stdout
     assert "Hypothesis backlog entries: 3" in result.stdout
     assert "Hypothesis backlog best score: 88" in result.stdout
-    assert "Task plan schema: task-plan-v1" in result.stdout
     assert "Goal source:" in result.stdout
-    assert "active.json" in result.stdout
-    assert "Outbox source:" in result.stdout
-    assert "latest.json" in result.stdout
+    assert "goal_text.json" in result.stdout
+    # #1222: coordinator-era sections are gone, not "unknown".
+    for retired_line in ("Runtime status:", "Cycle:", "Approval gate:", "Gate state:", "Next:", "Report source:",
+                         "Current task:", "Task counts:", "Plan source:", "History source:", "Outbox source:",
+                         "Credits balance:", "Experiment outcome:"):
+        assert retired_line not in result.stdout, retired_line
 
 
-def test_runtime_state_prefers_newest_evolution_report(tmp_path):
+def test_runtime_state_does_not_read_coordinator_artifacts(tmp_path):
+    """#1222: reports/evolution-*.json, outbox/, credits/ and goals/{registry,
+    active,current}.json were written only by the coordinator (deleted
+    2026-08-22). Present or absent, they contribute nothing — no field, no
+    "unknown" line, no staleness flag."""
     workspace = tmp_path / "workspace"
-    reports_dir = workspace / "state" / "reports"
-    reports_dir.mkdir(parents=True)
-    (workspace / "state" / "goals").mkdir(parents=True)
-    outbox_dir = workspace / "state" / "outbox"
-    outbox_dir.mkdir(parents=True)
-
-    (reports_dir / "evolution-20260401.json").write_text(
-        json.dumps({"cycle_id": "old"}),
-        encoding="utf-8",
-    )
-    (reports_dir / "evolution-20260412.json").write_text(
-        json.dumps({"cycle_id": "new"}),
-        encoding="utf-8",
-    )
-    (outbox_dir / "latest.json").write_text(
-        json.dumps({"approval_gate": {"state": "fresh"}}),
-        encoding="utf-8",
-    )
+    state = workspace / "state"
+    for rel, payload in (
+        ("reports/evolution-20260412.json", {"cycle_id": "new", "goal_id": "goal-frozen"}),
+        ("outbox/latest.json", {"approval_gate": {"state": "fresh"}, "status": "PASS"}),
+        ("credits/latest.json", {"balance": 5, "delta": -1}),
+        ("goals/registry.json", {"active_goal_id": "goal-frozen"}),
+        ("goals/active.json", {"active_goal": "goal-frozen"}),
+        ("goals/current.json", {"current_task_id": "record-reward", "task_counts": {"total": 3}}),
+    ):
+        path = state / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
 
     runtime = load_runtime_state(workspace)
 
-    assert runtime["cycle_id"] == "new"
-
-
-def test_runtime_state_marks_missing_gate_and_hint(tmp_path):
-    workspace = tmp_path / "workspace"
-    (workspace / "state" / "reports").mkdir(parents=True)
-    (workspace / "state" / "goals").mkdir(parents=True)
-    (workspace / "state" / "outbox").mkdir(parents=True)
-
-    runtime = load_runtime_state(workspace)
-
-    assert runtime["approval_gate"] is None
-    assert runtime["next_hint"] == "approval gate missing; refresh manually"
+    assert runtime["active_goal"] is None  # no goal_text.json -> no goal, frozen registry ignored
+    for retired in ("cycle_id", "report_path", "report_stale", "approval_gate", "next_hint",
+                    "credits_balance", "credits_decommissioned", "outbox_path", "outbox_decommissioned",
+                    "current_task_id", "task_counts", "task_plan", "goal_rotation_reason"):
+        assert retired not in runtime, retired
+    assert not any("decommissioned" in line or "frozen" in line for line in format_runtime_state(runtime))
 
 
 

--- a/tests/test_cycle_health_summary.py
+++ b/tests/test_cycle_health_summary.py
@@ -28,12 +28,21 @@ def _fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(command, 1, "", "unexpected")
 
 
+def _write_ledger(state: Path, cycle_id: str) -> None:
+    """#1222: the cycle ledger is the loop's heartbeat — latest cycle id and
+    staleness come from it, not from the coordinator's reports/evolution-*.json."""
+    path = state / "ledger" / "cycles.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"phase": "proposed", "cycle_id": cycle_id, "task_title": "t"}) + "\n"
+        + json.dumps({"phase": "outcome", "cycle_id": cycle_id, "outcome": "success", "ts": "2026-09-03T00:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_build_cycle_health_summary_reads_state_and_systemd(tmp_path: Path):
     state = tmp_path / "state"
-    _write_json(
-        state / "reports" / "evolution-001.json",
-        {"cycle_id": "cycle-001", "result_status": "PASS"},
-    )
+    _write_ledger(state, "cycle-001")
     _write_json(
         state / "subagents" / "telemetry-001.json",
         {"subagent_id": "sub-001", "status": "ok"},
@@ -42,12 +51,15 @@ def test_build_cycle_health_summary_reads_state_and_systemd(tmp_path: Path):
         state / "promotions" / "latest.json",
         {"promotion_candidate_id": "promo-001", "review_status": "ready_for_policy_review", "decision": "ready_for_policy_review"},
     )
-    _write_json(state / "outbox" / "latest.json", {"approval_gate": {"state": "fresh"}})
+    # A frozen coordinator report is not a source (#1222).
+    _write_json(state / "reports" / "evolution-001.json", {"cycle_id": "cycle-frozen", "result_status": "PASS"})
 
     summary = build_cycle_health_summary(state, runner=_fake_runner)
 
     assert summary["schema_version"] == "cycle-health-summary-v2"
     assert summary["latest_cycle_id"] == "cycle-001"
+    assert isinstance(summary["ledger_age_seconds"], float)
+    assert "latest_report_path" not in summary
     assert summary["latest_subagent_telemetry_id"] == "sub-001"
     assert summary["service_status"]["active_state"] == "active"
     assert summary["failed_units_count"] == 0
@@ -63,8 +75,7 @@ def test_build_cycle_health_summary_reads_state_and_systemd(tmp_path: Path):
 
 def test_cycle_health_cli_json(tmp_path: Path, monkeypatch):
     state = tmp_path / "state"
-    _write_json(state / "reports" / "evolution-001.json", {"cycle_id": "cycle-cli"})
-    _write_json(state / "outbox" / "latest.json", {"approval_gate": {"state": "fresh"}})
+    _write_ledger(state, "cycle-cli")
     _write_json(
         state / "promotions" / "latest.json",
         {"promotion_candidate_id": "promo-cli", "review_status": "ready_for_policy_review", "decision": "ready_for_policy_review"},
@@ -141,8 +152,7 @@ def test_read_subagent_queue_depth_missing_dir_returns_zero(tmp_path: Path):
 
 def test_build_cycle_health_summary_includes_success_signals(tmp_path: Path):
     state = tmp_path / "state"
-    _write_json(state / "reports" / "evolution-001.json", {"cycle_id": "cycle-001"})
-    _write_json(state / "outbox" / "latest.json", {"approval_gate": {"state": "fresh"}})
+    _write_ledger(state, "cycle-001")
     requests_dir = state / "subagents" / "requests"
     requests_dir.mkdir(parents=True)
     (requests_dir / "req-0.json").write_text("{}", encoding="utf-8")

--- a/tests/test_cycle_ledger.py
+++ b/tests/test_cycle_ledger.py
@@ -287,13 +287,11 @@ def _init_selfevo_repo(base: Path) -> tuple[Path, Path]:
 
 
 def _seed_bridge_request(state_dir: Path, request_id: str, cycle_id: str, **extra) -> None:
-    (state_dir / "outbox").mkdir(parents=True, exist_ok=True)
-    (state_dir / "outbox" / "report.index.json").write_text(
-        json.dumps({"source": "test-source", "goal": {"goal_id": "goal-1"}}), encoding="utf-8",
-    )
+    # #1222: the bridge resolves the active goal from goals/goal_text.json
+    # (operator canon); the coordinator's outbox/registry are not read.
     (state_dir / "goals").mkdir(parents=True, exist_ok=True)
-    (state_dir / "goals" / "registry.json").write_text(
-        json.dumps({"active_goal_id": "goal-1", "goals": {"goal-1": {"text": "test goal"}}}),
+    (state_dir / "goals" / "goal_text.json").write_text(
+        json.dumps({"schema_version": "goal-text-v1", "goal_id": "goal-1", "text": "test goal"}),
         encoding="utf-8",
     )
     (state_dir / "subagents" / "requests").mkdir(parents=True, exist_ok=True)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -14,7 +14,6 @@ def _fixture(tmp_path: Path) -> dict[str, Path]:
     (state / "reflector").mkdir()
     (state / "skill_evals").mkdir()
     (state / "knowledge_lift").mkdir()
-    (state / "completed").mkdir()
     (state / "demand").mkdir()
     (state / "ledger" / "cycles.jsonl").write_text(
         json.dumps({"phase": "outcome", "ts": "2026-08-31T12:00:00Z"}) + "\n",
@@ -114,7 +113,9 @@ def test_watermark_without_last_run_is_valid_when_present(tmp_path: Path, monkey
 def test_malformed_json_rows_are_counted_per_file(tmp_path: Path) -> None:
     paths = _fixture(tmp_path)
     (paths["state"] / "ledger" / "cycles.jsonl").write_text("not-json\n{}\n", encoding="utf-8")
-    (paths["state"] / "completed" / "completed.json").write_text("{bad", encoding="utf-8")
+    # #1222: the probe targets the live sidecar demand/completed.json, not the
+    # never-written completed/completed.json.
+    (paths["state"] / "demand" / "completed.json").write_text("{bad", encoding="utf-8")
     result = doctor.run_doctor(state_dir=paths["state"], repo_dir=paths["repo"], release_link=paths["current"], command_runner=_runner)
     integrity = next(check for check in result.checks if check.name == "integrity")
     assert integrity.status == "WARN"

--- a/tests/test_runtime_state_live.py
+++ b/tests/test_runtime_state_live.py
@@ -141,7 +141,10 @@ def test_live_section_empty_for_fully_empty_state_dir(tmp_path: Path):
     assert any("Scorecard (live): unknown" in line for line in formatted)
 
 
-def test_legacy_artifacts_present_are_marked_decommissioned(tmp_path: Path):
+def test_coordinator_artifacts_are_not_read_and_promotions_are_live(tmp_path: Path):
+    """#1222 supersedes #914's "(decommissioned — frozen data)" labelling: the
+    frozen outbox/ and credits/ files are not read at all, so there is nothing
+    to label; promotions/latest.json is written by the bridge and is live."""
     state_root = tmp_path / "state"
     _write_json(state_root / "outbox" / "latest.json", {"status": "PASS"})
     _write_json(state_root / "credits" / "latest.json", {"balance": 5, "delta": -1})
@@ -149,40 +152,25 @@ def test_legacy_artifacts_present_are_marked_decommissioned(tmp_path: Path):
 
     runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
 
-    assert runtime["outbox_decommissioned"] is True
-    assert runtime["credits_decommissioned"] is True
-    assert runtime["experiment_decommissioned"] is False
-    assert runtime["promotion_decommissioned"] is True
+    for retired in ("outbox_decommissioned", "credits_decommissioned", "experiment_decommissioned",
+                    "promotion_decommissioned", "credits_balance", "outbox_path"):
+        assert retired not in runtime, retired
+    assert runtime["promotion_candidate_id"] == "promo-1"
 
     formatted = format_runtime_state(runtime)
-    assert any(
-        line.startswith("  Outbox source:") and "(decommissioned — frozen data)" in line
-        for line in formatted
-    )
-    assert any(
-        line.startswith("  Credits source:") and "(decommissioned — frozen data)" in line
-        for line in formatted
-    )
-    assert not any(
-        line.startswith("  Experiment source:") and "(decommissioned — frozen data)" in line
-        for line in formatted
-    )
-    assert any(
-        line.startswith("  Promotion source:") and "(decommissioned — frozen data)" in line
-        for line in formatted
-    )
+    assert any(line.startswith("  Promotion source:") and line.endswith("latest.json") for line in formatted)
+    assert not any("decommissioned" in line for line in formatted)
+    assert not any(line.startswith("  Outbox source:") or line.startswith("  Credits") for line in formatted)
 
 
-def test_legacy_artifacts_absent_are_not_marked_and_do_not_error(tmp_path: Path):
+def test_empty_state_root_does_not_error(tmp_path: Path):
     state_root = tmp_path / "state"
     state_root.mkdir(parents=True)
 
     runtime = load_runtime_state_from_root(state_root, source_kind="workspace_state")
 
-    assert runtime["outbox_decommissioned"] is False
-    assert runtime["credits_decommissioned"] is False
-    assert runtime["experiment_decommissioned"] is False
-    assert runtime["promotion_decommissioned"] is False
-
+    assert runtime["active_goal"] is None
+    assert runtime["promotion_candidate_id"] is None
     formatted = format_runtime_state(runtime)
+    assert formatted[0] == "Runtime:"
     assert not any("decommissioned" in line for line in formatted)

--- a/tests/test_runtime_state_live.py
+++ b/tests/test_runtime_state_live.py
@@ -25,7 +25,8 @@ def _write_ledger(path: Path, rows: list[dict]) -> None:
 
 def test_live_section_populated_from_full_live_state_dir(tmp_path: Path):
     state_root = tmp_path / "state"
-    _write_json(state_root / "goals" / "registry.json", {"active_goal_id": "goal-live-1"})
+    # #1222: the live goal id is the operator canon's goal_text.json:goal_id.
+    _write_json(state_root / "goals" / "goal_text.json", {"goal_id": "goal-live-1", "text": "goal"})
     _write_ledger(
         state_root / "ledger" / "cycles.jsonl",
         [
@@ -100,7 +101,7 @@ def test_live_section_populated_from_full_live_state_dir(tmp_path: Path):
 
 def test_live_section_partial_when_scorecard_missing(tmp_path: Path):
     state_root = tmp_path / "state"
-    _write_json(state_root / "goals" / "registry.json", {"active_goal_id": "goal-live-2"})
+    _write_json(state_root / "goals" / "goal_text.json", {"goal_id": "goal-live-2", "text": "goal"})
     _write_ledger(
         state_root / "ledger" / "cycles.jsonl",
         [


### PR DESCRIPTION
Closes #1222. Design table and per-row verdicts: https://github.com/ozand/eeebot/issues/1222#issuecomment-5519193468

## What this does

Every row of #1222 is a reader of a file the coordinator wrote until it was deleted on 2026-08-22 (#916/#923). Per row the duty was classified superseded / dropped / orphaned and the reader either repointed to the component that owns the duty today or removed. No reader in `nanobot/` reads `outbox/`, `credits/`, `goals/{registry,active,current}.json` or `completed/completed.json` any more; `reports/evolution-*.json` has one reader left (autoevolve, #1224).

| row | verdict | change |
|---|---|---|
| `goals/registry.json`, `active.json`, `current.json` | superseded by the operator canon `goals/goal_text.json:goal_id` | new `goal_review.active_goal_id()`; bridge, backlog_snapshot, llm_proposer and state.py read it. `current_task_id` / `subagent_policy` dropped (frozen values had matched nothing since 08-22; behaviour unchanged) |
| `outbox/*` | superseded (goal bootstrap → goal_text.json; status snapshot → ledger/scorecard; approval gate → `approvals/apply.ok`) | bridge fallback and every state.py read removed |
| `credits/latest.json` | dropped (#864 removed the ledger, #914 already labelled it frozen) | reader + fields + render lines removed |
| `reports/evolution-*.json` (status/health reader) | superseded by `ledger/cycles.jsonl` | health staleness = ledger age (>24h stale, absent unavailable); `latest_cycle_id` from the live section; report fields removed |
| `hypotheses/durable.json` | **not orphaned** — writer is `strategist → hypothesis_backlog.append_hypotheses` (daily 00:00 UTC; host file: all 20 entries `source=strategist`) | `orphan:` entry removed; the docstring that named the wrong file fixed |
| `completed/completed.json` | orphaned probe; live file is `demand/completed.json` | doctor integrity probe repointed |
| `control_plane/current_summary.json`, `self_evolution/`, autoevolve's `reports/` read | superseded — autoevolve has not run since 2026-06-20, nothing invokes it, `deploy_release.sh` + bridge integrate do its job | **not built here**: #1224 (decommission autoevolve as one unit, duty inventory in the issue); registry entries re-tagged `orphan:#1224` |
| `goals/cycle_archive.json` | orphaned — feeds the #877 line-switch trigger; frozen at 200 × reward 1.0 so `stalled()` is a constant False; restore a reward writer or retire the trigger is the owner's call | **not built here**: #1225; registry entry `orphan:#1225` |

`STATE_PATH_WRITERS` carries no `orphan:#1222`.

## Operator-visible change

`nanobot status --runtime-state-root …` and `nanobot cycle-health` lose ~40 fields that have read `unknown` or frozen values since 08-22 (cycle id/started/ended, evidence, runtime status, approval gate copy, next hint, goal rotation, task plan/counts/reward, experiment_*, credits_*, report/outbox sources, the "(decommissioned — frozen data)" suffix). They gain `Goal source` (goal_text.json), `Approval gate (apply.ok)` and `Ledger age`. Nothing on the host runs either command (checked: monitor = `~/bin/monitoring.sh`, verifier = `eeepc_promotion_verifier.py`).

## Deliberately not changed

- `scripts/eeepc_privileged_rollout_preflight.py` still requires `outbox/report.index.json` and `goals/registry.json` to be readable (`read_authority_outbox` / `read_goal_registry` blockers) — a reader outside `nanobot/` and outside the registry scan, pinned by two test files and a runbook. Same class as this issue; not touched here, noted for the owner.
- `nanobot/agent/subagent.py` correlation context still `.get()`s `report_path` / `current_task_id` from the runtime dict; they are absent now and are simply omitted from the correlation. Left as is.
- `control_plane/stale_execution_repair.json` (08-28) has no reader and no in-repo writer; not in scope.

## Tests

Full suite on Windows: `18 failed, 2957 passed, 17 skipped` — the 18 are exactly the documented Windows baseline (test_autoevolve.py ×5, test_autoevolve_commit.py ×3, test_autoevolve_guards.py ×1, test_autoevolve_remote_target.py ×1, test_autoevolve_state.py ×2, test_bridge_locking.py ×3, test_selfevo_export_security.py ×2, test_bridge_cycle_tags.py::test_fail_open_tag_failure_never_breaks_a_green_cycle ×1), checked by list.
