### PR TITLE
fix(deploy): gate the dashboard HTML page, not only its JSON endpoints (#1270)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -534,6 +534,29 @@ if [ "$DASHBOARD_LOAD_STATE" = "loaded" ]; then
       fi
       die "could not fetch health or metrics from :8080"
     fi
+    # #1270: the page a person actually reads. /api/health and /api/metrics
+    # are built by a different code path from the HTML renderer, so a
+    # KeyError in the renderer shipped behind a green gate and / returned
+    # 500 for 25 minutes. Status code and a body-size floor only — never
+    # markup: an unhandled exception yields a non-200, a broken renderer
+    # yields a stub, and coupling the gate to HTML content is how a gate
+    # gets routed around. gate_read keeps #1259's distinction: curl that
+    # cannot connect is `unreadable: …/ (exit 7: …)`, a page that answers
+    # with an error is reported as its status code. No --fail here: a 500
+    # must reach the status check, not the unreadable branch.
+    DASHBOARD_PAGE_BODY="$(mktemp)"
+    DASHBOARD_PAGE_STATUS="$(gate_read "http://127.0.0.1:8080/" curl --silent --show-error --max-time 30 --output "$DASHBOARD_PAGE_BODY" --write-out '%{http_code}' http://127.0.0.1:8080/)"
+    DASHBOARD_PAGE_BYTES="$(wc -c <"$DASHBOARD_PAGE_BODY" | tr -d ' ')"
+    rm -f "$DASHBOARD_PAGE_BODY"
+    if [ "$DASHBOARD_PAGE_STATUS" != "200" ]; then
+      die "dashboard page / returned HTTP $DASHBOARD_PAGE_STATUS ($DASHBOARD_PAGE_BYTES bytes); the HTML renderer is broken while /api/* may still be healthy"
+    fi
+    # Live page is ~18.8 KB; the floor catches a stub or an error page that
+    # somehow carries a 200, and nothing a working renderer produces.
+    if [ "$DASHBOARD_PAGE_BYTES" -lt 1024 ]; then
+      die "dashboard page / body is $DASHBOARD_PAGE_BYTES bytes (< 1024); the renderer produced a stub"
+    fi
+    echo "[remote] dashboard page / HTTP $DASHBOARD_PAGE_STATUS, $DASHBOARD_PAGE_BYTES bytes"
     DASHBOARD_HEALTH="$DASHBOARD_HEALTH" DASHBOARD_METRICS="$DASHBOARD_METRICS" python3 - <<'PY'
 import json
 import os

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -199,6 +200,16 @@ def test_dashboard_activation_fails_when_enabled_unit_restart_fails(repo, mock_b
     assert 'curl --fail --silent --show-error http://127.0.0.1:8080/api/health' in content
     assert 'curl --fail --silent --show-error http://127.0.0.1:8080/api/metrics' in content
     assert 'dashboard listener :8080 is not active' in content
+    # #1270: the page a person reads. A KeyError in the HTML renderer shipped
+    # behind a green gate because only the two /api/* endpoints were fetched.
+    # Status + body-size floor, through gate_read (connect failure stays
+    # `unreadable`), and deliberately no --fail so a 500 reaches the status check.
+    assert 'gate_read "http://127.0.0.1:8080/" curl --silent --show-error --max-time 30 --output "$DASHBOARD_PAGE_BODY" --write-out \'%{http_code}\' http://127.0.0.1:8080/' in content
+    assert 'die "dashboard page / returned HTTP $DASHBOARD_PAGE_STATUS' in content
+    assert 'if [ "$DASHBOARD_PAGE_BYTES" -lt 1024 ]; then' in content
+    assert 'die "dashboard page / body is $DASHBOARD_PAGE_BYTES bytes (< 1024)' in content
+    urls = sorted(set(re.findall(r"http://127\.0\.0\.1:8080[a-z/_]*", content)))
+    assert urls == ["http://127.0.0.1:8080/", "http://127.0.0.1:8080/api/health", "http://127.0.0.1:8080/api/metrics"], urls
 
 
 def test_dashboard_activation_verifies_pid_release_identity(repo, mock_bin):
@@ -627,7 +638,7 @@ def test_verify_only_no_mutation_end_to_end_sandbox(tmp_path):
     mock("sudo", f'''echo "sudo $*" >> {log}
     case "$1" in readlink) echo {shlex.quote(str(release))};; cat) if [[ "$2" == *SOURCE_COMMIT ]]; then echo {sha}; else printf "python3 /opt/eeepc-agent/runtimes/self-evolving-agent/current/scripts/eeebot_dashboard.py --serve --port 8080 --host 0.0.0.0\\0"; fi;; ss) echo 'LISTEN 0 128 0.0.0.0:8080 0.0.0.0:* users:(("python3",pid=4242,fd=3))';; *) exit 97;; esac''')
     mock("ss", f'''echo "ss $*" >> {log}; echo 'LISTEN 0 128 0.0.0.0:8080 0.0.0.0:* users:(("python3",pid=4242,fd=3))' ''')
-    mock("curl", f'''echo "curl $*" >> {log}; case "$*" in *health*) echo '{{"overall":"WARN","dimensions":{{"reward":{{"status":"WARN","detail":"source=stale"}},"gate":{{"status":"WARN","detail":"source=stale"}}}},"goal":"stale","active_task":"stale","reward_average":"stale; age=100.0h (context-only artifact)"}}';; *) echo '{{"goal":"stale; age=100.0h (context-only artifact)","active_task":"stale; age=100.0h (context-only artifact)","approval_gate_state":"stale; age=100.0h (context-only artifact)","reward_average":"stale; age=100.0h (context-only artifact)","reward_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"goal_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"active_task_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"approval_gate_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"latest_report_path":null,"materialized_path":null}}';; esac''')
+    mock("curl", f'''echo "curl $*" >> {log}; case "$*" in *--write-out*) out=""; prev=""; for a in "$@"; do [ "$prev" = "--output" ] && out="$a"; prev="$a"; done; head -c 2048 /dev/zero | tr "\\0" x > "$out"; echo 200;; *health*) echo '{{"overall":"WARN","dimensions":{{"reward":{{"status":"WARN","detail":"source=stale"}},"gate":{{"status":"WARN","detail":"source=stale"}}}},"goal":"stale","active_task":"stale","reward_average":"stale; age=100.0h (context-only artifact)"}}';; *) echo '{{"goal":"stale; age=100.0h (context-only artifact)","active_task":"stale; age=100.0h (context-only artifact)","approval_gate_state":"stale; age=100.0h (context-only artifact)","reward_average":"stale; age=100.0h (context-only artifact)","reward_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"goal_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"active_task_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"approval_gate_source":{{"status":"stale","age_hours":100.0,"authoritative":false,"context_only":true}},"latest_report_path":null,"materialized_path":null}}';; esac''')
     mock("sleep", f'''echo "sleep $*" >> {log}; exit 97''')
     mock("stat", f'''echo "stat $*" >> {log}; echo 0:0''')
 
@@ -785,3 +796,57 @@ def test_die_and_gate_read_semantics_under_the_remote_shell_options(tmp_path) ->
     assert res.returncode == 1 and "CRITICAL: no good" in res.stderr and "TRAP-FIRED" in res.stderr and "unreachable" not in res.stdout
     res = run('g() { echo "CRITICAL: old shape" >&2; exit 1; }\ng')
     assert res.returncode == 1 and "TRAP-FIRED" not in res.stderr
+
+
+def _remote_page_check(script: str) -> str:
+    """The `/` page gate cut from the remote block (#1270), from the body
+    tempfile to the success echo, so a test can run it with a fake curl."""
+    block = _remote_block(script)
+    start = block.index('DASHBOARD_PAGE_BODY="$(mktemp)"')
+    end = block.index('echo "[remote] dashboard page /', start)
+    end = block.index("\n", end) + 1
+    return block[start:end]
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+def test_dashboard_page_gate_fires_on_error_status_stub_and_unreachable(tmp_path) -> None:
+    """#1270: run the real page-gate text under the remote shell options with
+    a fake curl. 500 → its own CRITICAL naming the status; a 200 with a tiny
+    body → the floor; connect failure → `unreadable` (the #1259 distinction,
+    not an empty value); a 200 with a real-sized body → passes and echoes."""
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    helpers = _remote_helpers(script)
+    page = _remote_page_check(script)
+
+    def run(code: str, body_bytes: int, connect_fail: bool = False) -> subprocess.CompletedProcess:
+        fake_curl = (
+            "curl() {\n"
+            "  local out=\"\"; local prev=\"\"\n"
+            "  for a in \"$@\"; do [ \"$prev\" = \"--output\" ] && out=\"$a\"; prev=\"$a\"; done\n"
+            + ("  echo 'curl: (7) Failed to connect to 127.0.0.1 port 8080' >&2; return 7\n" if connect_fail else
+               f"  head -c {body_bytes} /dev/zero | tr '\\0' x > \"$out\"; printf '%s' {code}\n")
+            + "}\n"
+        )
+        t = tmp_path / "page.sh"
+        t.write_text("set -eEuo pipefail\ntrap 'echo TRAP-FIRED >&2' ERR\n" + helpers + fake_curl + page + 'echo PASSED\n', newline="\n")
+        return subprocess.run(["bash", str(t)], capture_output=True, text=True)
+
+    res = run("500", 4000)
+    assert res.returncode == 1, res
+    assert "CRITICAL: dashboard page / returned HTTP 500 (4000 bytes)" in res.stderr and "TRAP-FIRED" in res.stderr
+    assert "PASSED" not in res.stdout
+
+    res = run("200", 18)
+    assert res.returncode == 1, res
+    assert "CRITICAL: dashboard page / body is 18 bytes (< 1024)" in res.stderr
+    assert "PASSED" not in res.stdout
+
+    res = run("200", 0, connect_fail=True)
+    assert res.returncode == 7, res
+    assert "CRITICAL: unreadable: http://127.0.0.1:8080/ (exit 7: curl: (7) Failed to connect" in res.stderr
+    assert "returned HTTP" not in res.stderr, "a connect failure must not be reported as a status"
+
+    res = run("200", 18804)
+    assert res.returncode == 0, res
+    assert "[remote] dashboard page / HTTP 200, 18804 bytes" in res.stdout and "PASSED" in res.stdout
+    assert "CRITICAL" not in res.stderr


### PR DESCRIPTION
Closes #1270. **Do not merge on my say-so** — opened for review; the operator merges.

## Defect

The dashboard gate fetched exactly two URLs, `/api/health` and `/api/metrics`. On 2026-09-04 the HTML renderer raised `KeyError: 'overall_health'` on every request for ~25 minutes while both JSON endpoints stayed healthy (different code path), and the deploy that shipped it passed its gate. The page a person reads was never requested.

## Change

One request added beside the two that already run, after the socket-owner and JSON checks:

```bash
DASHBOARD_PAGE_BODY="$(mktemp)"
DASHBOARD_PAGE_STATUS="$(gate_read "http://127.0.0.1:8080/" curl --silent --show-error --max-time 30 --output "$DASHBOARD_PAGE_BODY" --write-out '%{http_code}' http://127.0.0.1:8080/)"
DASHBOARD_PAGE_BYTES="$(wc -c <"$DASHBOARD_PAGE_BODY" | tr -d ' ')"
[ "$DASHBOARD_PAGE_STATUS" != "200" ]     → die "dashboard page / returned HTTP <code> (<n> bytes); the HTML renderer is broken while /api/* may still be healthy"
[ "$DASHBOARD_PAGE_BYTES" -lt 1024 ]      → die "dashboard page / body is <n> bytes (< 1024); the renderer produced a stub"
echo "[remote] dashboard page / HTTP 200, <n> bytes"
```

Status code and a body-size floor only. **No markup validation.** Runs in normal deploy mode and `--verify-only` alike (same block). #1259's distinction is kept: `gate_read` reports a curl that cannot connect as `unreadable: http://127.0.0.1:8080/ (exit 7: …)`; a page that answers with an error is reported by its status. Deliberately no `--fail`, so a 500 reaches the status check instead of the unreadable branch. Since #1266, every one of these `die`s rolls back in deploy mode.

## Demonstration — `--verify-only` against `eeepc-lan`, nothing deployed, no unit touched

**Healthy host, this branch:**
```
[remote] dashboard page / HTTP 200, 18804 bytes
[deploy] === Deploy complete ===          exit 0
```

**Firing**, scratch copies with only the page URL pointed at `:18080`, served by an ephemeral user-level `python3 -m http.server` in `/tmp` (killed and its dirs removed afterwards):

| case | message |
|---|---|
| F1 nothing listening on `:18080` | `CRITICAL: unreadable: http://127.0.0.1:18080/ (exit 7: curl: (7) Failed to connect to 127.0.0.1 port 18080 after 0 ms: Couldn't connect to server)` |
| F2 `200` with an 18-byte body | `CRITICAL: dashboard page / body is 18 bytes (< 1024); the renderer produced a stub` |
| F3 `404` (335-byte error page) | `CRITICAL: dashboard page / returned HTTP 404 (335 bytes); the HTML renderer is broken while /api/* may still be healthy` |

Each aborted with `[remote] check failed in verify-only mode; leaving live release alone`. The production failure (500 with a traceback page) takes F3's branch.

## Four-defect reproduction, re-run on this branch

| defect | caught | message |
|---|---|---|
| D1 `sudo` removed from cwd `readlink` | **yes** | `unreadable: /proc/27790/cwd (exit 1: readlink: … Permission denied)` |
| D2 cmdline compared to `$RELEASE_DIR` | **yes** | `… has unexpected command line: …/venv/bin/python3 …/current/scripts/eeebot_dashboard.py --serve …` |
| D3 `sudo` removed from `ss -ltnpH` | **yes** | `:8080 must have exactly one owner, dashboard PID 27790; saw listeners=1 pids=''` |
| D4 socket sampled once | no, by design | verify-only does not restart the service |

## False positive: what it would look like, and why the floor will not produce one

A false positive is a healthy release rolled back because `/` answered non-200 or under 1 KB. Candidates:

- **Slow first render after restart.** Measured live, five sequential GETs of `/`: `1.146 s` (cold), then `0.005 s` ×4, all `200 18804B`. The check runs after the gate has already polled the socket for up to 10 s and fetched both JSON endpoints, and carries `--max-time 30`. A first render 25× slower than the cold one measured would still pass.
- **Body under the floor.** The live page is 18,804 B; the floor is 1,024 B, an 18× margin. The dashboard has no empty-state render that small — the sandbox fixture's own page mock returns 2 KB. A working renderer that produces < 1 KB of HTML would be a product change large enough to notice.
- **Transient 5xx during startup.** The socket is bound and `/api/*` answered by this point, so the process is serving; the renderer either works or does not for a given release. The 25-minute outage was deterministic, not flapping.
- **curl missing / connect refused** → `unreadable`, abort. Correct: the gate cannot certify what it cannot read.

The remaining risk is a genuinely broken renderer being rolled back — which is the intended behaviour, and what did not happen on 2026-09-04.

## Tests

`tests/test_deploy_release.py` + `tests/test_deploy_integrity.py`: **36 passed** (+1). New `test_dashboard_page_gate_fires_on_error_status_stub_and_unreachable` runs the real page-gate text under `set -eEuo pipefail` + ERR trap with a fake `curl`: 500 → status CRITICAL + trap; 200/18 B → floor; connect failure → `unreadable … exit 7` and *not* a status message; 200/18804 B → passes and echoes. Content test pins the exact `gate_read … curl` line, both `die` messages, the floor, and that the URL set the script fetches is exactly `{/, /api/health, /api/metrics}`. The sandbox end-to-end test's curl mock now answers `--write-out` with `200` and a 2 KB body.

Full suite result posted as a comment when the run finishes (baseline 4 by id: bridge tag fail-open + three `TestAcquireBridgeLock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
