### PR TITLE
fix(deploy): match the dashboard command line against current, not a release dir

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -391,10 +391,16 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
       echo "CRITICAL: activated release SOURCE_COMMIT does not equal full requested SHA" >&2
       exit 1
     fi
+    # The unit's ExecStart names the `current` symlink, not a release directory
+    # — that indirection is what a release flip is. So the command line can
+    # never contain $RELEASE_DIR, and asserting it did failed every deploy
+    # (#1246). What binds this process to the new release is the cwd check
+    # above, which resolves the symlink; this one only asserts the unit is
+    # running the script and arguments we expect.
     case "$DASHBOARD_CMDLINE" in
-      *"$RELEASE_DIR/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*) : ;;
+      *"/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*) : ;;
       *)
-        echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line" >&2
+        echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line: $DASHBOARD_CMDLINE" >&2
         exit 1
         ;;
     esac

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -542,3 +542,29 @@ def test_proc_reads_for_the_dashboard_use_sudo() -> None:
         "the cmdline read must be sudo'd as the command, not behind a shell redirect")
     assert '$(sudo tr' not in script, (
         'a sudo tr behind a shell redirect opens the file as the unprivileged user')
+
+
+def test_dashboard_cmdline_check_matches_the_current_symlink_not_a_release_dir() -> None:
+    """The unit's ExecStart names `current`; a release path can never appear.
+
+    Release 20260903T142719Z aborted on
+
+        CRITICAL: eeebot-dashboard.service PID 14387 has unexpected command line
+
+    because the check required the command line to contain `$RELEASE_DIR`,
+    while the host's ExecStart is
+
+        .../venv/bin/python3 .../self-evolving-agent/current/scripts/eeebot_dashboard.py
+            --serve --port 8080 --host 0.0.0.0
+
+    That indirection is what a release flip *is*, so the assertion contradicted
+    the unit it was checking and could not pass on any deploy (#1246). The
+    binding to the new release is proven by the cwd check, which resolves the
+    symlink; this check only pins the script and its arguments.
+    """
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert '*"/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*' in script, (
+        "the command-line check must match the current symlink the unit actually runs")
+    assert '"$RELEASE_DIR/scripts/eeebot_dashboard.py' not in script, (
+        "a release directory never appears in the dashboard command line")


### PR DESCRIPTION
Second half of #1246. #1247 fixed the cwd read; the deploy then got one check further and failed on the next one:

```
CRITICAL: eeebot-dashboard.service PID 14387 has unexpected command line
```

The check required the command line to contain `$RELEASE_DIR`. The host's ExecStart is:

```
.../venv/bin/python3 .../self-evolving-agent/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0
```

It names `current`. That indirection **is** what a release flip is, so a release directory can never appear there and the assertion could not pass on any deploy. It contradicted the unit it was checking.

The dashboard unit file is not in this repository — it is installed on the host — so the pattern was written from an assumption rather than from the unit. Read from the live host before fixing.

**What still binds the process to the new release:** the cwd check above it, which resolves the symlink (`sudo readlink /proc/<pid>/cwd` → `.../releases/20260903T142719Z-...`). This check now only pins that the unit runs the expected script with the expected arguments — and prints the command line it saw when it does not, which is what would have made the first failure diagnosable from its own output.

**Tests:** `test_dashboard_cmdline_check_matches_the_current_symlink_not_a_release_dir`. `tests/test_deploy_release.py` + `tests/test_deploy_integrity.py`: 26 passed.

**Note on how two deploys were needed to find two checks:** each aborts at the first failure, so the second was invisible until the first was fixed. Both were introduced together by #1242 and neither was exercised before merge — the deploy script's tests do not run a deploy. That is the real gap, and it is worth its own issue rather than a third patch in this series.