### PR TITLE
fix(deploy): verify dashboard ownership and endpoint semantics

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -353,6 +353,8 @@ sync_timer eeebot-strategist.timer optional
 # the static oneshot bridge, it keeps the old Python process alive across a
 # symlink flip unless explicitly restarted (#1236).
 DASHBOARD_UNIT=eeebot-dashboard.service
+DASHBOARD_PREV_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value 2>/dev/null || true)"
+DASHBOARD_PREV_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value 2>/dev/null || true)"
 DASHBOARD_LOAD_STATE="$(systemctl show "$DASHBOARD_UNIT" -p LoadState --value 2>/dev/null || true)"
 DASHBOARD_UNIT_STATE="$(systemctl is-enabled "$DASHBOARD_UNIT" 2>/dev/null || true)"
 if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
@@ -391,9 +393,12 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     echo "[remote] $DASHBOARD_UNIT active: MainPID=$DASHBOARD_PID start=$DASHBOARD_START previous_pid=$DASHBOARD_PREV_PID previous_start=$DASHBOARD_PREV_START cwd=$DASHBOARD_CWD source=$FULL_COMMIT"
 
     # Semantic dashboard gate: listener + valid JSON + bounded/no-leak fields.
-    DASHBOARD_SOCKET_PID="$(ss -ltnpH 2>/dev/null | sed -n 's/.*pid=\([0-9]*\),.*/\1/p' | head -n 1)"
-    if [ "$DASHBOARD_SOCKET_PID" != "$DASHBOARD_PID" ]; then
-      echo "CRITICAL: :8080 is not owned by dashboard PID $DASHBOARD_PID" >&2
+    DASHBOARD_SOCKET_ROWS="$(ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
+    DASHBOARD_LISTENER_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | sed '/^$/d' | wc -l)"
+    DASHBOARD_SOCKET_PIDS="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)"
+    DASHBOARD_SOCKET_PID_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_PIDS" | sed '/^$/d' | wc -l)"
+    if [ "$DASHBOARD_LISTENER_COUNT" != "1" ] || [ "$DASHBOARD_SOCKET_PID_COUNT" != "1" ] || [ "$DASHBOARD_SOCKET_PIDS" != "$DASHBOARD_PID" ]; then
+      echo "CRITICAL: :8080 must have exactly one owner, dashboard PID $DASHBOARD_PID" >&2
       exit 1
     fi
     if ! ss -ltnH | awk '$4 ~ /:8080$/ {found=1} END {exit !found}'; then
@@ -410,6 +415,7 @@ health = json.loads(os.environ["DASHBOARD_HEALTH"])
 metrics = json.loads(os.environ["DASHBOARD_METRICS"])
 required_health = {"overall", "dimensions", "goal", "active_task", "reward_average"}
 required_metrics = {"goal", "active_task", "approval_gate_state", "reward_source"}
+source_keys = ("goal_source", "active_task_source", "approval_gate_source", "reward_source")
 for payload, required in ((health, required_health), (metrics, required_metrics)):
     if not all(isinstance(payload.get(key), (str, dict, int, float, list)) for key in required):
         raise SystemExit("dashboard endpoint has invalid bounded field types")
@@ -421,12 +427,22 @@ raw_markers = ("evolution-", "materialized-cycle-", "reward_signal")
 payload = json.dumps({"health": health, "metrics": metrics}, sort_keys=True)
 if any(marker in payload for marker in raw_markers):
     raise SystemExit("dashboard endpoint contains raw retired artifact payload")
-for key in ("goal_source", "active_task_source", "approval_gate_source", "reward_source"):
+for key in source_keys:
     source = metrics.get(key)
     if not isinstance(source, dict) or not {"status", "age_hours", "authoritative", "context_only"} <= source.keys():
         raise SystemExit("dashboard endpoint missing bounded source metadata")
+    if source["authoritative"] is not False or source["context_only"] is not True:
+        raise SystemExit("dashboard endpoint source authority flags are unsafe")
+    if source["status"] not in {"fresh", "stale", "missing", "permission", "unreadable", "malformed", "valid-empty"}:
+        raise SystemExit("dashboard endpoint source status is invalid")
+    if source["status"] != "fresh" and source.get("age_hours") is not None and not isinstance(source["age_hours"], (int, float)):
+        raise SystemExit("dashboard endpoint source age is invalid")
 if metrics.get("latest_report_path") is not None or metrics.get("materialized_path") is not None:
     raise SystemExit("dashboard endpoint exposes an artifact path")
