### PR TITLE
fix(dashboard): centralize queue path redaction

### DIFF
--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -918,8 +918,7 @@ def format_stale_request_reference(
     oldest_stale_request_path: Path | None,
 ) -> tuple[str, str]:
     age_text = format_oldest_stale_request_age(oldest_stale_age_hours)
-    # Public dashboard surfaces retain age but never expose host filesystem paths.
-    return age_text, "path-redacted" if oldest_stale_request_path is not None else "none"
+    return age_text, format_oldest_stale_request_path(oldest_stale_request_path)
 
 
 
@@ -990,7 +989,7 @@ def format_oldest_stale_request_age(oldest_stale_age_hours: float | None) -> str
 def format_oldest_stale_request_path(oldest_stale_request_path: Path | None) -> str:
     if oldest_stale_request_path is None:
         return "none"
-    return "path-redacted"
+    return str(oldest_stale_request_path)
 
 
 def format_age_hours(age_hours: float | None) -> str:

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -18,6 +18,7 @@ import html
 import http.server
 import json
 import os
+import re
 import signal
 import sys
 import time
@@ -922,14 +923,27 @@ def format_stale_request_reference(
 
 
 
+_QUEUE_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_])(?:[A-Za-z]:[\\/][^\s/:()]+(?:[\\/][^\s/:()]+)*|[/\\]{1,2}[^\s/:()]+(?:[\\/][^\s/:()]+)*)"
+)
+
+
 def _redact_queue_path(value: Any) -> str:
