### PR TITLE
fix(demand): write the doc_only_budget row on change, deferral and once per cycle (#1238)

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -397,6 +397,39 @@ def doc_only_budget_24h() -> int:
         return _DEFAULT_DOC_ONLY_24H_BUDGET
 
 
+# #1238: the ``doc_only_budget`` ledger row was 27% of the live ledger because
+# ``collect_demand`` runs two-to-three times per bridge invocation (gate probe
+# + context build) and appended the row on every pass, restating an unchanged
+# state. What carries information is a *change* of state plus one heartbeat
+# per cycle, so the row is written when the state differs from the last row
+# written in this process, always when something was deferred, and once at
+# process start. The bridge is a ``Type=oneshot`` unit — one process per
+# invocation — so "this process" is "this cycle", the same reasoning as
+# ``llm_proposer._record_idle``. Process memory is the only thing cheaper than
+# the row it suppresses: no state file, no scan, no read on the write path.
+# Keyed by state_dir so independent state roots (test fixtures) never share
+# a memo. Value: ``[state_tuple, passes_folded_since_last_written_row]``.
+_doc_budget_last_row: dict[str, list] = {}
+
+
+def _doc_budget_row_due(state_dir: Path, state: tuple[bool, bool, bool]) -> int:
+    """Return the number of passes a row written now would stand for, or 0
+    when the pass restates the last row and should be folded into the next.
+
+    ``state`` is ``(doc_budget_exceeded, ledger_blind, doc_only_deferred > 0)``.
+    A pass that deferred anything is always due — a deferral is never a no-op.
+    """
+    key = str(state_dir)
+    memo = _doc_budget_last_row.get(key)
+    deferred = state[2]
+    if memo is not None and not deferred and memo[0] == state:
+        memo[1] += 1
+        return 0
+    passes = 1 + (memo[1] if memo is not None else 0)
+    _doc_budget_last_row[key] = [state, 0]
+    return passes
+
+
 def count_doc_only_integrations_24h(state_dir: Path, now: datetime | None = None) -> int:
     """Count doc-only ``outcome: success`` rows in the last 24 h across the live
     ledger and its rotated day archives (``state_access.ledger_window``, #1175).
@@ -2884,17 +2917,24 @@ def collect_demand(
         # doc-only budget's ledger row.
         items_considered = len(post_doc_guard) + doc_only_deferred
         result = _apply_futile_surfaces(state_dir, post_doc_guard)
-        from nanobot.runtime.cycle_ledger import append_event
+        # #1238: one row per state change, per deferral and per invocation —
+        # not per pass. ``passes`` says how many passes the row stands for.
+        passes = _doc_budget_row_due(
+            state_dir, (doc_budget_exceeded, ledger_blind, doc_only_deferred > 0)
+        )
+        if passes:
+            from nanobot.runtime.cycle_ledger import append_event
 
-        append_event(state_dir, {
-            "phase": "doc_only_budget",
-            "doc_only_deferred": doc_only_deferred,
-            "doc_only_integrations_24h": doc_count_24h,
-            "doc_only_budget_24h": doc_budget,
-            "ledger_blind": ledger_blind,
-            "doc_budget_exceeded": doc_budget_exceeded,
-            "items_considered": items_considered,
-        })
+            append_event(state_dir, {
+                "phase": "doc_only_budget",
+                "doc_only_deferred": doc_only_deferred,
+                "doc_only_integrations_24h": doc_count_24h,
+                "doc_only_budget_24h": doc_budget,
+                "ledger_blind": ledger_blind,
+                "doc_budget_exceeded": doc_budget_exceeded,
+                "items_considered": items_considered,
+                "passes": passes,
+            })
 
         # #815: best-effort, operator-visible V1-vs-V2 split of what's
         # actually presented — never affects the returned list. Opt-in

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -3490,3 +3490,126 @@ class TestIssue1108DenominatorExcludesLaterFilters:
         assert record["items_considered"] == 3, (
             "the futile-surface drop was charged to the doc-only budget's denominator"
         )
+
+
+class TestIssue1238DocBudgetRowVolume:
+    """The ``doc_only_budget`` row is written when it says something, not on
+    every pass (#1238). ``collect_demand`` runs two-to-three times per bridge
+    invocation; before this the row was appended each time and became 27% of
+    the live ledger. The constraint is two-sided: fewer rows, but "reached and
+    deferring nothing" must stay visible (#1108), so the first pass of a
+    process always writes and any deferral always writes.
+    """
+
+    @staticmethod
+    def _doc_rows(state_dir: Path) -> list[dict]:
+        path = state_dir / "ledger" / "cycles.jsonl"
+        if not path.is_file():
+            return []
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        return [r for r in rows if r.get("phase") == "doc_only_budget"]
+
+    @staticmethod
+    def _arrange(monkeypatch, *, items, integrations_24h, blind=False):
+        monkeypatch.setattr(demand, "_priority_items", lambda *args, **kwargs: list(items))
+        monkeypatch.setattr(
+            demand, "count_doc_only_integrations_24h", lambda *args, **kwargs: integrations_24h
+        )
+        monkeypatch.setenv("EEEBOT_DOC_ONLY_24H_BUDGET", "5")
+        rows = demand.LedgerRows()
+        if blind:
+            rows.status = "unavailable"
+            rows.notes = ("test",)
+        monkeypatch.setattr(demand, "_load_ledger_rows", lambda *args, **kwargs: rows)
+
+    def test_unchanged_state_deferring_nothing_writes_one_row_per_process(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        code_item = demand._make_item("priority", "Priority 1 — scripts/worker.py", "Improve scripts/worker.py")
+        self._arrange(monkeypatch, items=[code_item], integrations_24h=5)
+
+        for _ in range(3):
+            assert [i["id"] for i in demand.collect_demand(state_dir, None)] == [code_item["id"]]
+
+        rows = self._doc_rows(state_dir)
+        assert len(rows) == 1
+        assert rows[0]["doc_only_deferred"] == 0
+        assert rows[0]["doc_budget_exceeded"] is True
+        assert rows[0]["passes"] == 1
+
+    def test_every_deferring_pass_writes_with_the_count(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        doc_item = demand._make_item("priority", "Priority 1 — docs/runbook.md", "Update docs/runbook.md")
+        self._arrange(monkeypatch, items=[doc_item], integrations_24h=5)
+
+        for _ in range(3):
+            assert demand.collect_demand(state_dir, None) == []
+
+        rows = self._doc_rows(state_dir)
+        assert len(rows) == 3
+        assert [r["doc_only_deferred"] for r in rows] == [1, 1, 1]
+        assert [r["passes"] for r in rows] == [1, 1, 1]
+
+    def test_every_transition_direction_writes(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        code_item = demand._make_item("priority", "Priority 1 — scripts/worker.py", "Improve scripts/worker.py")
+
+        # exceeded 0 -> 1 -> 0, then blind 0 -> 1 -> 0, each step run twice so
+        # the second pass of every state is the one that must be folded.
+        steps = [
+            dict(integrations_24h=0, blind=False),  # first pass: heartbeat
+            dict(integrations_24h=5, blind=False),  # exceeded 0 -> 1
+            dict(integrations_24h=0, blind=False),  # exceeded 1 -> 0
+            dict(integrations_24h=0, blind=True),   # blind 0 -> 1 (exceeded follows)
+            dict(integrations_24h=0, blind=False),  # blind 1 -> 0
+        ]
+        for step in steps:
+            self._arrange(monkeypatch, items=[code_item], **step)
+            demand.collect_demand(state_dir, None)
+            demand.collect_demand(state_dir, None)
+
+        rows = self._doc_rows(state_dir)
+        assert [(r["doc_budget_exceeded"], r["ledger_blind"]) for r in rows] == [
+            (False, False),
+            (True, False),
+            (False, False),
+            (True, True),
+            (False, False),
+        ]
+        # Each written row stands for itself plus the one folded pass before it.
+        assert [r["passes"] for r in rows] == [1, 2, 2, 2, 2]
+
+    def test_reached_and_deferring_nothing_is_distinct_from_never_reached_and_no_data(self, tmp_path, monkeypatch):
+        # Never reached: no collect_demand pass -> no row at all.
+        untouched = _state_dir(tmp_path / "untouched")
+        assert self._doc_rows(untouched) == []
+
+        # Reached, deferring nothing: exactly one row saying so.
+        reached = _state_dir(tmp_path / "reached")
+        code_item = demand._make_item("priority", "Priority 1 — scripts/worker.py", "Improve scripts/worker.py")
+        self._arrange(monkeypatch, items=[code_item], integrations_24h=5)
+        demand.collect_demand(reached, None)
+        [row] = self._doc_rows(reached)
+        assert row["doc_only_deferred"] == 0
+        assert row["doc_budget_exceeded"] is True
+        assert row["ledger_blind"] is False
+
+        # No data: the ledger could not be read — its own row, its own flag.
+        blind = _state_dir(tmp_path / "blind")
+        self._arrange(monkeypatch, items=[code_item], integrations_24h=0, blind=True)
+        demand.collect_demand(blind, None)
+        [row] = self._doc_rows(blind)
+        assert row["ledger_blind"] is True
+        assert row["doc_budget_exceeded"] is True
+
+    def test_dashboard_fields_are_unchanged_and_passes_is_additive(self, tmp_path, monkeypatch):
+        """ozand/eeebot-ops-dashboard #201 reads these six names by ``.get``."""
+        state_dir = _state_dir(tmp_path)
+        code_item = demand._make_item("priority", "Priority 1 — scripts/worker.py", "Improve scripts/worker.py")
+        self._arrange(monkeypatch, items=[code_item], integrations_24h=2)
+        demand.collect_demand(state_dir, None)
+        [row] = self._doc_rows(state_dir)
+        assert {
+            "doc_only_deferred", "doc_only_integrations_24h", "doc_only_budget_24h",
+            "ledger_blind", "doc_budget_exceeded", "items_considered",
+        } <= set(row)
+        assert row["passes"] == 1


### PR DESCRIPTION
Tracks #1238 (stays open at `status:roll-out` until the live rows-per-cycle measurement is quoted there).

## What

`collect_demand` appended the `doc_only_budget` ledger row on every pass, and it runs two-to-three times per bridge invocation (gate probe in `should_propose` + context build in `propose`). Measured on the host: 140 rows against 49 `outcome` rows, 27% of the live ledger, nearly all `doc_only_deferred: 0` with unchanged budget state.

Now the row is written when it says something:

| condition | writes? |
|---|---|
| `doc_only_deferred > 0` | always — a deferral is never a no-op |
| first pass in this process | yes — the per-cycle heartbeat that keeps "reached, deferring nothing" visible (#1108) |
| `(doc_budget_exceeded, ledger_blind, doc_only_deferred > 0)` differs from the last row written in this process | yes — all four transition directions |
| otherwise | no; the pass is counted and folded into the next written row |

New additive field `passes` (int ≥ 1): how many passes the row stands for — itself plus the identical passes folded since the previous row in this invocation.

## Why this shape

The memory that remembers the last row is a module-level dict keyed by `str(state_dir)` — the same mechanism `llm_proposer._record_idle` already uses for its once-per-cycle idle heartbeat (#760). The bridge unit is `Type=oneshot`, one process per invocation (≤55 min by `TimeoutStartSec`), so "this process" is "this cycle". Zero I/O: no state file, no scan, nothing added to the write path — process memory is the only thing cheaper than the row it suppresses.

The process boundary *is* the heartbeat: the first pass of every invocation writes because the memo is empty. That is what keeps silence unambiguous — a cycle that reached the guard and deferred nothing still leaves a row with `doc_only_deferred: 0`, distinct from no row (never reached) and from `ledger_blind: true` (no data).

**Rejected:** writing only on the `emit_split=True` pass (#815's once-per-cycle trick) — the gate-probe pass is the one that runs in idle cycles; if it defers nothing the context build never happens, the row is lost, and #1108 reopens. Seeding the memo from the already-loaded in-memory `ledger_rows` would also work at zero I/O but removes the per-cycle heartbeat in exchange for nothing the issue asked for.

**Stated limitation:** passes folded *after* the last written row of a process are never reported — the process exits before another row is due. Today that is ≤2 identical passes per invocation; it is the volume being removed, not information about the guard.

## Effect on row count

Steady state: ~2.9 rows per invocation → **1**. Deferring invocations: one row per deferring pass (unchanged by design). Transitions: one extra row each. Live check owed after deploy: `doc_only_budget` rows per `outcome` row over a natural window, quoted on #1238 against today's 140:49.

## Compatibility — `ozand/eeebot-ops-dashboard` #201 (merged, `4457cd8`)

`scripts/techtree_viewer.py::_build_doc_only_budget_item` takes the latest `phase == 'doc_only_budget'` row from `ledger_tail` by reversed scan and reads `ledger_blind`, `doc_only_deferred`, `doc_only_integrations_24h`, `doc_only_budget_24h`, `doc_budget_exceeded`, `items_considered` via `.get`. No schema check, no row aging. All six keep name and meaning; `passes` is additive and ignored there. Fewer duplicates means the bounded `ledger_tail` reaches further back, which only helps that panel. Pinned by `test_dashboard_fields_are_unchanged_and_passes_is_additive`.

## Not changed

The guard, `N=5`, the classifier, `count_doc_only_integrations_24h`, every existing field, `items_considered`'s denominator (#1226 fix intact — its test still passes).

## Tests — the four acceptance criteria (`tests/test_demand.py::TestIssue1238DocBudgetRowVolume`)

1. `test_unchanged_state_deferring_nothing_writes_one_row_per_process` — three passes, unchanged, nothing deferred → one row, `passes: 1`.
2. `test_every_deferring_pass_writes_with_the_count` — three deferring passes → three rows, each `doc_only_deferred: 1`.
3. `test_every_transition_direction_writes` — `exceeded` 0→1, 1→0 and `blind` 0→1, 1→0, each state run twice → five rows (heartbeat + four transitions), `passes` = `[1, 2, 2, 2, 2]`.
4. `test_reached_and_deferring_nothing_is_distinct_from_never_reached_and_no_data` — no row / `deferred: 0` row / `ledger_blind: true` row are three different things.

Plus `test_dashboard_fields_are_unchanged_and_passes_is_additive`. The three pre-existing doc-guard row tests (#1108, #1175, #1226) pass unchanged — they all defer, so they always write.

## Full suite (Windows, `python -m pytest tests/`)

**4 failed, 2970 passed, 17 skipped** (1164s), CI 3.11/3.12/3.13 pass.

```
tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle
tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free
tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended
tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock
```

Expected baseline is exactly these 4 `fcntl.flock`-dependent bridge tests (set by #1235). CI (ubuntu) 3.11/3.12/3.13: see checks.

## Files

- `nanobot/runtime/demand.py` — `_doc_budget_last_row` memo + `_doc_budget_row_due`; the write site gated on it and carrying `passes`.
- `tests/test_demand.py` — `TestIssue1238DocBudgetRowVolume` (5 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
