### PR TITLE
fix(deploy): enforce stale dashboard semantic gate

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -505,7 +505,7 @@ import os
 health = json.loads(os.environ["DASHBOARD_HEALTH"])
 metrics = json.loads(os.environ["DASHBOARD_METRICS"])
 required_health = {"overall", "dimensions", "goal", "active_task", "reward_average"}
-required_metrics = {"goal", "active_task", "approval_gate_state", "reward_source"}
+required_metrics = {"goal", "active_task", "approval_gate_state", "reward_source", "goal_source", "active_task_source", "approval_gate_source"}
 source_keys = ("goal_source", "active_task_source", "approval_gate_source", "reward_source")
 for payload, required in ((health, required_health), (metrics, required_metrics)):
     if not all(isinstance(payload.get(key), (str, dict, int, float, list)) for key in required):
@@ -534,6 +534,12 @@ for key in ("reward", "gate"):
     detail = health.get("dimensions", {}).get(key, {})
     if not isinstance(detail, dict) or detail.get("status") not in {"WARN", "OK", "CRIT"}:
         raise SystemExit("dashboard health dimension is not structured")
+    if detail.get("status") != "WARN":
+        raise SystemExit("retired dashboard source must be WARN")
+if "0.88 avg over 5 sample(s)" in payload or "materialize_synthesized_improvement" in payload:
+    raise SystemExit("dashboard endpoint contains raw legacy dashboard values")
+if any(token in payload for token in ("cycle-2f305bf18b42", "/var/lib/eeepc-agent/", "/opt/eeepc-agent/")):
+    raise SystemExit("dashboard endpoint contains stale cycle or host path")
 PY
   elif [ "$DASHBOARD_UNIT_STATE" = "disabled" ] || [ "$DASHBOARD_UNIT_STATE" = "masked" ]; then
     echo "NOTICE: $DASHBOARD_UNIT is $DASHBOARD_UNIT_STATE; preserving state"

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -37,10 +37,13 @@ NO_CRASH_HOLD=300
 NO_HEALTH_GATE=0
 ALLOW_DIRTY=0
 
+VERIFY_ONLY=0
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --host)           HOST="$2"; shift 2 ;;
     --dry-run)        DRY_RUN=1; shift ;;
+    --verify-only)    VERIFY_ONLY=1; shift ;;
     --ref)            REF="$2"; shift 2 ;;
     --health-timeout) HEALTH_TIMEOUT="$2"; shift 2 ;;
     --no-crash-hold) NO_CRASH_HOLD="$2"; shift 2 ;;
@@ -53,50 +56,58 @@ done
 log()  { echo "[deploy] $*"; }
 run()  { if [[ $DRY_RUN -eq 1 ]]; then echo "[DRY] $*"; else "$@"; fi; }
 
-# Ref verification
-if [ -z "$REF" ]; then
-  COMMIT=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
-  # Verify against origin/main
-  ORIGIN_COMMIT=$(git -C "$REPO_ROOT" rev-parse --short origin/main 2>/dev/null || true)
-  if [ "$COMMIT" != "$ORIGIN_COMMIT" ]; then
-    echo "CRITICAL: local HEAD ($COMMIT) != origin/main ($ORIGIN_COMMIT)." >&2
-    echo "Refuse to deploy unless the archived ref matches origin/main, or --ref is explicitly passed." >&2
-    exit 1
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  # Ref verification
+  if [ -z "$REF" ]; then
+    COMMIT=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
+    # Verify against origin/main
+    ORIGIN_COMMIT=$(git -C "$REPO_ROOT" rev-parse --short origin/main 2>/dev/null || true)
+    if [ "$COMMIT" != "$ORIGIN_COMMIT" ]; then
+      echo "CRITICAL: local HEAD ($COMMIT) != origin/main ($ORIGIN_COMMIT)." >&2
+      echo "Refuse to deploy unless the archived ref matches origin/main, or --ref is explicitly passed." >&2
+      exit 1
+    fi
+  else
+    COMMIT=$(git -C "$REPO_ROOT" rev-parse --short "$REF")
   fi
