### PR TITLE
fix(deploy): say "unreadable" instead of an empty value, and let CRITICAL roll back (#1259)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -128,6 +128,45 @@ run ssh "ozand@${HOST}" "REMOTE_ARCHIVE='${REMOTE_ARCHIVE:-}' RELEASE_NAME='${RE
 # Make ERR trap inherit to shell functions (the rollback trap)
 set -eEuo pipefail
 
+# `set -E` alone does not make the rollback trap cover a CRITICAL: the ERR trap
+# fires on a command that FAILS, and `exit 1` is not a failing command, so
+# every `echo CRITICAL; exit 1` in this block left `current` flipped with no
+# rollback (four half-activated releases on 2026-09-03, #1246). `die` returns
+# non-zero instead: under `set -eE` that runs the ERR trap (rollback_remote,
+# once installed) and then aborts the block with status 1. Fail direction of
+# every CRITICAL below: abort, and roll back if `current` was flipped.
+die() {
+  echo "CRITICAL: $*" >&2
+  return 1
+}
+
+# Every read that feeds a gate goes through this (#1259). `cmd 2>/dev/null ||
+# true` collapsed "the read failed" into "the value is empty" and the gate then
+# described the emptiness: `cwd is ''` meant EITHER wrong release OR a failed
+# read, and the four 2026-09-03 deploys died on the second while the message
+# said the first. gate_read prints the command's stdout unchanged (an EMPTY
+# successful read is still returned — the consuming gate decides what empty
+# means); a non-zero exit is reported as `unreadable: <what> (exit N: <stderr
+# tail>)` and propagates through the assignment, so `set -e` aborts and the ERR
+# trap rolls back. Fail direction: a gate that cannot read must not guess.
+gate_read() {
+  local what="$1"; shift
+  local out err rc=0
+  out="$(mktemp)"; err="$(mktemp)"
+  # Stream through a file, not a variable: a bash command substitution drops
+  # NUL bytes, and /proc/<pid>/cmdline is NUL-separated — capturing it here
+  # would hand the caller's `| tr "\0" " "` nothing to convert (seen on the
+  # healthy host as `python3/opt/…--serve--port8080`, via --verify-only).
+  if "$@" >"$out" 2>"$err"; then rc=0; else rc=$?; fi
+  if [ "$rc" -ne 0 ]; then
+    echo "CRITICAL: unreadable: $what (exit $rc: $(tr '\n' ' ' <"$err" | tail -c 200))" >&2
+    rm -f "$out" "$err"
+    return "$rc"
+  fi
+  cat "$out"
+  rm -f "$out" "$err"
+}
+
 ARCHIVE="${REMOTE_ARCHIVE:-}"
 RELEASE_NAME="${RELEASE_NAME:-}"
 FULL_COMMIT="${FULL_COMMIT:-}"
@@ -140,14 +179,12 @@ VENV_BASE=/opt/eeepc-agent/runtimes/self-evolving-agent/venv
 
 if [ "$VERIFY_ONLY" -eq 1 ]; then
   echo "[remote] VERIFY-ONLY mode: using current live release for checks"
-  RELEASE_DIR="$(sudo readlink "$CURRENT_SYMLINK" || true)"
+  RELEASE_DIR="$(gate_read "$CURRENT_SYMLINK" sudo readlink -v "$CURRENT_SYMLINK")"
   if [ -z "$RELEASE_DIR" ]; then
-    echo "CRITICAL: could not resolve current release symlink in verify-only mode" >&2
-    exit 1
+    die "current release symlink $CURRENT_SYMLINK resolved to an empty target in verify-only mode"
   fi
   if [ ! -f "$RELEASE_DIR/SOURCE_COMMIT" ]; then
-    echo "CRITICAL: no SOURCE_COMMIT found in current release $RELEASE_DIR" >&2
-    exit 1
+    die "no SOURCE_COMMIT found in current release $RELEASE_DIR"
   fi
   FULL_COMMIT="$(sudo cat "$RELEASE_DIR/SOURCE_COMMIT")"
 else
@@ -159,8 +196,7 @@ else
   sudo tar xzf "$ARCHIVE" -C "$RELEASES_DIR"
   echo "$FULL_COMMIT" | sudo tee "$RELEASE_DIR/SOURCE_COMMIT" > /dev/null
   if [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
-    echo "CRITICAL: SOURCE_COMMIT does not match full deployed commit" >&2
-    exit 1
+    die "SOURCE_COMMIT does not match full deployed commit"
   fi
 
   echo "[remote] linking venv into release"
@@ -195,12 +231,10 @@ else
   sudo chmod -R go-w "$RELEASE_DIR"
 
   if [ "$(stat -c '%u:%g' "$RELEASE_DIR")" != "0:0" ]; then
-    echo "CRITICAL: $RELEASE_DIR is not owned by root:root" >&2
-    exit 1
+    die "$RELEASE_DIR is not owned by root:root"
   fi
   if [ "$(stat -c '%u:%g' /opt/eeepc-agent/runtimes/self-evolving-agent)" != "0:0" ]; then
-    echo "CRITICAL: /opt/eeepc-agent/runtimes/self-evolving-agent is not owned by root:root" >&2
-    exit 1
+    die "/opt/eeepc-agent/runtimes/self-evolving-agent is not owned by root:root"
   fi
 
   echo "[remote] updating current symlink"
@@ -211,6 +245,13 @@ fi
 # Once current has moved, every later remote failure must restore the previous
 # release immediately; never leave a failed release active (#1236).
 rollback_remote() {
+  # A failing gate_read raises ERR twice: once inside the `$(...)` subshell
+  # (where nothing set here would survive) and once in the parent for the
+  # failed assignment. Act only in the parent, and only once.
+  if [ "${BASH_SUBSHELL:-0}" -gt 0 ] || [ -n "${ROLLBACK_DONE:-}" ]; then
+    return
+  fi
+  ROLLBACK_DONE=1
   if [ "$VERIFY_ONLY" -eq 1 ]; then
     echo "[remote] check failed in verify-only mode; leaving live release alone" >&2
     return
@@ -223,8 +264,7 @@ rollback_remote() {
 trap rollback_remote ERR
 
 if [ "$(stat -c '%u:%g' "$CURRENT_SYMLINK")" != "0:0" ]; then
-  echo "CRITICAL: $CURRENT_SYMLINK is not owned by root:root" >&2
-  exit 1
+  die "$CURRENT_SYMLINK is not owned by root:root"
 fi
 
 echo "[remote] goals.md available at: $RELEASE_DIR/goals.md"
@@ -272,17 +312,14 @@ fi
 for ghost_unit in eeepc-network-fallback.timer eeepc-network-fallback.service; do
   ghost_load_state="$(systemctl show "$ghost_unit" -p LoadState --value)"
   if [ "$ghost_load_state" != "not-found" ]; then
-    echo "CRITICAL: $ghost_unit remains loaded after purge (state: $ghost_load_state)" >&2
-    exit 1
+    die "$ghost_unit remains loaded after purge (state: $ghost_load_state)"
   fi
   if systemctl is-active --quiet "$ghost_unit"; then
-    echo "CRITICAL: $ghost_unit is still active after purge" >&2
-    exit 1
+    die "$ghost_unit is still active after purge"
   fi
 done
 if [ -e /etc/systemd/system/eeepc-network-fallback.timer ] || [ -e /etc/systemd/system/eeepc-network-fallback.service ]; then
-  echo "CRITICAL: ghost unit files still present on disk" >&2
-  exit 1
+  die "ghost unit files still present on disk"
 fi
 
 if [ "$VERIFY_ONLY" -eq 0 ]; then
@@ -410,8 +447,7 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     if [ "$VERIFY_ONLY" -eq 1 ]; then
       echo "[remote] verify-only mode: checking $DASHBOARD_UNIT without restart"
       if ! systemctl is-active --quiet "$DASHBOARD_UNIT"; then
-        echo "CRITICAL: $DASHBOARD_UNIT is not active" >&2
-        exit 1
+        die "$DASHBOARD_UNIT is not active"
       fi
       DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
       DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
@@ -421,14 +457,12 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
       DASHBOARD_PREV_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
       sudo systemctl restart "$DASHBOARD_UNIT"
       if ! systemctl is-active --quiet "$DASHBOARD_UNIT"; then
-        echo "CRITICAL: $DASHBOARD_UNIT is not active after restart" >&2
-        exit 1
+        die "$DASHBOARD_UNIT is not active after restart"
       fi
       DASHBOARD_PID="$(systemctl show "$DASHBOARD_UNIT" -p MainPID --value)"
       DASHBOARD_START="$(systemctl show "$DASHBOARD_UNIT" -p ExecMainStartTimestamp --value)"
       if [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
-        echo "CRITICAL: $DASHBOARD_UNIT restart did not produce a new process identity" >&2
-        exit 1
+        die "$DASHBOARD_UNIT restart did not produce a new process identity"
       fi
     fi
     # /proc/<pid>/cwd and cmdline belong to the unit's user, not to the
@@ -436,30 +470,31 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     # empty and the check below fails a healthy deploy: observed on release
     # 20260903T141455Z, where the dashboard was correctly running from the new
     # release and the verification could not see it (#1245).
-    DASHBOARD_CWD="$(sudo readlink "/proc/$DASHBOARD_PID/cwd" 2>/dev/null || true)"
+    # Both reads go through gate_read (#1259): a failed read — the process
+    # exited between `systemctl show` and here, /proc unreadable, sudo denied —
+    # aborts as `unreadable: /proc/<pid>/cwd (exit N: <stderr>)`, never as the
+    # `cwd is ''` text below, which now means exactly one thing: the process
+    # runs from somewhere other than the release.
+    DASHBOARD_CWD="$(gate_read "/proc/$DASHBOARD_PID/cwd" sudo readlink -v "/proc/$DASHBOARD_PID/cwd")"
     # `sudo tr ... < file` would not work: the shell opens the redirect as the
     # deploying user before sudo runs. The read itself has to be the sudo'd
-    # command.
-    DASHBOARD_CMDLINE="$(sudo cat "/proc/$DASHBOARD_PID/cmdline" 2>/dev/null | tr "\0" " " || true)"
+    # command; gate_read streams it (see there) so the NULs reach `tr`.
+    DASHBOARD_CMDLINE="$(gate_read "/proc/$DASHBOARD_PID/cmdline" sudo cat "/proc/$DASHBOARD_PID/cmdline" | tr "\0" " ")"
     if [ "$VERIFY_ONLY" -eq 0 ] && [ "$DASHBOARD_PID" = "$DASHBOARD_PREV_PID" ] && [ "$DASHBOARD_START" = "$DASHBOARD_PREV_START" ]; then
-      echo "CRITICAL: $DASHBOARD_UNIT restart did not produce a new process identity" >&2
-      exit 1
+      die "$DASHBOARD_UNIT restart did not produce a new process identity"
     fi
     if [ "$DASHBOARD_CWD" != "$RELEASE_DIR" ]; then
-      echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID cwd is '$DASHBOARD_CWD', expected '$RELEASE_DIR'" >&2
-      exit 1
+      die "$DASHBOARD_UNIT PID $DASHBOARD_PID cwd is '$DASHBOARD_CWD', expected '$RELEASE_DIR'"
     fi
     if [ "$VERIFY_ONLY" -eq 0 ] && [ "$(cat "$RELEASE_DIR/SOURCE_COMMIT")" != "$FULL_COMMIT" ]; then
-      echo "CRITICAL: activated release SOURCE_COMMIT does not equal full requested SHA" >&2
-      exit 1
+      die "activated release SOURCE_COMMIT does not equal full requested SHA"
     fi
     # The unit's ExecStart names the `current` symlink; the cwd check resolves
     # that symlink to the release, while this exact check pins script and args.
     case "$DASHBOARD_CMDLINE" in
       *"/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0"*) : ;;
       *)
-        echo "CRITICAL: $DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line" >&2
-        exit 1
+        die "$DASHBOARD_UNIT PID $DASHBOARD_PID has unexpected command line: $DASHBOARD_CMDLINE"
         ;;
     esac
     echo "[remote] $DASHBOARD_UNIT active: MainPID=$DASHBOARD_PID start=$DASHBOARD_START previous_pid=$DASHBOARD_PREV_PID previous_start=$DASHBOARD_PREV_START cwd=$DASHBOARD_CWD source=$FULL_COMMIT"
@@ -472,9 +507,12 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     # `systemctl restart` returns before the process binds :8080. Wait bounded
     # for the listener in normal deploy mode; verify-only cannot reproduce the
     # bind race because it deliberately does not restart the service.
+    # `ss` itself failing (missing binary, sudo denied) is `unreadable: ss
+    # -ltnpH`; an empty row set from a successful `ss` is the listener not being
+    # up, and the owner gate below says so with the counts it saw.
     DASHBOARD_SOCKET_ROWS=""
     for _ in $(seq 1 40); do
-      DASHBOARD_SOCKET_ROWS="$(sudo ss -ltnpH 2>/dev/null | awk '$4 ~ /:8080$/')"
+      DASHBOARD_SOCKET_ROWS="$(gate_read "ss -ltnpH" sudo ss -ltnpH | awk '$4 ~ /:8080$/')"
       [ -n "$DASHBOARD_SOCKET_ROWS" ] && break
       sleep 0.25
     done
@@ -482,12 +520,11 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
     DASHBOARD_SOCKET_PIDS="$(printf '%s\n' "$DASHBOARD_SOCKET_ROWS" | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u || true)"
     DASHBOARD_SOCKET_PID_COUNT="$(printf '%s\n' "$DASHBOARD_SOCKET_PIDS" | sed '/^$/d' | wc -l)"
     if [ "$DASHBOARD_LISTENER_COUNT" != "1" ] || [ "$DASHBOARD_SOCKET_PID_COUNT" != "1" ] || [ "$DASHBOARD_SOCKET_PIDS" != "$DASHBOARD_PID" ]; then
-      echo "CRITICAL: :8080 must have exactly one owner, dashboard PID $DASHBOARD_PID; saw listeners=$DASHBOARD_LISTENER_COUNT pids='$DASHBOARD_SOCKET_PIDS'" >&2
-      exit 1
+      die ":8080 must have exactly one owner, dashboard PID $DASHBOARD_PID; saw listeners=$DASHBOARD_LISTENER_COUNT pids='$DASHBOARD_SOCKET_PIDS'"
     fi
-    if ! sudo ss -ltnH 2>/dev/null | awk '$4 ~ /:8080$/ {found=1} END {exit !found}'; then
-      echo "CRITICAL: dashboard listener :8080 is not active" >&2
-      exit 1
+    DASHBOARD_PLAIN_ROWS="$(gate_read "ss -ltnH" sudo ss -ltnH | awk '$4 ~ /:8080$/')"
+    if [ -z "$DASHBOARD_PLAIN_ROWS" ]; then
+      die "dashboard listener :8080 is not active"
     fi
     DASHBOARD_HEALTH="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/health 2>/dev/null || true)"
     DASHBOARD_METRICS="$(curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics 2>/dev/null || true)"
@@ -495,8 +532,7 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
       if [ "$VERIFY_ONLY" -eq 1 ]; then
         echo "VERIFY_ONLY HEALTH_FETCH_FAILED" >&2
       fi
-      echo "CRITICAL: could not fetch health or metrics from :8080" >&2
-      exit 1
+      die "could not fetch health or metrics from :8080"
     fi
     DASHBOARD_HEALTH="$DASHBOARD_HEALTH" DASHBOARD_METRICS="$DASHBOARD_METRICS" python3 - <<'PY'
 import json
@@ -561,14 +597,12 @@ PY
   elif [ "$DASHBOARD_UNIT_STATE" = "disabled" ] || [ "$DASHBOARD_UNIT_STATE" = "masked" ]; then
     echo "NOTICE: $DASHBOARD_UNIT is $DASHBOARD_UNIT_STATE; preserving state"
   else
-    echo "CRITICAL: $DASHBOARD_UNIT is loaded but not enabled (state: $DASHBOARD_UNIT_STATE)" >&2
-    exit 1
+    die "$DASHBOARD_UNIT is loaded but not enabled (state: $DASHBOARD_UNIT_STATE)"
   fi
 elif [ "$DASHBOARD_LOAD_STATE" = "not-found" ] || [ -z "$DASHBOARD_LOAD_STATE" ]; then
   echo "NOTICE: $DASHBOARD_UNIT is not found; preserving absence"
 else
-  echo "CRITICAL: unexpected $DASHBOARD_UNIT LoadState=$DASHBOARD_LOAD_STATE" >&2
-  exit 1
+  die "unexpected $DASHBOARD_UNIT LoadState=$DASHBOARD_LOAD_STATE"
 fi
 
 # Ensure bridge service is restarted correctly. Keep the activation rollback trap
@@ -670,7 +704,24 @@ while :; do
   # #1200's recorder: a failure recorded after the flip is a crash the journal
   # grep above may not have seen yet (or a signal/OOM once the ExecStopPost
   # drop-in is installed); a success recorded after the flip is a full run.
-  STREAK_RAW=$(ssh "ozand@${HOST}" "sudo cat $EXIT_STREAK_PATH 2>/dev/null || true")
+  # #1259: an unreadable recorder file is not "no signal yet". It means the
+  # CLEAN-EXIT / FAIL verdicts that come from this file can never arrive, and
+  # the gate will run to its timeout on the journal alone. Say so once, with
+  # the exit status and stderr, instead of polling silently. The DECISION is
+  # unchanged (the journal verdicts below still decide; a missing file still
+  # counts as no signal) — only what is said changed.
+  STREAK_ERR="$(mktemp)"
+  if STREAK_RAW=$(ssh "ozand@${HOST}" "sudo cat $EXIT_STREAK_PATH" 2>"$STREAK_ERR"); then
+    :
+  else
+    STREAK_RC=$?
+    STREAK_RAW=""
+    if [ -z "${STREAK_UNREADABLE_LOGGED:-}" ]; then
+      log "Health gate: unreadable: $EXIT_STREAK_PATH (exit $STREAK_RC: $(tr '\n' ' ' <"$STREAK_ERR" | tail -c 200)) — the exit recorder's CLEAN-EXIT/FAIL signals cannot arrive; deciding on the journal alone."
+      STREAK_UNREADABLE_LOGGED=1
+    fi
+  fi
+  rm -f "$STREAK_ERR"
   if [ -n "$STREAK_RAW" ]; then
     STREAK_FAIL_TS=$(echo "$STREAK_RAW" | grep -o '"last_failure_ts": "[^"]*"' | cut -d'"' -f4 || true)
     STREAK_OK_TS=$(echo "$STREAK_RAW" | grep -o '"last_success_ts": "[^"]*"' | cut -d'"' -f4 || true)

--- a/tests/test_deploy_integrity.py
+++ b/tests/test_deploy_integrity.py
@@ -58,14 +58,15 @@ def test_deploy_script_fail_closed_and_ghost_cleanup() -> None:
     assert "eeepc-network-fallback.timer" in content
     assert "eeepc-network-fallback.service" in content
     assert "sudo rm -f /etc/systemd/system/eeepc-network-fallback.timer /etc/systemd/system/eeepc-network-fallback.service" in content
-    assert '"CRITICAL: $ghost_unit is still active after purge"' in content
+    # #1259: CRITICALs go through `die` (same text, returns 1 so the ERR trap fires)
+    assert 'die "$ghost_unit is still active after purge"' in content
 
     # #1236: a long-running dashboard must restart after current activation,
     # while rollback restores it before restarting the bridge.
     assert 'DASHBOARD_UNIT=eeebot-dashboard.service' in content
     assert 'sudo systemctl restart "$DASHBOARD_UNIT"' in content
     assert 'systemctl show "$DASHBOARD_UNIT" -p MainPID --value' in content
-    assert 'readlink "/proc/$DASHBOARD_PID/cwd"' in content
+    assert 'readlink -v "/proc/$DASHBOARD_PID/cwd"' in content
     assert 'sudo systemctl restart eeebot-dashboard.service && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service' in content
     assert content.index('updating current symlink') < content.index('sudo systemctl restart "$DASHBOARD_UNIT"') < content.index('Ensure bridge service is restarted correctly')
 

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -184,7 +184,7 @@ def test_dashboard_activation_and_rollback_are_in_deploy_script(repo, mock_bin):
     assert 'DASHBOARD_UNIT=eeebot-dashboard.service' in content
     assert 'sudo systemctl restart "$DASHBOARD_UNIT"' in content
     assert 'systemctl show "$DASHBOARD_UNIT" -p MainPID --value' in content
-    assert 'readlink "/proc/$DASHBOARD_PID/cwd"' in content
+    assert 'readlink -v "/proc/$DASHBOARD_PID/cwd"' in content
     assert 'sudo systemctl restart eeebot-dashboard.service && sudo systemctl restart eeepc-self-evolving-subagent-bridge.service' in content
     assert content.index("updating current symlink") < content.index('sudo systemctl restart "$DASHBOARD_UNIT"')
     assert content.index('sudo systemctl restart "$DASHBOARD_UNIT"') < content.index("Ensure bridge service is restarted correctly")
@@ -193,7 +193,9 @@ def test_dashboard_activation_and_rollback_are_in_deploy_script(repo, mock_bin):
 def test_dashboard_activation_fails_when_enabled_unit_restart_fails(repo, mock_bin):
     content = (repo / "host" / "eeepc" / "scripts" / "deploy_release.sh").read_text()
     assert 'if ! systemctl is-active --quiet "$DASHBOARD_UNIT"' in content
-    assert 'CRITICAL: $DASHBOARD_UNIT is not active after restart' in content
+    # #1259: CRITICALs go through `die` (prints "CRITICAL: ..." and returns 1 so
+    # the ERR trap rolls back); the emitted text is unchanged.
+    assert 'die "$DASHBOARD_UNIT is not active after restart"' in content
     assert 'curl --fail --silent --show-error http://127.0.0.1:8080/api/health' in content
     assert 'curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics' in content
     assert 'dashboard listener :8080 is not active' in content
@@ -536,9 +538,15 @@ def test_proc_reads_for_the_dashboard_use_sudo() -> None:
     """
     script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
 
-    assert 'sudo readlink "/proc/$DASHBOARD_PID/cwd"' in script, (
+    # #1259: both reads go through gate_read, which runs the sudo'd command as
+    # its argv — the privilege is still on the read itself.
+    assert 'gate_read "/proc/$DASHBOARD_PID/cwd" sudo readlink -v "/proc/$DASHBOARD_PID/cwd"' in script, (
         "the dashboard cwd read must be sudo'd or it returns empty for another user's process")
-    assert 'sudo cat "/proc/$DASHBOARD_PID/cmdline"' in script, (
+    # gate_read streams the sudo'd cat through a file so the NUL separators
+    # reach `tr` — a bash command substitution drops NUL bytes, and capturing
+    # first yielded `python3/opt/…--serve--port8080` on the healthy host
+    # (found by --verify-only, #1259).
+    assert 'gate_read "/proc/$DASHBOARD_PID/cmdline" sudo cat "/proc/$DASHBOARD_PID/cmdline" | tr "\\0" " "' in script, (
         "the cmdline read must be sudo'd as the command, not behind a shell redirect")
     assert '$(sudo tr' not in script, (
         'a sudo tr behind a shell redirect opens the file as the unprivileged user')
@@ -559,7 +567,7 @@ def test_dashboard_cmdline_check_matches_the_current_symlink_not_a_release_dir()
 
 def test_verify_only_uses_privileged_current_reads_and_skips_mutations() -> None:
     script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
-    assert 'RELEASE_DIR="$(sudo readlink "$CURRENT_SYMLINK"' in script
+    assert 'RELEASE_DIR="$(gate_read "$CURRENT_SYMLINK" sudo readlink -v "$CURRENT_SYMLINK")"' in script
     assert 'FULL_COMMIT="$(sudo cat "$RELEASE_DIR/SOURCE_COMMIT")"' in script
     assert 'if [ "$VERIFY_ONLY" -eq 0 ]; then' in script
     assert 'VERIFY_ONLY" -eq 1' in script
@@ -652,9 +660,9 @@ def test_socket_owner_check_reads_ss_with_sudo() -> None:
     assert "sudo ss -ltnpH" in script, (
         "the socket owner read must be sudo'd or it sees no owners at all")
     assert '"$(ss -ltnpH' not in script, "an unprivileged ss -p read cannot see owners"
-    # The plain listener probe needs no privilege: it asks whether anything is
-    # bound, not who. Keeping it unprivileged is deliberate, not an oversight.
-    assert "sudo ss -ltnH 2>/dev/null |" in script
+    # The plain listener probe: `ss` failing is `unreadable`, an empty row set
+    # from a successful `ss` is "listener not active" (#1259).
+    assert 'DASHBOARD_PLAIN_ROWS="$(gate_read "ss -ltnH" sudo ss -ltnH |' in script
 
 
 def test_socket_check_waits_for_the_listener_instead_of_sampling_once() -> None:
@@ -682,3 +690,98 @@ def test_socket_check_waits_for_the_listener_instead_of_sampling_once() -> None:
     assert '[ -n "$DASHBOARD_SOCKET_ROWS" ] && break' in socket_block, (
         "the loop must stop as soon as a listener appears rather than always sleeping 10s")
     assert "sudo ss -ltnpH" in socket_block, "the retried read still needs the owner field"
+
+
+def _remote_block(script: str) -> str:
+    start = script.index("<<'REMOTE'")
+    end = script.index("\nREMOTE\n", start)
+    return script[start:end]
+
+
+def _remote_helpers(script: str) -> str:
+    """The `die` / `gate_read` definitions, cut from the remote block so a test
+    can run them under a real bash with the same `set -eEuo pipefail`."""
+    block = _remote_block(script)
+    start = block.index("die() {")
+    end = block.index('ARCHIVE="${REMOTE_ARCHIVE:-}"')
+    return block[start:end]
+
+
+def test_gate_reads_distinguish_unreadable_from_empty() -> None:
+    """#1259: `cmd 2>/dev/null || true` collapsed a failed read into an empty
+    value, and the gate then described the emptiness — `cwd is ''` meant either
+    "wrong release" or "the read failed", and four deploys died on the second
+    while the message said the first (#1246). Every gate read now goes through
+    gate_read, and none of the four named reads keeps the collapsing shape."""
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    block = _remote_block(script)
+
+    for what in ('"/proc/$DASHBOARD_PID/cwd"', '"/proc/$DASHBOARD_PID/cmdline"', '"ss -ltnpH"', '"ss -ltnH"', '"$CURRENT_SYMLINK"'):
+        assert f"gate_read {what} sudo " in block, f"gate read missing for {what}"
+    assert 'readlink "/proc/$DASHBOARD_PID/cwd" 2>/dev/null || true' not in block
+    assert 'cmdline" 2>/dev/null | tr' not in block
+    assert 'sudo ss -ltnpH 2>/dev/null' not in block
+    assert 'sudo ss -ltnH 2>/dev/null' not in block
+    assert 'readlink "$CURRENT_SYMLINK" || true' not in block
+    assert 'unreadable: $what (exit $rc:' in block
+    # The health gate's recorder read says "unreadable" once instead of polling
+    # silently to a timeout; the decision it feeds is unchanged.
+    assert 'sudo cat $EXIT_STREAK_PATH 2>/dev/null || true' not in script
+    assert 'Health gate: unreadable: $EXIT_STREAK_PATH' in script
+
+
+def test_every_remote_critical_goes_through_die_so_the_err_trap_fires() -> None:
+    """`set -E` was already there and did not cover a single CRITICAL: the ERR
+    trap fires on a FAILING command, and `exit 1` is not one, so every
+    `echo CRITICAL; exit 1` skipped rollback_remote (#1246 left four releases
+    half-activated). `die` returns 1 instead."""
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    block = _remote_block(script)
+    code_lines = [line for line in block.splitlines() if not line.lstrip().startswith("#")]
+    assert not [line for line in code_lines if "exit 1" in line], "a CRITICAL that exits bypasses the ERR trap; use die"
+    assert "set -eEuo pipefail" in block
+    assert "trap rollback_remote ERR" in block
+    assert 'echo "CRITICAL: $*" >&2' in block and "return 1" in block
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_die_and_gate_read_semantics_under_the_remote_shell_options(tmp_path) -> None:
+    """Run the real helper definitions under `set -eEuo pipefail` with an ERR
+    trap, exactly as the remote block does, and show: (1) a failing gate read
+    reports `unreadable` with the exit status and stderr, fires the trap and
+    aborts — it does not hand the gate an empty value; (2) an EMPTY successful
+    read is returned as-is (the gate decides what empty means); (3) `die`
+    fires the trap; (4) the shape it replaces, `exit 1`, does not."""
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    helpers = _remote_helpers(script)
+
+    def run(body: str) -> subprocess.CompletedProcess:
+        test_script = tmp_path / "t.sh"
+        test_script.write_text("set -eEuo pipefail\ntrap 'echo TRAP-FIRED >&2' ERR\n" + helpers + "\n" + body + "\n", newline="\n")
+        return subprocess.run(["bash", str(test_script)], capture_output=True, text=True)
+
+    # (1) failed read: unreadable, trap, abort, and the gate line never runs.
+    res = run('V="$(gate_read "/proc/999999/cwd" bash -c \'echo boom >&2; exit 3\')"\necho "cwd is \'$V\'"')
+    assert res.returncode == 3, res
+    assert "CRITICAL: unreadable: /proc/999999/cwd (exit 3: boom" in res.stderr, res.stderr
+    assert "TRAP-FIRED" in res.stderr
+    assert "cwd is" not in res.stdout
+
+    # (2) empty successful read: no CRITICAL, value handed on untouched.
+    res = run('V="$(gate_read "x" true)"\necho "got [$V]"')
+    assert res.returncode == 0, res
+    assert res.stdout.strip() == "got []"
+    assert "CRITICAL" not in res.stderr
+
+    # (2b) NUL bytes survive to a downstream `tr` — /proc/<pid>/cmdline is
+    # NUL-separated, and a first draft that captured into a variable before
+    # `tr` produced `python3/opt/…--serve--port8080` on the healthy host.
+    res = run('V="$(gate_read "cmdline" printf \'python3\\0--serve\\0\' | tr "\\0" " ")"\necho "got [$V]"')
+    assert res.returncode == 0, res
+    assert res.stdout.strip() == "got [python3 --serve ]"  # trailing NUL → trailing space
+
+    # (3) die fires the trap and aborts with 1; (4) exit 1 inside a function does not.
+    res = run('f() { die "no good"; }\nf\necho unreachable')
+    assert res.returncode == 1 and "CRITICAL: no good" in res.stderr and "TRAP-FIRED" in res.stderr and "unreachable" not in res.stdout
+    res = run('g() { echo "CRITICAL: old shape" >&2; exit 1; }\ng')
+    assert res.returncode == 1 and "TRAP-FIRED" not in res.stderr


### PR DESCRIPTION
Closes #1259. From #1173's amendment, item 1.

## Defect

Every host read feeding a `CRITICAL` used `cmd 2>/dev/null || true`, discarding the exit status and the error text. `cwd is ''` meant either "wrong release" or "the read failed"; four deploys died on the second on 2026-09-03 while the message said the first (#1246). The health gate's `exit_streak.json` read had the same shape with a worse consequence: an unreadable file was a silently missing success signal.

## Change — what is said, not what is decided

**`gate_read <what> <cmd…>`** wraps every gate read in the remote block: the `current` symlink (verify-only), `/proc/<pid>/cwd`, `/proc/<pid>/cmdline`, `ss -ltnpH`, `ss -ltnH`. A non-zero exit → `CRITICAL: unreadable: <what> (exit N: <stderr tail>)` and abort. An **empty successful read is passed through unchanged** — the consuming gate still decides what empty means, so no gate's verdict moved. It streams through a file rather than a variable because a bash command substitution drops NUL bytes (below).

**`die <msg>`** replaces every `echo "CRITICAL: …" >&2; exit 1` in the remote block. **`set -E` was already there and covered no CRITICAL**: the ERR trap fires on a failing *command*, and `exit 1` is not one — verified empirically:

```
set -eEuo pipefail; trap 'echo TRAP' ERR
f(){ exit 1; };   f      → no TRAP, rc=1      (every CRITICAL until now)
g(){ return 1; }; g      → TRAP, rc=1         (die)
V="$(h)" with h failing  → TRAP               (gate_read assignment)
r | tr with r failing    → TRAP, rc=3         (gate_read in a pipeline, pipefail)
```

So every half-activated release on 2026-09-03 stayed active because the abort path never reached `rollback_remote`. `die` returns 1 with the same text; the trap runs, then `set -e` aborts. `rollback_remote` now acts once and only in the parent shell — a failing `gate_read` raises ERR twice, once inside the `$(…)` subshell and once for the assignment. `sync_timer` already used `return 1` and was covered.

**Health gate**: the `exit_streak.json` read keeps its decision (a missing file is still no signal; the journal verdicts still decide) but an unreadable file is logged **once** as `Health gate: unreadable: <path> (exit N: <stderr>) — the exit recorder's CLEAN-EXIT/FAIL signals cannot arrive; deciding on the journal alone.`

`readlink` gained `-v` so a failure carries its reason on stderr.

## Unreadable vs empty — demonstrated on `eeepc-lan` with `--verify-only`

Scratch copies mutated one line each; nothing deployed, no unit touched. Live release `20260903T220549Z-canonical-6b1d070e`, dashboard PID 5974.

| run | mutation | before this PR | now |
|---|---|---|---|
| unmutated | — | green | green (`=== Deploy complete ===`, exit 0) |
| M0 | `DASHBOARD_PID=999999` (read fails; the value is not wrong) | `cwd is '', expected '/opt/…'` | `CRITICAL: unreadable: /proc/999999/cwd (exit 1: readlink: /proc/999999/cwd: No such file or directory)` |
| M1 | `ss` binary missing | `saw listeners=0 pids=''` | `CRITICAL: unreadable: ss -ltnpH (exit 1: sudo: ss-nonexistent: command not found)` |

## Four-defect reproduction, re-run

| defect | caught | message now |
|---|---|---|
| D1 `sudo` removed from the cwd `readlink` | **yes** | `CRITICAL: unreadable: /proc/5974/cwd (exit 1: readlink: /proc/5974/cwd: Permission denied)` — **message changed**: it was `cwd is ''`, which is now reserved for a process genuinely running elsewhere |
| D2 cmdline compared to `$RELEASE_DIR` | **yes** | `CRITICAL: … has unexpected command line: /opt/…/venv/bin/python3 /opt/…/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0` — unchanged |
| D3 `sudo` removed from `ss -ltnpH` | **yes** | `CRITICAL: :8080 must have exactly one owner, dashboard PID 5974; saw listeners=1 pids=''` — unchanged, and correctly **not** `unreadable`: `ss` succeeded, the value is what is wrong |
| D4 socket sampled once | **no, by design** | verify-only does not restart the service, so the bind race cannot occur — unchanged |

Detection is unchanged; the text under D1 is the whole point of the issue.

## The regression `--verify-only` caught in this PR

The first draft captured the sudo'd `cat` into a variable inside `gate_read` and applied `tr "\0" " "` afterwards. The healthy host failed: `unexpected command line: …python3/opt/…/eeebot_dashboard.py--serve--port8080--host0.0.0.0` — bash command substitution drops NUL bytes, so `tr` had nothing to convert. The sandbox test could not see it (its fixture ends in a single NUL). Fixed by streaming through a temp file; pinned by `test_die_and_gate_read_semantics…` case 2b (`printf 'python3\0--serve\0' | tr` → `python3 --serve `). Two `--verify-only` runs, one minute, one regression that would have been a broken deploy.

## Not changed, stated

- `systemctl show … 2>/dev/null || true` for `LoadState`/`is-enabled` (lines ~430-433) feed a *skip*, not a CRITICAL: a failed `systemctl` there makes the whole dashboard block silently skip. Same class, different decision; out of this issue's stated set. Open question below.
- `sync_timer`'s `is-enabled … || true`: `is-enabled` exits 1 for a legitimately disabled unit, so `|| true` is needed for the value there; a failed `systemctl` reads as `''` → "state is , failing verify-only". Not one of the four reads; noted.
- `curl … || true` for `/api/health`: a fetch, whose failure is the finding; message unchanged.

## Tests

`tests/test_deploy_release.py` + `tests/test_deploy_integrity.py`: 35 passed (was 32; +3). New: `test_gate_reads_distinguish_unreadable_from_empty` (content: the five reads go through `gate_read`, none keeps `2>/dev/null || true`, the health gate read says unreadable), `test_every_remote_critical_goes_through_die_so_the_err_trap_fires` (no `exit 1` in the remote block; `set -eEuo`, trap, `die` present), `test_die_and_gate_read_semantics_under_the_remote_shell_options` (runs the real helper text under `set -eEuo pipefail` + ERR trap: failed read → unreadable + trap + abort; empty read passes through; NULs survive; `die` fires the trap; `exit 1` does not). Six existing literal assertions updated to the new shape (`readlink -v`, `die "…"`, `gate_read …`); the messages they pin are unchanged.

Full suite result posted as a comment (baseline 4 by id: bridge tag fail-open + three `TestAcquireBridgeLock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