-    """Replace a queue filesystem path while retaining action and age text."""
-    text = str(value)
-    if " @ /" in text:
-        return text.split(" @ /", 1)[0] + " @ path-redacted"
-    if text.startswith("/"):
-        return "path-redacted" + (text[text.find(" ("):] if " (" in text else "")
-    return text
+    """Replace absolute queue filesystem paths in bounded display text."""
+    return _QUEUE_ABSOLUTE_PATH_RE.sub("path-redacted", str(value))
+
+
+def _sanitize_cleanup_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Redact queue paths before cleanup results reach CLI or HTTP output."""
+    sanitized = dict(result)
+    sanitized["paths"] = [_redact_queue_path(path) for path in result.get("paths", [])]
+    sanitized["skipped_details"] = [
+        (_redact_queue_path(path), _redact_queue_path(error))
+        for path, error in result.get("skipped_details", [])
+    ]
+    if result.get("archive_dir") is not None:
+        sanitized["archive_dir"] = _redact_queue_path(result["archive_dir"])
+    return sanitized
 
 
 def format_queue_action(
@@ -2685,7 +2699,7 @@ class DashboardHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", "application/json; charset=utf-8")
             self.end_headers()
-            self.wfile.write(json.dumps(result).encode("utf-8"))
+            self.wfile.write(json.dumps(_sanitize_cleanup_result(result)).encode("utf-8"))
         elif self.path == "/api/refresh-host-caps":
             caps = refresh_host_capabilities()
             self.send_response(200)
@@ -2781,7 +2795,7 @@ Examples:
             if result["archived"] > 10:
                 print(f"  ... and {result['archived'] - 10} more")
         else:
-            print(f"Archived {result['archived']} stale request(s) to {result['archive_dir']}/")
+            print(f"Archived {result['archived']} stale request(s) to {_redact_queue_path(result['archive_dir'])}/")
             if result["skipped"] > 0:
                 print(f"Skipped {result['skipped']} request(s) due to errors:")
                 for p, e in result["skipped_details"][:5]:

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -2777,7 +2777,7 @@ Examples:
         if dry_run:
             print(f"[DRY RUN] Would archive {result['archived']} stale request(s)")
             for p in result["paths"][:10]:
-                print(f"  {p}")
+                print(f"  {_redact_queue_path(p)}")
             if result["archived"] > 10:
                 print(f"  ... and {result['archived'] - 10} more")
         else:
@@ -2785,7 +2785,7 @@ Examples:
             if result["skipped"] > 0:
                 print(f"Skipped {result['skipped']} request(s) due to errors:")
                 for p, e in result["skipped_details"][:5]:
-                    print(f"  {p}: {e}")
+                    print(f"  {_redact_queue_path(f'{p}: {e}')}")
 
             # Update health record
             new_health = update_health_with_cleanup(result["archived"])

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -299,7 +299,13 @@ def test_cleanup_queue_dry_run_redacts_request_paths(monkeypatch, capsys) -> Non
     monkeypatch.setattr(
         DASHBOARD,
         "archive_stale_subagent_requests",
-        lambda **_: {"archived": 1, "paths": [raw_path], "skipped": 0, "skipped_details": []},
+        lambda **_: {
+            "archived": 1,
+            "paths": [raw_path],
+            "skipped": 0,
+            "skipped_details": [],
+            "archive_dir": "/secret/queue/archive",
+        },
     )
     monkeypatch.setattr(DASHBOARD, "scan_subagent_tree_stats", lambda: (0, 0, None, 0, None))
     monkeypatch.setattr(DASHBOARD.sys, "argv", ["dashboard", "--cleanup-queue", "--dry-run"])
@@ -316,7 +322,13 @@ def test_cleanup_queue_error_paths_are_redacted(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         DASHBOARD,
         "archive_stale_subagent_requests",
-        lambda **_: {"archived": 0, "paths": [], "skipped": 1, "skipped_details": [(raw_path, "permission denied")]},
+        lambda **_: {
+            "archived": 0,
+            "paths": [],
+            "skipped": 1,
+            "skipped_details": [(raw_path, "permission denied")],
+            "archive_dir": "/secret/queue/archive",
+        },
     )
     monkeypatch.setattr(DASHBOARD, "update_health_with_cleanup", lambda _count: {})
     monkeypatch.setattr(DASHBOARD, "scan_subagent_tree_stats", lambda: (0, 0, None, 0, None))
@@ -329,9 +341,24 @@ def test_cleanup_queue_error_paths_are_redacted(monkeypatch, capsys) -> None:
     assert "path-redacted" in output
 
 
+def test_cleanup_result_redacts_http_json_paths() -> None:
+    result = {
+        "archived": 1,
+        "paths": ["/secret/queue/request.json"],
+        "skipped": 1,
+        "skipped_details": [("/secret/queue/blocked.json", "/secret/error.log")],
+        "archive_dir": "/secret/queue/archive",
+    }
+    rendered = DASHBOARD.json.dumps(DASHBOARD._sanitize_cleanup_result(result))
+    assert "/secret/" not in rendered
+    assert rendered.count("path-redacted") == 4
+
+
 def test_queue_path_redaction_preserves_action_metadata() -> None:
     assert DASHBOARD._redact_queue_path("archive 1 stale request(s) — oldest 42.0h @ /secret/a.json") == "archive 1 stale request(s) — oldest 42.0h @ path-redacted"
     assert DASHBOARD._redact_queue_path("/secret/a.json (42.0h)") == "path-redacted (42.0h)"
+    assert DASHBOARD._redact_queue_path(r"C:\\secret\\a.json") == "path-redacted"
+    assert DASHBOARD._redact_queue_path(r"\\secret\\a.json") == "path-redacted"
 
 
 def test_queue_reference_keeps_raw_internal_value_until_public_sanitization() -> None:

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -294,6 +294,41 @@ def test_cli_export_modes_do_not_emit_report_rows(monkeypatch, capsys) -> None:
         assert "unavailable" in output
 
 
+def test_cleanup_queue_dry_run_redacts_request_paths(monkeypatch, capsys) -> None:
+    raw_path = "/secret/queue/request.json"
+    monkeypatch.setattr(
+        DASHBOARD,
+        "archive_stale_subagent_requests",
+        lambda **_: {"archived": 1, "paths": [raw_path], "skipped": 0, "skipped_details": []},
+    )
+    monkeypatch.setattr(DASHBOARD, "scan_subagent_tree_stats", lambda: (0, 0, None, 0, None))
+    monkeypatch.setattr(DASHBOARD.sys, "argv", ["dashboard", "--cleanup-queue", "--dry-run"])
+
+    DASHBOARD.main()
+    output = capsys.readouterr().out
+
+    assert raw_path not in output
+    assert "path-redacted" in output
+
+
+def test_cleanup_queue_error_paths_are_redacted(monkeypatch, capsys) -> None:
+    raw_path = "/secret/queue/request.json"
+    monkeypatch.setattr(
+        DASHBOARD,
+        "archive_stale_subagent_requests",
+        lambda **_: {"archived": 0, "paths": [], "skipped": 1, "skipped_details": [(raw_path, "permission denied")]},
+    )
+    monkeypatch.setattr(DASHBOARD, "update_health_with_cleanup", lambda _count: {})
+    monkeypatch.setattr(DASHBOARD, "scan_subagent_tree_stats", lambda: (0, 0, None, 0, None))
+    monkeypatch.setattr(DASHBOARD.sys, "argv", ["dashboard", "--cleanup-queue"])
+
+    DASHBOARD.main()
+    output = capsys.readouterr().out
+
+    assert raw_path not in output
+    assert "path-redacted" in output
+
+
 def test_queue_path_redaction_preserves_action_metadata() -> None:
     assert DASHBOARD._redact_queue_path("archive 1 stale request(s) — oldest 42.0h @ /secret/a.json") == "archive 1 stale request(s) — oldest 42.0h @ path-redacted"
     assert DASHBOARD._redact_queue_path("/secret/a.json (42.0h)") == "path-redacted (42.0h)"

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -299,6 +299,19 @@ def test_queue_path_redaction_preserves_action_metadata() -> None:
     assert DASHBOARD._redact_queue_path("/secret/a.json (42.0h)") == "path-redacted (42.0h)"
 
 
+def test_queue_reference_keeps_raw_internal_value_until_public_sanitization() -> None:
+    reference = DASHBOARD.format_stale_request_reference(42.0, Path("/secret/a.json"))
+    assert reference == ("42.0h", "/secret/a.json")
+    sanitized = DASHBOARD.sanitize_public_metrics({
+        "oldest_stale_request_path": Path("/secret/a.json"),
+        "oldest_stale_request_path_text": "/secret/a.json",
+        "queue_action": f"archive oldest 42.0h @ {reference[1]}",
+        "queue_archive_target": f"{reference[1]} (42.0h)",
+    })
+    assert sanitized["queue_action"].endswith("@ path-redacted")
+    assert sanitized["queue_archive_target"] == "path-redacted (42.0h)"
+
+
 def test_export_endpoints_use_metadata_only(monkeypatch) -> None:
     from io import BytesIO
 


### PR DESCRIPTION
## Summary

Closes #1268.

- Keep `format_stale_request_reference()` and `format_oldest_stale_request_path()` as raw internal formatting helpers.
- Make `sanitize_public_metrics()` the single public redaction boundary.
- Add a regression test proving the internal formatter retains the raw path until sanitization, while public queue fields expose only `path-redacted` and preserve age/action metadata.

## Reachability decision

No dashboard surface calls either formatter output directly without sanitization:

```python
# scripts/eeebot_dashboard.py:1421
stale_request_reference = format_stale_request_reference(
    oldest_stale_age_hours,
    oldest_stale_request_path,
)

# scripts/eeebot_dashboard.py:1594, 1608, 1729, 1748, 1787-1788,
# 1831, 1854, 1861, 2013, 2259
# public render/export paths call sanitize_public_metrics()
```

The former upstream formatter redactions were therefore redundant. Raw paths are now allowed only in the internal metrics construction path and are redacted centrally before public serialization/rendering. `stale_request_reference` is an internal tuple used to construct queue display fields; it is not itself included in the returned metrics mapping.

## Scope decision

The HTTP server has no authentication or operator/public route split: any client that can reach its listener can request `/`, `/api/metrics`, `/api/health`, and the other routes. Those HTTP surfaces are public at the application boundary and all pass through sanitized metrics. CLI/TUI/snapshot/diff output is also treated as public/export output and remains redacted. There is no separate operator dashboard surface in this module that should retain the raw path; direct local state/filesystem access is the operator debugging path.

## Verification

- `python -m pytest tests/test_eeebot_dashboard_truth.py -v` — 21 passed.
- Full pytest: 2999 passed, 17 skipped, 4 failed; failures are the established baseline:
  - `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`
- `git diff --check` — passed.
- No host access or deployment was performed.
