### PR TITLE
fix(runtime): deny validator harness from promotion

### DIFF
--- a/docs/TRUST_KERNEL.md
+++ b/docs/TRUST_KERNEL.md
@@ -38,6 +38,7 @@ nanobot/runtime/tech_tree.py
 nanobot/runtime/skill_fitness.py
 nanobot/runtime/skill_eval_harness.py
 nanobot/runtime/knowledge_lift.py
+nanobot/runtime/validator_harness.py
 nanobot/runtime/model_registry.py
 nanobot/runtime/knowledge_curator.py
 nanobot/runtime/context_compaction.py

--- a/nanobot/runtime/runtime_deny.py
+++ b/nanobot/runtime/runtime_deny.py
@@ -104,6 +104,12 @@ _RUNTIME_DENY_ALWAYS_FILES = frozenset({
     'nanobot/runtime/skill_eval_harness.py',
     # #1093: knowledge-lift evaluation harness
     'nanobot/runtime/knowledge_lift.py',
+    # #1274: validator harness — selects and grades the loop's own validator
+    # output; the instance must never rewrite the judge that determines whether
+    # its validators pass. No basename token match applies here ('harness' is
+    # not in _RUNTIME_DENY_TOKENS, deliberately); this explicit entry is the
+    # only protection for this exact grader.
+    'nanobot/runtime/validator_harness.py',
     # #899: the single resolver for runtime LLM model selection (operator
     # control-plane, same tier as bridge.py's own model knobs) — the loop
     # must never be able to rewrite which model each role runs on.

--- a/tests/test_promotion_verifier.py
+++ b/tests/test_promotion_verifier.py
@@ -287,6 +287,17 @@ class TestRejectionPaths:
             (verifier.promoted_tree / "manifest.json").read_text()
         ) == {"_schema_version": "promoted-manifest-v1"}
 
+    def test_validator_harness_is_rejected_by_root_verifier(self, verifier):
+        path = "nanobot/runtime/validator_harness.py"
+        head_sha = _init_instance_repo(verifier.instance_repo, {path: "X = 1\n"})
+        _write_candidate(verifier.state_dir, "promotion-runtime-validator-harness", [path], head_sha)
+
+        summary = verifier.verify_pass()
+        assert summary["rejected"] == 1
+        state = json.loads((verifier.promoted_tree / "verifier_state.json").read_text())
+        candidate = state["candidates"]["promotion-runtime-validator-harness"]
+        assert candidate["reason"] == f"module is on the immutable runtime deny-set: {path}"
+
     def test_module_not_in_operator_slice_is_rejected(self, verifier, monkeypatch):
         monkeypatch.setenv("SELFEVO_RUNTIME_SLICE", "nanobot/runtime/existence_index.py")
         head_sha = _init_instance_repo(

--- a/tests/test_runtime_slice.py
+++ b/tests/test_runtime_slice.py
@@ -14,6 +14,7 @@ the candidate path is exercised indirectly via ``_record_runtime_slice_candidate
 """
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -103,6 +104,7 @@ def test_deny_covers_the_rest_of_the_verification_kernel():
         "nanobot/runtime/usage_evidence.py",
         "nanobot/runtime/promoted_overlay.py",
         "nanobot/runtime/runtime_deny.py",
+        "nanobot/runtime/validator_harness.py",
         "nanobot/runtime/heldout/microbench.py",
         "nanobot/runtime/heldout/__init__.py",
         "nanobot/runtime/heldout/checkers.py",
@@ -222,6 +224,63 @@ def test_classify_runtime_file_not_in_slice_is_violation(monkeypatch):
     assert blocked == []
     assert len(violations) == 1
     assert tier == "script"
+
+
+def test_validator_harness_is_denied_by_all_three_trust_call_sites(tmp_path, monkeypatch):
+    """#1274: the validator grader must not be runtime-slice promotable."""
+    path = "nanobot/runtime/validator_harness.py"
+    assert runtime_deny._is_runtime_deny(path) is True
+
+    monkeypatch.setenv(_SLICE_ENV, path)
+    blocked, violations, tier = bridge._classify_mutation_surface([path])
+    assert blocked == []
+    assert len(violations) == 1
+    assert "deny-set" in violations[0]
+    assert tier == "script"
+
+    from nanobot.runtime import promoted_overlay
+    assert promoted_overlay.effective_runtime_slice(path, "T:/nonexistent-promoted-tree") == set()
+    module_bytes = b"VALUE = 1\n"
+    (tmp_path / "nanobot__runtime__validator_harness.py").write_bytes(module_bytes)
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({path: {"sha256": hashlib.sha256(module_bytes).hexdigest(), "status": "active"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(promoted_overlay, "_boundary_ok", lambda *_: True)
+    assert promoted_overlay.install_promoted_overlay(tmp_path) == []
+
+    import importlib.util
+    import os
+    import sys
+    import uuid
+    verifier_path = Path(__file__).parents[1] / "host" / "eeepc" / "libexec" / "eeepc_promotion_verifier.py"
+    name = f"eeepc_promotion_verifier_1274_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, verifier_path)
+    verifier = importlib.util.module_from_spec(spec)
+    sys.modules[name] = verifier
+    old_skip = os.environ.get("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK")
+    old_release = os.environ.get("SELFEVO_RELEASE_DIR")
+    os.environ["EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK"] = "1"
+    os.environ["SELFEVO_RELEASE_DIR"] = str(verifier_path.parents[3])
+    try:
+        spec.loader.exec_module(verifier)
+        eligible, reason, module_path = verifier._classify_candidate(
+            {"changed_files": [path]}, {path}
+        )
+    finally:
+        sys.modules.pop(name, None)
+        if old_skip is None:
+            os.environ.pop("EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK", None)
+        else:
+            os.environ["EEEPC_VERIFIER_SKIP_OWNERSHIP_CHECK"] = old_skip
+        if old_release is None:
+            os.environ.pop("SELFEVO_RELEASE_DIR", None)
+        else:
+            os.environ["SELFEVO_RELEASE_DIR"] = old_release
+    assert eligible is False
+    assert "deny-set" in reason
+    assert module_path is None
+
 
 def test_classify_deny_path_is_violation_even_if_in_slice(monkeypatch):
     # operator mistakenly lists a deny path AND the loop touches it → hard block


### PR DESCRIPTION
## Summary

Closes #1274.

The premise holds: `nanobot/runtime/validator_harness.py` is a runtime-slice candidate unless explicitly denied. It is the module that selects and grades the loop's own validator output, so the instance must never rewrite it.

## Premise evidence

Exact local classifier decision before this change:

```text
runtime_deny nanobot/runtime/validator_harness.py False
runtime_slice_paths explicit {'nanobot/runtime/validator_harness.py'}
bridge_runtime_slice_paths_env {'nanobot/runtime/validator_harness.py'}
bridge_classifier_env ([], [], 'runtime')
verifier classifier with slice (True, '', 'nanobot/runtime/validator_harness.py')
```

The unrelated runtime-slice exclusion did not apply. Promotion history was checked on the host across `17,801` promotion JSON files: **0** candidate records touched `nanobot/runtime/validator_harness.py`.

## Change

Added an explicit `_RUNTIME_DENY_ALWAYS_FILES` entry with a #1274 rationale. `_RUNTIME_DENY_TOKENS` was not widened; `harness` remains intentionally absent.

The documented `docs/TRUST_KERNEL.md` manifest is synchronized.

## Three-site enforcement

Tests assert all three #875 boundaries reject the path when it is supplied in the runtime slice:

- bridge classifier: `runtime deny-set` violation;
- root verifier eligibility: `module is on the immutable runtime deny-set: nanobot/runtime/validator_harness.py`;
- agent-side overlay: `effective_runtime_slice(...) == set()` and an active manifest entry is refused by `install_promoted_overlay()`.

## Verification

Focused trust/promotion suite:

```text
113 passed, 6 skipped
```

Full pytest on Python 3.13:

```text
3013 passed, 17 skipped, 4 failed
```

The four failures are the established Windows baseline:

- `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
- `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
- `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
- `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`

No deployment, host mutation, unit restart, or `current` change was performed. This PR is intentionally open for review and CI; it was not merged.
