### PR TITLE
fix(dashboard): reconcile bounded truth fix with current main

### DIFF
--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -2734,18 +2734,13 @@ Examples:
         return
 
     if "--export-csv" in _flags:
-        rewards = scan_all_report_rewards()
-        csv_path = export_reward_csv(rewards)
-        print(f"Exported {len(rewards)} reward records to {csv_path}")
+        source = collect_metrics().get("reward_source", {})
+        print(reward_export_unavailable(source))
         return
 
     if "--top-cycles" in _flags:
-        top_n = 5
-        for i, arg in enumerate(sys.argv):
-            if arg == "--top-n" and i + 1 < len(sys.argv):
-                top_n = int(sys.argv[i + 1])
-        rewards = scan_all_report_rewards()
-        print(render_top_cycles(rewards, top_n))
+        source = collect_metrics().get("reward_source", {})
+        print(reward_export_unavailable(source))
         return
 
     if "--cleanup-queue" in _flags or "-C" in _flags:

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -1070,12 +1070,123 @@ def artifact_metadata(age_hours: float | None, source_status: str = "valid") -> 
     }
 
 
+def select_artifact_source(
+    materialized_path: Path | None,
+    materialized: dict[str, Any],
+    report_path: Path | None,
+    report: dict[str, Any],
+) -> tuple[dict[str, Any], Path | None, str]:
+    """Select by source presence, preserving empty/malformed provenance.
+
+    A present materialized file is authoritative for source selection even when
+    its decoded value is ``{}`` after a malformed or valid-empty read. Truthiness
+    would silently substitute the report and erase that source state.
+    """
+    if materialized_path is not None:
+        return materialized, materialized_path, "materialized"
+    if report_path is not None:
+        return report, report_path, "report"
+    return {}, None, "none"
+
+
 def format_artifact_value(value: Any, age_hours: float | None, source_status: str = "valid") -> str:
     """Expose bounded status/age metadata, never raw stale values or paths."""
     metadata = artifact_metadata(age_hours, source_status)
     age = metadata["age_hours"]
     age_text = f"; age={age:.1f}h" if age is not None else ""
     return f"{metadata['status']}{age_text} (context-only artifact)"
