### PR TITLE
fix(dashboard): stop nesting the sanitized reward label inside itself

### DIFF
--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -1670,7 +1670,16 @@ def _build_health_dimensions(m: dict[str, Any]) -> list[tuple[str, str, str]]:
     reward_momentum = m["reward_momentum"]
     report_status = m.get("latest_report_artifact_status", "unavailable")
     reward_health = "OK" if report_status == "fresh" and "no recent" not in reward_avg else "WARN"
-    reward_detail = f"{reward_avg} ({reward_momentum}); source={report_status}"
+    # `sanitize_public_metrics` replaces average, momentum and range with one
+    # shared source label when the report family is not authoritative, so the
+    # parenthetical would nest that label inside itself:
+    #   "stale; age=302.5h (context-only artifact) (stale; age=302.5h (...))"
+    # Momentum is only worth printing when it says something the average does not.
+    reward_detail = (
+        f"{reward_avg}; source={report_status}"
+        if reward_momentum == reward_avg
+        else f"{reward_avg} ({reward_momentum}); source={report_status}"
+    )
     dims.append(("reward", reward_health, reward_detail))
 
     # Gate health: materialized snapshots have no live writer in this dashboard.

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -321,3 +321,38 @@ def test_dashboard_documents_live_source_of_truth_decision() -> None:
     assert "Source-of-truth decision (#1206)" in source
     assert "retired report/materialized artifacts" in source
     assert "labelled stale or unavailable" in source
+
+
+def test_sanitized_reward_label_is_not_nested_inside_itself() -> None:
+    """`sanitize_public_metrics` collapses average, momentum and range to one label.
+
+    When the report family is not authoritative it writes the same
+    "stale; age=Nh (context-only artifact)" string into `reward_average` and
+    `reward_momentum`. The health detail used to interpolate both, producing the
+    label nested in its own parenthetical — observed live on :8080 as
+    "stale; age=302.5h (context-only artifact) (stale; age=302.5h (context-only
+    artifact)); source=stale". Momentum is only worth printing when it says
+    something the average does not.
+    """
+    label = "stale; age=302.5h (context-only artifact)"
+    metrics = _health_metrics(report_status="stale", materialized_status="stale")
+    metrics["reward_average"] = label
+    metrics["reward_momentum"] = label
+
+    dimensions = DASHBOARD._build_health_dimensions(metrics)
+    detail = {name: detail for name, _status, detail in dimensions}["reward"]
+
+    assert detail == f"{label}; source=stale"
+    assert detail.count("context-only artifact") == 1, detail
+    assert "(stale;" not in detail
+
+
+def test_distinct_momentum_is_still_shown() -> None:
+    """The collapse must not swallow a momentum that carries its own information."""
+    metrics = _health_metrics(report_status="fresh", materialized_status="fresh")
+    dimensions = DASHBOARD._build_health_dimensions(metrics)
+    detail = {name: detail for name, _status, detail in dimensions}["reward"]
+
+    assert "0.88 avg over 5 sample(s)" in detail
+    assert "up +0.40 vs previous" in detail
+    assert detail == "0.88 avg over 5 sample(s) (up +0.40 vs previous); source=fresh"


### PR DESCRIPTION
Follow-up to #1234, found while verifying #1206 on the live dashboard after deploy.

## The defect

`sanitize_public_metrics` replaces `reward_average`, `reward_momentum` and `reward_range` with **one shared source label** when the report family is not authoritative:

```python
for field in ("reward_average", "reward_momentum", "reward_range"):
    sanitized[field] = report_label
```

`_build_health_dimensions` then interpolated the first two into a single string:

```python
reward_detail = f"{reward_avg} ({reward_momentum}); source={report_status}"
```

Both being the same label, it landed inside its own parenthetical. Live on `:8080` after `20260903T132208Z` deployed:

```
"stale; age=302.5h (context-only artifact) (stale; age=302.5h (context-only artifact)); source=stale"
```

## The fix

The parenthetical is printed only when momentum carries something the average does not:

```python
reward_detail = (
    f"{reward_avg}; source={report_status}"
    if reward_momentum == reward_avg
    else f"{reward_avg} ({reward_momentum}); source={report_status}"
)
```

## Tests, both directions

`test_sanitized_reward_label_is_not_nested_inside_itself` asserts the collapsed form and that `"context-only artifact"` appears exactly once. `test_distinct_momentum_is_still_shown` asserts the collapse does not swallow a momentum that means something — the obvious way to "fix" this is to drop the parenthetical unconditionally, which would lose real information whenever the source is fresh.

Mutation-checked rather than assumed: restoring the old one-line interpolation fails the first test and nothing else.

## Why it is worth a PR rather than a note

It is cosmetic, and it is operator-facing on the panel that had just been changed to stop reporting a dead writer as healthy. A value that visibly stutters undermines the thing #1206 was about — an operator reading `WARN` needs the detail beside it to look like it was written on purpose.

It also got in because #1234 was merged without the independent review its own description asked for. Not a process complaint — just where to look if something similar turns up in the same file.

## Validation

- `tests/test_eeebot_dashboard_truth.py`: 18 passed.
- Full pytest: `4 failed, 2967 passed, 17 skipped` — the four are the current Windows baseline by test id (`test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`, and the three `test_bridge_locking.py::TestAcquireBridgeLock` cases). Checked as a list.
- Rebased onto `3522b060` (#1241) and re-verified after the rebase.
