### PR TITLE
fix(demand): read the doc-only denominator before the futility filter (#1108)

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -2878,6 +2878,11 @@ def collect_demand(
                 if steering_note not in summary:
                     item["summary"] = f"{summary} {steering_note}".strip()
             post_doc_guard.append(item)
+        # #1108: the denominator is what entered *this* guard, so it is read
+        # before ``_apply_futile_surfaces`` runs — that filter drops items of its
+        # own (#1184), and counting after it would silently charge those to the
+        # doc-only budget's ledger row.
+        items_considered = len(post_doc_guard) + doc_only_deferred
         result = _apply_futile_surfaces(state_dir, post_doc_guard)
         from nanobot.runtime.cycle_ledger import append_event
 
@@ -2888,7 +2893,7 @@ def collect_demand(
             "doc_only_budget_24h": doc_budget,
             "ledger_blind": ledger_blind,
             "doc_budget_exceeded": doc_budget_exceeded,
-            "items_considered": len(result) + doc_only_deferred,
+            "items_considered": items_considered,
         })
 
         # #815: best-effort, operator-visible V1-vs-V2 split of what's

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -3432,3 +3432,61 @@ class TestIssue1040DemandIODiet:
         items = demand.collect_demand(state_dir, None)
         assert items
         assert load_count == 1
+
+
+class TestIssue1108DenominatorExcludesLaterFilters:
+    """The doc-only ledger row's ``items_considered`` is a denominator.
+
+    ``_apply_futile_surfaces`` (#1184) drops items of its own *after* the doc-only
+    guard has run. Reading the count from the list it returns charges those drops
+    to the doc-only budget: the row then reports fewer items considered than the
+    guard actually saw, which understates every ratio taken from it. The original
+    #1108 test could not see this — its fixture has no futile surface, so the
+    filter is a pass-through and both computations agree.
+    """
+
+    def test_futile_surface_drops_do_not_shrink_the_denominator(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_item = demand._make_item(
+            "priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md"
+        )
+        kept_item = demand._make_item(
+            "priority", "Priority 2 — scripts/worker.py", "Improve scripts/worker.py"
+        )
+        futile_item = demand._make_item(
+            "priority", "Priority 3 — scripts/checker.py", "Improve scripts/checker.py"
+        )
+        monkeypatch.setattr(
+            demand,
+            "_priority_items",
+            lambda *args, **kwargs: [doc_item, kept_item, futile_item],
+        )
+        monkeypatch.setattr(demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: 5)
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+
+        from nanobot.runtime import goal_gap_futility
+
+        monkeypatch.setattr(
+            goal_gap_futility,
+            "futile_surfaces",
+            lambda *args, **kwargs: [{"gap_id": "gap-x", "surface": ["scripts/checker.py"]}],
+        )
+
+        items = demand.collect_demand(state_dir, None)
+
+        # One deferred by the doc-only budget, one dropped by the futile surface.
+        assert [item["id"] for item in items] == [kept_item["id"]]
+
+        records = [
+            json.loads(line)
+            for line in (state_dir / "ledger" / "cycles.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip()
+        ]
+        record = [r for r in records if r.get("phase") == "doc_only_budget"][-1]
+
+        assert record["doc_only_deferred"] == 1
+        assert record["items_considered"] == 3, (
+            "the futile-surface drop was charged to the doc-only budget's denominator"
+        )


### PR DESCRIPTION
Follow-up to #1226 (issue #1108). One defect, latent today, in the row that issue exists to produce.

## The defect

`items_considered` is the denominator for `doc_only_deferred` in the `doc_only_budget` ledger event. It was read from `result` *after* that name had been rebound:

```python
result = _apply_futile_surfaces(state_dir, post_doc_guard)
...
"items_considered": len(result) + doc_only_deferred,
```

`_apply_futile_surfaces` (#1184) drops items of its own — non-`defect` items aimed at a futile lever surface. Every one of those drops shrank the doc-only budget's denominator, charging another guard's suppressions to this one. In the observability event whose entire purpose is to make the doc-only guard countable, the count was taken against the wrong base.

The fix reads the count before the filter runs, which is the value that actually entered the loop:

```python
items_considered = len(post_doc_guard) + doc_only_deferred
result = _apply_futile_surfaces(state_dir, post_doc_guard)
```

## Latent, not currently corrupting

`goal_gap_futility.futile_surfaces()` returns `0` on the host right now, so the filter is a pass-through and today's live rows are correct:

```
phase=doc_only_budget  deferred=0  obs24h=5  budget=5  blind=False  exceeded=True  considered=8
```

That is why nobody saw it, and it is also why the #1226 test could not: **that fixture has no active futile surface either**, so the filter is a pass-through there too and both computations agree. A test and the code agreeing about a case neither one exercises is not coverage.

Worth fixing while dormant rather than after the surface returns — #1184 exists precisely because those surfaces do become active, and a wrong denominator is silent when it starts.

## Red state

The added test activates one surface and asserts the denominator still counts the item it removed. Against the merged code:

```
E       AssertionError: the futile-surface drop was charged to the doc-only budget's denominator
E       assert 2 == 3
WARNING  nanobot.runtime.demand:demand.py:2673 futile surface: dropped 1 demand item(s): [('priority-93502036bc9c', 'gap-x')]
```

The warning line is the confirmation that the path under test actually ran, rather than the assertion failing for some unrelated reason.

## Deliberately unchanged

Everything #1226 listed as unchanged stays unchanged: the deferral is still a selection-time `continue`, no lifecycle, dedup or exhaustion effect, `N=5` and `value.doc_only_integrations_24h` untouched, one shared classifier. The event's field names and shape are also unchanged — only the value of `items_considered` differs, and only when a futile surface is active.

## Validation

- `tests/test_demand.py`: `176 passed`.
- Full pytest: `18 failed, 2960 passed, 17 skipped` — the 18 are exactly the Windows baseline by file (`test_autoevolve.py` ×5, `test_autoevolve_commit.py` ×3, `test_autoevolve_guards.py` ×1, `test_autoevolve_remote_target.py` ×1, `test_autoevolve_state.py` ×2, `test_bridge_locking.py` ×3, `test_selfevo_export_security.py` ×2, `test_bridge_cycle_tags.py` ×1), checked by list.
- Rebased onto `b222d7f6` (#1227) and re-run after the rebase.