+for key in ("reward", "gate"):
+    detail = health.get("dimensions", {}).get(key, {})
+    if not isinstance(detail, dict) or detail.get("status") not in {"WARN", "OK", "CRIT"}:
+        raise SystemExit("dashboard health dimension is not structured")
 PY
   elif [ "$DASHBOARD_UNIT_STATE" = "disabled" ] || [ "$DASHBOARD_UNIT_STATE" = "masked" ]; then
     echo "NOTICE: $DASHBOARD_UNIT is $DASHBOARD_UNIT_STATE; preserving state"
@@ -442,7 +458,8 @@ else
 fi
 
 trap - ERR
-# Ensure bridge service is restarted correctly
+# Ensure bridge service is restarted correctly. The activation rollback trap
+# remains installed so a bridge restart failure restores the previous release.
 sudo systemctl restart eeepc-self-evolving-subagent-bridge.service
 
 REMOTE

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -78,10 +78,12 @@ BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref "$COMMIT" 2>/dev/null || ech
 SUBJECT=$(git -C "$REPO_ROOT" log -1 --format="%s" "$COMMIT")
 TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
 RELEASE_NAME="${TIMESTAMP}-canonical-${COMMIT}"
+FULL_COMMIT="$(git -C "$REPO_ROOT" rev-parse "$COMMIT^{commit}")"
 ARCHIVE="/tmp/eeebot-release-${RELEASE_NAME}.tar.gz"
 
 log "repo:    $REPO_ROOT"
 log "commit:  $COMMIT ($SUBJECT) ($BRANCH)"
+log "full commit: $FULL_COMMIT"
 log "release: $RELEASE_NAME"
 log "host:    $HOST"
 
@@ -98,14 +100,25 @@ run scp "$ARCHIVE" "ozand@${HOST}:${REMOTE_ARCHIVE}"
 
 # Resolve PREV_RELEASE so we can roll back if needed
 PREV_RELEASE_PATH=$(ssh "ozand@${HOST}" "readlink /opt/eeepc-agent/runtimes/self-evolving-agent/current || true")
+PREV_RELEASE_PATH="${PREV_RELEASE_PATH//$'\r'/}"
+if [ -z "$PREV_RELEASE_PATH" ]; then
+  echo "CRITICAL: could not resolve previous current release for rollback" >&2
+  exit 1
+fi
+
+rollback_release() {
+  log "Rolling back to $PREV_RELEASE_PATH..."
+  ssh "ozand@${HOST}" "sudo ln -sfn \"$PREV_RELEASE_PATH\" /opt/eeepc-agent/runtimes/self-evolving-agent/current && sudo systemctl restart eeebot-dashboard.service && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service"
+}
 
 # 3. Extract, build venv, update symlink, restart
 log "installing on $HOST..."
-run ssh "ozand@${HOST}" bash -s -- "$REMOTE_ARCHIVE" "$RELEASE_NAME" "$COMMIT" <<'REMOTE'
+run ssh "ozand@${HOST}" bash -s -- "$REMOTE_ARCHIVE" "$RELEASE_NAME" "$FULL_COMMIT" "$PREV_RELEASE_PATH" <<'REMOTE'
 set -euo pipefail
 ARCHIVE="$1"
 RELEASE_NAME="$2"
-COMMIT="$3"
+FULL_COMMIT="$3"
+PREV_RELEASE_PATH="$4"
 
 RELEASES_DIR=/opt/eeepc-agent/runtimes/self-evolving-agent/releases
 RELEASE_DIR="$RELEASES_DIR/$RELEASE_NAME"
@@ -115,7 +128,11 @@ echo "[remote] extracting to $RELEASE_DIR"
 sudo mkdir -p "$RELEASES_DIR"
 cd /tmp
 sudo tar xzf "$ARCHIVE" -C "$RELEASES_DIR"
