### PR TITLE
feat(validator-harness): record why findings_count is None (#1208 step 1)

### DIFF
--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -136,6 +136,15 @@ defect when a script did not anticipate it:
 - Non-zero exit = a finding worth surfacing: it becomes ``defect`` demand
   with your stderr/stdout as evidence (see
   ``demand._validator_defect_items``).
+- ``--json`` output is read for a findings count ONLY from a top-level
+  object carrying one of :data:`_FINDINGS_KEYS` as a list/dict. Any other
+  shape yields ``findings_count: None`` (exit code decides alone) and the
+  sidecar row says why — ``findings_parse`` is ``matched`` /
+  ``not_json`` / ``not_object`` / ``unrecognised_keys`` (with the
+  ``stdout_keys`` seen), ``json_flag`` says whether the flag was passed,
+  ``stdout_truncated`` whether the :data:`_MAX_OUTPUT_BYTES` cap cut the
+  document (#1208 step 1: measured live, six validators emitted JSON daily
+  under keys this parser never read, invisibly).
 - Decay self-declaration is detected from printed output (#936): when a
    script's captured stdout+stderr contains :data:`_DECAY_DECL_RE` AND the
    script's own repo-relative path (``scripts/<filename>``), the run is
@@ -532,23 +541,40 @@ def _accepts_json_flag(script: Path) -> bool:
         return False
 
 
-def _parse_findings_count(stdout: str) -> int | None:
-    """Deliberately tiny findings heuristic: a top-level JSON object with a
-    ``findings``/``alerts``/``missing``/``failures`` field that is a list or
-    dict yields that field's length; anything else (unparseable, not an
-    object, no matching field) yields ``None`` — the caller then falls back
-    to the raw exit code alone, never a fabricated count."""
+_MAX_RECORDED_KEYS = 24  # top-level keys kept in ``stdout_keys`` for an unrecognised object
+
+
+def _classify_findings(stdout: str) -> tuple[int | None, str, list[str]]:
+    """Deliberately tiny findings heuristic, now with its verdict spelled
+    out (#1208 step 1). Returns ``(findings_count, findings_parse, stdout_keys)``:
+
+    - ``"matched"``: a top-level JSON object with a
+      ``findings``/``alerts``/``missing``/``failures`` list or dict —
+      ``findings_count`` is that field's length.
+    - ``"not_json"``: stdout did not parse (plain text, empty, or a JSON
+      document truncated at :data:`_MAX_OUTPUT_BYTES`).
+    - ``"not_object"``: valid JSON whose top level is not an object.
+    - ``"unrecognised_keys"``: a valid object with none of
+      :data:`_FINDINGS_KEYS` — ``stdout_keys`` carries the top-level keys
+      actually seen (sorted, first :data:`_MAX_RECORDED_KEYS`).
+
+    Every state but ``"matched"`` yields ``findings_count`` ``None``; the
+    caller then falls back to the raw exit code alone, never a fabricated
+    count. Before #1208 the three ``None`` states were one value, which is
+    how six live validators emitted JSON daily to keys nobody read without
+    anything recording it."""
     try:
         data = json.loads(stdout)
     except Exception:
-        return None
+        return None, "not_json", []
     if not isinstance(data, dict):
-        return None
+        return None, "not_object", []
     for key in _FINDINGS_KEYS:
         value = data.get(key)
         if isinstance(value, (list, dict)):
-            return len(value)
-    return None
+            return len(value), "matched", []
+    keys = sorted(str(k) for k in data.keys())[:_MAX_RECORDED_KEYS]
+    return None, "unrecognised_keys", keys
 
 
 def _terminal_stderr_line(stderr: str) -> str:
@@ -707,7 +733,8 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
     started = datetime.now(timezone.utc)
 
     cmd = [sys.executable, str(script)]
-    if _accepts_json_flag(script):
+    json_flag = _accepts_json_flag(script)
+    if json_flag:
         cmd.append("--json")
 
     exit_code: int | None = None
@@ -805,15 +832,26 @@ def _run_one(script: Path, selfevo_repo: Path, timeout: float) -> dict[str, Any]
 
     finished = datetime.now(timezone.utc)
 
+    findings_count, findings_parse, stdout_keys = _classify_findings(stdout)
     record: dict[str, Any] = {
         "path": rel,
         "started_at": _iso(started),
         "finished_at": _iso(finished),
         "duration_s": round((finished - started).total_seconds(), 3),
         "exit_code": exit_code,
-        "findings_count": _parse_findings_count(stdout),
+        "findings_count": findings_count,
+        # #1208 step 1: RECORD why findings_count is what it is. Nothing
+        # downstream decides on these three fields — demand still keys on
+        # exit_code / findings_count / harness_contract exactly as before.
+        "json_flag": json_flag,
+        "findings_parse": findings_parse,
+        # stdout is captured HEAD-first up to _MAX_OUTPUT_BYTES; a JSON
+        # document cut there reads as "not_json", so say when that happened.
+        "stdout_truncated": len(stdout) >= _MAX_OUTPUT_BYTES,
         "stderr_tail": stderr[-2000:],
     }
+    if stdout_keys:
+        record["stdout_keys"] = stdout_keys
     usage_error = exit_code == 2 and _is_argparse_usage_error(stderr)
     if (
         isinstance(exit_code, int)

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -510,6 +510,10 @@ class TestExecution:
         rows = _last_runs(state_dir)
         assert rows[0]["exit_code"] == 0
         assert rows[0]["findings_count"] == 3
+        assert rows[0]["json_flag"] is True
+        assert rows[0]["findings_parse"] == "matched"
+        assert rows[0]["stdout_truncated"] is False
+        assert "stdout_keys" not in rows[0]
         items = demand._validator_defect_items(state_dir)
         assert items[0]["summary"] == "validator scripts/check_findings.py reports 3 findings"
 
@@ -521,6 +525,8 @@ class TestExecution:
         rows = _last_runs(state_dir)
         assert rows[0]["exit_code"] == 0
         assert rows[0]["findings_count"] is None
+        assert rows[0]["json_flag"] is False
+        assert rows[0]["findings_parse"] == "not_json"
 
     def test_non_json_stdout_yields_no_findings_count(self, tmp_path):
         repo = _init_repo(tmp_path)
@@ -529,6 +535,97 @@ class TestExecution:
         validator_harness.run_validator_harness(state_dir, repo)
         rows = _last_runs(state_dir)
         assert rows[0]["findings_count"] is None
+        assert rows[0]["findings_parse"] == "not_json"
+        assert rows[0]["stdout_truncated"] is False
+
+    def test_json_array_stdout_is_recorded_as_not_object(self, tmp_path):
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_array.py",
+            "import argparse, json\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "p.parse_args()\n"
+            "print(json.dumps([1, 2, 3]))\n",
+            days_ago=2,
+        )
+        state_dir = _state_dir(tmp_path)
+        validator_harness.run_validator_harness(state_dir, repo)
+        rows = _last_runs(state_dir)
+        assert rows[0]["findings_count"] is None
+        assert rows[0]["json_flag"] is True
+        assert rows[0]["findings_parse"] == "not_object"
+        assert "stdout_keys" not in rows[0]
+
+    def test_unrecognised_json_keys_are_recorded_and_do_not_change_demand(self, tmp_path):
+        """#1208 step 1: the live shape — six validators emit
+        ``{"success", "checked_count", "failed_count", "results"}`` under
+        ``--json`` and the parser reads none of those keys. The row must now
+        SAY so and name the keys, while what becomes demand is unchanged:
+        exit 0 + None → no item (same as before), exit 1 + None → the same
+        exit-code item as before. Recording changed; deciding did not."""
+        script = (
+            "import argparse, json, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "p.parse_args()\n"
+            "print(json.dumps({'success': %s, 'checked_count': 67, 'failed_count': %d, 'results': [{'file': 'a.py'}]}))\n"
+            "sys.exit(%d)\n"
+        )
+        # exit 0 with unrecognised keys: recorded, no demand.
+        (tmp_path / "clean").mkdir()
+        (tmp_path / "failing").mkdir()
+        repo = _init_repo(tmp_path / "clean")
+        _add_script(repo, "check_shape.py", script % ("True", 0, 0), days_ago=2)
+        state_dir = _state_dir(tmp_path / "clean")
+        validator_harness.run_validator_harness(state_dir, repo)
+        row = _last_runs(state_dir)[0]
+        assert row["exit_code"] == 0
+        assert row["findings_count"] is None
+        assert row["json_flag"] is True
+        assert row["findings_parse"] == "unrecognised_keys"
+        assert row["stdout_keys"] == ["checked_count", "failed_count", "results", "success"]
+        assert demand._validator_defect_items(state_dir) == []
+
+        # exit 1 with the same shape: still the exit-code defect, nothing more.
+        repo2 = _init_repo(tmp_path / "failing")
+        _add_script(repo2, "check_shape.py", script % ("False", 2, 1), days_ago=2)
+        state_dir2 = _state_dir(tmp_path / "failing")
+        validator_harness.run_validator_harness(state_dir2, repo2)
+        row2 = _last_runs(state_dir2)[0]
+        assert row2["exit_code"] == 1
+        assert row2["findings_count"] is None
+        assert row2["findings_parse"] == "unrecognised_keys"
+        items = demand._validator_defect_items(state_dir2)
+        assert len(items) == 1
+        assert items[0]["affected_path"] == "scripts/check_shape.py"
+        assert "findings" not in items[0]["summary"]  # the exit-code wording, not a count
+
+    def test_stdout_cut_at_cap_is_recorded_as_truncated_not_json(self, tmp_path, monkeypatch):
+        """A JSON document longer than the capture cap (the live
+        ``check_style.py`` / ``verify_imports.py`` case: 572 KB and 2.2 MB
+        against a 64 KiB cap) arrives cut, so it parses as ``not_json`` — the
+        row must say the cap did it, or a real shape mismatch and a chatty
+        validator read the same."""
+        monkeypatch.setattr(validator_harness, "_MAX_OUTPUT_BYTES", 512)
+        repo = _init_repo(tmp_path)
+        _add_script(
+            repo,
+            "check_big.py",
+            "import argparse, json\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "p.parse_args()\n"
+            "print(json.dumps({'findings': ['x' * 50] * 40}))\n",
+            days_ago=2,
+        )
+        state_dir = _state_dir(tmp_path)
+        validator_harness.run_validator_harness(state_dir, repo)
+        row = _last_runs(state_dir)[0]
+        assert row["findings_count"] is None
+        assert row["findings_parse"] == "not_json"
+        assert row["stdout_truncated"] is True
 
 
 # ─── process-group kill on timeout (security review MINOR fix) ────────────


### PR DESCRIPTION
Step 1 of #1208 (see the verification comment there naming the two steps). Step 2 — the schema decision — is deliberately **not** in this PR.

## What was wrong

`_parse_findings_count` returned `None` for three different situations: stdout was not JSON; it was JSON but not a top-level object; it was a top-level object whose keys the parser does not read. The third is the live case: six instance validators emit `{"success","checked_count","failed_count","results"}` under `--json` on every harness run, `_FINDINGS_KEYS` is `("findings","alerts","missing","failures")`, intersection empty. On the host, 0 of 45 sidecar rows for those six carry a `findings_count`, and nothing said why — `None` from "unreadable shape" was byte-identical to `None` from "ran fine, printed text".

## What this changes — recording, not deciding

Each `state/validator_harness/last_runs.jsonl` row now carries four additive fields:

| field | values | meaning |
|---|---|---|
| `json_flag` | bool | whether `--json` was appended (script declared it) |
| `findings_parse` | `matched` / `not_json` / `not_object` / `unrecognised_keys` | which branch produced `findings_count` |
| `stdout_keys` | sorted list, ≤24, only on `unrecognised_keys` | the top-level keys the script actually emitted |
| `stdout_truncated` | bool | head capture hit `_MAX_OUTPUT_BYTES` (64 KiB) — a long JSON document then reads as `not_json`, and this says the cap did it |

`findings_count` itself is computed exactly as before (`_classify_findings` returns the same integer or `None` from the same branches). `demand._validator_defect_items` reads `exit_code` / `findings_count` / `harness_contract` / `stderr_tail` and none of the new fields, so **what becomes demand is unchanged**: exit 0 + `None` → no item; exit non-zero + `None` → the same exit-code defect as before. `test_unrecognised_json_keys_are_recorded_and_do_not_change_demand` pins both halves of that with the live key shape.

`_FINDINGS_KEYS` is not widened. Whether `failed_count` is a findings count by another name, and for how many scripts, is what these rows will now show — step 2 decides from that data.

Cost on the normal path: one `sorted()` over top-level keys, only when an object parses and matches nothing; one `len()` compare. No new I/O, no new subprocess, row grows by ~80–200 bytes against the 16 KiB per-record cap.

## The three states as a real harness run now records them

Ran the instance repo at `origin/main` (`1626dcbf`) through the branch's `_accepts_json_flag` / `_classify_findings` with the harness's 64 KiB head capture — same command, same cwd shape, read-only:

| script | allowlisted | json_flag | exit | stdout | findings_parse | stdout_truncated | stdout_keys |
|---|---|---|---|---|---|---|---|
| validate_open_encoding.py | yes | true | 0 | 13.6 KB | **unrecognised_keys** | false | checked_count, failed_count, results, success |
| validate_deprecation_status.py | yes | true | 0 | 16.8 KB | **unrecognised_keys** | false | + warnings_count |
| validate_timezone_aware_datetime.py | yes | true | 0 | 13.7 KB | **unrecognised_keys** | false | + summary |
| validate_unused_imports.py | yes | true | 0 | 14.1 KB | **unrecognised_keys** | false | + summary |
| check_style.py | yes | true | 1 | 573 KB | **not_json** | **true** | — |
| verify_imports.py | yes | true | 1 | 2.18 MB | **not_json** | **true** | — |
| prevent_repeat_failures.py | **no** (prefix) | true | 2 | 4.3 KB | not_json | false | — (usage error: requires args) |
| archive_old_reports.py | **no** (prefix) | true | 1 | 38 B | unrecognised_keys | false | error |

So the eight split three ways, not one: four are a pure key mismatch; two never reach the parser as JSON because the capture cap cuts the document — for those the schema question is moot until the output shrinks or the cap is reconsidered; two are not harness candidates at all and their `--json` modes have no runtime caller whatever their shape. Step 2 needs that split, which is why guessing keys for "eight scripts" would have been wrong for four of them.

## Tests

Extended `test_json_findings_are_counted`, `test_plain_invocation_when_script_has_no_json_flag`, `test_non_json_stdout_yields_no_findings_count` with the new fields; added `test_json_array_stdout_is_recorded_as_not_object`, `test_unrecognised_json_keys_are_recorded_and_do_not_change_demand` (exit 0 → no demand; exit 1 → same exit-code item, wording without a count), `test_stdout_cut_at_cap_is_recorded_as_truncated_not_json` (cap monkeypatched to 512 B).

`tests/test_validator_harness.py`: 108 passed, 5 skipped. Full suite result posted as a comment when the run finishes (baseline 4 known Windows failures: bridge tag fail-open + 3 `TestAcquireBridgeLock`).

Also documents the JSON expectation in the module's INVOCATION CONTRACT, which previously covered arguments, time budget, exit codes and decay but said nothing about the JSON shape the parser reads.

## Readers of `last_runs.jsonl` checked

`demand.py:990-1130` (fields above, additive-safe), `usage_evidence.py:465-467` (reads the parent log's `validator` / `finished_at`, not the sidecar), `validator_harness._select_within_budget` (byte/line caps, per-record 16 KiB), tests. No dashboard reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