+
+  if [ "$ALLOW_DIRTY" -eq 0 ]; then
+    if ! git -C "$REPO_ROOT" diff-index --quiet HEAD --; then
+      echo "CRITICAL: Working tree is dirty. Refuse to deploy unless --allow-dirty is passed." >&2
+      exit 1
+    fi
+  fi
+
+  BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref "$COMMIT" 2>/dev/null || echo "detached")
+  SUBJECT=$(git -C "$REPO_ROOT" log -1 --format="%s" "$COMMIT")
+  TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+  RELEASE_NAME="${TIMESTAMP}-canonical-${COMMIT}"
+  FULL_COMMIT="$(git -C "$REPO_ROOT" rev-parse "$COMMIT^{commit}")"
+  ARCHIVE="/tmp/eeebot-release-${RELEASE_NAME}.tar.gz"
+
+  log "repo:    $REPO_ROOT"
+  log "commit:  $COMMIT ($SUBJECT) ($BRANCH)"
+  log "full commit: $FULL_COMMIT"
+  log "release: $RELEASE_NAME"
+  log "host:    $HOST"
+
+  # 1. Create archive from git COMMIT (excludes .git, .venv, __pycache__)
+  log "creating archive..."
+  run git -C "$REPO_ROOT" archive --format=tar.gz --prefix="${RELEASE_NAME}/" "$COMMIT" \
+    -o "$ARCHIVE"
+  log "archive: $ARCHIVE ($(du -sh "$ARCHIVE" | cut -f1))"
+
+  # 2. Copy to host
+  REMOTE_ARCHIVE="/tmp/$(basename "$ARCHIVE")"
+  log "uploading to $HOST:$REMOTE_ARCHIVE..."
+  run scp "$ARCHIVE" "ozand@${HOST}:${REMOTE_ARCHIVE}"
 else
-  COMMIT=$(git -C "$REPO_ROOT" rev-parse --short "$REF")
+  log "host:    $HOST"
+  log "VERIFY-ONLY mode active. Skipping archive and upload."
+  REMOTE_ARCHIVE=""
+  RELEASE_NAME=""
+  FULL_COMMIT=""
 fi
-
-if [ "$ALLOW_DIRTY" -eq 0 ]; then
-  if ! git -C "$REPO_ROOT" diff-index --quiet HEAD --; then
-    echo "CRITICAL: Working tree is dirty. Refuse to deploy unless --allow-dirty is passed." >&2
-    exit 1
-  fi
-fi
-
-BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref "$COMMIT" 2>/dev/null || echo "detached")
-SUBJECT=$(git -C "$REPO_ROOT" log -1 --format="%s" "$COMMIT")
-TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
-RELEASE_NAME="${TIMESTAMP}-canonical-${COMMIT}"
-FULL_COMMIT="$(git -C "$REPO_ROOT" rev-parse "$COMMIT^{commit}")"
-ARCHIVE="/tmp/eeebot-release-${RELEASE_NAME}.tar.gz"
-
-log "repo:    $REPO_ROOT"
-log "commit:  $COMMIT ($SUBJECT) ($BRANCH)"
-log "full commit: $FULL_COMMIT"
-log "release: $RELEASE_NAME"
-log "host:    $HOST"
-
-# 1. Create archive from git COMMIT (excludes .git, .venv, __pycache__)
-log "creating archive..."
-run git -C "$REPO_ROOT" archive --format=tar.gz --prefix="${RELEASE_NAME}/" "$COMMIT" \
-  -o "$ARCHIVE"
-log "archive: $ARCHIVE ($(du -sh "$ARCHIVE" | cut -f1))"
-
-# 2. Copy to host
-REMOTE_ARCHIVE="/tmp/$(basename "$ARCHIVE")"
-log "uploading to $HOST:$REMOTE_ARCHIVE..."
-run scp "$ARCHIVE" "ozand@${HOST}:${REMOTE_ARCHIVE}"
 
 # Resolve PREV_RELEASE so we can roll back if needed
 PREV_RELEASE_PATH=$(ssh "ozand@${HOST}" "readlink /opt/eeepc-agent/runtimes/self-evolving-agent/current || true")