-echo "$COMMIT" | sudo tee "$RELEASE_DIR/SOURCE_COMMIT" > /dev/null
+echo "$FULL_COMMIT" | sudo tee "$RELEASE_DIR/SOURCE_COMMIT" > /dev/null
+if [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
+  echo "CRITICAL: SOURCE_COMMIT does not match full deployed commit" >&2
+  exit 1
+fi
 
 echo "[remote] linking venv into release"
 sudo ln -sfn "/opt/eeepc-agent/venv" "$RELEASE_DIR/.venv"
@@ -160,6 +177,16 @@ fi
 echo "[remote] updating current symlink"
 sudo ln -sfn "$RELEASE_DIR" /opt/eeepc-agent/runtimes/self-evolving-agent/current
 sudo chown -h root:root /opt/eeepc-agent/runtimes/self-evolving-agent/current
+
+# Once current has moved, every later remote failure must restore the previous
+# release immediately; never leave a failed release active (#1236).
+rollback_remote() {
+  echo "[remote] rollback after activation failure: $PREV_RELEASE_PATH" >&2
+  sudo ln -sfn "$PREV_RELEASE_PATH" /opt/eeepc-agent/runtimes/self-evolving-agent/current
+  sudo systemctl restart eeebot-dashboard.service 2>/dev/null || true
+  sudo systemctl restart eeepc-self-evolving-subagent-bridge.service 2>/dev/null || true
+}
+trap rollback_remote ERR
 
 if [ "$(stat -c '%u:%g' /opt/eeepc-agent/runtimes/self-evolving-agent/current)" != "0:0" ]; then
   echo "CRITICAL: /opt/eeepc-agent/runtimes/self-evolving-agent/current is not owned by root:root" >&2
@@ -322,6 +349,99 @@ sync_timer eeebot-action-index.timer optional
 sync_timer eeebot-reflector.timer optional
 sync_timer eeebot-strategist.timer optional
 
+# Activate the long-running dashboard against the new current release. Unlike
+# the static oneshot bridge, it keeps the old Python process alive across a
+# symlink flip unless explicitly restarted (#1236).
+DASHBOARD_UNIT=eeebot-dashboard.service
+DASHBOARD_LOAD_STATE="$(systemctl show "$DASHBOARD_UNIT" -p LoadState --value 2>/dev/null || true)"
+DASHBOARD_UNIT_STATE="$(systemctl is-enabled "$DASHBOARD_UNIT" 2>/dev/null || true)"
+if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
+  if [ "$DASHBOARD_UNIT_STATE" = "enabled" ]; then
+    echo "[remote] restarting $DASHBOARD_UNIT after current activation"
+    DASHBOARD_PREV_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
+    DASHBOARD_PREV_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
+    sudo systemctl restart "$DASHBOARD_UNIT"
+    if ! systemctl is-active --quiet "$DASHBOARD_UNIT"; then
+      echo "CRITICAL: $DASHBOARD_UNIT is not active after restart" >&2
+      exit 1
+    fi
+    DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
+    DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
+    DASHBOARD_CWD="$(readlink "/proc/$DASHBOARD_PID/cwd" 2>/dev/null || true)"
+    DASHBOARD_CMDLINE="$(tr "\0" " " < "/proc/$DASHBOARD_PID/cmdline" 2>/dev/null || true)"
+    if [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
+      echo "CRITICAL: $DASHBOARD_UNIT restart did not produce a new process identity" >&2
+      exit 1
+    fi
+    if [ "$DASHBOARD_CWD" != "$RELEASE_DIR" ]; then
+      echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID cwd is '$DASHBOARD_CWD', expected '$RELEASE_DIR'" >&2
+      exit 1
+    fi
+    if [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
+      echo "CRITICAL: activated release SOURCE_COMMIT does not equal full requested SHA" >&2
+      exit 1
+    fi
+    case "$DASHBOARD_CMDLINE" in
+      *"$RELEASE_DIR/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*) : ;;
+      *)
+        echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line" >&2
+        exit 1
+        ;;
+    esac
+    echo "[remote] $DASHBOARD_UNIT active: MainPID=$DASHBOARD_PID start=$DASHBOARD_START previous_pid=$DASHBOARD_PREV_PID previous_start=$DASHBOARD_PREV_START cwd=$DASHBOARD_CWD source=$FULL_COMMIT"
+
+    # Semantic dashboard gate: listener + valid JSON + bounded/no-leak fields.
+    DASHBOARD_SOCKET_PID="$(ss -ltnpH 2>/dev/null | sed -n 's/.*pid=\([0-9]*\),.*/\1/p' | head -n 1)"
+    if [ "$DASHBOARD_SOCKET_PID" != "$DASHBOARD_PID" ]; then
+      echo "CRITICAL: :8080 is not owned by dashboard PID $DASHBOARD_PID" >&2
+      exit 1
+    fi
+    if ! ss -ltnH | awk '$4 ~ /:8080$/ {found=1} END {exit !found}'; then
+      echo "CRITICAL: dashboard listener :8080 is not active" >&2
+      exit 1
+    fi
+    DASHBOARD_HEALTH="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/health)"
+    DASHBOARD_METRICS="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics)"
+    DASHBOARD_HEALTH="$DASHBOARD_HEALTH" DASHBOARD_METRICS="$DASHBOARD_METRICS" python3 - <<'PY'
+import json
+import os
+
+health = json.loads(os.environ["DASHBOARD_HEALTH"])
+metrics = json.loads(os.environ["DASHBOARD_METRICS"])
+required_health = {"overall", "dimensions", "goal", "active_task", "reward_average"}
+required_metrics = {"goal", "active_task", "approval_gate_state", "reward_source"}
+for payload, required in ((health, required_health), (metrics, required_metrics)):
+    if not all(isinstance(payload.get(key), (str, dict, int, float, list)) for key in required):
+        raise SystemExit("dashboard endpoint has invalid bounded field types")
+if not required_health <= health.keys() or not isinstance(health["dimensions"], dict):
+    raise SystemExit("dashboard health JSON missing bounded fields")
+if not required_metrics <= metrics.keys():
+    raise SystemExit("dashboard metrics JSON missing bounded fields")
+raw_markers = ("evolution-", "materialized-cycle-", "reward_signal")
+payload = json.dumps({"health": health, "metrics": metrics}, sort_keys=True)
+if any(marker in payload for marker in raw_markers):
+    raise SystemExit("dashboard endpoint contains raw retired artifact payload")
+for key in ("goal_source", "active_task_source", "approval_gate_source", "reward_source"):
+    source = metrics.get(key)
+    if not isinstance(source, dict) or not {"status", "age_hours", "authoritative", "context_only"} <= source.keys():
+        raise SystemExit("dashboard endpoint missing bounded source metadata")
+if metrics.get("latest_report_path") is not None or metrics.get("materialized_path") is not None:
+    raise SystemExit("dashboard endpoint exposes an artifact path")
+PY
+  elif [ "$DASHBOARD_UNIT_STATE" = "disabled" ] || [ "$DASHBOARD_UNIT_STATE" = "masked" ]; then
+    echo "NOTICE: $DASHBOARD_UNIT is $DASHBOARD_UNIT_STATE; preserving state"
+  else
+    echo "CRITICAL: $DASHBOARD_UNIT is loaded but not enabled (state: $DASHBOARD_UNIT_STATE)" >&2
+    exit 1
+  fi
+elif [ "$DASHBOARD_LOAD_STATE" = "not-found" ] || [ -z "$DASHBOARD_LOAD_STATE" ]; then
+  echo "NOTICE: $DASHBOARD_UNIT is not found; preserving absence"
+else
+  echo "CRITICAL: unexpected $DASHBOARD_UNIT LoadState=$DASHBOARD_LOAD_STATE" >&2
+  exit 1
+fi
+
+trap - ERR
 # Ensure bridge service is restarted correctly
 sudo systemctl restart eeepc-self-evolving-subagent-bridge.service
 
@@ -385,8 +505,7 @@ while :; do
   if [ -n "$TRACEBACK_LINE" ]; then
     log "FAIL: Traceback or error observed in journal:"
     echo "$TRACEBACK_LINE"
-    log "Rolling back to $PREV_RELEASE_PATH..."
-    ssh "ozand@${HOST}" "sudo ln -sfn \"$PREV_RELEASE_PATH\" /opt/eeepc-agent/runtimes/self-evolving-agent/current && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service"
+    rollback_release
     log "Rollback complete."
     exit 1
   fi
@@ -401,8 +520,7 @@ while :; do
   if [ -n "$MAIN_PID_EXIT" ]; then
     log "FAIL: Bridge process crashed:"
     echo "$MAIN_PID_EXIT"
-    log "Rolling back to $PREV_RELEASE_PATH..."
-    ssh "ozand@${HOST}" "sudo ln -sfn \"$PREV_RELEASE_PATH\" /opt/eeepc-agent/runtimes/self-evolving-agent/current && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service"
+    rollback_release
     exit 1
   fi
 
@@ -425,8 +543,7 @@ while :; do
     if [ -n "$STREAK_FAIL_TS" ] && [[ "$STREAK_FAIL_TS" > "$FLIP_TS" ]]; then
       log "FAIL: bridge exit recorder shows a failure after the flip (consecutive_failures=${STREAK_N:-?}, last_failure_ts=$STREAK_FAIL_TS):"
       echo "$STREAK_RAW" | grep -E '"last_(error|where|exit_status)"' || true
-      log "Rolling back to $PREV_RELEASE_PATH..."
-      ssh "ozand@${HOST}" "sudo ln -sfn \"$PREV_RELEASE_PATH\" /opt/eeepc-agent/runtimes/self-evolving-agent/current && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service"
+      rollback_release
       exit 1
     fi
     if [ -n "$STREAK_OK_TS" ] && [[ "$STREAK_OK_TS" > "$FLIP_TS" ]] && [ "${STREAK_N:-0}" = "0" ]; then

--- a/tests/test_deploy_integrity.py
+++ b/tests/test_deploy_integrity.py
@@ -60,6 +60,15 @@ def test_deploy_script_fail_closed_and_ghost_cleanup() -> None:
     assert "sudo rm -f /etc/systemd/system/eeepc-network-fallback.timer /etc/systemd/system/eeepc-network-fallback.service" in content
     assert '"CRITICAL: $ghost_unit is still active after purge"' in content
 
+    # #1236: a long-running dashboard must restart after current activation,
+    # while rollback restores it before restarting the bridge.
+    assert 'DASHBOARD_UNIT=eeebot-dashboard.service' in content
+    assert 'sudo systemctl restart "$DASHBOARD_UNIT"' in content
+    assert 'systemctl show "$DASHBOARD_UNIT" -p MainPID --value' in content
+    assert 'readlink "/proc/$DASHBOARD_PID/cwd"' in content
+    assert 'sudo systemctl restart eeebot-dashboard.service && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service' in content
+    assert content.index('updating current symlink') < content.index('sudo systemctl restart "$DASHBOARD_UNIT"') < content.index('Ensure bridge service is restarted correctly')
+
     # Timer synchronization honors disabled units and verifies both enabled and active states
     assert "sync_timer" in content
     assert "administratively disabled" in content

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -210,8 +210,9 @@ def test_dashboard_activation_verifies_pid_release_identity(repo, mock_bin):
     assert 'cwd is' in content
     assert 'activated release SOURCE_COMMIT' in content
     assert 'unexpected command line' in content
-    assert 'DASHBOARD_SOCKET_PID=' in content
-    assert 'not owned by dashboard PID' in content
+    assert 'DASHBOARD_SOCKET_PIDS=' in content
+    assert 'DASHBOARD_SOCKET_PID_COUNT=' in content
+    assert 'exactly one owner, dashboard PID' in content
     assert 'dashboard endpoint missing bounded source metadata' in content
 
 

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -1,10 +1,11 @@
 import os
 import shlex
+import shutil
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
 import pytest
-import shutil
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_SCRIPT = REPO_ROOT / "host" / "eeepc" / "scripts" / "deploy_release.sh"
@@ -37,12 +38,12 @@ def repo(tmp_path):
     # author's worktree passed only on that machine and turned CI red on main.
     test_script = script_dir / "deploy_release.sh"
     shutil.copy(DEPLOY_SCRIPT, test_script)
-    
+
     _git("init", cwd=repo_root, check=True)
     (repo_root / "README").write_text("hello")
     _git("add", ".", cwd=repo_root, check=True)
     _git("commit", "-m", "init", cwd=repo_root, check=True)
-    
+
     return repo_root
 
 def _write_mock(path, body):
@@ -82,7 +83,17 @@ def run_deploy(repo_root, mock_bin, args):
     return res
 
 def set_ssh_mock(mock_bin, script_content):
-    _write_mock(mock_bin / "ssh", script_content)
+    # The deploy captures the current release before running the remote
+    # heredoc. Give every scenario a rollback target unless it explicitly
+    # overrides this preflight response.
+    wrapper = f'''
+    if [[ "$*" == *"readlink /opt/eeepc-agent/runtimes/self-evolving-agent/current"* ]]; then
+        echo /opt/eeepc-agent/runtimes/self-evolving-agent/releases/previous-good
+        exit 0
+    fi
+    {script_content}
+    '''
+    _write_mock(mock_bin / "ssh", wrapper)
 
 
 def _journal_replay_mock(*journal_lines):
@@ -159,26 +170,62 @@ def test_a_local_head_not_origin_main(repo, tmp_path, mock_bin):
     _git("clone", "--bare", str(repo), str(tmp_path / "origin.git"), check=True)
     _git("remote", "add", "origin", str(tmp_path / "origin.git"), cwd=repo, check=True)
     _git("fetch", "origin", cwd=repo, check=True)
-    
+
     (repo / "file").write_text("diverge")
     _git("add", "file", cwd=repo, check=True)
     _git("commit", "-m", "diverge", cwd=repo, check=True)
-    
+
     res = run_deploy(repo, mock_bin, [])
     assert res.returncode != 0
     assert "refuse" in (res.stdout + res.stderr).lower()
+
+def test_dashboard_activation_and_rollback_are_in_deploy_script(repo, mock_bin):
+    content = (repo / "host" / "eeepc" / "scripts" / "deploy_release.sh").read_text()
+    assert 'DASHBOARD_UNIT=eeebot-dashboard.service' in content
+    assert 'sudo systemctl restart "$DASHBOARD_UNIT"' in content
+    assert 'systemctl show "$DASHBOARD_UNIT" -p MainPID --value' in content
+    assert 'readlink "/proc/$DASHBOARD_PID/cwd"' in content
+    assert 'sudo systemctl restart eeebot-dashboard.service && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service' in content
+    assert content.index("updating current symlink") < content.index('sudo systemctl restart "$DASHBOARD_UNIT"')
+    assert content.index('sudo systemctl restart "$DASHBOARD_UNIT"') < content.index("Ensure bridge service is restarted correctly")
+
+
+def test_dashboard_activation_fails_when_enabled_unit_restart_fails(repo, mock_bin):
+    content = (repo / "host" / "eeepc" / "scripts" / "deploy_release.sh").read_text()
+    assert 'if ! systemctl is-active --quiet "$DASHBOARD_UNIT"' in content
+    assert 'CRITICAL: $DASHBOARD_UNIT is not active after restart' in content
+    assert 'curl --fail --silent --show-error http://127.0.0.1:8080/api/health' in content
+    assert 'curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics' in content
+    assert 'dashboard listener :8080 is not active' in content
+
+
+def test_dashboard_activation_verifies_pid_release_identity(repo, mock_bin):
+    content = (repo / "host" / "eeepc" / "scripts" / "deploy_release.sh").read_text()
+    assert 'DASHBOARD_PID=' in content
+    assert 'DASHBOARD_PREV_PID=' in content
+    assert 'DASHBOARD_START=' in content
+    assert 'DASHBOARD_PREV_START=' in content
+    assert 'DASHBOARD_CWD=' in content
+    assert 'DASHBOARD_CMDLINE=' in content
+    assert 'cwd is' in content
+    assert 'activated release SOURCE_COMMIT' in content
+    assert 'unexpected command line' in content
+    assert 'DASHBOARD_SOCKET_PID=' in content
+    assert 'not owned by dashboard PID' in content
+    assert 'dashboard endpoint missing bounded source metadata' in content
+
 
 def test_b_ref_deploys_exact_sha(repo, tmp_path, mock_bin):
     _git("branch", "-M", "main", cwd=repo, check=True)
     _git("clone", "--bare", str(repo), str(tmp_path / "origin.git"), check=True)
     _git("remote", "add", "origin", str(tmp_path / "origin.git"), cwd=repo, check=True)
     _git("fetch", "origin", cwd=repo, check=True)
-    
+
     (repo / "file").write_text("diverge")
     _git("add", "file", cwd=repo, check=True)
     _git("commit", "-m", "diverge", cwd=repo, check=True)
     commit_sha = _git("rev-parse", "--short", "HEAD", cwd=repo, capture_output=True, text=True).stdout.strip()
-    
+
     set_ssh_mock(mock_bin, "exit 0")
     res = run_deploy(repo, mock_bin, ["--ref", commit_sha, "--no-health-gate"])
     assert res.returncode == 0


### PR DESCRIPTION
Clean replacement for the stale #1237 branch.

Base: current `origin/main` at `97cb973a`. Deploy-only scope:
- restart enabled dashboard after current activation;
- verify full SHA/SOURCE_COMMIT, pre/post PID/start, cwd and exact command line;
- verify dashboard PID owns :8080 and `/api/health` + `/api/metrics` contain bounded source metadata and no retired payload/path markers;
- rollback immediately on post-flip activation, bridge, or gate failure, restarting dashboard before bridge.

Files are limited to `host/eeepc/scripts/deploy_release.sh`, `tests/test_deploy_integrity.py`, and `tests/test_deploy_release.py`. No dashboard application, provider, scheduler, state, or unrelated unit changes.

Focused deploy tests: 24 passed; bash -n, Ruff, and diff check passed. No host rollout included; independent review required.