### PR TITLE
fix(deploy): sudo the /proc reads that verify the dashboard restart

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -369,8 +369,16 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     fi
     DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
     DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
-    DASHBOARD_CWD="$(readlink "/proc/$DASHBOARD_PID/cwd" 2>/dev/null || true)"
-    DASHBOARD_CMDLINE="$(tr "\0" " " < "/proc/$DASHBOARD_PID/cmdline" 2>/dev/null || true)"
+    # /proc/<pid>/cwd and cmdline belong to the unit's user, not to the
+    # deploying account, so both reads need sudo. Without it readlink returns
+    # empty and the check below fails a healthy deploy: observed on release
+    # 20260903T141455Z, where the dashboard was correctly running from the new
+    # release and the verification could not see it (#1245).
+    DASHBOARD_CWD="$(sudo readlink "/proc/$DASHBOARD_PID/cwd" 2>/dev/null || true)"
+    # `sudo tr ... < file` would not work: the shell opens the redirect as the
+    # deploying user before sudo runs. The read itself has to be the sudo'd
+    # command.
+    DASHBOARD_CMDLINE="$(sudo cat "/proc/$DASHBOARD_PID/cmdline" 2>/dev/null | tr "\0" " " || true)"
     if [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
       echo "CRITICAL: $DASHBOARD_UNIT restart did not produce a new process identity" >&2
       exit 1

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -517,3 +517,28 @@ def test_r_finished_line_never_outranks_a_crash_in_the_same_window(repo, tmp_pat
     combined = (res.stdout + res.stderr).lower()
     assert res.returncode != 0
     assert "rolling back" in combined and "clean-exit" not in combined, combined
+
+
+def test_proc_reads_for_the_dashboard_use_sudo() -> None:
+    """`/proc/<pid>/cwd` belongs to the unit's user, not the deploying account.
+
+    Release 20260903T141455Z aborted with
+
+        CRITICAL: eeebot-dashboard.service PID 11213 cwd is '', expected '.../releases/...'
+
+    while the dashboard was in fact running from the new release. `readlink`
+    without sudo returns empty for another user's process, and the check read
+    that emptiness as a mismatch — failing a healthy deploy (#1245).
+
+    A redirect cannot carry the privilege either: in `sudo tr ... < /proc/x`
+    the shell opens the file as the deploying user before sudo runs, so the
+    read itself has to be the sudo'd command.
+    """
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'sudo readlink "/proc/$DASHBOARD_PID/cwd"' in script, (
+        "the dashboard cwd read must be sudo'd or it returns empty for another user's process")
+    assert 'sudo cat "/proc/$DASHBOARD_PID/cmdline"' in script, (
+        "the cmdline read must be sudo'd as the command, not behind a shell redirect")
+    assert '$(sudo tr' not in script, (
+        'a sudo tr behind a shell redirect opens the file as the unprivileged user')


### PR DESCRIPTION
Closes #1246. Full detail there; the short version:

`/proc/<pid>/cwd` belongs to the unit's user, so `readlink` as the deploying account returns empty and #1242's post-restart check reads that emptiness as a mismatch. Every deploy has aborted since that merge — after flipping `current`, so the health gate is skipped too.

```
$ readlink /proc/11213/cwd            ->  (empty)
$ sudo readlink /proc/11213/cwd       ->  .../releases/20260903T141455Z-canonical-b45fb3e4
```

The dashboard was running from the new release the whole time. Both forms verified against the live host before writing the fix.

The cmdline read has the same problem and prefixing sudo alone does not fix it: in `sudo tr ... < /proc/x` the shell opens the redirect as the deploying user before sudo runs, so the read itself is now `sudo cat ... | tr`.

**Tests:** `test_proc_reads_for_the_dashboard_use_sudo` pins both forms; mutation-checked — dropping either sudo fails it and nothing else. `tests/test_deploy_release.py` + `tests/test_deploy_integrity.py`: 25 passed.

**Not fixed here:** the rollback trap did not fire on this abort, because `set -E` is absent and the `exit 1` is inside a shell function. It failed safe — the healthy new release stayed active — but the coverage is narrower than #1242's comments claim. Tracked as the last item on #1246.