### PR TITLE
fix(deploy): sudo the socket read that verifies :8080 has one owner

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -407,12 +407,16 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     echo "[remote] $DASHBOARD_UNIT active: MainPID=$DASHBOARD_PID start=$DASHBOARD_START previous_pid=$DASHBOARD_PREV_PID previous_start=$DASHBOARD_PREV_START cwd=$DASHBOARD_CWD source=$FULL_COMMIT"
 
     # Semantic dashboard gate: listener + valid JSON + bounded/no-leak fields.
-    DASHBOARD_SOCKET_ROWS="$(ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
+    # `ss -ltnp` prints the owning process only to root: without sudo the
+    # listener row is there but its users:(("python3",pid=...)) field is not,
+    # so the owner count reads 0 and this gate fails a healthy deploy — the
+    # third read in this block to need the privilege it was missing (#1246).
+    DASHBOARD_SOCKET_ROWS="$(sudo ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
     DASHBOARD_LISTENER_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | sed '/^$/d' | wc -l)"
     DASHBOARD_SOCKET_PIDS="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)"
     DASHBOARD_SOCKET_PID_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_PIDS" | sed '/^$/d' | wc -l)"
     if [ "$DASHBOARD_LISTENER_COUNT" != "1" ] || [ "$DASHBOARD_SOCKET_PID_COUNT" != "1" ] || [ "$DASHBOARD_SOCKET_PIDS" != "$DASHBOARD_PID" ]; then
-      echo "CRITICAL: :8080 must have exactly one owner, dashboard PID $DASHBOARD_PID" >&2
+      echo "CRITICAL: :8080 must have exactly one owner, dashboard PID $DASHBOARD_PID; saw listeners=$DASHBOARD_LISTENER_COUNT pids='$DASHBOARD_SOCKET_PIDS'" >&2
       exit 1
     fi
     if ! ss -ltnH | awk '$4 ~ /:8080$/ {found=1} END {exit !found}'; then

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -568,3 +568,26 @@ def test_dashboard_cmdline_check_matches_the_current_symlink_not_a_release_dir()
         "the command-line check must match the current symlink the unit actually runs")
     assert '"$RELEASE_DIR/scripts/eeebot_dashboard.py' not in script, (
         "a release directory never appears in the dashboard command line")
+
+
+def test_socket_owner_check_reads_ss_with_sudo() -> None:
+    """`ss -ltnp` prints the owning process only to root.
+
+    Without sudo the listener row appears but its
+    `users:(("python3",pid=...))` field does not, so the owner count reads 0
+    and the gate fails a healthy deploy. Release 20260903T143835Z aborted on
+
+        CRITICAL: :8080 must have exactly one owner, dashboard PID 16981
+
+    while `sudo ss -ltnpH` on the same host showed exactly that pid and no
+    other. Third read in this block to need a privilege it was missing, after
+    the cwd and cmdline reads (#1246) — the class, not three coincidences.
+    """
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert "sudo ss -ltnpH" in script, (
+        "the socket owner read must be sudo'd or it sees no owners at all")
+    assert '"$(ss -ltnpH' not in script, "an unprivileged ss -p read cannot see owners"
+    # The plain listener probe needs no privilege: it asks whether anything is
+    # bound, not who. Keeping it unprivileged is deliberate, not an oversight.
+    assert "ss -ltnH |" in script


### PR DESCRIPTION
Third and, on the evidence, last of #1246.

`ss -ltnp` prints the owning process only to root:

```
$ ss -ltnpH | grep :8080
LISTEN 0 5 0.0.0.0:8080 0.0.0.0:*                                    <- no owner field
$ sudo ss -ltnpH | grep :8080
LISTEN 0 5 0.0.0.0:8080 0.0.0.0:* users:(("python3",pid=16981,fd=3))
```

pid 16981 is the dashboard, and it is the only listener. The gate counted zero owners and rejected a healthy deploy.

**Why I am calling this the last one.** After fixing it I ran the rest of the block by hand against the live host rather than deploying again to find out:

- `ss -ltnH` (no `-p`) — needs no privilege, asks whether anything is bound rather than who;
- `curl /api/health` and `/api/metrics` on localhost — fine;
- the Python validation that follows — executed against the live payloads: no missing keys in either endpoint, all four `*_source` entries carry `{status, age_hours, authoritative, context_only}` with `authoritative=False`, `context_only=True`, `status='stale'`, and no raw artifact markers.

So everything downstream of this fix is verified to pass before the deploy runs, instead of one check per broken deploy.

**Tests:** `test_socket_owner_check_reads_ss_with_sudo`; `tests/test_deploy_release.py` + `tests/test_deploy_integrity.py` 27 passed.

The structural problem — that these checks are unexecuted code until a deploy runs them, and each abort hides the next — is #1250, not this PR.