### PR TITLE
docs(agents): one open PR per issue — rework goes to the same branch (#1244)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,14 @@ scale labels are enough).
 - Run `git status --short --branch` + `git fetch --all --prune` before edits.
 - Classify dirty files as task-related vs unrelated; never mix unrelated edits into
   one branch/PR. Re-check `git diff <base>...HEAD` before opening a PR.
+- **One open PR per issue.** Rework of an open PR — a stale base, review findings,
+  a branch that picked up unrelated edits — goes to the **same** branch: `git rebase
+  origin/main`, fix, `git push --force-with-lease`. Open a replacement branch only
+  when the old one cannot be repaired, and close the predecessor PR in the same
+  step with a comment naming the replacement. Suffixes such as `-v2`, `-clean`,
+  `-final`, `-reconciled` are the symptom this rule exists for (#1244). Before
+  reporting, this must print `[]`:
+  `gh pr list --state open --json number,headRefName --jq '[.[] | {n: (.headRefName | capture("(?<n>[0-9]{3,4})").n // "none"), pr: .number}] | group_by(.n) | map(select(length > 1))'`
 - Assume concurrent rename edits may land nearby; keep edits minimal and task-local;
   do not reintroduce legacy naming in new code unless compatibility requires it.
 


### PR DESCRIPTION
Diagnosis and the only change it justifies for #1244. Full evidence in the issue comment.

## Finding

**No in-repo code path decides a retry branch name.** `nanobot/runtime/bridge.py::_setup_cycle_branch` (L583–L619) names only `selfevo/cycle-<id>` and `_integrate_cycle_to_main` (L694) pushes `main` with `--force-with-lease`; no `-v2`/`-clean`/`-final`/`-reconciled` anywhere in `nanobot/`, `scripts/`, `host/`. The suffixed branches are the dev fleet's (all PRs by `ozand`, commits by "Andrey Oz"), not the runtime's. No prompt says it either: pi's `merge-resolver` rebases in place; its `implement-issue` prompt says "work on a branch, open a PR, on conflict use merge-resolver"; the reviewer never asked for a new branch on #1206 or #1236.

The habit: the agent's worktree falls behind `main` (bases 4–50 commits behind), it re-branches from current `main`, re-applies, opens a new PR, and leaves the old one open — the operator closed #1237 and #1233 by hand. #1233 called #1229 "contaminated"; #1229's file list was exactly the two task files.

## Change

One bullet in `AGENTS.md` "Working tree and branch safety": rework goes to the same branch (`rebase origin/main` + `push --force-with-lease`); a replacement branch must close its predecessor in the same step; and the `gh` one-liner that makes open-PRs-per-issue checkable (prints `[]` on live data now). Docs only — no runtime code, so no full-suite run; the 5 test files that mention `AGENTS.md` pass (123 passed).

## Not done, on purpose

No branch deleted. Candidates with per-branch evidence are in the issue comment; #1245 is an open duplicate of merged #1242 plus one comment line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)