### PR TITLE
fix(dashboard): label retired artifacts as stale

### DIFF
--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -1057,14 +1057,25 @@ def artifact_status(age_hours: float | None, source_status: str = "valid") -> st
         return source_status
     if age_hours is None:
         return "unavailable"
-    # These report/materialized families have no live writer on this dashboard.
-    return "context-only"
+    return "stale" if age_hours >= ARTIFACT_STALE_AFTER_HOURS else "fresh"
+
+
+def artifact_metadata(age_hours: float | None, source_status: str = "valid") -> dict[str, Any]:
+    """Return bounded source metadata without payloads or filesystem paths."""
+    return {
+        "status": artifact_status(age_hours, source_status),
+        "age_hours": round(max(0.0, age_hours), 1) if age_hours is not None else None,
+        "authoritative": False,
+        "context_only": True,
+    }
 
 
 def format_artifact_value(value: Any, age_hours: float | None, source_status: str = "valid") -> str:
-    """Expose bounded status metadata, never raw stale values or paths."""
-    return f"{artifact_status(age_hours, source_status)} (context-only artifact)"
-    """Keep a legacy value visible while labelling its source freshness."""
+    """Expose bounded status/age metadata, never raw stale values or paths."""
+    metadata = artifact_metadata(age_hours, source_status)
+    age = metadata["age_hours"]
+    age_text = f"; age={age:.1f}h" if age is not None else ""
+    return f"{metadata['status']}{age_text} (context-only artifact)"
 
 
 def format_recent_cycles(trend: list[tuple[str, float]]) -> str:
@@ -1074,9 +1085,7 @@ def format_recent_cycles(trend: list[tuple[str, float]]) -> str:
 
 
 def format_materialized_cycle(materialized: dict[str, Any]) -> str:
-    if not materialized:
-        return "unknown"
-    return str(materialized.get("cycle_id", "unknown"))
+    return "context-only artifact" if materialized else "unavailable artifact"
 
 
 def format_materialized_status(materialized: dict[str, Any]) -> str:
@@ -1348,7 +1357,15 @@ def collect_metrics_uncached() -> dict[str, Any]:
     return {
         "captured_at": captured_at,
         "goal": goal,
+        "goal_source": artifact_metadata(
+            materialized_age_hours if materialized else latest_report_age_hours,
+            materialized_source_status if materialized else report_source_status,
+        ),
         "active_task": active_task,
+        "active_task_source": artifact_metadata(
+            materialized_age_hours if materialized else latest_report_age_hours,
+            materialized_source_status if materialized else report_source_status,
+        ),
         "recent_cycles": format_recent_cycles(recent_rewards),
         "reward_trend": recent_rewards,
         "reward_momentum": reward_momentum,
@@ -1389,6 +1406,10 @@ def collect_metrics_uncached() -> dict[str, Any]:
         "oldest_stale_request_path_text": oldest_stale_request_path_text,
         "archived_count": archived_count,
         "approval_gate_state": approval_gate_state,
+        "approval_gate_source": artifact_metadata(
+            materialized_age_hours if materialized else latest_report_age_hours,
+            materialized_source_status if materialized else report_source_status,
+        ),
         "materialized_status": format_materialized_status(materialized),
         "concrete_statement": format_concrete_statement(materialized),
         "goal_artifact_signature": format_goal_artifact_signature(materialized),
@@ -1446,9 +1467,12 @@ def collect_metrics() -> dict[str, Any]:
 
 def serialize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
     serializable = dict(metrics)
-    for key in ("materialized_path", "latest_report_path", "oldest_stale_request_path"):
-        value = serializable.get(key)
-        serializable[key] = str(value) if value else None
+    # Artifact paths are intentionally omitted from public payloads: these
+    # report/materialized files are context-only and may expose host layout.
+    serializable["materialized_path"] = None
+    serializable["latest_report_path"] = None
+    value = serializable.get("oldest_stale_request_path")
+    serializable["oldest_stale_request_path"] = str(value) if value else None
     host_focus_name_set = serializable.get("host_focus_name_set")
     if isinstance(host_focus_name_set, set):
         serializable["host_focus_name_set"] = sorted(host_focus_name_set)
@@ -2051,20 +2075,12 @@ def _build_html_context(m: dict[str, Any]) -> dict[str, str]:
         ctx[html_key] = escape_html_text(m[_HTML_KEY_MAP[html_key]])
 
     # Conditional keys (escape only if truthy)
-    ctx["materialized_path_html"] = escape_html_text(m["materialized_path"]) if m["materialized_path"] else ""
-    ctx["latest_report_path_html"] = escape_html_text(m["latest_report_path"]) if m["latest_report_path"] else ""
-
-    # Precompute conditional HTML fragments so render_html can use str.format_map(ctx)
-    # without inline Python expressions in the template.
+    # Do not render report/materialized filesystem paths in public HTML.
+    ctx["materialized_path_html"] = ""
+    ctx["latest_report_path_html"] = ""
     ctx["oldest_stale_age_html"] = escape_html_text(m["oldest_stale_request_age"])
-    ctx["materialized_path_block"] = (
-        f'<div class="metric-item"><span class="metric-label">Materialized Artifact Path:</span><div class="path">{ctx["materialized_path_html"]}</div></div>'
-        if m["materialized_path"] else ""
-    )
-    ctx["latest_report_path_block"] = (
-        f'<div class="metric-item"><span class="metric-label">Latest Report Path:</span><div class="path">{ctx["latest_report_path_html"]}</div></div>'
-        if m["latest_report_path"] else ""
-    )
+    ctx["materialized_path_block"] = ""
+    ctx["latest_report_path_block"] = ""
 
     # System metrics (Vector 1: self-optimization monitoring)
     ctx["cpu_load_html"] = f"{m.get('cpu_load', 0.0):.2f}"

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -4,6 +4,11 @@
 The dashboard intentionally stays dependency-free so it can run on the weak
 host even when richer TUI libraries are unavailable.
 Supports CLI plain text output and a web interface (--serve).
+
+Source-of-truth decision (#1206): this remains the live dashboard on port 8080.
+Live queue, host-capability, cleanup, and system metrics remain authoritative;
+retired report/materialized artifacts are retained for context only and must be
+labelled stale or unavailable rather than reported as healthy current state.
 """
 
 from __future__ import annotations
@@ -138,6 +143,7 @@ TREE_SCAN_CACHE_TTL_SECONDS = 3.0
 HOST_CAPS_CACHE_TTL_SECONDS = 30.0
 REPORT_SCAN_CACHE_TTL_SECONDS = 5.0
 MATERIALIZED_CACHE_TTL_SECONDS = 5.0
+ARTIFACT_STALE_AFTER_HOURS = 24.0
 _METRICS_CACHE: dict[str, Any] = {"loaded_at": 0.0, "metrics": None}
 _SUBAGENT_TREE_CACHE: dict[str, Any] = {"loaded_at": 0.0, "hours": None, "root_mtime_ns": None, "stats": None}
 _HOST_CAPS_CACHE: dict[str, Any] = {"loaded_at": 0.0, "host_caps": None}
@@ -993,6 +999,24 @@ def format_file_recency(age_hours: float | None) -> str:
     return f"{age_hours:.1f}h ago"
 
 
+def artifact_status(age_hours: float | None) -> str:
+    """Classify a dashboard artifact without treating missing data as healthy."""
+    if age_hours is None:
+        return "unavailable"
+    return "stale" if age_hours >= ARTIFACT_STALE_AFTER_HOURS else "fresh"
+
+
+def format_artifact_value(value: Any, age_hours: float | None) -> str:
+    """Keep a legacy value visible while labelling its source freshness."""
+    value_text = str(value).strip() or "unknown"
+    status = artifact_status(age_hours)
+    if status == "unavailable":
+        return f"unavailable (source unavailable; value={value_text})"
+    if status == "stale":
+        return f"stale (source {format_file_recency(age_hours)}; value={value_text})"
+    return value_text
+
+
 def format_recent_cycles(trend: list[tuple[str, float]]) -> str:
     if not trend:
         return "no recent cycles"
@@ -1173,17 +1197,26 @@ def collect_metrics_uncached() -> dict[str, Any]:
         host_capability_probe_status,
     )
 
-    goal = materialized.get("goal_id", latest_report.get("goal_id", "unknown"))
-    active_task = materialized.get("feedback_decision", {}).get(
+    goal_value = materialized.get("goal_id", latest_report.get("goal_id", "unknown"))
+    active_task_value = materialized.get("feedback_decision", {}).get(
         "selected_task_label",
         latest_report.get("feedback_decision", {}).get(
             "selected_task_label",
             materialized.get("task_id", latest_report.get("current_task_id", "unknown")),
         ),
     )
-    approval_gate_state = materialized.get("feedback_decision", {}).get(
+    approval_gate_value = materialized.get("feedback_decision", {}).get(
         "mode",
         latest_report.get("feedback_decision", {}).get("mode", "unknown"),
+    )
+    # These values come from the retired report/materialized writers. Keep them
+    # visible for context, but never present them as current healthy state.
+    goal = format_artifact_value(goal_value, _materialized_age if materialized else _report_age)
+    active_task = format_artifact_value(
+        active_task_value, _materialized_age if materialized else _report_age
+    )
+    approval_gate_state = format_artifact_value(
+        approval_gate_value, _materialized_age if materialized else _report_age
     )
 
     (
@@ -1322,8 +1355,10 @@ def collect_metrics_uncached() -> dict[str, Any]:
         "next_bounded_candidate": format_next_candidate(materialized),
         "materialized_path": str(materialized_path) if materialized_path else None,
         "materialized_recency": format_file_recency(materialized_age_hours),
+        "materialized_artifact_status": artifact_status(materialized_age_hours),
         "latest_report_path": str(latest_report_path) if latest_report_path else None,
         "latest_report_recency": format_file_recency(latest_report_age_hours),
+        "latest_report_artifact_status": artifact_status(latest_report_age_hours),
         "artifact_freshness": artifact_freshness,
         "last_cleanup_count": last_cleanup_count,
         "last_cleanup_timestamp": last_cleanup_timestamp,
@@ -1451,23 +1486,19 @@ def _build_health_dimensions(m: dict[str, Any]) -> list[tuple[str, str, str]]:
     coverage_health = "OK" if missing == "none" else "WARN"
     dims.append(("host_coverage", coverage_health, f"{m['host_capability_coverage']} (missing: {missing})"))
 
-    # Reward health
+    # Reward health: the only reward source is a retired/frozen report family.
     reward_avg = m["reward_average"]
     reward_momentum = m["reward_momentum"]
-    if "no recent" in reward_avg:
-        reward_health = "WARN"
-    elif "up" in reward_momentum:
-        reward_health = "OK"
-    elif "down" in reward_momentum:
-        reward_health = "WARN"
-    else:
-        reward_health = "OK"
-    dims.append(("reward", reward_health, f"{reward_avg} ({reward_momentum})"))
+    report_status = m.get("latest_report_artifact_status", "unavailable")
+    reward_health = "OK" if report_status == "fresh" and "no recent" not in reward_avg else "WARN"
+    reward_detail = f"{reward_avg} ({reward_momentum}); source={report_status}"
+    dims.append(("reward", reward_health, reward_detail))
 
-    # Gate health
+    # Gate health: materialized snapshots have no live writer in this dashboard.
     gate = m["approval_gate_state"]
-    gate_health = "WARN" if gate in ("unknown", "missing", "expired", "stale") else "OK"
-    dims.append(("gate", gate_health, gate))
+    materialized_artifact_status = m.get("materialized_artifact_status", "unavailable")
+    gate_health = "OK" if materialized_artifact_status == "fresh" else "WARN"
+    dims.append(("gate", gate_health, f"{gate}; source={materialized_artifact_status}"))
 
     # CPU load health (Vector 1: self-optimization monitoring)
     cpu_load = m.get("cpu_load", 0.0)

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -147,8 +147,8 @@ ARTIFACT_STALE_AFTER_HOURS = 24.0
 _METRICS_CACHE: dict[str, Any] = {"loaded_at": 0.0, "metrics": None}
 _SUBAGENT_TREE_CACHE: dict[str, Any] = {"loaded_at": 0.0, "hours": None, "root_mtime_ns": None, "stats": None}
 _HOST_CAPS_CACHE: dict[str, Any] = {"loaded_at": 0.0, "host_caps": None}
-_REPORT_SCAN_CACHE: dict[str, Any] = {"loaded_at": 0.0, "limit": None, "root_mtime_ns": None, "result": None}
-_MATERIALIZED_CACHE: dict[str, Any] = {"loaded_at": 0.0, "root_mtime_ns": None, "result": None}
+_REPORT_SCAN_CACHE: dict[str, Any] = {"loaded_at": 0.0, "limit": None, "root_mtime_ns": None, "result": None, "source_status": "missing"}
+_MATERIALIZED_CACHE: dict[str, Any] = {"loaded_at": 0.0, "limit": None, "root_mtime_ns": None, "result": None, "source_status": "missing"}
 
 
 def refresh_host_capabilities() -> dict[str, Any]:
@@ -261,8 +261,60 @@ def load_json(path: Path, default: Any) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return default
+    except (PermissionError, OSError):
+        return default
     except json.JSONDecodeError:
         return default
+
+
+def read_json_state(path: Path) -> tuple[Any, str]:
+    """Read one dashboard state source with bounded, non-sensitive status metadata."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None, "missing"
+    except PermissionError:
+        return None, "permission"
+    except OSError:
+        return None, "unreadable"
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError:
+        return None, "malformed"
+    if value is None or value == {} or value == [] or value == "":
+        return value, "valid-empty"
+    return value, "valid"
+
+
+def source_status_for_directory(directory: Path, pattern: str) -> str:
+    """Classify a bounded JSON source without exposing its contents."""
+    try:
+        if not directory.exists():
+            return "missing"
+        matches = list(directory.glob(pattern))
+    except PermissionError:
+        return "permission"
+    except OSError:
+        return "unreadable"
+    if not matches:
+        return "valid-empty"
+    statuses = {read_json_state(path)[1] for path in matches[:5]}
+    if "valid" in statuses:
+        return "valid"
+    if "malformed" in statuses:
+        return "malformed"
+    if "permission" in statuses:
+        return "permission"
+    if "unreadable" in statuses:
+        return "unreadable"
+    return "valid-empty"
+
+
+def source_status_for_artifact(path: Path | None, directory: Path, pattern: str) -> str:
+    if path is None:
+        return source_status_for_directory(directory, pattern)
+    _, status = read_json_state(path)
+    return status
 
 
 def latest_file(directory: Path, pattern: str) -> Path | None:
@@ -999,22 +1051,20 @@ def format_file_recency(age_hours: float | None) -> str:
     return f"{age_hours:.1f}h ago"
 
 
-def artifact_status(age_hours: float | None) -> str:
-    """Classify a dashboard artifact without treating missing data as healthy."""
+def artifact_status(age_hours: float | None, source_status: str = "valid") -> str:
+    """Classify a retired artifact without treating it as authoritative state."""
+    if source_status != "valid":
+        return source_status
     if age_hours is None:
         return "unavailable"
-    return "stale" if age_hours >= ARTIFACT_STALE_AFTER_HOURS else "fresh"
+    # These report/materialized families have no live writer on this dashboard.
+    return "context-only"
 
 
-def format_artifact_value(value: Any, age_hours: float | None) -> str:
+def format_artifact_value(value: Any, age_hours: float | None, source_status: str = "valid") -> str:
+    """Expose bounded status metadata, never raw stale values or paths."""
+    return f"{artifact_status(age_hours, source_status)} (context-only artifact)"
     """Keep a legacy value visible while labelling its source freshness."""
-    value_text = str(value).strip() or "unknown"
-    status = artifact_status(age_hours)
-    if status == "unavailable":
-        return f"unavailable (source unavailable; value={value_text})"
-    if status == "stale":
-        return f"stale (source {format_file_recency(age_hours)}; value={value_text})"
-    return value_text
 
 
 def format_recent_cycles(trend: list[tuple[str, float]]) -> str:
@@ -1030,31 +1080,18 @@ def format_materialized_cycle(materialized: dict[str, Any]) -> str:
 
 
 def format_materialized_status(materialized: dict[str, Any]) -> str:
-    if not materialized:
-        return "no materialized improvement loaded"
-    cycle_id = str(materialized.get("cycle_id", "unknown"))
-    summary = str(materialized.get("summary", "")).strip()
-    if summary:
-        return f"{cycle_id} — {summary}"
-    return cycle_id
+    """Return bounded status metadata, not materialized payload text."""
+    return "context-only artifact" if materialized else "unavailable artifact"
 
 
 def format_next_candidate(materialized: dict[str, Any]) -> str:
-    candidate = materialized.get("next_bounded_candidate", {})
-    if not isinstance(candidate, dict) or not candidate:
-        return "no next candidate recorded"
-    task_id = str(candidate.get("task_id", "unknown"))
-    title = str(candidate.get("title", "")).strip()
-    if title:
-        return f"{task_id} — {title}"
-    return task_id
+    """Do not expose stale candidate titles or identifiers."""
+    return "context-only artifact" if materialized else "unavailable artifact"
 
 
 def format_goal_artifact_signature(materialized: dict[str, Any]) -> str:
-    signature = materialized.get("feedback_decision", {}).get("goal_artifact_signature", [])
-    if not isinstance(signature, list) or not signature:
-        return "no goal artifact signature recorded"
-    return " / ".join(str(part) for part in signature)
+    """Do not expose stale payload signatures."""
+    return "context-only artifact" if materialized else "unavailable artifact"
 
 
 def _extract_report_evidence(report: dict[str, Any]) -> str:
@@ -1077,20 +1114,13 @@ def _extract_report_evidence(report: dict[str, Any]) -> str:
 
 
 def format_latest_report_status(report: dict[str, Any]) -> str:
-    if not report:
-        return "no latest report loaded"
-    result = str(report.get("reward_signal", {}).get("result_status", "unknown"))
-    evidence = _extract_report_evidence(report)
-    if evidence:
-        return f"{result} — evidence {evidence}"
-    return result
+    """Do not expose stale report status, evidence IDs, or payload text."""
+    return "context-only artifact" if report else "unavailable artifact"
 
 
 def format_concrete_statement(materialized: dict[str, Any]) -> str:
-    statement = str(materialized.get("concrete_improvement_statement", "")).strip()
-    if statement:
-        return statement
-    return "no concrete improvement statement recorded"
+    """Do not expose stale materialized payload text."""
+    return "context-only artifact" if materialized else "unavailable artifact"
 
 
 def _load_host_capabilities_uncached() -> dict[str, Any]:
@@ -1179,6 +1209,12 @@ def collect_metrics_uncached() -> dict[str, Any]:
     health = load_json(STATE_DIR / "current_health.json", {})
     materialized_path, materialized = load_latest_materialized()
     latest_report_path, latest_report, recent_rewards = scan_report_artifacts()
+    report_source_status = source_status_for_artifact(
+        latest_report_path, REPORTS_DIR, "evolution-*.json"
+    )
+    materialized_source_status = source_status_for_artifact(
+        materialized_path, IMPROVEMENT_DIR, "materialized-cycle-*.json"
+    )
     reward_momentum = format_reward_momentum(recent_rewards)
     reward_average = format_reward_average(recent_rewards)
     reward_range = format_reward_range(recent_rewards)
@@ -1211,12 +1247,17 @@ def collect_metrics_uncached() -> dict[str, Any]:
     )
     # These values come from the retired report/materialized writers. Keep them
     # visible for context, but never present them as current healthy state.
-    goal = format_artifact_value(goal_value, _materialized_age if materialized else _report_age)
+    goal = format_artifact_value(
+        goal_value, _materialized_age if materialized else _report_age,
+        materialized_source_status if materialized else report_source_status,
+    )
     active_task = format_artifact_value(
-        active_task_value, _materialized_age if materialized else _report_age
+        active_task_value, _materialized_age if materialized else _report_age,
+        materialized_source_status if materialized else report_source_status,
     )
     approval_gate_state = format_artifact_value(
-        approval_gate_value, _materialized_age if materialized else _report_age
+        approval_gate_value, _materialized_age if materialized else _report_age,
+        materialized_source_status if materialized else report_source_status,
     )
 
     (
@@ -1355,10 +1396,16 @@ def collect_metrics_uncached() -> dict[str, Any]:
         "next_bounded_candidate": format_next_candidate(materialized),
         "materialized_path": str(materialized_path) if materialized_path else None,
         "materialized_recency": format_file_recency(materialized_age_hours),
-        "materialized_artifact_status": artifact_status(materialized_age_hours),
+        "materialized_artifact_status": artifact_status(
+            materialized_age_hours, materialized_source_status
+        ),
+        "materialized_source_status": materialized_source_status,
         "latest_report_path": str(latest_report_path) if latest_report_path else None,
         "latest_report_recency": format_file_recency(latest_report_age_hours),
-        "latest_report_artifact_status": artifact_status(latest_report_age_hours),
+        "latest_report_artifact_status": artifact_status(
+            latest_report_age_hours, report_source_status
+        ),
+        "report_source_status": report_source_status,
         "artifact_freshness": artifact_freshness,
         "last_cleanup_count": last_cleanup_count,
         "last_cleanup_timestamp": last_cleanup_timestamp,

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -12,6 +12,7 @@ def _health_metrics(*, report_status: str, materialized_status: str) -> dict:
     return {
         "queue_depth": 0,
         "stale_queue_requests": 0,
+        "archived_count": 0,
         "last_cleanup_status": "fresh",
         "last_cleanup_recency": "1m ago",
         "host_capability_probe_attention": "host probe current",
@@ -113,8 +114,72 @@ def test_artifact_value_hides_raw_payload() -> None:
         "secret task title", 100.0, "valid"
     )
     assert "secret task title" not in rendered
-    assert "100.0h" not in rendered
-    assert rendered == "context-only (context-only artifact)"
+    assert rendered == "stale; age=100.0h (context-only artifact)"
+
+
+def test_rendered_surfaces_use_status_age_and_hide_payloads() -> None:
+    metrics = _health_metrics(report_status="stale", materialized_status="stale")
+    metrics.update({
+        "captured_at": "now",
+        "goal": "stale; age=100.0h (context-only artifact)",
+        "goal_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
+        "active_task": "stale; age=100.0h (context-only artifact)",
+        "active_task_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
+        "approval_gate_state": "stale; age=100.0h (context-only artifact)",
+        "approval_gate_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
+        "materialized_cycle": "context-only artifact",
+        "materialized_status": "context-only artifact",
+        "concrete_statement": "context-only artifact",
+        "goal_artifact_signature": "context-only artifact",
+        "latest_report_status": "context-only artifact",
+        "next_bounded_candidate": "context-only artifact",
+        "artifact_freshness": "materialized=100.0h ago, report=100.0h ago",
+        "host_capability_badges_html": "",
+        "host_capability_details_html": "",
+        "dashboard_summary": "context-only",
+        "focus_line": "context-only",
+        "operator_attention": "context-only",
+
+        "queue_snapshot": "idle",
+        "recent_cycles": "no recent cycles",
+        "reward_trend": [],
+        "reward_range": "no recent reward samples",
+        "queue_freshness": "idle",
+        "queue_pressure": "idle",
+        "queue_action": "no queue work pending",
+        "queue_archive_target": "none",
+        "queue_priority": "normal",
+        "queue_hygiene": "cleanup=1m ago/fresh",
+        "oldest_stale_request_age": "none",
+        "oldest_stale_request_path_text": "none",
+        "queue_health": "last cleanup 0 @ now",
+        "last_cleanup_count": 0,
+        "last_cleanup_timestamp": "now",
+        "host_focus_status": "all",
+        "host_capability_coverage": "5/5",
+        "host_focus_missing": "none",
+        "host_capability_probe": "fresh",
+        "host_capability_probe_attention": "current",
+        "cpu_load": 0.1,
+        "mem_pct": 1.0,
+        "disk_pct": 1.0,
+        "reward_distribution": {},
+        "overall_health": "WARN",
+        "health_status": "WARN",
+        "materialized_path": "/secret/materialized.json",
+        "latest_report_path": "/secret/report.json",
+        "oldest_stale_request_path": None,
+    })
+    serialized = DASHBOARD.render_json(metrics)
+    health = DASHBOARD.render_health_json(metrics)
+    page = DASHBOARD.render_html(metrics)
+    for rendered in (serialized, health, page):
+        assert "/secret/" not in rendered
+        assert "secret task title" not in rendered
+        assert "stale" in rendered
+        assert "100.0h" in rendered or "age_hours" in rendered
+    assert '"goal_source"' in serialized
+    assert '"active_task_source"' in serialized
 
 
 def test_dashboard_documents_live_source_of_truth_decision() -> None:

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -31,14 +31,14 @@ def _health_metrics(*, report_status: str, materialized_status: str) -> dict:
 
 def test_stale_retired_artifacts_are_not_reported_as_healthy() -> None:
     dimensions = DASHBOARD._build_health_dimensions(
-        _health_metrics(report_status="stale", materialized_status="stale")
+        _health_metrics(report_status="context-only", materialized_status="context-only")
     )
     by_name = {name: (status, detail) for name, status, detail in dimensions}
 
     assert by_name["reward"][0] == "WARN"
-    assert "source=stale" in by_name["reward"][1]
+    assert "source=context-only" in by_name["reward"][1]
     assert by_name["gate"][0] == "WARN"
-    assert "source=stale" in by_name["gate"][1]
+    assert "source=context-only" in by_name["gate"][1]
 
 
 def test_unavailable_artifacts_are_explicitly_non_healthy() -> None:
@@ -53,6 +53,51 @@ def test_unavailable_artifacts_are_explicitly_non_healthy() -> None:
     assert "source=unavailable" in by_name["gate"][1]
 
 
+def test_malformed_artifacts_are_not_reported_as_healthy() -> None:
+    dimensions = DASHBOARD._build_health_dimensions(
+        _health_metrics(report_status="malformed", materialized_status="malformed")
+    )
+    by_name = {name: (status, detail) for name, status, detail in dimensions}
+
+    assert by_name["reward"][0] == "WARN"
+    assert "source=malformed" in by_name["reward"][1]
+    assert by_name["gate"][0] == "WARN"
+    assert "source=malformed" in by_name["gate"][1]
+
+
+def test_source_state_distinctions() -> None:
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        missing, missing_status = DASHBOARD.read_json_state(root / "missing.json")
+        assert missing is None and missing_status == "missing"
+        malformed_path = root / "malformed.json"
+        malformed_path.write_text("{", encoding="utf-8")
+        _, malformed_status = DASHBOARD.read_json_state(malformed_path)
+        assert malformed_status == "malformed"
+        empty_path = root / "empty.json"
+        empty_path.write_text("{}", encoding="utf-8")
+        _, empty_status = DASHBOARD.read_json_state(empty_path)
+        assert empty_status == "valid-empty"
+        valid_path = root / "valid.json"
+        valid_path.write_text('{"value": 1}', encoding="utf-8")
+        _, valid_status = DASHBOARD.read_json_state(valid_path)
+        assert valid_status == "valid"
+
+
+def test_missing_and_permission_artifacts_are_not_reported_as_healthy() -> None:
+    for status in ("missing", "permission", "unreadable", "valid-empty"):
+        dimensions = DASHBOARD._build_health_dimensions(
+            _health_metrics(report_status=status, materialized_status=status)
+        )
+        by_name = {name: (health, detail) for name, health, detail in dimensions}
+        assert by_name["reward"][0] == "WARN"
+        assert f"source={status}" in by_name["reward"][1]
+        assert by_name["gate"][0] == "WARN"
+        assert f"source={status}" in by_name["gate"][1]
+
+
 def test_fresh_artifacts_keep_existing_ok_semantics() -> None:
     dimensions = DASHBOARD._build_health_dimensions(
         _health_metrics(report_status="fresh", materialized_status="fresh")
@@ -61,6 +106,15 @@ def test_fresh_artifacts_keep_existing_ok_semantics() -> None:
 
     assert by_name["reward"][0] == "OK"
     assert by_name["gate"][0] == "OK"
+
+
+def test_artifact_value_hides_raw_payload() -> None:
+    rendered = DASHBOARD.format_artifact_value(
+        "secret task title", 100.0, "valid"
+    )
+    assert "secret task title" not in rendered
+    assert "100.0h" not in rendered
+    assert rendered == "context-only (context-only artifact)"
 
 
 def test_dashboard_documents_live_source_of_truth_decision() -> None:

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -1,0 +1,71 @@
+import importlib.util
+from pathlib import Path
+
+DASHBOARD_PATH = Path(__file__).resolve().parents[1] / "scripts" / "eeebot_dashboard.py"
+SPEC = importlib.util.spec_from_file_location("eeebot_dashboard", DASHBOARD_PATH)
+assert SPEC and SPEC.loader
+DASHBOARD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(DASHBOARD)
+
+
+def _health_metrics(*, report_status: str, materialized_status: str) -> dict:
+    return {
+        "queue_depth": 0,
+        "stale_queue_requests": 0,
+        "last_cleanup_status": "fresh",
+        "last_cleanup_recency": "1m ago",
+        "host_capability_probe_attention": "host probe current",
+        "host_capability_probe": "1m ago (fresh)",
+        "host_focus_missing": "none",
+        "host_capability_coverage": "5/5 focus devices available",
+        "reward_average": "0.88 avg over 5 sample(s)",
+        "reward_momentum": "up +0.40 vs previous",
+        "latest_report_artifact_status": report_status,
+        "approval_gate_state": "materialize_synthesized_improvement",
+        "materialized_artifact_status": materialized_status,
+        "cpu_load": 0.1,
+        "mem_pct": 20.0,
+        "disk_pct": 20.0,
+    }
+
+
+def test_stale_retired_artifacts_are_not_reported_as_healthy() -> None:
+    dimensions = DASHBOARD._build_health_dimensions(
+        _health_metrics(report_status="stale", materialized_status="stale")
+    )
+    by_name = {name: (status, detail) for name, status, detail in dimensions}
+
+    assert by_name["reward"][0] == "WARN"
+    assert "source=stale" in by_name["reward"][1]
+    assert by_name["gate"][0] == "WARN"
+    assert "source=stale" in by_name["gate"][1]
+
+
+def test_unavailable_artifacts_are_explicitly_non_healthy() -> None:
+    dimensions = DASHBOARD._build_health_dimensions(
+        _health_metrics(report_status="unavailable", materialized_status="unavailable")
+    )
+    by_name = {name: (status, detail) for name, status, detail in dimensions}
+
+    assert by_name["reward"][0] == "WARN"
+    assert "source=unavailable" in by_name["reward"][1]
+    assert by_name["gate"][0] == "WARN"
+    assert "source=unavailable" in by_name["gate"][1]
+
+
+def test_fresh_artifacts_keep_existing_ok_semantics() -> None:
+    dimensions = DASHBOARD._build_health_dimensions(
+        _health_metrics(report_status="fresh", materialized_status="fresh")
+    )
+    by_name = {name: (status, detail) for name, status, detail in dimensions}
+
+    assert by_name["reward"][0] == "OK"
+    assert by_name["gate"][0] == "OK"
+
+
+def test_dashboard_documents_live_source_of_truth_decision() -> None:
+    source = DASHBOARD_PATH.read_text(encoding="utf-8")
+
+    assert "Source-of-truth decision (#1206)" in source
+    assert "retired report/materialized artifacts" in source
+    assert "labelled stale or unavailable" in source


### PR DESCRIPTION
## Source-of-truth decision

Keep the live `scripts/eeebot_dashboard.py` service as the single dashboard on port 8080. Live queue, host capability, cleanup, and system metrics remain authoritative. The retired report/materialized artifact families are context-only and must be labelled stale/unavailable.

## Scope

- Add explicit dashboard source-of-truth policy documentation.
- Label report-backed reward and materialized snapshot-backed goal/task/gate values as `stale` or `unavailable` after the 24-hour artifact threshold.
- Make reward/gate health WARN unless their respective artifact source is fresh.
- Add focused regression tests for stale/unavailable/fresh health semantics and the source-of-truth policy.

No second dashboard, scheduler, state store, request logging, held-out contract, provider routing, or host configuration changes.

Closes #1206 after independent review, CI, and staged production verification.