### PR TITLE
fix(scorecard): count each wasted attempt once and include failed outcomes (#1255)

### DIFF
--- a/nanobot/runtime/scorecard.py
+++ b/nanobot/runtime/scorecard.py
@@ -618,6 +618,7 @@ def _loop_section(
     proposer_rejects = 0
     self_dedup_rejects = 0
     duplicate_failure_skips = 0
+    failed_outcomes = 0
     skips_by_class: dict[str, int] = {}
     # #800 churn split: cycles whose proposed row served a decay demand
     # (demand_id "decay-…", the #760 traceability field). A success outcome
@@ -684,10 +685,17 @@ def _loop_section(
                 # are not failures and must not feed repeat_failure_rate.
                 if str(row.get("reason") or "").strip() == "recent_duplicate_failure":
                     duplicate_failure_skips += 1
+            elif outcome == "failed":
+                failed_outcomes += 1
     cycleish = idle_rows + outcome_rows
     repeat_failures = duplicate_failure_skips + self_dedup_rejects
     attempts = proposals + proposer_rejects
-    wasted_attempts = repeat_failures + proposer_rejects
+    # #1055 definition: failed outcomes plus rejects. Each attempt counts at
+    # most once — self_dedup rejects are already inside proposer_rejects, so
+    # they must NOT be re-added via repeat_failures (#1255: that double
+    # count published 75 of 602 where the definition gives 53, and let the
+    # rate exceed 1.0 in a window of only self_dedup rejects).
+    wasted_attempts = duplicate_failure_skips + failed_outcomes + proposer_rejects
     return {
         # Value-bearing integrations ONLY (#800) — the fitness numerator
         # consumed by the _TARGETS gap analysis. Archival churn is reported

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -123,6 +123,72 @@ class TestLoopSection:
         assert loop["repeat_failure_rate"] == round(1 / 3, 4)
         assert loop["skips_by_class"] == {"skipped-duplicate": 3}
 
+    def test_wasted_attempt_rate_cannot_exceed_one(self, tmp_path):
+        """#1255: a window where every attempt is a self-dedup reject. The
+        pre-fix formula (repeat_failures + proposer_rejects) counted each
+        self_dedup reject twice and produced wasted_attempts 6 of 3 attempts —
+        a rate above 1.0 is self-refuting."""
+        state_dir = tmp_path / "state"
+        _write_ledger(state_dir, [
+            {"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(3)},
+            {"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(2)},
+            {"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(1)},
+        ])
+        loop = scorecard.compute_scorecard(state_dir, None, force=True)["loop"]
+        assert loop["attempts"] == 3
+        assert loop["wasted_attempts"] <= loop["attempts"]
+        assert loop["wasted_attempts"] == 3
+        assert loop["wasted_attempt_rate"] == 1.0
+
+    def test_wasted_attempts_composition(self, tmp_path):
+        """#1255 pins the #1055 definition — "failed outcomes plus rejects" —
+        term by term, so a formula wrong in two compensating ways cannot pass
+        on the aggregate alone: one self_dedup reject contributes exactly
+        once, one failed outcome contributes once, one recent_duplicate_failure
+        skip contributes once, and a success contributes nothing."""
+        state_dir = tmp_path / "state"
+        base = [
+            {"phase": "proposed", "cycle_id": "c-ok", "ts": _iso(9)},
+            {"phase": "outcome", "cycle_id": "c-ok", "outcome": "success", "ts": _iso(8)},
+        ]
+
+        def wasted(extra: list[dict]) -> int:
+            _write_ledger(state_dir, base + extra)
+            return scorecard.compute_scorecard(state_dir, None, force=True)["loop"]["wasted_attempts"]
+
+        assert wasted([]) == 0
+        assert wasted([{"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(5)}]) == 1
+        assert wasted([{"phase": "proposer_reject", "reason": "llm_unavailable", "ts": _iso(5)}]) == 1
+        assert wasted([
+            {"phase": "proposed", "cycle_id": "c-fail", "ts": _iso(5)},
+            {"phase": "outcome", "cycle_id": "c-fail", "outcome": "failed", "ts": _iso(4)},
+        ]) == 1
+        assert wasted([
+            {"phase": "proposed", "cycle_id": "c-dup", "ts": _iso(5)},
+            {"phase": "outcome", "cycle_id": "c-dup", "outcome": "skipped-duplicate", "reason": "recent_duplicate_failure", "ts": _iso(4)},
+        ]) == 1
+        # Healthy dedup skips are not waste (same rule as repeat_failures).
+        assert wasted([
+            {"phase": "proposed", "cycle_id": "c-done", "ts": _iso(5)},
+            {"phase": "outcome", "cycle_id": "c-done", "outcome": "skipped-duplicate", "reason": "already_done", "ts": _iso(4)},
+        ]) == 0
+        # All four together: 1 + 1 + 1 + 1 wasted out of 5 attempts
+        # (3 proposed rows + 2 proposer_reject rows).
+        _write_ledger(state_dir, base + [
+            {"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(7)},
+            {"phase": "proposer_reject", "reason": "llm_unavailable", "ts": _iso(6)},
+            {"phase": "proposed", "cycle_id": "c-fail", "ts": _iso(5)},
+            {"phase": "outcome", "cycle_id": "c-fail", "outcome": "failed", "ts": _iso(4)},
+            {"phase": "proposed", "cycle_id": "c-dup", "ts": _iso(3)},
+            {"phase": "outcome", "cycle_id": "c-dup", "outcome": "skipped-duplicate", "reason": "recent_duplicate_failure", "ts": _iso(2)},
+        ])
+        loop = scorecard.compute_scorecard(state_dir, None, force=True)["loop"]
+        assert loop["attempts"] == 5
+        assert loop["wasted_attempts"] == 4
+        assert loop["wasted_attempt_rate"] == round(4 / 5, 4)
+        # repeat_failures keeps its own #977/#1014 meaning: dup-failure skip + self_dedup.
+        assert loop["repeat_failures"] == 2
+
     def test_decay_successes_split_from_integrations(self, tmp_path):
         """#800 churn split: a success whose proposed row served a decay
         demand is an archival (bookkeeping churn) — it counts as


### PR DESCRIPTION
Closes #1255. Found while closing #1254.

## Defect

`scorecard._loop_section` computed `wasted_attempts = repeat_failures + proposer_rejects`. `repeat_failures` already contains `self_dedup_rejects`, which are a subset of `proposer_rejects`, so every self-dedup reject was counted twice. `failed` outcomes were never counted, although PR #1055 defined the metric as "failed outcomes plus rejects". In a window where every attempt is a self-dedup reject the published rate was 2.0.

## Fix

```python
wasted_attempts = duplicate_failure_skips + failed_outcomes + proposer_rejects
```

Each attempt contributes at most once. `repeat_failures` / `repeat_failure_rate` (the `_TARGETS` metric, #977/#1014 semantics) are untouched. `partial` outcomes are still not waste — the #1055 definition names `failed` only.

## What the strategist's input becomes (same live window, `history.jsonl` discontinuity)

Host `state/scorecard/latest.json` computed 2026-09-03T17:31:17Z, 7-day window since 2026-08-27T17:31Z, recomputed row-for-row from the live ledger + archives (read-only):

| quantity | before | after |
|---|---|---|
| attempts (proposals + rejects) | 602 | 602 |
| proposer_rejects (31 `self_dedup`, 3 `llm_unavailable`) | 34 | 34 |
| duplicate_failure_skips | 10 | 10 |
| failed outcomes (of 565 outcome rows) | not counted | 9 |
| self_dedup counted | twice (31 extra) | once |
| **wasted_attempts** | **75 of 602** | **53 of 602** |
| **wasted_attempt_rate** | **0.1246** | **0.0880** |
| repeat_failures / repeat_failure_rate | 41 / 0.0681 | 41 / 0.0681 (unchanged) |

Between 17:31Z and my recompute the live ledger gained 2 proposals in-window (604 attempts, rate 0.0877); the table uses the 602 the scorecard published. The next scorecard recompute after roll-out will step `wasted_attempt_rate` down by roughly 0.037 in `history.jsonl` with no change in loop behaviour — that step is this fix, not the loop.

## Readers re-checked before changing the meaning

- `_TARGETS` (scorecard.py:333): only `repeat_failure_rate` from the loop section. Not `wasted_*`. No gap, demand or futility record derives from it.
- `strategist_inputs.scorecard_input`: passes whole `latest.json` into the strategist prompt + generic trend series. Only consumer; prose context.
- `evolution_tree.py:337`, `state.py:1030`, `loop_explorer.py:325`: read `integrations`, `confirmed_integrations`, `repeat_failure_rate`, `idle_share`, `confirmed_integration_ratio` only.
- `hypothesis_backlog.py`, `hypothesis_verdict.py`, `goal_gap_futility.py`, `demand.py`, `scripts/loop_metrics_report.py`: no read of `wasted_attempts` / `wasted_attempt_rate`.
- `eeebot-ops-dashboard`: no occurrence of `wasted`.
- Tests: none asserted either key before this PR.

## Tests

`test_wasted_attempt_rate_cannot_exceed_one` — 3 self_dedup rejects, nothing else. Pre-fix failure:

```
>       assert loop["wasted_attempts"] <= loop["attempts"]
E       assert 6 <= 3
```

`test_wasted_attempts_composition` — one term at a time on a fixed base: self_dedup reject → 1, llm_unavailable reject → 1, failed outcome → 1, recent_duplicate_failure skip → 1, already_done skip → 0, success → 0; then all together 4 of 5 attempts with `repeat_failures` still 2. Pre-fix failure:

```
>       assert wasted([{"phase": "proposer_reject", "reason": "self_dedup", "ts": _iso(5)}]) == 1
E       AssertionError: assert 2 == 1
```

`tests/test_scorecard.py`: 66 passed. Full suite result posted as a comment when the run finishes (baseline 4 known failures: bridge tag fail-open + 3 `TestAcquireBridgeLock`).

Pre-existing, not touched: `ruff` F401 on `loguru.logger` in scorecard.py:89 is on `main` already; CI does not run ruff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
