### PR TITLE
fix(deploy): stop the dashboard gate rejecting any host path

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -548,8 +548,15 @@ if source_status["approval_gate_source"] != "fresh" and metrics.get("approval_ga
     raise SystemExit("dashboard gate payload is not bounded")
 if "0.88 avg over 5 sample(s)" in payload or "materialize_synthesized_improvement" in payload:
     raise SystemExit("dashboard endpoint contains raw legacy dashboard values")
-if any(token in payload for token in ("cycle-2f305bf18b42", "/var/lib/eeepc-agent/", "/opt/eeepc-agent/", "0.88 avg over 5 sample(s)", "materialize_synthesized_improvement")):
-    raise SystemExit("dashboard endpoint contains stale cycle or host path")
+# The bare host-path prefixes were in this list and rejected the healthy
+# live payload: `operator_attention` legitimately reports
+# `archive=/var/lib/eeepc-agent/self-evolving-agent/state/subagents/archive`,
+# which is an operational detail, not a leaked retired artifact. A host path
+# appearing anywhere is not evidence of staleness — the frozen cycle id and
+# the retired reward/gate strings are. Caught by `--verify-only` against a
+# healthy host before it could abort a deploy, which is what that mode is for.
+if any(token in payload for token in ("cycle-2f305bf18b42", "0.88 avg over 5 sample(s)", "materialize_synthesized_improvement")):
+    raise SystemExit("dashboard endpoint contains a stale cycle id or retired artifact value")
 PY
   elif [ "$DASHBOARD_UNIT_STATE" = "disabled" ] || [ "$DASHBOARD_UNIT_STATE" = "masked" ]; then
     echo "NOTICE: $DASHBOARD_UNIT is $DASHBOARD_UNIT_STATE; preserving state"

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -563,7 +563,14 @@ def test_verify_only_uses_privileged_current_reads_and_skips_mutations() -> None
     assert 'FULL_COMMIT="$(sudo cat "$RELEASE_DIR/SOURCE_COMMIT")"' in script
     assert 'if [ "$VERIFY_ONLY" -eq 0 ]; then' in script
     assert 'VERIFY_ONLY" -eq 1' in script
-    assert 'dashboard endpoint contains stale cycle or host path' in script
+    # Message reworded with the check: the bare host-path prefixes are gone,
+    # so "or host path" no longer describes what it rejects. The tokens it
+    # still rejects are asserted individually below.
+    assert 'dashboard endpoint contains a stale cycle id or retired artifact value' in script
+    assert '"/var/lib/eeepc-agent/"' not in script, (
+        "a host path appearing in the payload is not evidence of staleness — "
+        "operator_attention legitimately reports one, and listing it here "
+        "rejected every healthy deploy")
     assert 'expected = "OK" if source_status[source_key] == "fresh" else "WARN"' in script
     assert '0.88 avg over 5 sample(s)' in script
     assert 'health JSON missing bounded fields' in script


### PR DESCRIPTION
**`main` cannot deploy right now.** The semantic gate merged in #1262 aborts against the healthy live host:

```
[remote] verify-only mode: checking eeebot-dashboard.service without restart
dashboard endpoint contains stale cycle or host path
[remote] check failed in verify-only mode; leaving live release alone
```

## Cause

The token list included the bare prefixes `/var/lib/eeepc-agent/` and `/opt/eeepc-agent/`. Every healthy payload contains one — `operator_attention` reports:

```
… cleanup=33m ago/fresh · priority=urgent · archive=/var/lib/eeepc-agent/self-evolving-agent/state/subagents/archive
```

That is an operational detail, not a leaked retired artifact. **A host path appearing anywhere is not evidence of staleness.** The frozen cycle id and the retired reward/gate strings are, and they stay in the list.

In a real deploy this aborts *after* `current` is flipped — the same shape as all four defects of #1246, and it would have skipped the health gate too.

## How it was found, which is the point

By running `--verify-only` (#1250, merged four hours ago) against a healthy host. The check was rejected **before it could break a deploy**, instead of after four of them. That mode exists for exactly this and this is its first catch.

## Still failable

Injecting a token the live payload does contain:

```
  injected a token the live payload does contain
dashboard endpoint contains a stale cycle id or retired artifact value
```

Clarity did not cost detection.

## Tests

`tests/test_deploy_release.py` + `tests/test_deploy_integrity.py`: 32 passed. One assertion pinned the old wording, which named "host path" — precisely what the check no longer rejects; it is reworded with the check, and a negative assertion added so the bare prefix cannot return to the token list.

## Note on the branch traffic

#1260 and #1261 are two more branches for the closed #1250, both cut from `8fac1549` — before #1257 merged — so their diffs show my tests as deletions. They are stale; I am closing them. That is four branches for one issue (`-clean`, `-clean-final`, `-final-clean`, plus the merged one), which is #1244's pattern continuing.