### PR TITLE
docs(agents): decommission checklist — label every orphaned read in the same PR (#1173)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,17 @@ scale labels are enough).
   `docs/specs/<capability>/spec.md`. See `docs/changes/README.md`.
 - The change folder is durable *design* documentation tied to a PR — not a status
   tracker (status is the Issue). The two do not duplicate.
+- **Decommission** (removing a writer, unit or module): list its duties as
+  **superseded** (name what does it now), **dropped** (say why nobody needs it) or
+  **orphaned** (a reader still expects the output). In the **same PR**, grep every
+  path it wrote across `ozand/eeebot`, `ozand/eeebot-ops-dashboard`, the instance repo
+  and the host units (`host/eeepc/systemd/`, `/etc/systemd/system`); turn each orphaned
+  read into a labelled `unavailable`/`retired` naming the issue, never an empty default,
+  and record the writer as `orphan:#<issue>` in `nanobot/runtime/state_paths.py`. No
+  test catches this: the reader contract (#1173) lets "empty because absent" pass, so a
+  retired path renders healthy emptiness forever (#1219, #1222, #1224 → ops-dashboard
+  #205). Before reporting, this must show only labelled reads:
+  `rg -n "<state/dir it wrote>" . ../eeebot-ops-dashboard ../eeebot-self-evolving`
 
 ## Working tree and branch safety
 


### PR DESCRIPTION
One bullet under **Change workflow** in `AGENTS.md`. Refs #1173 (amendment of 2026-09-03, item 3: "cheaper as a line in the decommission procedure than as code"), #1224 and ozand/eeebot-ops-dashboard#205.

## Why a procedure line and not a check

The #1173 reader contract permits the failure: "empty-because-absent may proceed". A reader of a decommissioned path is empty-because-absent, so no status changes and no test fails — the panel or lane renders healthy emptiness forever. Nothing links a reader to its writer except `state_paths`, which readers do not consult. Three instances in two days, each costing a follow-up pass: #1219 (`state/research/` readers), #1222 (eight orphaned reads from the #916/#923 deletion, found twelve days later), #1224 → ops-dashboard #205 (dashboard readers of `state/self_evolution/*`, closed 2026-09-03).

## The lines (11, one bullet)

```
- **Decommission** (removing a writer, unit or module): list its duties as
  **superseded** (name what does it now), **dropped** (say why nobody needs it) or
  **orphaned** (a reader still expects the output). In the **same PR**, grep every
  path it wrote across `ozand/eeebot`, `ozand/eeebot-ops-dashboard`, the instance repo
  and the host units (`host/eeepc/systemd/`, `/etc/systemd/system`); turn each orphaned
  read into a labelled `unavailable`/`retired` naming the issue, never an empty default,
  and record the writer as `orphan:#<issue>` in `nanobot/runtime/state_paths.py`. No
  test catches this: the reader contract (#1173) lets "empty because absent" pass, so a
  retired path renders healthy emptiness forever (#1219, #1222, #1224 → ops-dashboard
  #205). Before reporting, this must show only labelled reads:
  `rg -n "<state/dir it wrote>" . ../eeebot-ops-dashboard ../eeebot-self-evolving`
```

Same shape as the #1244 bullet: a rule, the failure it prevents with issue numbers, and one checkable command.

## Existing coverage checked

No existing `AGENTS.md` rule covers decommission. The only nearby text is "What this project is" line 27 ("both entrypoints … must be preserved unless a task explicitly retires them"), which is about the two CLI entrypoints, not about readers of removed writers. `state_paths.py`'s own docstring documents `orphan:#N` (lines 29-37) — the bullet points at it rather than repeating it.

## Tests

No test pins the product `AGENTS.md` text (the #1188/#1193 tests pin the *instance* workspace file and `classify_change_tier`). Full suite result posted as a comment when the run finishes; expected baseline 4 by id (bridge tag fail-open + three `TestAcquireBridgeLock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
