### PR TITLE
fix(deploy): wait for the :8080 listener instead of racing the bind

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -411,7 +411,17 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     # listener row is there but its users:(("python3",pid=...)) field is not,
     # so the owner count reads 0 and this gate fails a healthy deploy — the
     # third read in this block to need the privilege it was missing (#1246).
-    DASHBOARD_SOCKET_ROWS="$(sudo ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
+    # `systemctl restart` returns when the unit is active, which is before the
+    # Python process has bound the port: measured on this host, :8080 is empty
+    # at t=0 and bound by t<0.4s. Sampling once raced the bind and reported
+    # listeners=0 on a healthy deploy (#1246). Wait for the listener, bounded,
+    # then read it once; an absent listener after the wait is a real failure.
+    DASHBOARD_SOCKET_ROWS=""
+    for _ in $(seq 1 40); do
+      DASHBOARD_SOCKET_ROWS="$(sudo ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
+      [ -n "$DASHBOARD_SOCKET_ROWS" ] && break
+      sleep 0.25
+    done
     DASHBOARD_LISTENER_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | sed '/^$/d' | wc -l)"
     DASHBOARD_SOCKET_PIDS="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)"
     DASHBOARD_SOCKET_PID_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_PIDS" | sed '/^$/d' | wc -l)"

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -591,3 +591,30 @@ def test_socket_owner_check_reads_ss_with_sudo() -> None:
     # The plain listener probe needs no privilege: it asks whether anything is
     # bound, not who. Keeping it unprivileged is deliberate, not an oversight.
     assert "ss -ltnH |" in script
+
+
+def test_socket_check_waits_for_the_listener_instead_of_sampling_once() -> None:
+    """`systemctl restart` returns before the process has bound the port.
+
+    Measured on the host: immediately after restart `:8080` has no listener,
+    and it appears within about a second (4 polls at 0.25s in one run, under
+    0.4s in another). Sampling once raced the bind and reported
+
+        CRITICAL: :8080 must have exactly one owner, dashboard PID 20144;
+                  saw listeners=0 pids=''
+
+    on a healthy deploy (#1246). `listeners=0` is the tell: an unprivileged
+    read still shows the listener row and only hides the owner, so zero rows
+    means the socket genuinely was not bound yet — a different defect from the
+    missing sudo, stacked behind it in the same check.
+    """
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    socket_block = script[script.index("DASHBOARD_SOCKET_ROWS=\"\""):]
+    socket_block = socket_block[: socket_block.index("DASHBOARD_LISTENER_COUNT=")]
+
+    assert "for _ in $(seq 1 40)" in socket_block, "the listener read must be retried, not sampled once"
+    assert "sleep 0.25" in socket_block, "the retry needs a bounded pause between polls"
+    assert '[ -n "$DASHBOARD_SOCKET_ROWS" ] && break' in socket_block, (
+        "the loop must stop as soon as a listener appears rather than always sleeping 10s")
+    assert "sudo ss -ltnpH" in socket_block, "the retried read still needs the owner field"


### PR DESCRIPTION
Fourth and — verified rather than hoped — final defect in #1246's chain.

`systemctl restart` returns when the unit is *active*, not when the process has bound its port. The gate sampled once:

```
CRITICAL: :8080 must have exactly one owner, dashboard PID 20144; saw listeners=0 pids=''
```

Measured on the host immediately after a restart:

```
t=0.0s  listeners=0
t=0.4s  listeners=1        (a later run: listener after 4 polls at 0.25s)
```

**`listeners=0` is what told these two defects apart.** An unprivileged `ss -ltnp` still prints the listener row and hides only the `users:((...))` field — so the missing sudo (#1251) produced *listeners=1, pids=''*, while the race produces *listeners=0*. Two defects in the same check, the second sitting behind the first. The diagnostic I added alongside the sudo fix is the only reason the second was diagnosable without another deploy.

**Checked the rest of the block rather than deploying to find out:** with the listener up, `curl /api/health` and `/api/metrics` both return 200 immediately, so no further waits are needed. That was measured, not assumed.

**Tests:** `test_socket_check_waits_for_the_listener_instead_of_sampling_once` pins the retry, the bounded pause, and the early break — a loop that always slept 10s would pass a naive assertion. `tests/test_deploy_release.py` + `tests/test_deploy_integrity.py`: 28 passed.

Four deploys to find four defects that shipped in one PR is the argument for #1250, not for a fifth patch.