### PR TITLE
fix(usage): include archived touch evidence safely

### DIFF
--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -140,6 +140,7 @@ _RUNTIME_CHURNED_EXACT: frozenset[str] = frozenset({
 _RESCAN_HOURS = 6
 _HEADER_LINES = 50  # bounded output-path extraction window
 _MAX_RESULT_FILES = 50  # same bounded-read discipline as demand._MAX_RESULT_FILES
+_TOUCH_EVIDENCE_BLOCKING_STATUSES = frozenset({"unavailable", "partial", "corrupt"})
 
 # #800: decay-eligibility epoch — the #761 usage-evidence deployment date.
 # Scripts created BEFORE this date can be legitimately stale without ever
@@ -472,35 +473,67 @@ def _harness_run_signal(script: Path, state_dir: Path, selfevo_repo: Path) -> st
         return None
 
 
-def _touched_from_results(state_dir: Path) -> dict[str, str]:
-    """``touched:result`` — repo-relative script paths mentioned in recent
-    subagent RESULT files' ``files_changed``, mapped to the newest such
-    result file's mtime. Bounded to the :data:`_MAX_RESULT_FILES` most
-    recently modified files (existence_index/demand bounded-read
-    discipline). Modification is tracked separately from usage: an edit
-    proves the loop touched the file, not that anything consumes it."""
+def _touched_from_results_with_status(state_dir: Path) -> tuple[dict[str, str], str]:
+    """Read bounded touch evidence from live and archived result artifacts.
+
+    The result archiver moves completed payloads from ``results/`` to the flat
+    ``archive/`` directory within the touch/decay horizon.  Scan the union
+    before applying the bound, newest-first, with a path tie-break so an
+    archived result cannot disappear merely because it is no longer live.
+
+    The status is persisted with the usage sidecar because an empty map is not
+    enough to distinguish a quiet window from unreadable evidence.  ``missing``
+    and the non-complete statuses are safe for Class-B consumers: they must not
+    manufacture destructive decay candidates from an incomplete read.
+    """
     touched: dict[str, str] = {}
     try:
-        results_dir = Path(state_dir) / "subagents" / "results"
-        if not results_dir.is_dir():
-            return touched
-        entries = [p for p in results_dir.glob("*.json") if p.is_file()]
+        root = Path(state_dir) / "subagents"
+        if not root.is_dir():
+            return touched, "missing"
+
+        entries: list[Path] = []
+        present_dirs = 0
+        inaccessible = False
+        for name in ("results", "archive"):
+            directory = root / name
+            try:
+                if not directory.is_dir():
+                    continue
+                present_dirs += 1
+                entries.extend(p for p in directory.iterdir() if p.is_file() and p.suffix == ".json")
+            except PermissionError:
+                inaccessible = True
+            except OSError:
+                inaccessible = True
+
+        if not present_dirs and not entries:
+            return touched, "missing"
+
         try:
-            entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-        except Exception:
-            pass
+            entries.sort(key=lambda p: (p.stat().st_mtime, p.parent.name, p.name), reverse=True)
+        except OSError:
+            return touched, "unavailable"
+
+        status = "unavailable" if inaccessible else "complete"
         for entry in entries[:_MAX_RESULT_FILES]:
             try:
                 data = json.loads(entry.read_text(encoding="utf-8"))
-            except Exception:
+            except PermissionError:
+                status = "unavailable"
+                continue
+            except (OSError, ValueError, json.JSONDecodeError):
+                status = "corrupt"
                 continue
             if not isinstance(data, dict):
+                status = "corrupt"
                 continue
             files = data.get("files_changed")
             if not isinstance(files, list):
                 continue
             mtime = _mtime_iso(entry)
             if mtime is None:
+                status = "partial"
                 continue
             for f in files:
                 rel = str(f or "").strip()
@@ -509,9 +542,26 @@ def _touched_from_results(state_dir: Path) -> dict[str, str]:
                 prev = touched.get(rel)
                 if prev is None or mtime > prev:
                     touched[rel] = mtime
-        return touched
+
+        if not entries:
+            status = "valid-empty"
+        return touched, status
+    except PermissionError:
+        return touched, "unavailable"
+    except OSError:
+        return touched, "unavailable"
     except Exception:
-        return touched
+        return touched, "partial"
+
+
+def _touched_from_results(state_dir: Path) -> dict[str, str]:
+    """Compatibility wrapper returning only the touch map.
+
+    Callers that make safety-sensitive decisions should use
+    :func:`_touched_from_results_with_status` and persist/inspect its status.
+    """
+    touched, _status = _touched_from_results_with_status(state_dir)
+    return touched
 
 
 _IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+(?:(?:scripts|surfaces)\.)?([A-Za-z_]\w*)", re.MULTILINE)
@@ -695,7 +745,8 @@ def refresh_usage(state_dir: Path, selfevo_repo: Path | None) -> dict[str, Any]:
             return data  # watermark no-op — idle cycles stay cheap
 
         entries: dict[str, Any] = data["entries"]
-        touched_map = _touched_from_results(state_dir)
+        touched_map, touched_status = _touched_from_results_with_status(state_dir)
+        data["touched_results_status"] = touched_status
         ref_index = _reference_index(state_dir, repo, sidecar_data=data) if _reference_signal_enabled() else {}
 
         script_files: list[Path] = []
@@ -1303,6 +1354,9 @@ def stale_artifacts(
         cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
         usage_data = sidecar_data or _load_usage(Path(state_dir))
         entries = usage_data.get("entries") or {}
+        touch_status = str(usage_data.get("touched_results_status") or "complete")
+        if touch_status in _TOUCH_EVIDENCE_BLOCKING_STATUSES:
+            return []
         protected = _decay_protected_paths() | _heldout_contracted_paths()
         out: list[dict[str, str]] = []
         script_files: list[Path] = []

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -494,11 +494,13 @@ def _touched_from_results_with_status(state_dir: Path) -> tuple[dict[str, str], 
 
         entries: list[Path] = []
         present_dirs = 0
+        missing_dirs = 0
         inaccessible = False
         for name in ("results", "archive"):
             directory = root / name
             try:
                 if not directory.is_dir():
+                    missing_dirs += 1
                     continue
                 present_dirs += 1
                 entries.extend(p for p in directory.iterdir() if p.is_file() and p.suffix == ".json")
@@ -515,7 +517,11 @@ def _touched_from_results_with_status(state_dir: Path) -> tuple[dict[str, str], 
         except OSError:
             return touched, "unavailable"
 
-        status = "unavailable" if inaccessible else "complete"
+        # A bounded prefix is safe only when the complete eligible set was
+        # inspected. Missing one of the expected directories is conservative:
+        # it cannot silently look like a complete empty horizon.
+        capped = len(entries) > _MAX_RESULT_FILES
+        status = "partial" if capped or missing_dirs or inaccessible else "complete"
         for entry in entries[:_MAX_RESULT_FILES]:
             try:
                 data = json.loads(entry.read_text(encoding="utf-8"))
@@ -543,7 +549,7 @@ def _touched_from_results_with_status(state_dir: Path) -> tuple[dict[str, str], 
                 if prev is None or mtime > prev:
                     touched[rel] = mtime
 
-        if not entries:
+        if not entries and not missing_dirs and not inaccessible:
             status = "valid-empty"
         return touched, status
     except PermissionError:

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -1368,12 +1368,27 @@ def stale_artifacts(
         if not selfevo_repo:
             return []
         repo = Path(selfevo_repo)
-        cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
-        usage_data = sidecar_data or _load_usage(Path(state_dir))
-        entries = usage_data.get("entries") or {}
-        touch_status = str(usage_data.get("touched_results_status") or "unknown")
+        now_value = now or datetime.now(timezone.utc)
+        cutoff = now_value - timedelta(days=older_than_days)
+        usage_data = dict(sidecar_data) if sidecar_data is not None else _load_usage(Path(state_dir))
+        # A decay decision must not trust a six-hour refresh watermark: the
+        # result/archive evidence can change independently of the repo HEAD.
+        # Re-read status and merge only the fresh bounded touch map here.
+        fresh_touched, fresh_status = _touched_from_results_with_status(Path(state_dir))
+        persisted_status = str(usage_data.get("touched_results_status") or "unknown")
+        touch_status = fresh_status if fresh_status != "valid-empty" else persisted_status
+        if fresh_status not in {"complete", "valid-empty"}:
+            touch_status = fresh_status
         if touch_status in _TOUCH_EVIDENCE_BLOCKING_STATUSES:
             return []
+        entries = dict(usage_data.get("entries") or {})
+        for rel, touched in fresh_touched.items():
+            entry = entries.get(rel)
+            entry = dict(entry) if isinstance(entry, dict) else {}
+            prior = str(entry.get("last_touched") or "")
+            if not prior or touched > prior:
+                entry["last_touched"] = touched
+                entries[rel] = entry
         protected = _decay_protected_paths() | _heldout_contracted_paths()
         out: list[dict[str, str]] = []
         script_files: list[Path] = []

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -28,6 +28,17 @@ so the three signals are all things the harness can observe on disk itself:
   tracked separately from *used* — editing a script is not evidence anyone
   consumes it); the result file's mtime is the touch timestamp.
 
+Touch evidence scans the union of ``subagents/results/`` and the flat
+``subagents/archive/`` newest-first, with a deterministic ``(mtime, directory,
+name)`` descending order and a shared bound of :data:`_MAX_RESULT_FILES`.
+A bounded or incomplete read is reported as ``partial`` (rather than silently
+being treated as complete); missing/unreadable/corrupt input is reported
+explicitly. Class-B consumers such as ``stale_artifacts`` must refuse
+ destructive decay candidates for ``missing``, ``unknown``, ``partial``,
+``unavailable`` or ``corrupt`` status. Operators must provision both expected
+result directories, including an explicitly empty archive, before a complete
+empty horizon can be claimed.
+
 systemd/cron execution traces are NOT reachable from the state dir — they
 are deliberately skipped, never faked.
 

--- a/nanobot/runtime/usage_evidence.py
+++ b/nanobot/runtime/usage_evidence.py
@@ -140,7 +140,7 @@ _RUNTIME_CHURNED_EXACT: frozenset[str] = frozenset({
 _RESCAN_HOURS = 6
 _HEADER_LINES = 50  # bounded output-path extraction window
 _MAX_RESULT_FILES = 50  # same bounded-read discipline as demand._MAX_RESULT_FILES
-_TOUCH_EVIDENCE_BLOCKING_STATUSES = frozenset({"unavailable", "partial", "corrupt"})
+_TOUCH_EVIDENCE_BLOCKING_STATUSES = frozenset({"missing", "unavailable", "partial", "corrupt", "unknown"})
 
 # #800: decay-eligibility epoch — the #761 usage-evidence deployment date.
 # Scripts created BEFORE this date can be legitimately stale without ever
@@ -1360,7 +1360,7 @@ def stale_artifacts(
         cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
         usage_data = sidecar_data or _load_usage(Path(state_dir))
         entries = usage_data.get("entries") or {}
-        touch_status = str(usage_data.get("touched_results_status") or "complete")
+        touch_status = str(usage_data.get("touched_results_status") or "unknown")
         if touch_status in _TOUCH_EVIDENCE_BLOCKING_STATUSES:
             return []
         protected = _decay_protected_paths() | _heldout_contracted_paths()

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -104,6 +104,13 @@ def _write_usage_sidecar(state_dir: Path, entries: dict, **top) -> None:
     (state_dir / "usage").mkdir(parents=True, exist_ok=True)
     data = {"schema_version": "usage-evidence-v1", "entries": entries}
     data.update(top)
+    # Existing fixtures model a successfully completed reader pass unless a
+    # test explicitly exercises missing/unknown legacy metadata.
+    data.setdefault("touched_results_status", "complete")
+    # Ordinary decay fixtures represent a known empty/completed artifact
+    # horizon; tests for missing input remove these directories explicitly.
+    for name in ("results", "archive"):
+        (state_dir / "subagents" / name).mkdir(parents=True, exist_ok=True)
     (state_dir / "usage" / "last_used.json").write_text(
         json.dumps(data), encoding="utf-8"
     )
@@ -382,26 +389,34 @@ class TestArchiveAwareTouchedEvidence:
         assert touched == {}
         assert status == "valid-empty"
 
-    def test_equal_mtime_prefers_archive_then_name_deterministically(self, tmp_path):
+    def test_equal_mtime_boundary_uses_deterministic_order(self, tmp_path):
         state_dir = _state_dir(tmp_path)
-        live = _write_result_artifact(
-            state_dir, "results", "result-z.json",
-            {"files_changed": ["scripts/live.py"]}, days_ago=2,
+        # Exactly 51 artifacts share one mtime. The first 50 in descending
+        # (mtime, directory, name) order are selected; the boundary item is not.
+        for i in range(51):
+            _write_result_artifact(
+                state_dir,
+                "archive" if i % 2 else "results",
+                f"result-{i:02d}.json",
+                {"files_changed": [f"scripts/tool_{i:02d}.py"]},
+                days_ago=2,
+            )
+        paths = list((state_dir / "subagents" / "results").glob("*.json")) + list(
+            (state_dir / "subagents" / "archive").glob("*.json")
         )
-        archived = _write_result_artifact(
-            state_dir, "archive", "result-a.json",
-            {"files_changed": ["scripts/archive.py"]}, days_ago=2,
-        )
-        mtime = live.stat().st_mtime
-        os.utime(archived, (mtime, mtime))
+        mtime = paths[0].stat().st_mtime
+        for path in paths:
+            os.utime(path, (mtime, mtime))
 
         touched, status = usage_evidence._touched_from_results_with_status(state_dir)
 
-        assert status == "complete"
-        assert set(touched) == {"scripts/live.py", "scripts/archive.py"}
-        # Reverse tuple ordering is explicit: archive sorts ahead of results
-        # for equal mtimes, and names sort descending within a directory.
-        assert list((state_dir / "subagents" / "archive").iterdir())[0].name == "result-a.json"
+        assert status == "partial"
+        assert len(touched) == 50
+        # `results` sorts ahead of `archive` in reverse tuple ordering; names
+        # descend within each directory, so archive/result-01 is the boundary
+        # item excluded while all results entries remain selected.
+        assert "scripts/tool_00.py" in touched
+        assert "scripts/tool_01.py" not in touched
 
     def test_one_missing_result_dir_is_partial(self, tmp_path):
         state_dir = _state_dir(tmp_path)
@@ -427,6 +442,20 @@ class TestArchiveAwareTouchedEvidence:
 
         _write_usage_sidecar(state_dir, {}, touched_results_status=status)
         repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
+
+    def test_missing_result_evidence_blocks_decay(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
+        _write_usage_sidecar(state_dir, {}, touched_results_status="missing")
+        import shutil
+        shutil.rmtree(state_dir / "subagents")
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
+
+    def test_unknown_sidecar_status_blocks_decay(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
+        _write_usage_sidecar(state_dir, {}, touched_results_status="unknown")
         assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
 
     def test_malformed_result_is_explicit_and_blocks_decay(self, tmp_path):

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -460,6 +460,23 @@ class TestArchiveAwareTouchedEvidence:
         assert persisted["schema_version"] == "usage-evidence-v1"
         assert "scripts/used_tool.py" in persisted["entries"]
 
+    def test_decay_refreshes_status_within_watermark(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
+        for name in ("results", "archive"):
+            (state_dir / "subagents" / name).mkdir(parents=True, exist_ok=True)
+        _write_usage_sidecar(
+            state_dir,
+            {"scripts/old_tool.py": {"last_used": _now_iso(days_ago=30), "last_touched": _now_iso(days_ago=20), "signal": "pycache"}},
+            touched_results_status="complete",
+            git_head="pinned", scanned_at_utc=_now_iso(),
+        )
+        bad = state_dir / "subagents" / "archive" / "result-new.json"
+        bad.write_text("{", encoding="utf-8")
+        _set_mtime(bad, 1)
+
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
+
     def test_missing_result_evidence_blocks_decay(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -444,6 +444,22 @@ class TestArchiveAwareTouchedEvidence:
         repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
         assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
 
+    def test_refresh_usage_persists_touch_reader_status(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        repo = _git_repo(tmp_path)
+        _write_result_artifact(
+            state_dir, "archive", "result-archived.json",
+            {"files_changed": ["scripts/used_tool.py"]}, days_ago=3,
+        )
+
+        data = usage_evidence.refresh_usage(state_dir, repo)
+        persisted = _usage_sidecar(state_dir)
+
+        assert data["touched_results_status"] == "partial"
+        assert persisted["touched_results_status"] == "partial"
+        assert persisted["schema_version"] == "usage-evidence-v1"
+        assert "scripts/used_tool.py" in persisted["entries"]
+
     def test_missing_result_evidence_blocks_decay(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -314,6 +314,87 @@ class TestRefreshUsageSignals:
         assert "scripts/used_tool.py" not in data["entries"]
 
 
+# ─── #1272: archive-aware touched evidence ───────────────────────────────────
+
+
+def _write_result_artifact(state_dir: Path, directory: str, name: str, payload: dict, days_ago: float = 0) -> Path:
+    path = state_dir / "subagents" / directory / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    _set_mtime(path, days_ago)
+    return path
+
+
+class TestArchiveAwareTouchedEvidence:
+    def test_archived_result_contributes_touched_evidence(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        archived = _write_result_artifact(
+            state_dir,
+            "archive",
+            "result-archived.json",
+            {"files_changed": ["scripts/used_tool.py"]},
+            days_ago=3,
+        )
+
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+
+        assert touched == {"scripts/used_tool.py": usage_evidence._mtime_iso(archived)}
+        assert status == "complete"
+
+    def test_touched_reader_uses_newest_deterministic_bounded_union(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        for i in range(50):
+            _write_result_artifact(
+                state_dir,
+                "archive" if i % 2 else "results",
+                f"result-{i:02d}.json",
+                {"files_changed": [f"scripts/tool_{i:02d}.py"]},
+                days_ago=i,
+            )
+        oldest = _write_result_artifact(
+            state_dir,
+            "archive",
+            "result-oldest.json",
+            {"files_changed": ["scripts/oldest.py"]},
+            days_ago=60,
+        )
+
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+
+        assert status == "complete"
+        assert len(touched) == 50
+        assert "scripts/tool_00.py" in touched
+        assert "scripts/tool_49.py" in touched
+        assert "scripts/oldest.py" not in touched
+        assert usage_evidence._mtime_iso(oldest) not in touched.values()
+
+    def test_missing_result_dirs_are_explicit_but_preserve_empty_behavior(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+        assert touched == {}
+        assert status == "missing"
+
+    def test_malformed_result_is_explicit_and_blocks_decay(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_result_artifact(
+            state_dir, "archive", "result-good.json",
+            {"files_changed": ["scripts/used_tool.py"]}, days_ago=3,
+        )
+        bad = state_dir / "subagents" / "archive" / "result-bad.json"
+        bad.write_text("{", encoding="utf-8")
+        _set_mtime(bad, 2)
+
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+        assert touched["scripts/used_tool.py"]
+        assert status == "corrupt"
+
+        _write_usage_sidecar(
+            state_dir, {}, touched_results_status=status,
+        )
+        repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
+
+
 # ─── refresh_usage: watermark + merge ───────────────────────────────────────
 
 

--- a/tests/test_usage_evidence.py
+++ b/tests/test_usage_evidence.py
@@ -339,7 +339,7 @@ class TestArchiveAwareTouchedEvidence:
         touched, status = usage_evidence._touched_from_results_with_status(state_dir)
 
         assert touched == {"scripts/used_tool.py": usage_evidence._mtime_iso(archived)}
-        assert status == "complete"
+        assert status == "partial"
 
     def test_touched_reader_uses_newest_deterministic_bounded_union(self, tmp_path):
         state_dir = _state_dir(tmp_path)
@@ -361,7 +361,7 @@ class TestArchiveAwareTouchedEvidence:
 
         touched, status = usage_evidence._touched_from_results_with_status(state_dir)
 
-        assert status == "complete"
+        assert status == "partial"
         assert len(touched) == 50
         assert "scripts/tool_00.py" in touched
         assert "scripts/tool_49.py" in touched
@@ -373,6 +373,61 @@ class TestArchiveAwareTouchedEvidence:
         touched, status = usage_evidence._touched_from_results_with_status(state_dir)
         assert touched == {}
         assert status == "missing"
+
+    def test_both_present_empty_result_dirs_are_valid_empty(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        for name in ("results", "archive"):
+            (state_dir / "subagents" / name).mkdir(parents=True)
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+        assert touched == {}
+        assert status == "valid-empty"
+
+    def test_equal_mtime_prefers_archive_then_name_deterministically(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        live = _write_result_artifact(
+            state_dir, "results", "result-z.json",
+            {"files_changed": ["scripts/live.py"]}, days_ago=2,
+        )
+        archived = _write_result_artifact(
+            state_dir, "archive", "result-a.json",
+            {"files_changed": ["scripts/archive.py"]}, days_ago=2,
+        )
+        mtime = live.stat().st_mtime
+        os.utime(archived, (mtime, mtime))
+
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+
+        assert status == "complete"
+        assert set(touched) == {"scripts/live.py", "scripts/archive.py"}
+        # Reverse tuple ordering is explicit: archive sorts ahead of results
+        # for equal mtimes, and names sort descending within a directory.
+        assert list((state_dir / "subagents" / "archive").iterdir())[0].name == "result-a.json"
+
+    def test_one_missing_result_dir_is_partial(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        (state_dir / "subagents" / "results").mkdir(parents=True)
+        _write_result_artifact(
+            state_dir, "results", "result-live.json",
+            {"files_changed": ["scripts/used_tool.py"]}, days_ago=1,
+        )
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+        assert touched["scripts/used_tool.py"]
+        assert status == "partial"
+
+    def test_capped_reader_is_partial_and_blocks_decay(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        for i in range(51):
+            _write_result_artifact(
+                state_dir, "archive", f"result-{i:02d}.json",
+                {"files_changed": [f"scripts/tool_{i:02d}.py"]}, days_ago=i / 10,
+            )
+        touched, status = usage_evidence._touched_from_results_with_status(state_dir)
+        assert status == "partial"
+        assert len(touched) == 50
+
+        _write_usage_sidecar(state_dir, {}, touched_results_status=status)
+        repo = _seed_old_repo_scripts(tmp_path, ["old_tool.py"])
+        assert usage_evidence.stale_artifacts(state_dir, repo, older_than_days=14) == []
 
     def test_malformed_result_is_explicit_and_blocks_decay(self, tmp_path):
         state_dir = _state_dir(tmp_path)


### PR DESCRIPTION
## Summary
- scan bounded newest-first touch evidence across live `results/` and flat `archive/`
- persist explicit touch-reader status and refuse destructive decay on incomplete evidence
- add archive-only, ordering/bound, missing, and corrupt evidence regression tests

## Scope
Only `nanobot/runtime/usage_evidence.py` and `tests/test_usage_evidence.py`, related to #1272 / #1173 / #1176.

## Red-first evidence
Before the implementation, the three new regression tests failed with `AttributeError` because `_touched_from_results_with_status` did not exist. Existing usage-evidence tests remained green.

No merge or deploy until independent pi-1 review and exact CI pass.