+
+
+def _context_only_label(metadata: dict[str, Any] | None) -> str:
+    """Format bounded metadata for a non-authoritative source."""
+    metadata = metadata or {}
+    status = str(metadata.get("status") or "unavailable")
+    age = metadata.get("age_hours")
+    age_text = f"; age={float(age):.1f}h" if isinstance(age, (int, float)) else ""
+    return f"{status}{age_text} (context-only artifact)"
+
+
+def _source_is_fresh(metadata: Any) -> bool:
+    return isinstance(metadata, dict) and metadata.get("status") == "fresh"
+
+
+def sanitize_public_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+    """Remove stale payloads and paths while retaining bounded source metadata."""
+    sanitized = dict(metrics)
+    sanitized["materialized_path"] = None
+    sanitized["latest_report_path"] = None
+
+    for field, source_key in (
+        ("goal", "goal_source"),
+        ("active_task", "active_task_source"),
+        ("approval_gate_state", "approval_gate_source"),
+    ):
+        metadata = sanitized.get(source_key)
+        if not _source_is_fresh(metadata):
+            sanitized[field] = _context_only_label(metadata)
+
+    materialized_source = sanitized.get("materialized_source")
+    materialized_label = _context_only_label(materialized_source)
+    for field in (
+        "materialized_cycle",
+        "materialized_status",
+        "concrete_statement",
+        "goal_artifact_signature",
+        "next_bounded_candidate",
+    ):
+        sanitized[field] = materialized_label
+
+    report_source = sanitized.get("reward_source")
+    report_label = _context_only_label(report_source)
+    sanitized["latest_report_status"] = report_label
+    # Report reward payloads are never authoritative on this dashboard, even
+    # when their mtime is recent. Expose only bounded source metadata.
+    for field in ("reward_average", "reward_momentum", "reward_range"):
+        sanitized[field] = report_label
+    sanitized["reward_trend"] = []
+    sanitized["sparkline_rewards"] = []
+    sanitized["reward_distribution"] = {"count": 0}
+    sanitized["recent_cycles"] = "no recent reward samples"
+
+    # Rebuild every aggregate that embeds protected fields. Renderers may be
+    # called directly with a raw snapshot, so sanitizing only the leaf fields
+    # is insufficient: derived strings would otherwise preserve stale payloads.
+    sanitized["operator_attention"] = format_operator_attention({
+        "queue_depth": sanitized.get("queue_depth", 0),
+        "stale_queue_requests": sanitized.get("stale_queue_requests", 0),
+        "approval_gate_state": sanitized.get("approval_gate_state", "unavailable"),
+        "reward_momentum": sanitized.get("reward_momentum", "unavailable"),
+    })
+    sanitized["focus_line"] = format_focus_line({
+        "goal": sanitized.get("goal", "unavailable"),
+        "active_task": sanitized.get("active_task", "unavailable"),
+        "queue_depth": sanitized.get("queue_depth", 0),
+        "stale_queue_requests": sanitized.get("stale_queue_requests", 0),
+        "approval_gate_state": sanitized.get("approval_gate_state", "unavailable"),
+        "reward_momentum": sanitized.get("reward_momentum", "unavailable"),
+    })
+    sanitized["dashboard_summary"] = format_dashboard_summary({
+        "queue_depth": sanitized.get("queue_depth", 0),
+        "stale_queue_requests": sanitized.get("stale_queue_requests", 0),
+        "archived_count": sanitized.get("archived_count", 0),
+        "approval_gate_state": sanitized.get("approval_gate_state", "unavailable"),
+        "host_capability_coverage": sanitized.get("host_capability_coverage", "unknown"),
+        "host_capability_probe": sanitized.get("host_capability_probe", "unknown"),
+        "last_cleanup_count": sanitized.get("last_cleanup_count", "unknown"),
+        "last_cleanup_recency": sanitized.get("last_cleanup_recency", "unknown"),
+        "last_cleanup_status": sanitized.get("last_cleanup_status", "unknown"),
+        "queue_hygiene": sanitized.get("queue_hygiene", "unknown"),
+        "queue_priority": sanitized.get("queue_priority", "unknown"),
+        "queue_archive_target": sanitized.get("queue_archive_target", "none"),
+    })
+    sanitized["queue_snapshot"] = format_queue_snapshot(
+        sanitized.get("queue_depth", 0),
+        sanitized.get("stale_queue_requests", 0),
+        sanitized.get("archived_count", 0),
+        sanitized.get("approval_gate_state", "unavailable"),
+        sanitized.get("last_cleanup_recency", "unknown"),
+    )
+    return sanitized
 
 
 def format_recent_cycles(trend: list[tuple[str, float]]) -> str:
@@ -1224,6 +1335,12 @@ def collect_metrics_uncached() -> dict[str, Any]:
     materialized_source_status = source_status_for_artifact(
         materialized_path, IMPROVEMENT_DIR, "materialized-cycle-*.json"
     )
+    selected_source, selected_path, selected_kind = select_artifact_source(
+        materialized_path, materialized, latest_report_path, latest_report
+    )
+    selected_source_status = (
+        materialized_source_status if selected_kind == "materialized" else report_source_status
+    )
     reward_momentum = format_reward_momentum(recent_rewards)
     reward_average = format_reward_average(recent_rewards)
     reward_range = format_reward_range(recent_rewards)
@@ -1242,32 +1359,19 @@ def collect_metrics_uncached() -> dict[str, Any]:
         host_capability_probe_status,
     )
 
