### PR TITLE
fix(runtime): bound archived result evidence readers

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -156,7 +156,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from nanobot.runtime.state_access import Window, evidence_status, ledger_window
+from nanobot.runtime.state_access import Window, artifacts, evidence_status, ledger_window
 
 logger = logging.getLogger(__name__)
 
@@ -785,23 +785,18 @@ def _result_file_defects(
     such placeholder results for every pre-spawn skip)."""
     items: list[dict[str, str]] = []
     try:
-        results_dir = Path(state_dir) / "subagents" / "results"
-        if not results_dir.is_dir():
+        window = artifacts(
+            state_dir,
+            newest=_MAX_RESULT_FILES,
+            max_age_hours=_DEFECT_WINDOW_HOURS,
+            statuses=frozenset({"failed", "blocked", "error"}),
+            directories=_RESULT_DIRS,
+        )
+        if window.status == "unavailable":
+            logger.warning("result-file defect evidence unavailable: %s", ",".join(window.notes))
             return []
-        cutoff_ts = (now - timedelta(hours=_DEFECT_WINDOW_HOURS)).timestamp()
         skipped_cycles = _skipped_cycle_ids(state_dir, now, ledger_rows=ledger_rows)
-        entries = [p for p in results_dir.glob("*.json") if p.is_file()]
-        try:
-            entries.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-        except Exception:
-            pass
-        for entry in entries[:_MAX_RESULT_FILES]:
-            try:
-                if entry.stat().st_mtime < cutoff_ts:
-                    continue
-                data = json.loads(entry.read_text(encoding="utf-8"))
-            except Exception:
-                continue
+        for entry, data in zip(window.paths, window.rows):
             if not isinstance(data, dict):
                 continue
             status = str(data.get("status") or "").strip().lower()

--- a/nanobot/runtime/state_access.py
+++ b/nanobot/runtime/state_access.py
@@ -32,6 +32,9 @@ class Window:
     files_skipped: int
     bytes_read: int
     notes: tuple[str, ...]
+    # Selected source paths are retained for readers whose evidence timestamp
+    # is the artifact mtime (for example usage ``touched:result``).
+    paths: tuple[Path, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -261,11 +264,13 @@ def rewrite_status(path: str | Path, *, max_bytes: int | None = None, json_objec
 WRITABLE_STATUSES = frozenset({"absent", "present"})
 
 
-def _artifact_dirs(state_dir: Path) -> Iterable[Path]:
+def _artifact_dirs(state_dir: Path, directories: tuple[str, ...] | None = None) -> Iterable[Path]:
     root = state_dir / "subagents"
-    yield root / "results"
-    yield root / "requests"
-    yield root / "archive"
+    names = directories or ("results", "requests", "archive")
+    for name in names:
+        if name not in {"results", "requests", "archive"}:
+            raise ValueError(f"unsupported artifact directory: {name}")
+        yield root / name
 
 
 def artifacts(
@@ -274,31 +279,56 @@ def artifacts(
     newest: int,
     max_age_hours: float | None = None,
     statuses: frozenset[str] | None = None,
+    directories: tuple[str, ...] | None = None,
+    required_key: str | None = None,
 ) -> Window:
-    """Return newest bounded JSON artifacts across live and archived flat dirs."""
-    root = Path(state_dir) / "subagents"
+    """Return newest usable JSON artifacts from selected flat directories.
+
+    ``newest`` bounds matching rows, not the pre-filter candidate pool.  This
+    matters for result evidence: successes, request files, and unrelated
+    artifacts must not evict a recent failure or a result carrying
+    ``files_changed``.  ``paths`` preserves the source mtime for consumers
+    that derive evidence timestamps from the file itself.
+    """
+    state_dir = Path(state_dir)
+    root = state_dir / "subagents"
     requested = _iso(datetime.now(timezone.utc) - timedelta(hours=max_age_hours)) if max_age_hours is not None else _iso(datetime.min.replace(tzinfo=timezone.utc))
+    now = datetime.now(timezone.utc).timestamp()
     try:
         if not root.is_dir():
             return Window((), "unavailable", requested, None, None, 0, 0, 0, ("dir_missing",))
-        paths: list[Path] = []
-        for directory in _artifact_dirs(Path(state_dir)):
+        paths: list[tuple[float, Path]] = []
+        readable_dirs = 0
+        for directory in _artifact_dirs(state_dir, directories):
             if not directory.is_dir():
                 continue
-            paths.extend(p for p in directory.iterdir() if p.is_file() and p.suffix == ".json")
-        paths = sorted(paths, key=lambda p: (p.stat().st_mtime, p.name), reverse=True)[:_DEFAULT_ARTIFACT_FILES]
+            readable_dirs += 1
+            try:
+                entries = list(directory.iterdir())
+            except PermissionError:
+                continue
+            except OSError:
+                continue
+            for path in entries:
+                try:
+                    if path.is_file() and path.suffix == ".json":
+                        mtime = path.stat().st_mtime
+                        if max_age_hours is None or now - mtime <= max_age_hours * 3600:
+                            paths.append((mtime, path))
+                except OSError:
+                    continue
+        if readable_dirs == 0:
+            return Window((), "unavailable", requested, None, None, 0, 0, 0, ("permission",))
+        paths.sort(key=lambda item: (item[0], item[1].name), reverse=True)
     except PermissionError:
         return Window((), "unavailable", requested, None, None, 0, 0, 0, ("permission",))
     except OSError:
         return Window((), "unavailable", requested, None, None, 0, 0, 0, ("io_error",))
-    now = datetime.now(timezone.utc)
     selected: list[dict] = []
+    selected_paths: list[Path] = []
     skipped = 0
-    for path in paths:
+    for _mtime, path in paths:
         try:
-            age = now.timestamp() - path.stat().st_mtime
-            if max_age_hours is not None and age > max_age_hours * 3600:
-                continue
             data = json.loads(path.read_text(encoding="utf-8"))
             if not isinstance(data, dict):
                 skipped += 1
@@ -306,14 +336,17 @@ def artifacts(
             status = str(data.get("status") or data.get("result_status") or "")
             if statuses and status not in statuses:
                 continue
+            if required_key is not None and required_key not in data:
+                continue
             selected.append(data)
+            selected_paths.append(path)
             if len(selected) >= max(0, newest):
                 break
         except PermissionError:
             skipped += 1
         except (OSError, ValueError, json.JSONDecodeError):
             skipped += 1
-    return Window(tuple(selected), "partial" if skipped else "complete", requested, None, None, len(paths), skipped, 0, ())
+    return Window(tuple(selected), "partial" if skipped else "complete", requested, None, None, len(paths), skipped, 0, (), tuple(selected_paths))
 
 
 def latest_file(directory: str | Path, pattern: str, *, max_age_s: float) -> Latest:

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -2792,6 +2792,20 @@ class TestIssue1038DemandLanesReproduction:
         items = demand._result_file_defects(state_dir, datetime.now(timezone.utc))
         assert len(items) == demand._MAX_RESULT_FILE_DEFECTS
 
+    def test_archived_result_defect_is_visible(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        archive_dir = state_dir / "subagents" / "archive"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        path = archive_dir / "result-archived.json"
+        path.write_text(
+            json.dumps({"status": "error", "task_title": "archived failure", "error": "boom"}),
+            encoding="utf-8",
+        )
+        os.utime(path, (datetime.now(timezone.utc).timestamp() - 3600,) * 2)
+        items = demand._result_file_defects(state_dir, datetime.now(timezone.utc))
+        assert len(items) == 1
+        assert items[0]["summary"] == "subagent result error: archived failure"
+
     def test_repro_per_kind_caps_applied_after_completed_folds(self, tmp_path, monkeypatch):
         """(2) Per-kind caps applied AFTER completed/exhausted folds."""
         state_dir = _state_dir(tmp_path)

--- a/tests/test_state_access.py
+++ b/tests/test_state_access.py
@@ -87,6 +87,24 @@ def test_ledger_file_reports_non_permission_io_error(tmp_path):
     assert result[-1] == "io_error"
 
 
+def test_artifacts_filters_before_newest_bound_and_supports_directory_selection(tmp_path):
+    root = tmp_path / "state" / "subagents"
+    for name in ("results", "requests", "archive"):
+        (root / name).mkdir(parents=True)
+    for i in range(60):
+        path = root / "requests" / f"request-{i:03d}.json"
+        path.write_text(json.dumps({"status": "pending"}), encoding="utf-8")
+        os.utime(path, (time.time() + i, time.time() + i))
+    result = root / "archive" / "old-result.json"
+    result.write_text(json.dumps({"files_changed": ["scripts/foo.py"]}), encoding="utf-8")
+    os.utime(result, (time.time() - 1, time.time() - 1))
+    window = state_access.artifacts(
+        tmp_path / "state", newest=1, directories=("results", "archive"), required_key="files_changed"
+    )
+    assert [row["files_changed"] for row in window.rows] == [["scripts/foo.py"]]
+    assert window.paths == (result,)
+
+
 def test_artifacts_unifies_dirs_and_tie_breaks(tmp_path):
     root = tmp_path / "state" / "subagents"
     for name in ("results", "requests", "archive"):
@@ -101,6 +119,16 @@ def test_artifacts_unifies_dirs_and_tie_breaks(tmp_path):
         os.utime(p, (stamp, stamp))
     result = state_access.artifacts(tmp_path / "state", newest=3, statuses=frozenset({"failed", "blocked", "error"}))
     assert [r["id"] for r in result.rows] == ["c.json", "b.json", "a.json"]
+
+
+def test_artifacts_unavailable_when_selected_sources_cannot_be_read(tmp_path, monkeypatch):
+    root = tmp_path / "state" / "subagents" / "results"
+    root.mkdir(parents=True)
+    original_is_dir = Path.is_dir
+    monkeypatch.setattr(Path, "is_dir", lambda self: False if self == root else original_is_dir(self))
+    result = state_access.artifacts(tmp_path / "state", newest=1, directories=("results",))
+    assert result.status == "unavailable"
+    assert "permission" in result.notes
 
 
 def test_latest_file_tie_break_and_stale(tmp_path):


### PR DESCRIPTION
## Summary

Implements the D4/D11 portion of issue #1173/#1176's residual audit.

- Extends `state_access.artifacts` with explicit directory selection and a payload-key filter.
- Applies the `newest` bound after candidate filtering, so `requests/` and successful/unrelated artifacts cannot evict relevant result evidence.
- Migrates `demand._result_file_defects` to bounded `results/` + `archive/` reads.
- Migrates `usage_evidence._touched_from_results` to bounded `results/` + `archive/` reads requiring `files_changed`.
- Preserves selected source paths in `Window` so touched evidence continues to use result-file mtimes.

## Caller classification

- Results-only: `demand._result_file_defects`, `demand._noop_evidence`, bridge failure/attempt readers, and `existence_index` attempt-title readers.
- Requests-only: bridge/backlog/health queue readers.
- Genuinely multi-directory: `state_access.artifacts` itself, now parameterized rather than forcing every consumer into the pooled `results + requests + archive` view.

## Verification

- Focused: 282 passed (`tests/test_state_access.py`, `tests/test_demand.py`, `tests/test_usage_evidence.py`).
- Full suite: 3002 passed, 17 skipped, 11 warnings, with exactly the four established baseline failures:
  - `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`
- Ruff passed on all changed Python files.
- New tests demonstrate an archived result is observed by both D4 and D11, and that an unreadable selected artifact source produces `Window.status == "unavailable"`.

## Rollout

No host access, deployment, `current` flip, service restart, or merge was performed. Operator review/merge and rollout remain pending.
