### PR TITLE
fix(strategist): read reusable lesson insights (#1231)

### DIFF
--- a/nanobot/runtime/strategist_inputs.py
+++ b/nanobot/runtime/strategist_inputs.py
@@ -35,7 +35,7 @@ _HISTORY_DAYS = 7
 _HISTORY_SAMPLES = 8
 _HISTORY_MAX_SERIES = 60
 _HISTORY_MAX_DEPTH = 3
-# Insight sources: v2 lesson cards, legacy ``reusable_insight`` rows, errors.
+# Insight sources: v2 lesson cards, legacy rows under either insight key, errors.
 _INSIGHTS_V2 = 10
 _INSIGHTS_LEGACY = 10
 _INSIGHTS_ERRORS = 5
@@ -239,9 +239,17 @@ def _clip(value: Any) -> str:
 
 def insights_input(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     """v2 lesson cards (``problem`` -> ``solution``, filler skipped via
-    ``lesson_v2.solution_is_meaningful``), distinct legacy
-    ``reusable_insight`` lines, ``errors.yaml`` summaries, plus the two
-    index files. Prefer v2 cards when both shapes are present."""
+    ``lesson_v2.solution_is_meaningful``), distinct legacy insight lines,
+    ``errors.yaml`` summaries, plus the two index files. Prefer v2 cards when
+    both shapes are present.
+
+    Legacy insights carry either key. ``reusable_insight`` is what the whole
+    corpus on ``origin/main`` uses (14 of 14 rows, #1231); ``generalized_insight``
+    is what ``bridge`` and ``knowledge_curator`` write today, so it is the shape
+    new rows arrive in. Reading only one of them leaves the other invisible,
+    which is the defect #1231 was filed for — in one direction before this
+    change and in the other after it. ``knowledge_curator`` already treats the
+    two as equivalent when it collects source text."""
     from nanobot.runtime.lesson_v2 import bounded_load_yaml, solution_is_meaningful
 
     root = Path(repo_root)
@@ -255,8 +263,8 @@ def insights_input(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
             elif len(cards) < _INSIGHTS_V2:
                 cards.append({"id": str(entry.get("id") or ""), "problem": _clip(entry.get("problem")),
                               "solution": _clip(entry.get("solution")), "first_seen": str(entry.get("first_seen") or "")})
-        elif entry.get("reusable_insight"):
-            text = _clip(entry.get("reusable_insight"))
+        elif entry.get("reusable_insight") or entry.get("generalized_insight"):
+            text = _clip(entry.get("reusable_insight") or entry.get("generalized_insight"))
             if text not in legacy and len(legacy) < _INSIGHTS_LEGACY:
                 legacy.append(text)
     errors = [{"title": _clip(e.get("title")), "root_cause": _clip(e.get("root_cause")), "prevention": _clip(e.get("prevention"))}

--- a/nanobot/runtime/strategist_inputs.py
+++ b/nanobot/runtime/strategist_inputs.py
@@ -35,7 +35,7 @@ _HISTORY_DAYS = 7
 _HISTORY_SAMPLES = 8
 _HISTORY_MAX_SERIES = 60
 _HISTORY_MAX_DEPTH = 3
-# Insight sources: v2 lesson cards, legacy ``generalized_insight`` rows, errors.
+# Insight sources: v2 lesson cards, legacy ``reusable_insight`` rows, errors.
 _INSIGHTS_V2 = 10
 _INSIGHTS_LEGACY = 10
 _INSIGHTS_ERRORS = 5
@@ -240,8 +240,8 @@ def _clip(value: Any) -> str:
 def insights_input(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     """v2 lesson cards (``problem`` -> ``solution``, filler skipped via
     ``lesson_v2.solution_is_meaningful``), distinct legacy
-    ``generalized_insight`` lines, ``errors.yaml`` summaries, plus the two
-    index files. The historical ``reusable_insight`` key never existed."""
+    ``reusable_insight`` lines, ``errors.yaml`` summaries, plus the two
+    index files. Prefer v2 cards when both shapes are present."""
     from nanobot.runtime.lesson_v2 import bounded_load_yaml, solution_is_meaningful
 
     root = Path(repo_root)
@@ -255,8 +255,8 @@ def insights_input(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
             elif len(cards) < _INSIGHTS_V2:
                 cards.append({"id": str(entry.get("id") or ""), "problem": _clip(entry.get("problem")),
                               "solution": _clip(entry.get("solution")), "first_seen": str(entry.get("first_seen") or "")})
-        elif entry.get("generalized_insight"):
-            text = _clip(entry.get("generalized_insight"))
+        elif entry.get("reusable_insight"):
+            text = _clip(entry.get("reusable_insight"))
             if text not in legacy and len(legacy) < _INSIGHTS_LEGACY:
                 legacy.append(text)
     errors = [{"title": _clip(e.get("title")), "root_cause": _clip(e.get("root_cause")), "prevention": _clip(e.get("prevention"))}
@@ -269,7 +269,7 @@ def insights_input(repo_root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
             indexes[rel] = ""
     data = {"cards": cards, "legacy_insights": legacy, "errors": errors, "indexes": indexes}
     meta = {"cards": len(cards), "filler_skipped": filler_skipped, "legacy": len(legacy), "errors": len(errors),
-            "status": "complete" if cards or legacy or errors else "empty"}
+            "status": "complete" if cards or legacy else "empty"}
     return data, meta
 
 def empty_inputs(inputs_status: dict[str, Any]) -> list[str]:

--- a/tests/fixtures/lessons-origin-main.yaml
+++ b/tests/fixtures/lessons-origin-main.yaml
@@ -1,0 +1,242 @@
+- id: LESS-AUTO-subagent-verify-materialized-improvement
+  category: successful-improvement
+  title: 'Optimization pattern: Use one bounded subagent-assisted review to verify
+    the materialized improvement artifact'
+  description: Self-evolving cycle PASS — goal=goal-bootstrap — evidence=evidence-75d045de8e28
+  impact: 'Yielded positive reward signal: 1.2'
+  approach: Implemented task 'subagent-verify-materialized-improvement' successfully.
+  reusable_insight: Consolidate this optimization pattern in subsequent cycles.
+  occurrences: 30
+  first_seen: '2026-06-13'
+  last_seen: '2026-06-14'
+  sample_cycle_id: cycle-5f6ae6aed73c
+  files_changed: []
+- id: LESS-AUTO-exploit-successful-improvement-path
+  category: successful-improvement
+  title: 'Optimization pattern: Exploit and expand the verified improvements in scripts/eeebot_dashboard.py'
+  description: Self-evolving cycle PASS — goal=goal-bootstrap — evidence=evidence-360470a29c66
+  impact: 'Yielded positive reward signal: 1.2'
+  approach: Implemented task 'exploit-successful-improvement-path' successfully.
+  reusable_insight: Consolidate this optimization pattern in subsequent cycles.
+  occurrences: 86
+  first_seen: '2026-06-13'
+  last_seen: '2026-06-14'
+  sample_cycle_id: cycle-7f4659a642d6
+  files_changed: []
+- id: LESS-AUTO-record-reward
+  category: successful-improvement
+  title: 'Optimization pattern: Record cycle reward'
+  description: Self-evolving cycle PASS — goal=goal-bootstrap — evidence=evidence-293eef293eef
+  impact: 'Yielded positive reward signal: 0.6'
+  approach: Implemented task 'record-reward' successfully.
+  reusable_insight: Consolidate this optimization pattern in subsequent cycles.
+  occurrences: 1
+  first_seen: '2026-04-28'
+  last_seen: '2026-04-28'
+  sample_cycle_id: cycle-293acc293acc
+  files_changed:
+  - /home/opencode/servers_team/repo_research/nanobot/.nanobot/subagents/forced-runtime-accounting-293.json
+- id: LESS-2026-06-15-001
+  date: '2026-06-15'
+  category: observability
+  title: Correct sources of truth for analysing subagent work
+  description: |
+    When reviewing what the self-evolving agent did over a period of time,
+    three wrong sources were consulted before the correct ones were found.
+  approach: |
+    Correct evidence hierarchy (strongest first):
+    1. git log in eeebot-self-evolving (Author: eeepc-agent) \u2014 definitive list of code changes
+    2. memory/HISTORY.md \u2014 subagent's own narrative of each action
+    3. journalctl -u eeepc-self-evolving-subagent-bridge.service \u2014 real-time tool calls
+    4. state/goals/history/cycle-*.json \u2014 cycle metadata (NOT code changes)
+    Wrong sources: state/subagents/results/ (coordinator stubs), artifact_paths in cycles (report files only)
+  reusable_insight: |
+    Always start analysis with 'git log --since=DATE --format="%ai %h %s"' in eeebot-self-evolving.
+    Never interpret files_changed:[] in results/ as "agent did nothing" \u2014 those are coordinator stubs.
+  prevention: |
+    Use the eeebot-agent-work-review skill (.pi/skills/eeebot-agent-work-review/SKILL.md)
+    which encodes the correct 7-step analysis procedure.
+
+- id: LESS-2026-06-15-002
+  date: '2026-06-15'
+  category: observability
+  title: UTC vs MSK timezone confusion when reading cycle timestamps
+  description: |
+    Cycle history files store recorded_at_utc in UTC. The eeepc host clock is MSK (UTC+3).
+    Git commits show local time (+0300). Reading UTC timestamps as local time causes
+    apparent "11 hour gaps" that are actually 40-minute gaps.
+  approach: |
+    Always convert before comparing:
+    - UTC 21:53 = MSK 00:53 (next calendar day)
+    - Use datetime.fromisoformat(ts.replace("Z","+00:00")) for proper UTC parsing
+    - When filtering history files, compare against datetime.now(timezone.utc)
+  reusable_insight: |
+    Never say "last cycle was N hours ago" without explicitly converting UTC\u2192MSK.
+    The correct formula: MSK = UTC + 3h. If UTC timestamp looks like "yesterday evening"
+    and local time is "early morning", they may be only minutes apart.
+  prevention: |
+    The eeebot-agent-work-review skill Step 1 always runs 'ssh eeepc date' and 'date'
+    to establish both timezones before any timestamp analysis.
+- id: LESS-2026-06-15-003
+  date: '2026-06-15'
+  category: task-execution
+  title: Уточнять временной период у пользователя перед анализом — не выбирать самостоятельно
+  description: |
+    Пользователь попросил показать "что агент сделал за это время" (имея в виду несколько
+    часов с последней проверки в чате). Вместо уточнения был выбран дефолтный период 24 часа.
+    Отчёт охватил неверный временной диапазон.
+  approach: |
+    Перед любым анализом с временным диапазоном:
+    1. Проверить историю чата — есть ли метка предыдущего анализа
+    2. Если есть — назвать её и спросить подтверждение
+    3. Если нет — явно спросить: "За какой период показать?"
+    4. Только после подтверждения выполнять запросы
+  reusable_insight: |
+    Неоднозначные временные формулировки ("за это время", "много часов", "недавно")
+    ВСЕГДА требуют уточнения. Выбор дефолтного значения вместо вопроса — ошибка.
+    Лучше один лишний вопрос, чем нерелевантный отчёт.
+  prevention: |
+    Скилл eeebot-agent-work-review содержит Step 0 (MANDATORY): определить период
+    до запуска любых команд. Скилл запрещает использовать timedelta(hours=6) или
+    --since='YYYY-MM-DD' без явного подтверждения от пользователя.
+
+- id: LESS-2026-06-15-004
+  date: '2026-06-15'
+  category: refactoring-bug
+  title: Duplication Overwrite in O(1) Dict Comprehension Optimizations
+  description: |
+    Converting a linear list scan (returning the first match) to a dict lookup can introduce bugs
+    if the list contains duplicate keys. The standard dict comprehension retains the last element,
+    effectively reversing match precedence.
+  approach: |
+    When replacing a linear scan that fetches the newest record (first in mtime-descending lists),
+    wrap the iterable in reversed() during dict comprehension:
+    {r['key']: r for r in reversed(records)}
+    This ensures that the first (newest) record in the original list overwrites older ones, preserving logic.
+  reusable_insight: |
+    Never assume dict comprehension naturally matches linear scan semantics. Check for duplicate keys
+    and list sorting order.
+  prevention: |
+    Write dedicated tests asserting newest-record precedence when optimizing query lists to dicts.
+
+- id: LESS-2026-06-15-005
+  date: '2026-06-15'
+  category: caching
+  title: Invalidating rollup cache on empty states to prevent cross-test contamination
+  description: |
+    A TTL-based cache failed to update when the query source returned empty (None).
+    This allowed stale cache data from previous runs or tests to persist, causing test pollution.
+  approach: |
+    Always set cache keys explicitly even when the computed value is empty or None.
+    A state change from "populated" to "empty" must be reflected in the cache immediately, rather than ignored.
+  reusable_insight: |
+    A cache update must not be conditional on the presence of data unless expiration/invalidation
+    is handled out-of-band. Empty states are also state.
+  prevention: |
+    Ensure that pytest cleanups or cache updates handle transitions to None/empty cleanly.
+
+- id: LESS-2026-06-15-006
+  date: '2026-06-15'
+  category: observability
+  title: Do not infer current time from service logs or historical entries
+  description: |
+    The agent inferred the current host time (03:22 MSK) from the last log line of journalctl,
+    but the service had not run for a while, making the log entry stale. The actual host time was 05:04 MSK.
+  approach: |
+    Never guess or assume the current time based on file modifications, journalctl logs, or history logs.
+    Always run 'date' explicitly on the host system to determine the exact current timestamp.
+  reusable_insight: |
+    Systemd logs and process outputs show when a process *ran*, not what time it *is now*.
+    Clock validation must be dynamic and fresh.
+  prevention: |
+    Strictly follow Step 1 of the eeebot-agent-work-review skill, which mandates running 'ssh eeepc date'
+    before doing any time-related calculations.
+
+- id: LESS-2026-06-15-007
+  date: '2026-06-15'
+  category: performance
+  title: Reusable os.scandir wrapper in coordinator to eliminate double-stat penalty
+  description: |
+    Scanning candidate directories using Path.glob() + Path.stat() performs two distinct stat() system calls per file (double-stat penalty). This is highly inefficient in coordinator loops that process hundreds of subagent records or history cycles.
+  approach: |
+    Implement and reuse a helper function '_json_files_sorted_by_mtime' based on os.scandir().
+    It filters entries directly during directory iteration and retrieves cached stat results from entry.stat()
+    to avoid secondary system calls.
+  reusable_insight: |
+    Always prefer os.scandir over Path.glob() when scanning directories containing a large number of files
+    if file metadata (mtime, size) is required in the same loop.
+  prevention: |
+    Avoid introducing new Path.glob() iterations in performance-critical coordinator loops (such as consumption snapshots, lane health checks, or history list scans).
+
+- id: LESS-2026-06-15-008
+  date: '2026-06-15'
+  category: performance
+  title: LLM Gateway Timeouts on constrained i386 hosts with large contexts
+  description: |
+    Calling the LiteLLM proxy (Gemini-3-flash) over Tailscale VPN from a slow i386 CPU (Eee PC)
+    with large prompt contexts (including full cycle histories and subagent rollups) periodically
+    exceeds default 25-45s timeouts, triggering '[llm_unavailable: Request timed out.]' errors.
+  approach: |
+    Increase timeout limits in systemd override.conf environment definitions:
+    - Set LITELLM_TIMEOUT_S=90 (up from 45)
+    - Set LITELLM_TOTAL_BUDGET_MS=120000 (up from 70000)
+    This provides a comfortable margin for connection negotiation, transfer, and inference.
+  reusable_insight: |
+    Constrained hardware under VPN network overhead must be given extra-large timeouts
+    for remote API processing, especially as token count grows across cycle histories.
+  prevention: |
+    Ensure both the main and health services include these custom timeout parameters in their override.conf.
+
+- id: LESS-2026-06-20-001
+  date: '2026-06-20'
+  category: installation
+  title: Fake dist-info metadata stub to bypass tiktoken compile-time Rust constraints on i386
+  description: |
+    Attempting to install 'eeebot' in a new python virtual environment on a resource-constrained i386 host fails when building wheel for 'tiktoken' (a transitively required dependency for OpenAI/LiteLLM APIs) due to the lack of a Rust compiler and the absence of pre-built i386 wheels on PyPI.
+  approach: |
+    Created a fake 'tiktoken' package directly in virtual environment's site-packages:
+    1. mkdir -p /opt/eeepc-agent/venv/lib/python3.11/site-packages/tiktoken
+    2. Wrote a mock __init__.py containing a fake 'Encoding' class and 'get_encoding'/'encoding_for_model' helpers returning dummy token counts (based on text length / 4).
+    3. Created a dummy metadata package info directory: 'tiktoken-0.13.0.dist-info/' containing a 'METADATA' file mapping Name: tiktoken and Version: 0.13.0.
+    This satisfied both 'pip' during setup.py requirements resolution and 'litellm' during runtime imports.
+  reusable_insight: |
+    Heavy compiled dependencies that provide non-critical fallbacks (like token-counting) can be bypassed
+    by creating metadata stubs and dummy imports in virtual environments on low-power devices.
+  prevention: |
+    Use this method whenever cryptography, tiktoken, or other heavy Rust-dependent wheels fail to build
+    during environment recreation on constrained targets.
+
+- id: LESS-2026-06-20-002
+  date: '2026-06-20'
+  category: configuration
+  title: Configure explicit api_base and provider in config.json for custom LiteLLM proxy models
+  description: |
+    LiteLLM fails to call local proxy model formats (such as cl/gpt-5.4-mini) with a BadRequestError ('LLM Provider NOT provided') if they are not standard, even if LITELLM_API_KEY and LITELLM_BASE_URL are correctly set in the environment.
+  approach: |
+    1. Created an explicit config.json inside the agent's HOME directory (~/.nanobot/config.json).
+    2. Configured the 'openai' provider block to map 'api_key' to the real proxy key (or dummy) and 'api_base' to the custom proxy endpoint (e.g., http://<litellm-proxy>/v1).
+    3. Prefixed the target model with 'openai/' (e.g., 'openai/cl/gpt-5.4-mini') to force LiteLLM to route it as a custom OpenAI-compatible endpoint.
+  reusable_insight: |
+    Environment variables for LiteLLM base URLs are not always inherited for non-standard models.
+    Always map custom proxy models to an explicit 'openai' provider with a set 'api_base' in config.json.
+  prevention: |
+    Ensure that custom subagent bridge configs (.env) define the model prefix (openai/cl/...) and map to a populated config.json.
+
+- id: LESS-2026-06-20-003
+  date: '2026-06-20'
+  category: workspace
+  title: Configure git core.fileMode false to ignore directory permission modification noise
+  description: |
+    During multi-user permissions restructuring or host migrations (e.g., SSD restores), recursively modifying directory permissions using chmod can cause git to mark all files in a repository as modified due to permissions changes (mode 100644 to 100755).
+  approach: |
+    Execute git config core.fileMode false inside the target repository:
+    git -C /path/to/repo config core.fileMode false
+    This instructs git to ignore the execution bit modifications on files and focus solely on actual code content changes.
+  reusable_insight: |
+    On shared directories or filesystems where permission flags are frequently adjusted, keeping core.fileMode active leads to dirty git working trees that block automated tools and confuse agents.
+  prevention: |
+    Always configure core.fileMode false in agent-managed write workspaces that undergo ownership migrations.
+
+
+
+

--- a/tests/test_strategist.py
+++ b/tests/test_strategist.py
@@ -63,7 +63,7 @@ def mock_state_and_repo(tmp_path: Path, monkeypatch):
         "- id: L1\n  schema_version: 2\n  problem: check timers drift after deploy\n"
         "  solution: assert the timer unit is enabled in the deploy smoke test\n"
         "  first_seen: 2026-08-30T00:00:00Z\n"
-        "- id: L0\n  generalized_insight: pin the model name in the unit env\n",
+        "- id: L0\n  reusable_insight: pin the model name in the unit env\n",
         encoding="utf-8",
     )
 

--- a/tests/test_strategist_inputs.py
+++ b/tests/test_strategist_inputs.py
@@ -15,8 +15,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
-from nanobot.runtime import strategist
+from nanobot.runtime import strategist, strategist_inputs
 from nanobot.runtime.strategist import (
     collect_inputs,
     load_watermark,
@@ -73,6 +74,12 @@ def _write_lessons(repo_root: Path, text: str) -> None:
     (repo_root / "lessons" / "lessons.yaml").write_text(text, encoding="utf-8")
 
 
+def _copy_real_lessons(repo_root: Path) -> None:
+    source = Path(__file__).parent / "fixtures" / "lessons-origin-main.yaml"
+    (repo_root / "lessons").mkdir(exist_ok=True)
+    (repo_root / "lessons" / "lessons.yaml").write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+
 def _write_tree(state_root: Path, nodes: dict, current: str) -> None:
     (state_root / "evolution").mkdir(exist_ok=True)
     (state_root / "evolution" / "tree.json").write_text(json.dumps({"nodes": nodes, "current_sha": current, "switches": []}), encoding="utf-8")
@@ -118,8 +125,26 @@ def test_charter_falls_back_to_goal_text_json(roots):
     assert inputs["inputs_status"]["goals"]["source"] == "goal_text.json"
 
 
+def test_insights_input_reads_the_real_origin_main_corpus(roots):
+    state_root, repo_root, _ = roots
+    _copy_real_lessons(repo_root)
+    entries = yaml.safe_load((repo_root / "lessons" / "lessons.yaml").read_text(encoding="utf-8"))
+
+    assert len(entries) == 14
+    assert all("reusable_insight" in entry for entry in entries)
+    assert all(not {"problem", "solution", "generalized_insight"}.intersection(entry) for entry in entries)
+
+    insights, status = strategist_inputs.insights_input(repo_root)
+
+    assert status["legacy"] == 10
+    assert status["cards"] == 0
+    assert status["status"] == "complete"
+    assert len(insights["legacy_insights"]) == 10
+    assert all(text for text in insights["legacy_insights"])
+
+
 def test_insights_come_from_v2_cards_and_report_filler_skipped(roots):
-    """Pre-fix: grepped for a 'reusable_insight' key that never existed -> []."""
+    """v2 cards remain preferred over legacy reusable insights."""
     state_root, repo_root, _ = roots
     _write_lessons(repo_root, _card(1, "add a deploy smoke test for the timer unit") + _card(2, "pin the runtime version in the unit env")
                    + _card(3, "split the module below the size cap") + _card(4, FILLER))
@@ -128,6 +153,36 @@ def test_insights_come_from_v2_cards_and_report_filler_skipped(roots):
     assert inputs["inputs_status"]["insights"]["filler_skipped"] == 1
     assert inputs["inputs_status"]["insights"]["status"] == "complete"
     assert "reusable_insight" not in inspect.getsource(strategist)
+
+
+def test_v2_cards_are_preferred_when_a_row_has_both_shapes(roots):
+    _, repo_root, _ = roots
+    _write_lessons(repo_root, "lessons:\n"
+                   "- id: CARD\n  schema_version: 2\n  problem: observed parser failures during bounded reads\n  solution: use bounded parser reads incrementally for large files\n  first_seen: 2026-08-10T00:00:00Z\n  reusable_insight: ignored legacy text\n"
+                   "- id: LEGACY\n  reusable_insight: retained legacy text\n")
+
+    insights, status = strategist_inputs.insights_input(repo_root)
+
+    assert status["cards"] == 1
+    assert status["legacy"] == 1
+    assert insights["cards"][0]["id"] == "CARD"
+    assert insights["legacy_insights"] == ["retained legacy text"]
+
+
+def test_empty_insights_report_empty_and_trigger_refusal(roots, monkeypatch):
+    state_root, repo_root, _ = roots
+    (repo_root / "lessons").mkdir()
+    (repo_root / "lessons" / "lessons.yaml").write_text("- id: L1\n  title: no insight\n", encoding="utf-8")
+    (repo_root / "lessons" / "errors.yaml").write_text("- id: E1\n  title: error context\n", encoding="utf-8")
+    (repo_root / "memory").mkdir()
+    (repo_root / "memory" / "index.md").write_text("- index context\n", encoding="utf-8")
+    (repo_root / "docs").mkdir()
+    (repo_root / "docs" / "index.md").write_text("- index context\n", encoding="utf-8")
+
+    inputs = collect_inputs(state_root, repo_root)
+    assert inputs["inputs_status"]["insights"]["status"] == "empty"
+    assert strategist_inputs.empty_inputs({"insights": inputs["inputs_status"]["insights"], "funnel": {"status": "empty"}}) == ["funnel", "insights"]
+    assert strategist_inputs.should_refuse({"insights": inputs["inputs_status"]["insights"], "funnel": {"status": "empty"}}) is True
 
 
 def test_funnel_reads_per_gap_futile_flag(roots):
@@ -266,7 +321,7 @@ def _live_shape(state_root: Path, repo_root: Path, release_root: Path) -> None:
                              "fitness": {"reward": None, "integrations": i, "confirmed_integrations": i // 2, "repeat_failure_rate": 0.1}}
                              for i in range(100)}, "sha099")
     _write_lessons(repo_root, "".join(_card(i, f"solution {i} " + "pin the exact version in the fixture " * 3) for i in range(1, 11))
-                   + "".join(f"- id: G{i}\n  generalized_insight: legacy insight {i} " + "words " * 20 + "\n" for i in range(10)))
+                   + "".join(f"- id: G{i}\n  reusable_insight: legacy insight {i} " + "words " * 20 + "\n" for i in range(10)))
     (repo_root / "lessons" / "errors.yaml").write_text("".join(
         f"- id: E{i}\n  title: error {i}\n  root_cause: {'cause ' * 30}\n  prevention: {'guard ' * 30}\n" for i in range(16)), encoding="utf-8")
     (repo_root / "memory").mkdir()

--- a/tests/test_strategist_inputs.py
+++ b/tests/test_strategist_inputs.py
@@ -408,3 +408,29 @@ def test_helper_names_used_by_strategist_inputs_exist():
     assert callable(lesson_v2.bounded_load_yaml)
     assert callable(lesson_v2.solution_is_meaningful)
     assert not lesson_v2.solution_is_meaningful("p", FILLER)
+
+
+def test_issue1231_both_legacy_insight_keys_are_read(tmp_path):
+    """Reading only one legacy key is the defect, whichever key that is.
+
+    `reusable_insight` is what the entire origin/main corpus uses; but
+    `generalized_insight` is what `bridge` and `knowledge_curator` write, so it
+    is the shape new rows arrive in. Before #1231 the reader saw only the second
+    and returned nothing from a corpus of 14; a fix that swaps rather than adds
+    would go blind the moment curator output lands.
+    """
+    (tmp_path / "lessons").mkdir()
+    (tmp_path / "lessons" / "lessons.yaml").write_text(
+        yaml.safe_dump([
+            {"id": "old", "date": "2026-01-01", "reusable_insight": "prefer the bounded read"},
+            {"id": "new", "date": "2026-02-01", "generalized_insight": "avoid the unbounded scan"},
+        ]),
+        encoding="utf-8",
+    )
+
+    data, meta = strategist_inputs.insights_input(tmp_path)
+
+    assert meta["legacy"] == 2, "one of the two legacy insight keys was ignored"
+    assert "prefer the bounded read" in data["legacy_insights"]
+    assert "avoid the unbounded scan" in data["legacy_insights"]
+    assert meta["status"] == "complete"


### PR DESCRIPTION
## Summary

Fix the final strategist input defect from #1231:

- `insights_input` now reads the existing `reusable_insight` field as the legacy insight source;
- v2 `problem`/`solution` cards remain preferred when present;
- `insights` reports `empty` when there are no cards or legacy insights, regardless of `errors.yaml` summaries or index context;
- the existing `should_refuse` rule can therefore act on an actually empty insights input.

## Evidence from the real corpus

Added `tests/fixtures/lessons-origin-main.yaml`, copied from `origin/main:lessons/lessons.yaml`. It contains 14 entries:

- 14/14 have `reusable_insight`;
- 0 have `problem`, `solution`, or `generalized_insight`;
- the reader returns 10 legacy insights, matching the existing `_INSIGHTS_LEGACY` cap.

## Validation

- Focused strategist input suite: `18 passed`.
- Full local pytest: `2962 passed, 19 failed, 17 skipped, 11 warnings`.
- The 19 failures are the established 18 Windows baseline plus the pre-existing `tests/test_strategist.py::test_collect_inputs` fixture expectation for the old `lessons` context shape; no changed strategist-input acceptance test failed.
- Ruff and `git diff --check`: passed.
- Host strategist/timer was not run or enabled. Live verification remains operator-owned and must call `collect_inputs()` read-only after deployment.

## Deliberately unchanged

- curator and lessons schema;
- timer state;
- `_MAX_EMPTY_INPUTS` and refusal rule;
- v2 card semantics and caps;
- errors/indexes as prompt context, but not evidence that insights are populated;
- host state.

Closes #1231
