### PR TITLE
feat(state): extend writer invocation coverage to ten segments (#1228)

### DIFF
--- a/nanobot/runtime/state_path_invocations.py
+++ b/nanobot/runtime/state_path_invocations.py
@@ -16,6 +16,21 @@ from nanobot.runtime import state_paths
 CommandRunner = Callable[[list[str]], subprocess.CompletedProcess[str]]
 
 WRITER_INVOKERS: dict[str, dict[str, str]] = {
+    "action_index": {
+        "writer": "nanobot.runtime.action_index:build_action_index",
+        "kind": "systemd",
+        "unit": "eeebot-action-index.timer",
+    },
+    "curator": {
+        "writer": "nanobot.runtime.knowledge_curator:promote_reflector_recommendations_to_v2",
+        "kind": "systemd",
+        "unit": "eeebot-knowledge-curator.timer",
+    },
+    "heldout": {
+        "writer": "nanobot.runtime.heldout:_save_results",
+        "kind": "systemd",
+        "unit": "eeebot-skill-evals.timer",
+    },
     "hypotheses": {
         "writer": "nanobot.runtime.hypothesis_backlog:append_hypotheses",
         "kind": "systemd",
@@ -23,6 +38,31 @@ WRITER_INVOKERS: dict[str, dict[str, str]] = {
     },
     "ledger": {
         "writer": "nanobot.runtime.cycle_ledger:append_event",
+        "kind": "direct",
+        "invoker": "nanobot.runtime.bridge:_main_impl_body",
+    },
+    "llm_calls": {
+        "writer": "nanobot.observability.llm_telemetry:record_llm_call",
+        "kind": "direct",
+        "invoker": "nanobot.runtime.bridge:_main_impl_body",
+    },
+    "reflector": {
+        "writer": "nanobot.runtime.reflector:_append_journal",
+        "kind": "systemd",
+        "unit": "eeebot-reflector.timer",
+    },
+    "scorecard": {
+        "writer": "nanobot.runtime.scorecard:compute_scorecard",
+        "kind": "direct",
+        "invoker": "nanobot.runtime.bridge:_main_impl_body",
+    },
+    "strategist": {
+        "writer": "nanobot.runtime.strategist:_record_decision",
+        "kind": "systemd",
+        "unit": "eeebot-strategist.timer",
+    },
+    "subagents": {
+        "writer": "nanobot.runtime.bridge:_write_bridge_completed_result",
         "kind": "direct",
         "invoker": "nanobot.runtime.bridge:_main_impl_body",
     },

--- a/tests/test_state_path_writers.py
+++ b/tests/test_state_path_writers.py
@@ -174,6 +174,12 @@ def test_writer_invocation_check_flags_disabled_strategist_timer_and_keeps_direc
     output = """
         eeebot-strategist.timer                disabled enabled
         eeebot-self-evolving-subagent-bridge.timer enabled enabled
+        eeebot-action-index.timer              enabled enabled
+        eeebot-knowledge-curator.timer         enabled enabled
+        eeebot-reflector.timer                 enabled enabled
+        eeebot-skill-evals.timer                enabled enabled
+        eeebot-validator-harness.timer          enabled enabled
+        eeepc-self-evolving-subagent-bridge.timer enabled enabled
     """
 
     def runner(command: list[str]):
@@ -184,7 +190,10 @@ def test_writer_invocation_check_flags_disabled_strategist_timer_and_keeps_direc
 
     assert report["results"]["hypotheses"]["status"] == "disabled"
     assert report["results"]["ledger"]["status"] == "per_cycle"
-    assert report["failures"] == ["hypotheses"]
+    assert report["results"]["action_index"]["status"] == "scheduled"
+    assert report["results"]["curator"]["status"] == "scheduled"
+    assert report["results"]["reflector"]["status"] == "scheduled"
+    assert report["failures"] == ["hypotheses", "strategist"]
 
 
 def test_writer_invocation_check_accepts_enabled_strategist_timer() -> None:
@@ -200,6 +209,15 @@ def test_writer_invocation_check_accepts_enabled_strategist_timer() -> None:
 
     assert report["ok"] is True
     assert report["results"]["hypotheses"]["status"] == "scheduled"
+
+
+def test_writer_invocation_check_covers_only_evidenced_entries() -> None:
+    assert set(state_path_invocations.WRITER_INVOKERS) == {
+        "action_index", "curator", "heldout", "hypotheses", "ledger",
+        "llm_calls", "reflector", "scorecard", "strategist", "subagents",
+    }
+    for segment, spec in state_path_invocations.WRITER_INVOKERS.items():
+        assert spec["writer"] in state_paths.STATE_PATH_WRITERS[segment]
 
 
 def test_writer_invocation_check_distinguishes_absent_timer() -> None:


### PR DESCRIPTION
Second increment on #1228, built by pi-2 and taken over by me when its model (`cl/gpt-5.6-luna`) started returning 404 from the gateway mid-task. The commit is pi-2's; I rebased it onto current `main`, verified it against the live host, and opened this.

Extends `WRITER_INVOKERS` from two segments to ten: `action_index`, `curator`, `heldout`, `llm_calls`, `reflector`, `scorecard`, `strategist`, `subagents` join `hypotheses` and `ledger`.

**Verified against the live host** rather than against fixtures — the whole point of this check is that it answers about the machine:

```
ok: True | failures: []
  action_index   scheduled   eeebot-action-index.timer
  curator        scheduled   eeebot-knowledge-curator.timer
  heldout        scheduled   eeebot-skill-evals.timer
  hypotheses     scheduled   eeebot-strategist.timer
  ledger         per_cycle   nanobot.runtime.bridge:_main_impl_body
  llm_calls      per_cycle   nanobot.runtime.bridge:_main_impl_body
  reflector      scheduled   eeebot-reflector.timer
  scorecard      per_cycle   nanobot.runtime.bridge:_main_impl_body
  strategist     scheduled   eeebot-strategist.timer
  subagents      per_cycle   nanobot.runtime.bridge:_main_impl_body
```

Every named timer exists on the host and is enabled; every `direct` entry names the bridge cycle as its invoker. Run yesterday, `hypotheses` would have reported `disabled` — that is the case this whole check exists for.

`tests/test_state_path_writers.py`: 17 passed. Tests still inject their runner, so nothing reaches real `systemctl` from the suite.

**Still not covered:** `STATE_PATH_WRITERS` declares more segments than ten. The remaining ones are the entries whose invoker could not be evidenced, and they stay out deliberately — a plausible invoker written into this table is worse than an absent entry, because it converts an unknown into a false assurance. #1228 stays open for them.