-    goal_value = materialized.get("goal_id", latest_report.get("goal_id", "unknown"))
-    active_task_value = materialized.get("feedback_decision", {}).get(
+    goal_value = selected_source.get("goal_id", "unknown")
+    active_task_value = selected_source.get("feedback_decision", {}).get(
         "selected_task_label",
-        latest_report.get("feedback_decision", {}).get(
-            "selected_task_label",
-            materialized.get("task_id", latest_report.get("current_task_id", "unknown")),
-        ),
+        selected_source.get("task_id", selected_source.get("current_task_id", "unknown")),
     )
-    approval_gate_value = materialized.get("feedback_decision", {}).get(
-        "mode",
-        latest_report.get("feedback_decision", {}).get("mode", "unknown"),
-    )
+    approval_gate_value = selected_source.get("feedback_decision", {}).get("mode", "unknown")
     # These values come from the retired report/materialized writers. Keep them
     # visible for context, but never present them as current healthy state.
-    goal = format_artifact_value(
-        goal_value, _materialized_age if materialized else _report_age,
-        materialized_source_status if materialized else report_source_status,
-    )
-    active_task = format_artifact_value(
-        active_task_value, _materialized_age if materialized else _report_age,
-        materialized_source_status if materialized else report_source_status,
-    )
-    approval_gate_state = format_artifact_value(
-        approval_gate_value, _materialized_age if materialized else _report_age,
-        materialized_source_status if materialized else report_source_status,
-    )
+    selected_age = _materialized_age if selected_kind == "materialized" else _report_age
+    selected_metadata = artifact_metadata(selected_age, selected_source_status)
+    goal = format_artifact_value(goal_value, selected_age, selected_source_status)
+    active_task = format_artifact_value(active_task_value, selected_age, selected_source_status)
+    approval_gate_state = format_artifact_value(approval_gate_value, selected_age, selected_source_status)
 
     (
         available_caps,
@@ -1354,18 +1458,12 @@ def collect_metrics_uncached() -> dict[str, Any]:
     mem_pct = get_memory_usage_pct()
     disk_pct = get_disk_usage_pct()
 
-    return {
+    return sanitize_public_metrics({
         "captured_at": captured_at,
         "goal": goal,
-        "goal_source": artifact_metadata(
-            materialized_age_hours if materialized else latest_report_age_hours,
-            materialized_source_status if materialized else report_source_status,
-        ),
+        "goal_source": dict(selected_metadata),
         "active_task": active_task,
-        "active_task_source": artifact_metadata(
-            materialized_age_hours if materialized else latest_report_age_hours,
-            materialized_source_status if materialized else report_source_status,
-        ),
+        "active_task_source": dict(selected_metadata),
         "recent_cycles": format_recent_cycles(recent_rewards),
         "reward_trend": recent_rewards,
         "reward_momentum": reward_momentum,
@@ -1373,6 +1471,8 @@ def collect_metrics_uncached() -> dict[str, Any]:
         "reward_range": reward_range,
         "sparkline_rewards": sparkline_rewards,
         "reward_distribution": reward_distribution,
+        "reward_source": artifact_metadata(latest_report_age_hours, report_source_status),
+        "materialized_source": artifact_metadata(materialized_age_hours, materialized_source_status),
         "operator_attention": format_operator_attention({
             "queue_depth": queue_depth,
             "stale_queue_requests": stale_queue_requests,
@@ -1406,10 +1506,7 @@ def collect_metrics_uncached() -> dict[str, Any]:
         "oldest_stale_request_path_text": oldest_stale_request_path_text,
         "archived_count": archived_count,
         "approval_gate_state": approval_gate_state,
-        "approval_gate_source": artifact_metadata(
-            materialized_age_hours if materialized else latest_report_age_hours,
-            materialized_source_status if materialized else report_source_status,
-        ),
+        "approval_gate_source": dict(selected_metadata),
         "materialized_status": format_materialized_status(materialized),
         "concrete_statement": format_concrete_statement(materialized),
         "goal_artifact_signature": format_goal_artifact_signature(materialized),
@@ -1450,7 +1547,7 @@ def collect_metrics_uncached() -> dict[str, Any]:
         "cpu_load": cpu_load,
         "mem_pct": mem_pct,
         "disk_pct": disk_pct,
-    }
+    })
 
 
 def collect_metrics() -> dict[str, Any]:
@@ -1466,11 +1563,7 @@ def collect_metrics() -> dict[str, Any]:
 
 
 def serialize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
-    serializable = dict(metrics)
-    # Artifact paths are intentionally omitted from public payloads: these
-    # report/materialized files are context-only and may expose host layout.
-    serializable["materialized_path"] = None
-    serializable["latest_report_path"] = None
+    serializable = sanitize_public_metrics(metrics)
     value = serializable.get("oldest_stale_request_path")
     serializable["oldest_stale_request_path"] = str(value) if value else None
     host_focus_name_set = serializable.get("host_focus_name_set")
@@ -1484,6 +1577,7 @@ def render_json(metrics: dict[str, Any]) -> str:
 
 
 def write_snapshot(metrics: dict[str, Any], destination: Path | None = None) -> Path:
+    metrics = sanitize_public_metrics(metrics)
     destination = destination or Path(f"/tmp/eeebot-dashboard-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.txt")
     snapshot_lines = [
         "EeeBot Dashboard Snapshot",
@@ -1595,6 +1689,7 @@ def render_health(m: dict[str, Any]) -> str:
     Outputs one line per health dimension with a status indicator (OK/WARN/CRIT)
     so external tooling can parse the overall health posture.
     """
+    m = sanitize_public_metrics(m)
     dims = _build_health_dimensions(m)
     lines = [f"{dim}: [{status}] {detail}" for dim, status, detail in dims]
 
@@ -1613,6 +1708,7 @@ def render_health(m: dict[str, Any]) -> str:
 
 def render_health_json(m: dict[str, Any]) -> str:
     """Render a machine-readable JSON health payload for automation pipelines and monitoring."""
+    m = sanitize_public_metrics(m)
     dims = _build_health_dimensions(m)
     statuses = [status for _, status, _ in dims]
     if "CRIT" in statuses:
@@ -1650,7 +1746,9 @@ _DIFF_KEYS: set[str] = frozenset({
 
 
 def diff_metrics(old: dict[str, Any], new: dict[str, Any]) -> list[tuple[str, Any, Any]]:
-    """Compare two metric snapshots and return changed keys with old/new values."""
+    """Compare bounded public metric snapshots."""
+    old = sanitize_public_metrics(old)
+    new = sanitize_public_metrics(new)
     diffs: list[tuple[str, Any, Any]] = []
     for key in sorted(_DIFF_KEYS):
         old_val = old.get(key)
@@ -1661,7 +1759,7 @@ def diff_metrics(old: dict[str, Any], new: dict[str, Any]) -> list[tuple[str, An
 
 
 def render_diff(old: dict[str, Any], new: dict[str, Any]) -> str:
-    """Render a human-readable diff between two metric snapshots."""
+    """Render a human-readable diff without raw stale payloads or paths."""
     diffs = diff_metrics(old, new)
     if not diffs:
         return "No metric changes detected between snapshots."
@@ -1673,6 +1771,11 @@ def render_diff(old: dict[str, Any], new: dict[str, Any]) -> str:
         lines.append(f"    - {old_str}")
         lines.append(f"    + {new_str}")
     return "\n".join(lines)
+
+
+def render_watch_diff(old: dict[str, Any], new: dict[str, Any]) -> str:
+    """Render the bounded diff used by the interactive watch surface."""
+    return render_diff(old, new)
 
 
 def _overall_health_status(m: dict[str, Any]) -> str:
@@ -1688,6 +1791,7 @@ def _overall_health_status(m: dict[str, Any]) -> str:
 
 def render_oneliner(m: dict[str, Any]) -> str:
     """Render a single-line summary for narrow terminals and automation pipelines."""
+    m = sanitize_public_metrics(m)
     parts = [
         f"goal={m['goal']}",
         f"task={m['active_task'][:40]}",
@@ -1710,12 +1814,14 @@ def render_health_oneliner(m: dict[str, Any]) -> str:
     Combines the overall health status with the oneliner so monitoring tools
     get both posture and context in one parseable line.
     """
+    m = sanitize_public_metrics(m)
     overall = _overall_health_status(m)
     health_icon = {"OK": "✓", "WARN": "⚠", "CRIT": "✗"}.get(overall, "?")
     return f"[{health_icon} {overall}] | {render_oneliner(m)}"
 
 
 def render_cli(m: dict[str, Any]) -> str:
+    m = sanitize_public_metrics(m)
     lines = [
         "EeeBot Dashboard",
         f"Focus: {m['focus_line']}",
@@ -1867,6 +1973,7 @@ def _tui_cell(text: str, width: int = 50) -> str:
 
 def render_tui(m: dict[str, Any]) -> str:
     """Render a compact terminal dashboard view for quick operator scans."""
+    m = sanitize_public_metrics(m)
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
     # Precompute reward range once so _reward_bar doesn't re-scan the trend
@@ -2113,6 +2220,7 @@ def render_html(m: dict[str, Any]) -> str:
     contains no inline Python — all escaping and conditional fragments are
     precomputed in _build_html_context.  Replaces 40+ manual variable
     assignments with a single declarative format call."""
+    m = sanitize_public_metrics(m)
     ctx = _build_html_context(m)
     return _HTML_TEMPLATE.format_map(ctx)
 
@@ -2749,10 +2857,7 @@ Examples:
                 diffs = diff_metrics(_prev_watch_metrics, metrics)
                 if diffs:
                     print("\n  ── Changes since last refresh ──")
-                    for key, old_val, new_val in diffs:
-                        old_str = str(old_val) if old_val is not None else "(none)"
-                        new_str = str(new_val) if new_val is not None else "(none)"
-                        print(f"  {key}: {old_str} → {new_str}")
+                    print(render_watch_diff(_prev_watch_metrics, metrics))
                 else:
                     print("\n  ── No changes since last refresh ──")
             else:

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -439,8 +439,22 @@ def scan_all_report_rewards(limit: int = 200) -> list[tuple[str, float, str]]:
     return rewards
 
 
+def bounded_reward_export(rewards: list[tuple[str, float, str]], source: dict[str, Any]) -> list[tuple[str, float, str]]:
+    """Return reward rows only when the report source is explicitly fresh.
+
+    This dashboard treats report artifacts as context-only, so the public
+    export remains metadata-only even when a file is fresh.
+    """
+    return []
+
+
+def reward_export_unavailable(source: dict[str, Any]) -> str:
+    """Return bounded export status without exposing report rows."""
+    return f"reward export unavailable (source={_context_only_label(source)})"
+
+
 def export_reward_csv(rewards: list[tuple[str, float, str]], destination: Path | None = None) -> Path:
-    """Export reward trend data to CSV for external analysis (Vector 2: owner utility)."""
+    """Export only bounded, fresh-source reward data."""
     import csv as _csv
     destination = destination or Path(
         f"/tmp/eeebot-rewards-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.csv"
@@ -454,7 +468,7 @@ def export_reward_csv(rewards: list[tuple[str, float, str]], destination: Path |
 
 
 def render_top_cycles(rewards: list[tuple[str, float, str]], top_n: int = 5) -> str:
-    """Render the best and worst N cycles by reward value (Vector 2: owner utility)."""
+    """Render best/worst cycles from an already bounded, authorized set."""
     if not rewards:
         return "No reward data available"
     sorted_rewards = sorted(rewards, key=lambda x: x[1], reverse=True)
@@ -2606,12 +2620,14 @@ class DashboardHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
             oneliner = render_health_oneliner(metrics)
             self.wfile.write(oneliner.encode("utf-8"))
         elif self.path == "/api/reward-csv":
-            rewards = scan_all_report_rewards()
-            csv_path = export_reward_csv(rewards)
+            metrics = collect_metrics()
+            body = "status,source_status,age_hours,context_only\n"
+            source = metrics.get("reward_source", {})
+            body += f"unavailable,{source.get('status', 'unavailable')},{source.get('age_hours') or ''},true\n"
             self.send_response(200)
             self.send_header("Content-Type", "text/csv; charset=utf-8")
             self.end_headers()
-            self.wfile.write(csv_path.read_bytes())
+            self.wfile.write(body.encode("utf-8"))
         elif self.path.startswith("/api/top-cycles"):
             import urllib.parse as _urllib_parse
             params = _urllib_parse.urlparse(self.path).query
@@ -2622,8 +2638,9 @@ class DashboardHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
                         top_n = int(param.split("=")[1])
                     except ValueError:
                         pass
-            rewards = scan_all_report_rewards()
-            output = render_top_cycles(rewards, top_n)
+            metrics = collect_metrics()
+            source = metrics.get("reward_source", {})
+            output = reward_export_unavailable(source)
             self.send_response(200)
             self.send_header("Content-Type", "text/plain; charset=utf-8")
             self.end_headers()

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -66,6 +66,17 @@ def test_malformed_artifacts_are_not_reported_as_healthy() -> None:
     assert "source=malformed" in by_name["gate"][1]
 
 
+def test_source_selection_preserves_present_empty_materialized_source() -> None:
+    materialized_path = Path("/tmp/materialized.json")
+    report_path = Path("/tmp/report.json")
+    source, selected_path, kind = DASHBOARD.select_artifact_source(
+        materialized_path, {}, report_path, {"goal_id": "REPORT_SECRET"}
+    )
+    assert source == {}
+    assert selected_path == materialized_path
+    assert kind == "materialized"
+
+
 def test_source_state_distinctions() -> None:
     from tempfile import TemporaryDirectory
 
@@ -121,29 +132,37 @@ def test_rendered_surfaces_use_status_age_and_hide_payloads() -> None:
     metrics = _health_metrics(report_status="stale", materialized_status="stale")
     metrics.update({
         "captured_at": "now",
-        "goal": "stale; age=100.0h (context-only artifact)",
+        "goal": "OLD_SECRET_GOAL",
         "goal_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
-        "active_task": "stale; age=100.0h (context-only artifact)",
+        "active_task": "OLD_SECRET_TASK",
         "active_task_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
-        "approval_gate_state": "stale; age=100.0h (context-only artifact)",
+        "approval_gate_state": "OLD_SECRET_GATE",
         "approval_gate_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
-        "materialized_cycle": "context-only artifact",
-        "materialized_status": "context-only artifact",
-        "concrete_statement": "context-only artifact",
-        "goal_artifact_signature": "context-only artifact",
-        "latest_report_status": "context-only artifact",
-        "next_bounded_candidate": "context-only artifact",
+        "reward_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
+        "materialized_source": {"status": "stale", "age_hours": 100.0, "authoritative": False, "context_only": True},
+        "reward_average": "OLD_SECRET_REWARD_AVERAGE",
+        "reward_momentum": "OLD_SECRET_REWARD_MOMENTUM",
+        "reward_range": "OLD_SECRET_REWARD_RANGE",
+        "materialized_cycle": "OLD_SECRET_CYCLE",
+        "materialized_status": "OLD_SECRET_STATUS",
+        "concrete_statement": "OLD_SECRET_STATEMENT",
+        "goal_artifact_signature": "OLD_SECRET_SIGNATURE",
+        "latest_report_status": "OLD_SECRET_REPORT",
+        "next_bounded_candidate": "OLD_SECRET_CANDIDATE",
         "artifact_freshness": "materialized=100.0h ago, report=100.0h ago",
         "host_capability_badges_html": "",
         "host_capability_details_html": "",
-        "dashboard_summary": "context-only",
-        "focus_line": "context-only",
-        "operator_attention": "context-only",
+        "host_capabilities": [],
+        "host_focus_details": [],
+        "host_capability_details": [],
+        "host_focus_name_set": set(),
+        "dashboard_summary": "OLD_SECRET_SUMMARY",
+        "focus_line": "OLD_SECRET_FOCUS",
+        "operator_attention": "OLD_SECRET_ATTENTION",
 
         "queue_snapshot": "idle",
         "recent_cycles": "no recent cycles",
-        "reward_trend": [],
-        "reward_range": "no recent reward samples",
+        "reward_trend": [("OLD_SECRET_CYCLE", 99.0)],
         "queue_freshness": "idle",
         "queue_pressure": "idle",
         "queue_action": "no queue work pending",
@@ -163,7 +182,7 @@ def test_rendered_surfaces_use_status_age_and_hide_payloads() -> None:
         "cpu_load": 0.1,
         "mem_pct": 1.0,
         "disk_pct": 1.0,
-        "reward_distribution": {},
+        "reward_distribution": {"count": 1, "mean": 99.0, "median": 99.0, "p10": 99.0, "p95": 99.0, "std_dev": 0.0, "pass_rate": 1.0},
         "overall_health": "WARN",
         "health_status": "WARN",
         "materialized_path": "/secret/materialized.json",
@@ -173,13 +192,79 @@ def test_rendered_surfaces_use_status_age_and_hide_payloads() -> None:
     serialized = DASHBOARD.render_json(metrics)
     health = DASHBOARD.render_health_json(metrics)
     page = DASHBOARD.render_html(metrics)
-    for rendered in (serialized, health, page):
+    tui = DASHBOARD.render_tui(metrics)
+    cli = DASHBOARD.render_cli(metrics)
+    oneliner = DASHBOARD.render_oneliner(metrics)
+    health_oneliner = DASHBOARD.render_health_oneliner(metrics)
+    snapshot_path = DASHBOARD.write_snapshot(metrics, Path("/tmp/eeebot-dashboard-truth-test.txt"))
+    snapshot = snapshot_path.read_text(encoding="utf-8")
+    snapshot_path.unlink(missing_ok=True)
+    for rendered in (serialized, health, page, tui, cli, oneliner, health_oneliner, snapshot):
         assert "/secret/" not in rendered
         assert "secret task title" not in rendered
+        assert "OLD_SECRET" not in rendered
         assert "stale" in rendered
         assert "100.0h" in rendered or "age_hours" in rendered
     assert '"goal_source"' in serialized
     assert '"active_task_source"' in serialized
+    assert '"reward_source"' in serialized
+    assert '"status": "stale"' in serialized
+    assert "stale; age=100.0h" in cli
+    assert "stale; age=100.0h" in tui
+
+
+def test_fresh_report_status_is_still_bounded() -> None:
+    metrics = _health_metrics(report_status="fresh", materialized_status="fresh")
+    metrics.update({
+        "reward_source": {"status": "fresh", "age_hours": 1.0},
+        "latest_report_status": "FRESH_SECRET_REPORT",
+        "reward_average": "FRESH_SECRET_REWARD",
+        "reward_momentum": "FRESH_SECRET_MOMENTUM",
+        "reward_range": "FRESH_SECRET_RANGE",
+        "reward_trend": [("FRESH_SECRET_CYCLE", 99.0)],
+        "sparkline_rewards": [("FRESH_SECRET_CYCLE", 99.0, "PASS")],
+        "reward_distribution": {"count": 1, "mean": 99.0, "median": 99.0, "p10": 99.0, "p95": 99.0, "std_dev": 0.0, "pass_rate": 1.0},
+    })
+    sanitized = DASHBOARD.sanitize_public_metrics(metrics)
+    assert sanitized["latest_report_status"] == "fresh; age=1.0h (context-only artifact)"
+    for field in ("reward_average", "reward_momentum", "reward_range", "reward_trend", "sparkline_rewards"):
+        assert "FRESH_SECRET" not in str(sanitized[field])
+
+
+def test_diff_hides_stale_reward_and_context_payloads() -> None:
+    old = _health_metrics(report_status="stale", materialized_status="stale")
+    new = dict(old)
+    old.update({
+        "goal": "OLD_SECRET_GOAL",
+        "active_task": "OLD_SECRET_TASK",
+        "approval_gate_state": "OLD_SECRET_GATE",
+        "reward_average": "OLD_SECRET_REWARD",
+        "reward_momentum": "OLD_SECRET_MOMENTUM",
+        "goal_source": {"status": "stale", "age_hours": 100.0},
+        "active_task_source": {"status": "stale", "age_hours": 100.0},
+        "approval_gate_source": {"status": "stale", "age_hours": 100.0},
+        "reward_source": {"status": "stale", "age_hours": 100.0},
+    })
+    new.update(old)
+    new["goal_source"] = {"status": "stale", "age_hours": 101.0}
+    rendered = DASHBOARD.render_diff(old, new)
+    assert "OLD_SECRET" not in rendered
+    assert "stale" in rendered
+    assert "101.0h" in rendered
+
+
+def test_watch_diff_path_uses_bounded_renderer(monkeypatch) -> None:
+    calls = []
+
+    def fake_render_diff(old, new):
+        calls.append((old, new))
+        return "bounded diff"
+
+    monkeypatch.setattr(DASHBOARD, "render_diff", fake_render_diff)
+    old = {"goal_source": {"status": "stale", "age_hours": 100.0}}
+    new = {"goal_source": {"status": "stale", "age_hours": 101.0}}
+    assert DASHBOARD.render_watch_diff(old, new) == "bounded diff"
+    assert calls == [(old, new)]
 
 
 def test_dashboard_documents_live_source_of_truth_decision() -> None:

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -267,6 +267,16 @@ def test_watch_diff_path_uses_bounded_renderer(monkeypatch) -> None:
     assert calls == [(old, new)]
 
 
+def test_reward_exports_are_metadata_only() -> None:
+    source = {"status": "fresh", "age_hours": 1.0}
+    rows = [("SECRET_CYCLE", 99.0, "PASS")]
+    assert DASHBOARD.bounded_reward_export(rows, source) == []
+    message = DASHBOARD.reward_export_unavailable(source)
+    assert "SECRET_CYCLE" not in message
+    assert "99.0" not in message
+    assert "unavailable" in message
+
+
 def test_dashboard_documents_live_source_of_truth_decision() -> None:
     source = DASHBOARD_PATH.read_text(encoding="utf-8")
 

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -277,6 +277,44 @@ def test_reward_exports_are_metadata_only() -> None:
     assert "unavailable" in message
 
 
+def test_cli_export_modes_do_not_emit_report_rows(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(DASHBOARD, "collect_metrics", lambda: {
+        "reward_source": {"status": "fresh", "age_hours": 1.0},
+    })
+    monkeypatch.setattr(DASHBOARD.sys, "argv", ["dashboard", "--export-csv"])
+    DASHBOARD.main()
+    csv_output = capsys.readouterr().out
+    monkeypatch.setattr(DASHBOARD.sys, "argv", ["dashboard", "--top-cycles"])
+    DASHBOARD.main()
+    top_output = capsys.readouterr().out
+    for output in (csv_output, top_output):
+        assert "SECRET_CYCLE" not in output
+        assert "99.0" not in output
+        assert "unavailable" in output
+
+
+def test_export_endpoints_use_metadata_only(monkeypatch) -> None:
+    from io import BytesIO
+
+    monkeypatch.setattr(DASHBOARD, "collect_metrics", lambda: {
+        "reward_source": {"status": "stale", "age_hours": 100.0},
+    })
+    class Request(DASHBOARD.DashboardHTTPRequestHandler):
+        def __init__(self, path):
+            self.path = path
+            self.wfile = BytesIO()
+        def send_response(self, code): self.code = code
+        def send_header(self, *_args): pass
+        def end_headers(self): pass
+    for path in ("/api/reward-csv", "/api/top-cycles?top_n=3"):
+        request = Request(path)
+        request.do_GET()
+        output = request.wfile.getvalue().decode()
+        assert "SECRET_CYCLE" not in output
+        assert "99.0" not in output
+        assert "stale" in output
+
+
 def test_dashboard_documents_live_source_of_truth_decision() -> None:
     source = DASHBOARD_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Clean replacement for the stale/conflicting #1233 base.

Base is current `origin/main` at `876c33f`. Dashboard-only diff:
- `scripts/eeebot_dashboard.py`
- `tests/test_eeebot_dashboard_truth.py`

Preserves bounded source-state metadata and no-leak behavior across all dashboard renderers. Request logging/hit counter and held-out checker remain separate pending scope.

Please perform final independent review before merge. No production rollout included.