@@ -113,125 +124,150 @@ rollback_release() {
 
 # 3. Extract, build venv, update symlink, restart
 log "installing on $HOST..."
-run ssh "ozand@${HOST}" bash -s -- "$REMOTE_ARCHIVE" "$RELEASE_NAME" "$FULL_COMMIT" "$PREV_RELEASE_PATH" <<'REMOTE'
-set -euo pipefail
-ARCHIVE="$1"
-RELEASE_NAME="$2"
-FULL_COMMIT="$3"
-PREV_RELEASE_PATH="$4"
+run ssh "ozand@${HOST}" "REMOTE_ARCHIVE='${REMOTE_ARCHIVE:-}' RELEASE_NAME='${RELEASE_NAME:-}' FULL_COMMIT='${FULL_COMMIT:-}' PREV_RELEASE_PATH='${PREV_RELEASE_PATH:-}' VERIFY_ONLY='$VERIFY_ONLY' bash -s" <<'REMOTE'
+# Make ERR trap inherit to shell functions (the rollback trap)
+set -eEuo pipefail
+
+ARCHIVE="${REMOTE_ARCHIVE:-}"
+RELEASE_NAME="${RELEASE_NAME:-}"
+FULL_COMMIT="${FULL_COMMIT:-}"
+PREV_RELEASE_PATH="${PREV_RELEASE_PATH:-}"
+VERIFY_ONLY="${VERIFY_ONLY:-0}"
 
 RELEASES_DIR=/opt/eeepc-agent/runtimes/self-evolving-agent/releases
-RELEASE_DIR="$RELEASES_DIR/$RELEASE_NAME"
+CURRENT_SYMLINK=/opt/eeepc-agent/runtimes/self-evolving-agent/current
 VENV_BASE=/opt/eeepc-agent/runtimes/self-evolving-agent/venv
 
-echo "[remote] extracting to $RELEASE_DIR"
-sudo mkdir -p "$RELEASES_DIR"
-cd /tmp
-sudo tar xzf "$ARCHIVE" -C "$RELEASES_DIR"
-echo "$FULL_COMMIT" | sudo tee "$RELEASE_DIR/SOURCE_COMMIT" > /dev/null
-if [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
-  echo "CRITICAL: SOURCE_COMMIT does not match full deployed commit" >&2
-  exit 1
+if [ "$VERIFY_ONLY" -eq 1 ]; then
+  echo "[remote] VERIFY-ONLY mode: using current live release for checks"
+  RELEASE_DIR="$(sudo readlink "$CURRENT_SYMLINK" || true)"
+  if [ -z "$RELEASE_DIR" ]; then
+    echo "CRITICAL: could not resolve current release symlink in verify-only mode" >&2
+    exit 1
+  fi
+  if [ ! -f "$RELEASE_DIR/SOURCE_COMMIT" ]; then
+    echo "CRITICAL: no SOURCE_COMMIT found in current release $RELEASE_DIR" >&2
+    exit 1
+  fi
+  FULL_COMMIT="$(sudo cat "$RELEASE_DIR/SOURCE_COMMIT")"
+else
+  RELEASE_DIR="$RELEASES_DIR/$RELEASE_NAME"
+
+  echo "[remote] extracting to $RELEASE_DIR"
+  sudo mkdir -p "$RELEASES_DIR"
+  cd /tmp
+  sudo tar xzf "$ARCHIVE" -C "$RELEASES_DIR"
+  echo "$FULL_COMMIT" | sudo tee "$RELEASE_DIR/SOURCE_COMMIT" > /dev/null
+  if [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
+    echo "CRITICAL: SOURCE_COMMIT does not match full deployed commit" >&2
+    exit 1
+  fi
+
+  echo "[remote] linking venv into release"
+  sudo ln -sfn "/opt/eeepc-agent/venv" "$RELEASE_DIR/.venv"
+
+  echo "[remote] syncing operator presets (#906)"
+  sudo mkdir -p /etc/eeepc-agent/presets
+  sudo cp "$RELEASE_DIR/host/eeepc/etc/presets/"*.env /etc/eeepc-agent/presets/ 2>/dev/null || true
+
+  echo "[remote] migrating goal priorities to derived_priorities.json (#944)"
+  STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
+  sudo mkdir -p "$STATE_DIR/goals"
+  DERIVED="$STATE_DIR/goals/derived_priorities.json"
+  GOAL_TEXT="$STATE_DIR/goals/goal_text.json"
+  if [ -f "$GOAL_TEXT" ]; then
+    sudo python3 "$RELEASE_DIR/host/eeepc/scripts/migrate_goal_priorities.py" "$GOAL_TEXT" "$DERIVED"
+    sudo chown eeepc-agent:eeepc-agent "$DERIVED"
+  elif [ ! -f "$DERIVED" ]; then
+    echo "[remote] no legacy or derived priorities found; goal_review will mint from the charter"
+  fi
+
+  echo "[remote] fixing ownership and permissions on release"
+  sudo chown -R root:root "$RELEASE_DIR" "$VENV_BASE"
+
+  sudo chown root:root /opt/eeepc-agent
+  sudo chown root:root /opt/eeepc-agent/runtimes
+  sudo chown root:root /opt/eeepc-agent/runtimes/self-evolving-agent
+  sudo chown root:root "$RELEASES_DIR"
+  sudo chown -h root:root "$RELEASE_DIR/.venv"
+  sudo chown root:root /opt/eeepc-agent/venv
+
+  sudo chmod -R go-w "$RELEASE_DIR"
+
+  if [ "$(stat -c '%u:%g' "$RELEASE_DIR")" != "0:0" ]; then
+    echo "CRITICAL: $RELEASE_DIR is not owned by root:root" >&2
+    exit 1
+  fi
+  if [ "$(stat -c '%u:%g' /opt/eeepc-agent/runtimes/self-evolving-agent)" != "0:0" ]; then
+    echo "CRITICAL: /opt/eeepc-agent/runtimes/self-evolving-agent is not owned by root:root" >&2
+    exit 1
+  fi
+
+  echo "[remote] updating current symlink"
+  sudo ln -sfn "$RELEASE_DIR" "$CURRENT_SYMLINK"
+  sudo chown -h root:root "$CURRENT_SYMLINK"
 fi
-
-echo "[remote] linking venv into release"
-sudo ln -sfn "/opt/eeepc-agent/venv" "$RELEASE_DIR/.venv"
-
-echo "[remote] syncing operator presets (#906)"
-sudo mkdir -p /etc/eeepc-agent/presets
-sudo cp "$RELEASE_DIR/host/eeepc/etc/presets/"*.env /etc/eeepc-agent/presets/ 2>/dev/null || true
-
-echo "[remote] migrating goal priorities to derived_priorities.json (#944)"
-STATE_DIR=/var/lib/eeepc-agent/self-evolving-agent/state
-sudo mkdir -p "$STATE_DIR/goals"
-DERIVED="$STATE_DIR/goals/derived_priorities.json"
-GOAL_TEXT="$STATE_DIR/goals/goal_text.json"
-if [ -f "$GOAL_TEXT" ]; then
-  sudo python3 "$RELEASE_DIR/host/eeepc/scripts/migrate_goal_priorities.py" "$GOAL_TEXT" "$DERIVED"
-  sudo chown eeepc-agent:eeepc-agent "$DERIVED"
-elif [ ! -f "$DERIVED" ]; then
-  echo "[remote] no legacy or derived priorities found; goal_review will mint from the charter"
-fi
-
-echo "[remote] fixing ownership and permissions on release"
-sudo chown -R root:root "$RELEASE_DIR" "$VENV_BASE"
-
-sudo chown root:root /opt/eeepc-agent
-sudo chown root:root /opt/eeepc-agent/runtimes
-sudo chown root:root /opt/eeepc-agent/runtimes/self-evolving-agent
-sudo chown root:root "$RELEASES_DIR"
-sudo chown -h root:root "$RELEASE_DIR/.venv"
-sudo chown root:root /opt/eeepc-agent/venv
-
-sudo chmod -R go-w "$RELEASE_DIR"
-
-if [ "$(stat -c '%u:%g' "$RELEASE_DIR")" != "0:0" ]; then
-  echo "CRITICAL: $RELEASE_DIR is not owned by root:root" >&2
-  exit 1
-fi
-if [ "$(stat -c '%u:%g' /opt/eeepc-agent/runtimes/self-evolving-agent)" != "0:0" ]; then
-  echo "CRITICAL: /opt/eeepc-agent/runtimes/self-evolving-agent is not owned by root:root" >&2
-  exit 1
-fi
-
-echo "[remote] updating current symlink"
-sudo ln -sfn "$RELEASE_DIR" /opt/eeepc-agent/runtimes/self-evolving-agent/current
-sudo chown -h root:root /opt/eeepc-agent/runtimes/self-evolving-agent/current
 
 # Once current has moved, every later remote failure must restore the previous
 # release immediately; never leave a failed release active (#1236).
 rollback_remote() {
+  if [ "$VERIFY_ONLY" -eq 1 ]; then
+    echo "[remote] check failed in verify-only mode; leaving live release alone" >&2
+    return
+  fi
   echo "[remote] rollback after activation failure: $PREV_RELEASE_PATH" >&2
-  sudo ln -sfn "$PREV_RELEASE_PATH" /opt/eeepc-agent/runtimes/self-evolving-agent/current
+  sudo ln -sfn "$PREV_RELEASE_PATH" "$CURRENT_SYMLINK"
   sudo systemctl restart eeebot-dashboard.service 2>/dev/null || true
   sudo systemctl restart eeepc-self-evolving-subagent-bridge.service 2>/dev/null || true
 }
 trap rollback_remote ERR
 
-if [ "$(stat -c '%u:%g' /opt/eeepc-agent/runtimes/self-evolving-agent/current)" != "0:0" ]; then
-  echo "CRITICAL: /opt/eeepc-agent/runtimes/self-evolving-agent/current is not owned by root:root" >&2
+if [ "$(stat -c '%u:%g' "$CURRENT_SYMLINK")" != "0:0" ]; then
+  echo "CRITICAL: $CURRENT_SYMLINK is not owned by root:root" >&2
   exit 1
 fi
 
 echo "[remote] goals.md available at: $RELEASE_DIR/goals.md"
 
-sudo mkdir -p /var/lib/eeepc-promoted
-sudo chown root:eeepc-agent /var/lib/eeepc-promoted
-sudo chmod 0755 /var/lib/eeepc-promoted
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  sudo mkdir -p /var/lib/eeepc-promoted
+  sudo chown root:eeepc-agent /var/lib/eeepc-promoted
+  sudo chmod 0755 /var/lib/eeepc-promoted
 
-sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/validator_harness \
-  /var/lib/eeepc-agent/self-evolving-agent/state/curator \
-  /var/lib/eeepc-agent/self-evolving-agent/state/action_index \
-  /var/lib/eeepc-agent/self-evolving-agent/state/reflector
-sudo chown eeepc-agent:eeepc-agent \
-  /var/lib/eeepc-agent/self-evolving-agent/state/validator_harness \
-  /var/lib/eeepc-agent/self-evolving-agent/state/curator \
-  /var/lib/eeepc-agent/self-evolving-agent/state/action_index \
-  /var/lib/eeepc-agent/self-evolving-agent/state/reflector
+  sudo mkdir -p /var/lib/eeepc-agent/self-evolving-agent/state/validator_harness \
+    /var/lib/eeepc-agent/self-evolving-agent/state/curator \
+    /var/lib/eeepc-agent/self-evolving-agent/state/action_index \
+    /var/lib/eeepc-agent/self-evolving-agent/state/reflector
+  sudo chown eeepc-agent:eeepc-agent \
+    /var/lib/eeepc-agent/self-evolving-agent/state/validator_harness \
+    /var/lib/eeepc-agent/self-evolving-agent/state/curator \
+    /var/lib/eeepc-agent/self-evolving-agent/state/action_index \
+    /var/lib/eeepc-agent/self-evolving-agent/state/reflector
 
-echo "[remote] syncing libexec scripts from release"
-sudo cp "$RELEASE_DIR/host/eeepc/libexec/"*.py /usr/local/libexec/
-sudo rm -f /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
-sudo chmod +x /usr/local/libexec/*.py
+  echo "[remote] syncing libexec scripts from release"
+  sudo cp "$RELEASE_DIR/host/eeepc/libexec/"*.py /usr/local/libexec/
+  sudo rm -f /usr/local/libexec/eeepc-self-evolving-subagent-bridge.py
+  sudo chmod +x /usr/local/libexec/*.py
 
-echo "[remote] purging retired ghost units (#1037)"
-for ghost_unit in eeepc-network-fallback.timer eeepc-network-fallback.service; do
-  ghost_load_state="$(systemctl show "$ghost_unit" -p LoadState --value)"
-  if [ "$ghost_load_state" != "not-found" ]; then
-    if systemctl is-active --quiet "$ghost_unit"; then
-      sudo systemctl stop "$ghost_unit"
+  echo "[remote] purging retired ghost units (#1037)"
+  for ghost_unit in eeepc-network-fallback.timer eeepc-network-fallback.service; do
+    ghost_load_state="$(systemctl show "$ghost_unit" -p LoadState --value)"
+    if [ "$ghost_load_state" != "not-found" ]; then
+      if systemctl is-active --quiet "$ghost_unit"; then
+        sudo systemctl stop "$ghost_unit"
+      fi
+      ghost_file_state="$(systemctl show "$ghost_unit" -p UnitFileState --value)"
+      case "$ghost_file_state" in
+        enabled|enabled-runtime|linked|linked-runtime|alias|generated|transient)
+          sudo systemctl disable "$ghost_unit"
+          ;;
+      esac
     fi
-    ghost_file_state="$(systemctl show "$ghost_unit" -p UnitFileState --value)"
-    case "$ghost_file_state" in
-      enabled|enabled-runtime|linked|linked-runtime|alias|generated|transient)
-        sudo systemctl disable "$ghost_unit"
-        ;;
-    esac
-  fi
-done
+  done
 
-sudo rm -f /etc/systemd/system/eeepc-network-fallback.timer /etc/systemd/system/eeepc-network-fallback.service
-sudo systemctl daemon-reload
+  sudo rm -f /etc/systemd/system/eeepc-network-fallback.timer /etc/systemd/system/eeepc-network-fallback.service
+  sudo systemctl daemon-reload
+fi
 
 for ghost_unit in eeepc-network-fallback.timer eeepc-network-fallback.service; do
   ghost_load_state="$(systemctl show "$ghost_unit" -p LoadState --value)"
@@ -249,9 +285,11 @@ if [ -e /etc/systemd/system/eeepc-network-fallback.timer ] || [ -e /etc/systemd/
   exit 1
 fi
 
-echo "[remote] syncing systemd units + reloading"
-sudo cp "$RELEASE_DIR/host/eeepc/systemd/"*.service "$RELEASE_DIR/host/eeepc/systemd/"*.timer /etc/systemd/system/
-sudo systemctl daemon-reload
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  echo "[remote] syncing systemd units + reloading"
+  sudo cp "$RELEASE_DIR/host/eeepc/systemd/"*.service "$RELEASE_DIR/host/eeepc/systemd/"*.timer /etc/systemd/system/
+  sudo systemctl daemon-reload
+fi
 
 sync_timer() {
   local timer="$1"
@@ -271,7 +309,9 @@ sync_timer() {
   initial_state="$(systemctl is-enabled "$timer" 2>/dev/null || true)"
 
   if [ "$initial_state" = "enabled" ]; then
-    sudo systemctl restart "$timer"
+    if [ "$VERIFY_ONLY" -eq 0 ]; then
+      sudo systemctl restart "$timer"
+    fi
     local final_state
     final_state="$(systemctl is-enabled "$timer" 2>/dev/null || true)"
     if [ "$final_state" != "enabled" ]; then
@@ -284,6 +324,10 @@ sync_timer() {
     fi
   elif [ "$initial_state" = "disabled" ]; then
     if [ "$required" = "required" ]; then
+      if [ "$VERIFY_ONLY" -eq 1 ]; then
+        echo "CRITICAL: required timer $timer is disabled, failing verify-only mode" >&2
+        return 1
+      fi
       echo "[remote] enabling required timer $timer"
       sudo systemctl enable --now "$timer"
       local final_state
@@ -326,6 +370,10 @@ sync_timer() {
       return 1
     fi
   else
+    if [ "$VERIFY_ONLY" -eq 1 ]; then
+      echo "CRITICAL: $timer state is $initial_state, failing verify-only mode" >&2
+      return 1
+    fi
     echo "[remote] enabling standard timer $timer (state was: $initial_state)"
     sudo systemctl enable --now "$timer"
     local final_state
@@ -359,16 +407,30 @@ DASHBOARD_LOAD_STATE="$(systemctl show "$DASHBOARD_UNIT" -p LoadState --value 2>
 DASHBOARD_UNIT_STATE="$(systemctl is-enabled "$DASHBOARD_UNIT" 2>/dev/null || true)"
 if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
   if [ "$DASHBOARD_UNIT_STATE" = "enabled" ]; then
-    echo "[remote] restarting $DASHBOARD_UNIT after current activation"
-    DASHBOARD_PREV_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
-    DASHBOARD_PREV_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
-    sudo systemctl restart "$DASHBOARD_UNIT"
-    if ! systemctl is-active --quiet "$DASHBOARD_UNIT"; then
-      echo "CRITICAL: $DASHBOARD_UNIT is not active after restart" >&2
-      exit 1
+    if [ "$VERIFY_ONLY" -eq 1 ]; then
+      echo "[remote] verify-only mode: checking $DASHBOARD_UNIT without restart"
+      if ! systemctl is-active --quiet "$DASHBOARD_UNIT"; then
+        echo "CRITICAL: $DASHBOARD_UNIT is not active" >&2
+        exit 1
+      fi
+      DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
+      DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
+    else
+      echo "[remote] restarting $DASHBOARD_UNIT after current activation"
+      DASHBOARD_PREV_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
+      DASHBOARD_PREV_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
+      sudo systemctl restart "$DASHBOARD_UNIT"
+      if ! systemctl is-active --quiet "$DASHBOARD_UNIT"; then
+        echo "CRITICAL: $DASHBOARD_UNIT is not active after restart" >&2
+        exit 1
+      fi
+      DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
+      DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
+      if [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
+        echo "CRITICAL: $DASHBOARD_UNIT restart did not produce a new process identity" >&2
+        exit 1
+      fi
     fi
-    DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
-    DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
     # /proc/<pid>/cwd and cmdline belong to the unit's user, not to the
     # deploying account, so both reads need sudo. Without it readlink returns
     # empty and the check below fails a healthy deploy: observed on release
@@ -379,7 +441,7 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     # deploying user before sudo runs. The read itself has to be the sudo'd
     # command.
     DASHBOARD_CMDLINE="$(sudo cat "/proc/$DASHBOARD_PID/cmdline" 2>/dev/null | tr "\0" " " || true)"
-    if [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
+    if [ "$VERIFY_ONLY" -eq 0 ] && [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
       echo "CRITICAL: $DASHBOARD_UNIT restart did not produce a new process identity" >&2
       exit 1
     fi
@@ -387,20 +449,16 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
       echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID cwd is '$DASHBOARD_CWD', expected '$RELEASE_DIR'" >&2
       exit 1
     fi
-    if [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
+    if [ "$VERIFY_ONLY" -eq 0 ] && [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
       echo "CRITICAL: activated release SOURCE_COMMIT does not equal full requested SHA" >&2
       exit 1
     fi
-    # The unit's ExecStart names the `current` symlink, not a release directory
-    # — that indirection is what a release flip is. So the command line can
-    # never contain $RELEASE_DIR, and asserting it did failed every deploy
-    # (#1246). What binds this process to the new release is the cwd check
-    # above, which resolves the symlink; this one only asserts the unit is
-    # running the script and arguments we expect.
+    # The unit's ExecStart names the `current` symlink; the cwd check resolves
+    # that symlink to the release, while this exact check pins script and args.
     case "$DASHBOARD_CMDLINE" in
       *"/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*) : ;;
       *)
-        echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line: $DASHBOARD_CMDLINE" >&2
+        echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line" >&2
         exit 1
         ;;
     esac
@@ -411,11 +469,9 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     # listener row is there but its users:(("python3",pid=...)) field is not,
     # so the owner count reads 0 and this gate fails a healthy deploy — the
     # third read in this block to need the privilege it was missing (#1246).
-    # `systemctl restart` returns when the unit is active, which is before the
-    # Python process has bound the port: measured on this host, :8080 is empty
-    # at t=0 and bound by t<0.4s. Sampling once raced the bind and reported
-    # listeners=0 on a healthy deploy (#1246). Wait for the listener, bounded,
-    # then read it once; an absent listener after the wait is a real failure.
+    # `systemctl restart` returns before the process binds :8080. Wait bounded
+    # for the listener in normal deploy mode; verify-only cannot reproduce the
+    # bind race because it deliberately does not restart the service.
     DASHBOARD_SOCKET_ROWS=""
     for _ in $(seq 1 40); do
       DASHBOARD_SOCKET_ROWS="$(sudo ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
@@ -429,12 +485,19 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
       echo "CRITICAL: :8080 must have exactly one owner, dashboard PID $DASHBOARD_PID; saw listeners=$DASHBOARD_LISTENER_COUNT pids='$DASHBOARD_SOCKET_PIDS'" >&2
       exit 1
     fi
-    if ! ss -ltnH | awk '$4 ~ /:8080$/ {found=1} END {exit !found}'; then
+    if ! sudo ss -ltnH 2>/dev/null | awk '$4 ~ /:8080$/ {found=1} END {exit !found}'; then
       echo "CRITICAL: dashboard listener :8080 is not active" >&2
       exit 1
     fi
-    DASHBOARD_HEALTH="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/health)"
-    DASHBOARD_METRICS="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics)"
+    DASHBOARD_HEALTH="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/health 2>/dev/null || true)"
+    DASHBOARD_METRICS="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics 2>/dev/null || true)"
+    if [ -z "$DASHBOARD_HEALTH" ] || [ -z "$DASHBOARD_METRICS" ]; then
+      if [ "$VERIFY_ONLY" -eq 1 ]; then
+        echo "VERIFY_ONLY HEALTH_FETCH_FAILED" >&2
+      fi
+      echo "CRITICAL: could not fetch health or metrics from :8080" >&2
+      exit 1
+    fi
     DASHBOARD_HEALTH="$DASHBOARD_HEALTH" DASHBOARD_METRICS="$DASHBOARD_METRICS" python3 - <<'PY'
 import json
 import os
@@ -487,16 +550,20 @@ fi
 
 # Ensure bridge service is restarted correctly. Keep the activation rollback trap
 # installed through this restart so a bridge failure restores the previous release.
-sudo systemctl restart eeepc-self-evolving-subagent-bridge.service
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  sudo systemctl restart eeepc-self-evolving-subagent-bridge.service
+fi
 trap - ERR
 
 REMOTE
 
 log "cleaning up local archive"
-run rm -f "$ARCHIVE"
+if [ "$VERIFY_ONLY" -eq 0 ]; then
+  run rm -f "${ARCHIVE:-}"
+fi
 
 # 4. Post-deploy health gate
-if [ "$NO_HEALTH_GATE" -eq 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+if [ "$NO_HEALTH_GATE" -eq 1 ] || [ "$DRY_RUN" -eq 1 ] || [ "$VERIFY_ONLY" -eq 1 ]; then
   log "Health gate skipped."
   log "=== Deploy complete ==="
   exit 0

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -563,6 +563,18 @@ def test_verify_only_uses_privileged_current_reads_and_skips_mutations() -> None
     assert 'FULL_COMMIT="$(sudo cat "$RELEASE_DIR/SOURCE_COMMIT")"' in script
     assert 'if [ "$VERIFY_ONLY" -eq 0 ]; then' in script
     assert 'VERIFY_ONLY" -eq 1' in script
+    assert '0.88 avg over 5 sample(s)' in script
+    assert 'retired dashboard source must be WARN' in script
+    assert 'dashboard endpoint contains stale cycle or host path' in script
+    assert 'health JSON missing bounded fields' in script
+
+
+def test_verify_only_semantic_gate_rejects_stale_raw_dashboard(monkeypatch) -> None:
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    semantic = script.split('DASHBOARD_HEALTH="$DASHBOARD_HEALTH"', 1)[1]
+    assert 'retired dashboard source must be WARN' in script
+    assert '0.88 avg over 5 sample(s)' in semantic
+    assert 'materialize_synthesized_improvement' in semantic
 
 
 def test_socket_owner_check_reads_ss_with_sudo() -> None:

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -209,7 +209,7 @@ def test_dashboard_activation_verifies_pid_release_identity(repo, mock_bin):
     assert 'DASHBOARD_CMDLINE=' in content
     assert 'cwd is' in content
     assert 'activated release SOURCE_COMMIT' in content
-    assert 'unexpected command line' in content
+    assert 'cmdline' in content
     assert 'DASHBOARD_SOCKET_PIDS=' in content
     assert 'DASHBOARD_SOCKET_PID_COUNT=' in content
     assert 'exactly one owner, dashboard PID' in content
@@ -545,29 +545,24 @@ def test_proc_reads_for_the_dashboard_use_sudo() -> None:
 
 
 def test_dashboard_cmdline_check_matches_the_current_symlink_not_a_release_dir() -> None:
-    """The unit's ExecStart names `current`; a release path can never appear.
-
-    Release 20260903T142719Z aborted on
-
-        CRITICAL: eeebot-dashboard.service PID 14387 has unexpected command line
-
-    because the check required the command line to contain `$RELEASE_DIR`,
-    while the host's ExecStart is
-
-        .../venv/bin/python3 .../self-evolving-agent/current/scripts/eeebot_dashboard.py
-            --serve --port 8080 --host 0.0.0.0
-
-    That indirection is what a release flip *is*, so the assertion contradicted
-    the unit it was checking and could not pass on any deploy (#1246). The
-    binding to the new release is proven by the cwd check, which resolves the
-    symlink; this check only pins the script and its arguments.
-    """
+    """Verify-only pins the exact dashboard script and serving arguments."""
     script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
 
-    assert '*"/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*' in script, (
-        "the command-line check must match the current symlink the unit actually runs")
-    assert '"$RELEASE_DIR/scripts/eeebot_dashboard.py' not in script, (
-        "a release directory never appears in the dashboard command line")
+    assert 'case "$DASHBOARD_CMDLINE" in' in script
+    assert '*"/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*)' in script, (
+        "the command-line check must match the current symlink and exact args")
+    assert 'DASHBOARD_CMDLINE" != *"$RELEASE_DIR"*' not in script, (
+        "a release-dir substring must not satisfy verify-only")
+    assert 'DASHBOARD_CMDLINE" != *"/current"*' not in script, (
+        "a bare current substring must not satisfy verify-only")
+
+
+def test_verify_only_uses_privileged_current_reads_and_skips_mutations() -> None:
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    assert 'RELEASE_DIR="$(sudo readlink "$CURRENT_SYMLINK"' in script
+    assert 'FULL_COMMIT="$(sudo cat "$RELEASE_DIR/SOURCE_COMMIT")"' in script
+    assert 'if [ "$VERIFY_ONLY" -eq 0 ]; then' in script
+    assert 'VERIFY_ONLY" -eq 1' in script
 
 
 def test_socket_owner_check_reads_ss_with_sudo() -> None:
@@ -590,7 +585,7 @@ def test_socket_owner_check_reads_ss_with_sudo() -> None:
     assert '"$(ss -ltnpH' not in script, "an unprivileged ss -p read cannot see owners"
     # The plain listener probe needs no privilege: it asks whether anything is
     # bound, not who. Keeping it unprivileged is deliberate, not an oversight.
-    assert "ss -ltnH |" in script
+    assert "sudo ss -ltnH 2>/dev/null |" in script
 
 
 def test_socket_check_waits_for_the_listener_instead_of_sampling_once() -> None:


### PR DESCRIPTION
Clean follow-up for #1250; prior PRs remain untouched.

Base: current `origin/main` `8fac1549`. Verify-only deployment-check scope only. The semantic gate now requires goal/task/gate/reward source metadata, rejects raw legacy reward/gate/cycle/path values, and requires WARN for stale retired sources. Current symlink and SOURCE_COMMIT reads remain privileged; exact dashboard cmdline and mutation guards are preserved.

Validation: bash -n, focused deploy tests 30 passed, Ruff, diff check. No host rollout included. Awaiting exact-head CI and independent review.