### PR TITLE
fix(bridge): record an executor LLM failure as a failed cycle, not completed (#1280)

### DIFF
--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2912,6 +2912,7 @@ async def _main_impl_body():
             _decide_handled_marker(
                 handled_marker, req_path,
                 llm_error=bool(_executor_llm_error_text and cycle_commit_count == 0),
+                state_dir=STATE_DIR, cycle_id=_cycle_id,
             )
 
             # ── Closed-loop repair cycle (issue #526) ────────────────────────────
@@ -4212,17 +4213,53 @@ def _llm_error_retries_exhausted(request_id: 'str | None') -> bool:
     the point at which its failed rows start counting for the #716 recent-
     failure suppression. Unknown request or unreadable counter → True: the
     old behaviour (row counts as a failure), never a wider exemption."""
+    path = _llm_error_retry_path(request_id)
+    if path is None:
+        return True
     try:
-        path = _llm_error_retry_path(request_id)
-        if path is None or not path.exists():
+        if not path.exists():
+            # Observable on purpose (#1282 review): a lost counter retires a
+            # request that may still have had budget, and without this line
+            # that is indistinguishable from a normal three-attempt retirement.
+            print(f'executor_llm_error: retry counter {path.name} missing — treating the budget as spent (#1280)')
             return True
         count = int((json.loads(path.read_text(encoding='utf-8')) or {}).get('count') or 0)
         return count >= LLM_ERROR_MAX_RETRIES
     except Exception:
+        print(f'executor_llm_error: retry counter {path.name} unreadable — treating the budget as spent (#1280)')
         return True
 
 
-def _decide_handled_marker(handled_marker: Path, req_path: 'Path | str', *, llm_error: bool) -> str:
+def _recorded_llm_error_attempts(state_dir: 'Path | str', cycle_id: 'str | None') -> int:
+    """#1280 review: the durable witness that a request was previously live.
+    Counts this cycle's ``outcome`` rows with ``reason == executor_llm_error``
+    in the ledger (live + archives, via ``state_access.ledger_window``). The
+    ledger is append-only and rotated, never pruned inside the retention
+    window — unlike ``subagents/results``, which the archiver migrates and
+    prunes within a cycle, and unlike the ``retry_<id>.json`` counter, which
+    is one file. Fail-open to 0 (reads as "first attempt"): a ledger-read
+    failure must not retire a request that nothing says was offered before.
+    """
+    if not cycle_id:
+        return 0
+    try:
+        from nanobot.runtime.state_access import ledger_window
+        since = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(time.time() - 30 * 86400))
+        window = ledger_window(Path(state_dir), since_ts=since, phases=frozenset({'outcome'}))
+        return sum(
+            1 for row in window.rows
+            if isinstance(row, dict)
+            and str(row.get('cycle_id') or '') == str(cycle_id)
+            and str(row.get('reason') or '') == 'executor_llm_error'
+        )
+    except Exception:
+        return 0
+
+
+def _decide_handled_marker(
+    handled_marker: Path, req_path: 'Path | str', *, llm_error: bool,
+    state_dir: 'Path | str | None' = None, cycle_id: 'str | None' = None,
+) -> str:
     """#1280: write the ``handled_`` marker — retiring the request forever —
     unless the subagent died on its LLM call without producing anything, in
     which case re-offer the request up to :data:`LLM_ERROR_MAX_RETRIES`
@@ -4230,8 +4267,21 @@ def _decide_handled_marker(handled_marker: Path, req_path: 'Path | str', *, llm_
     it. Bounded on purpose: an unbounded re-offer turns a permanently-bad
     request into an infinite loop, a worse failure than the one being fixed.
 
-    Returns ``"handled"``, ``"retry"`` or ``"retired_after_retries"`` for the
-    journal. Fail-open: any error writes the marker, the pre-#1280 behaviour.
+    Lost-counter rule (#1282 review), the same direction on both sides: the
+    reader ``_llm_error_retries_exhausted`` treats a missing or unreadable
+    counter as budget spent; so does this writer, for a request that was
+    previously live. "Previously live" is witnessed by the ledger
+    (:func:`_recorded_llm_error_attempts`), not by the counter itself — when
+    the counter AND the failed result rows are gone (results migrate to the
+    pruned archive within a cycle), the suppression finds nothing and this
+    is the only place left that can stop an unbounded re-offer. An
+    unreadable counter is always "previously live" (someone wrote it).
+    A missing counter with no recorded attempt is a genuine first attempt.
+
+    Returns ``"handled"``, ``"retry"``, ``"retired_after_retries"`` or
+    ``"retired_state_lost"`` for the journal, and prints the lost-state
+    case so it is distinguishable from an ordinary retirement. Fail-open:
+    any error writes the marker, the pre-#1280 behaviour.
     """
     try:
         if not llm_error:
@@ -4239,11 +4289,23 @@ def _decide_handled_marker(handled_marker: Path, req_path: 'Path | str', *, llm_
             return 'handled'
         retry_path = handled_marker.with_name(handled_marker.name.replace('handled_', 'retry_', 1)).with_suffix('.json')
         count = 0
+        state_lost = ''
         if retry_path.exists():
             try:
                 count = int((json.loads(retry_path.read_text(encoding='utf-8')) or {}).get('count') or 0)
             except Exception:
-                count = 0
+                state_lost = 'unreadable'
+        else:
+            prior = _recorded_llm_error_attempts(state_dir, cycle_id) if state_dir is not None else 0
+            if prior >= 1:
+                state_lost = f'missing after {prior} recorded attempt(s)'
+        if state_lost:
+            handled_marker.write_text(str(req_path), encoding='utf-8')
+            print(
+                f'executor_llm_error: retry counter {retry_path.name} {state_lost} — '
+                'treating the budget as spent and retiring the request (retired_state_lost, #1280)'
+            )
+            return 'retired_state_lost'
         count += 1
         retry_path.write_text(
             json.dumps({

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -4196,6 +4196,32 @@ def _executor_llm_error(state_dir: Path, task_id: 'str | None') -> str:
         return ''
 
 
+def _llm_error_retry_path(request_id: 'str | None') -> 'Path | None':
+    """The retry counter `_decide_handled_marker` keeps for a request whose
+    subagent died on the LLM call (#1280): ``retry_<safe_id>.json`` beside
+    the ``handled_<safe_id>.txt`` marker, same ``safe_id`` derivation."""
+    if not request_id:
+        return None
+    safe_id = str(request_id).replace('/', '_')[:120]
+    return BRIDGE_STATE_DIR / f'retry_{safe_id}.json'
+
+
+def _llm_error_retries_exhausted(request_id: 'str | None') -> bool:
+    """#1280: True once the request's LLM-failure retry budget is spent (its
+    ``retry_<id>.json`` count has reached :data:`LLM_ERROR_MAX_RETRIES`) —
+    the point at which its failed rows start counting for the #716 recent-
+    failure suppression. Unknown request or unreadable counter → True: the
+    old behaviour (row counts as a failure), never a wider exemption."""
+    try:
+        path = _llm_error_retry_path(request_id)
+        if path is None or not path.exists():
+            return True
+        count = int((json.loads(path.read_text(encoding='utf-8')) or {}).get('count') or 0)
+        return count >= LLM_ERROR_MAX_RETRIES
+    except Exception:
+        return True
+
+
 def _decide_handled_marker(handled_marker: Path, req_path: 'Path | str', *, llm_error: bool) -> str:
     """#1280: write the ``handled_`` marker — retiring the request forever —
     unless the subagent died on its LLM call without producing anything, in
@@ -4448,6 +4474,11 @@ def _recent_failure_match(
     every later same-vocabulary proposal (the 2026-07-18 decay cascade: 5
     candidates, 11 wasted proposals, zero spawns). Such rows — and any
     ``skipped*`` result_status — are excluded from the scan entirely.
+    Transport deaths are not evidence either (#1280): a row whose
+    ``rollback.reason`` is ``executor_llm_error`` is skipped while its
+    request still has LLM-failure retry budget (see
+    :func:`_llm_error_retries_exhausted`) and counts as a failure only
+    once that budget is spent.
 
     Cross-target precision (#798): result rows also carry the historical
     entry's own ``target_path`` (see :func:`_write_bridge_completed_result`),
@@ -4531,6 +4562,16 @@ def _recent_failure_match(
             if str(status or '').lower().startswith('skipped'):
                 continue
             if not reason and status not in ('blocked', 'no_commit'):
+                continue
+            if reason == 'executor_llm_error' and not _llm_error_retries_exhausted(data.get('request_id')):
+                # #1280: a cycle that died on the LLM call says nothing about
+                # the proposal, so while its request still has retry budget
+                # the row must not feed suppression — otherwise this branch
+                # retires the request on attempt 2 of 3 and the bounded retry
+                # never runs (found in review, reproduced with a
+                # production-shaped request). Once the budget is spent the
+                # row counts like any other failure: a title that keeps
+                # dying earns the 24 h window like everything else.
                 continue
             failures.append(data)
             if len(failures) >= max_scan:

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -111,7 +111,21 @@ TARGET_WORKSPACE = Path(os.environ.get('TARGET_WORKSPACE', '/opt/eeepc-agent/run
 RELEASE_ROOT = Path(os.environ.get('RELEASE_ROOT', '/opt/eeepc-agent/runtimes/self-evolving-agent/current'))
 CONFIG_PATH = Path(os.environ.get('NANOBOT_CONFIG_PATH', '/run/user/1001/nanobot-eeepc/config.json'))
 BRIDGE_STATE_DIR = Path(os.environ.get('SUBAGENT_BRIDGE_STATE_DIR', str(STATE_DIR / 'subagent_bridge')))
-BRIDGE_ENABLED = os.environ.get('SUBAGENT_BRIDGE_ENABLED', '1').strip().lower() in {'1', 'true', 'yes', 'on'}
+
+# #1280: a cycle whose executor LLM call never returned is a failed cycle, and
+# the process says so with its exit status — the __main__ guard turns any
+# non-zero code into a `failure` row in bridge/exit_streak.json (#1197), so a
+# sustained model outage moves consecutive_failures instead of reading as a
+# run of successes. Distinct from 1 (internal error) so the journal and the
+# streak's last_exit_status name the class.
+EXIT_EXECUTOR_LLM_ERROR = 3
+# How many times a request whose subagent died on the LLM call is re-offered
+# before it is retired with the handled_ marker like any other request. Bounded
+# so a permanently-bad request (bad model name, oversize prompt) cannot spin
+# through every cycle forever; 3 covers an outage of two or three cycles and
+# leaves the rest to the next proposal.
+LLM_ERROR_MAX_RETRIES = int(os.environ.get('SUBAGENT_BRIDGE_LLM_ERROR_MAX_RETRIES', '3'))
+BRIDGE_ENABLED =os.environ.get('SUBAGENT_BRIDGE_ENABLED', '1').strip().lower() in {'1', 'true', 'yes', 'on'}
 FORCE_PROFILE = os.environ.get('SUBAGENT_BRIDGE_FORCE_PROFILE', '').strip()
 FORCE_BUDGET = os.environ.get('SUBAGENT_BRIDGE_FORCE_BUDGET', '').strip()
 BRIDGE_MODEL = resolve_model('executor')
@@ -2807,7 +2821,11 @@ async def _main_impl_body():
                     await asyncio.gather(*list(mgr._running_tasks.values()), return_exceptions=True)
                     print("All timed-out subagent tasks cancelled.")
 
-            handled_marker.write_text(str(req_path), encoding='utf-8')
+            # #1280: the handled_ marker is no longer written here unconditionally
+            # — see _decide_handled_marker below, after the cycle's commits are
+            # counted, so a request whose subagent died on the LLM call is
+            # re-offered (bounded) instead of retired with nothing done.
+            _executor_llm_error_text = _executor_llm_error(STATE_DIR, _subagent_task_id)
             latest = TARGET_WORKSPACE / '.nanobot' / 'subagents' / 'latest.json'
             print(latest)
 
@@ -2879,6 +2897,22 @@ async def _main_impl_body():
                             print(f'  ~ {v}')
             else:
                 print(f'cycle-branch: eeebot-self-evolving not found at {_selfevo_repo}')
+
+            # #1280: decide the request's fate now that we know whether the
+            # subagent produced anything. A subagent whose LLM call died
+            # (`status: error`, "LLM execution failed") with NO commits is a
+            # failed cycle: reason `executor_llm_error`, re-offered up to
+            # LLM_ERROR_MAX_RETRIES times before the marker retires it. If the
+            # subagent had already edited files before the call died, the
+            # auto-commit above captured real work and the normal gate decides
+            # (cycle 3cbcc1f77d25 on 2026-09-04 integrated exactly that way);
+            # the error text still rides along in the result's learnings.
+            if _executor_llm_error_text and cycle_commit_count == 0:
+                _rollback_reason = _rollback_reason or 'executor_llm_error'
+            _decide_handled_marker(
+                handled_marker, req_path,
+                llm_error=bool(_executor_llm_error_text and cycle_commit_count == 0),
+            )
 
             # ── Closed-loop repair cycle (issue #526) ────────────────────────────
             # After the first commit, run smoke tests. If they fail, spawn a repair
@@ -3473,6 +3507,7 @@ async def _main_impl_body():
             'score': locals().get('cand_score', float('-inf')),
             'cycle_tier': locals().get('_cycle_tier', 'script'),
             'subagent_task_id': locals().get('_subagent_task_id', None),
+            'executor_llm_error': locals().get('_executor_llm_error_text', ''),
             'origin_main_observed': locals().get('_origin_main_observed', locals().get('main_sha_before', ''))
         }
 
@@ -3572,6 +3607,7 @@ async def _main_impl_body():
     _integrated = _res['integrated']
     _cycle_tier = _res.get('cycle_tier', 'script')
     _subagent_task_id = _res.get('subagent_task_id')
+    _executor_llm_error_text = str(_res.get('executor_llm_error') or '')
     commits_pushed = cycle_commit_count if _integrated else 0
     import subprocess as _sp
 
@@ -3587,6 +3623,16 @@ async def _main_impl_body():
     ) if _smoke_ran else None
     _bridge_status = 'completed'
     if _revision_record and _revision_record['outcome'] == 'blocked':
+        _bridge_status = 'blocked'
+    if _rollback_reason == 'executor_llm_error':
+        # #1280: the executor's LLM call never returned and nothing was
+        # committed — this is `blocked`, not a new spelling. `blocked` is one
+        # of the two statuses `_recent_failure_match` already treats as a
+        # failure (with rollback.reason set it matches on either test), so
+        # the 24 h suppression window and the proposer's "recent failures"
+        # context see the outage cycle; a fresh status would have been
+        # invisible to every reader, which is how twelve such cycles read
+        # `completed` on 2026-09-04.
         _bridge_status = 'blocked'
     _rollback = {
         'integrated': _integrated,
@@ -3614,13 +3660,23 @@ async def _main_impl_body():
         # #789: a spawn-window fitness-sidecar write is surfaced in the
         # cycle's own learnings so the gate/history reflects the incident.
         extra_learnings=(
-            [
-                'INTEGRITY WARNING (#789): fitness sidecar(s) '
-                f'{", ".join(_integrity_changed)} were written during the '
-                'subagent spawn window — only the harness may write fitness '
-                'inputs; recorded as an integrity ledger incident.'
-            ]
-            if _integrity_changed else None
+            (
+                [
+                    'INTEGRITY WARNING (#789): fitness sidecar(s) '
+                    f'{", ".join(_integrity_changed)} were written during the '
+                    'subagent spawn window — only the harness may write fitness '
+                    'inputs; recorded as an integrity ledger incident.'
+                ]
+                if _integrity_changed else []
+            )
+            + (
+                # #1280: the provider error the executor died on, so the
+                # proposer's "recent failures" context and a reader of the
+                # result see WHY nothing was produced, not just that it wasn't.
+                [f'EXECUTOR LLM ERROR (#1280): {_executor_llm_error_text}']
+                if _executor_llm_error_text else []
+            )
+            or None
         ),
     )
     # #720: terminal ledger row, written in the SAME step as the result/merge
@@ -3634,7 +3690,10 @@ async def _main_impl_body():
     # accounting above rather than a distinct outcome.
     if _integrated:
         _cycle_outcome = 'success'
-    elif _rollback_reason == 'internal_error':
+    elif _rollback_reason in ('internal_error', 'executor_llm_error'):
+        # #1280: an executor whose LLM call never returned is a failure with
+        # zero commits, not a `partial` no-op — `partial` is what eleven
+        # outage cycles read on 2026-09-04 and it kept every reader calm.
         _cycle_outcome = 'failed'
     elif _cycle_tier == 'runtime' and _smoke_passed and cycle_commit_count > 0:
         # #812: a green runtime-slice cycle produced a valid promotion candidate.
@@ -3782,7 +3841,15 @@ async def _main_impl_body():
         except Exception:
             pass  # fail-open
 
-
+    if _rollback_reason == 'executor_llm_error':
+        # #1280: say it with the exit status. The __main__ guard records any
+        # non-zero code as a `failure` in bridge/exit_streak.json, so an
+        # outage moves consecutive_failures; systemd shows the unit failed;
+        # and the deploy health gate — which reads both — will not certify a
+        # release whose executor cannot reach its model. That last effect is
+        # deliberate: a deploy during a model outage cannot be verified, and
+        # "cannot certify" must not read as "green".
+        return EXIT_EXECUTOR_LLM_ERROR
     return 0
 
 
@@ -4096,8 +4163,82 @@ _INCONCLUSIVE_REASONS = frozenset({
     'gate_failed', 'mutation_surface_violation', 'blocked_file_present',
     'out_of_band_main_detected', 'switch_base_gate_error',
     'switch_base_gate_blocked', 'head_on_main_precondition_failed',
-    'no_commit', 'internal_error',
+    'no_commit', 'internal_error', 'executor_llm_error',
 })
+
+
+def _executor_llm_error(state_dir: Path, task_id: 'str | None') -> str:
+    """#1280: the executor's own verdict that its LLM call never returned.
+
+    ``nanobot.agent.subagent._run_subagent`` writes the telemetry payload with
+    ``status: "error"`` and ``summary: "Error: LLM execution failed: …"`` when
+    the provider raised (``litellm.InternalServerError … Connection error``,
+    ``litellm.NotFoundError``, timeouts). Until #1280 nothing in the bridge
+    read that field: twelve such cycles on 2026-09-04 were recorded
+    ``result_status: completed``, ledger ``partial``, and the request was
+    retired by the handled_ marker with nothing done.
+
+    Returns the error text (bounded) when the payload says so, else ``""``.
+    Fail-open to ``""`` on any read problem — a miss here leaves the old
+    behaviour in place, never a false failure.
+    """
+    if not task_id:
+        return ''
+    try:
+        payload = json.loads((Path(state_dir) / 'subagents' / f'{task_id}.json').read_text(encoding='utf-8'))
+        if not isinstance(payload, dict) or str(payload.get('status') or '').lower() != 'error':
+            return ''
+        text = str(payload.get('summary') or payload.get('result') or '')
+        if 'LLM execution failed' not in text:
+            return ''
+        return text.strip()[:400]
+    except Exception:
+        return ''
+
+
+def _decide_handled_marker(handled_marker: Path, req_path: 'Path | str', *, llm_error: bool) -> str:
+    """#1280: write the ``handled_`` marker — retiring the request forever —
+    unless the subagent died on its LLM call without producing anything, in
+    which case re-offer the request up to :data:`LLM_ERROR_MAX_RETRIES`
+    times (a sibling ``retry_<id>.json`` counts them) and only then retire
+    it. Bounded on purpose: an unbounded re-offer turns a permanently-bad
+    request into an infinite loop, a worse failure than the one being fixed.
+
+    Returns ``"handled"``, ``"retry"`` or ``"retired_after_retries"`` for the
+    journal. Fail-open: any error writes the marker, the pre-#1280 behaviour.
+    """
+    try:
+        if not llm_error:
+            handled_marker.write_text(str(req_path), encoding='utf-8')
+            return 'handled'
+        retry_path = handled_marker.with_name(handled_marker.name.replace('handled_', 'retry_', 1)).with_suffix('.json')
+        count = 0
+        if retry_path.exists():
+            try:
+                count = int((json.loads(retry_path.read_text(encoding='utf-8')) or {}).get('count') or 0)
+            except Exception:
+                count = 0
+        count += 1
+        retry_path.write_text(
+            json.dumps({
+                'count': count,
+                'max': LLM_ERROR_MAX_RETRIES,
+                'last_ts': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+            }),
+            encoding='utf-8',
+        )
+        if count >= LLM_ERROR_MAX_RETRIES:
+            handled_marker.write_text(str(req_path), encoding='utf-8')
+            print(f'executor_llm_error: request retired after {count} failed LLM attempts (cap {LLM_ERROR_MAX_RETRIES})')
+            return 'retired_after_retries'
+        print(f'executor_llm_error: request left pending for retry ({count}/{LLM_ERROR_MAX_RETRIES})')
+        return 'retry'
+    except Exception:
+        try:
+            handled_marker.write_text(str(req_path), encoding='utf-8')
+        except Exception:
+            pass
+        return 'handled'
 
 
 def _executor_reported_skipped(state_dir: Path, task_id: 'str | None') -> bool:

--- a/tests/test_bridge_executor_llm_error.py
+++ b/tests/test_bridge_executor_llm_error.py
@@ -196,6 +196,58 @@ class TestExecutorLLMErrorIsAFailure:
         assert "already_handled" in out
         assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == 3
 
+    def test_lost_counter_and_result_rows_between_attempts_cannot_reoffer_indefinitely(self, tmp_path, monkeypatch, capsys):
+        """#1282 review, the demonstrated case: when BOTH the retry counter and
+        the failed result rows vanish between offers (results migrate into the
+        pruned archive within a cycle; the counter is one file), the #716
+        suppression finds nothing, so the writer's own fallback is the only
+        thing left that can stop an unbounded re-offer. Its witness is the
+        ledger: a recorded executor_llm_error outcome for this cycle means the
+        request was previously live, and a missing counter then retires it —
+        the same direction the reader takes. Counter-only loss is NOT tested
+        here because that case already retires via the suppression branch and
+        would pass while proving nothing."""
+        state_dir = _wire(tmp_path, monkeypatch, _LLMDeadSubagentManager)
+        monkeypatch.setattr(bridge, "LLM_ERROR_MAX_RETRIES", 3)
+        title = "Add markdown catalog link path resolver to workspace_validation_helpers.py"
+        artifact = tmp_path / "improvements" / "llm-proposed-cycle-lost.json"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text(json.dumps({"next_bounded_candidate": {"title": title}}), encoding="utf-8")
+        _seed_bridge_request(
+            state_dir, "req-lost", "cycle-lost", task_title=title, source_artifact=str(artifact),
+        )
+        bridge_state = state_dir / "subagent_bridge"
+
+        def lose_state():
+            (bridge_state / "retry_req-lost.json").unlink(missing_ok=True)
+            for p in (state_dir / "subagents").rglob("result-*.json"):
+                p.unlink()
+
+        rc = asyncio.run(bridge._main_impl())
+        out = capsys.readouterr().out
+        assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR
+        assert "request left pending for retry (1/3)" in out
+        assert json.loads((bridge_state / "retry_req-lost.json").read_text())["count"] == 1
+        lose_state()
+        # The ledger still knows this cycle failed on the LLM once.
+        assert bridge._recorded_llm_error_attempts(state_dir, "cycle-lost") == 1
+        assert bridge._recent_failure_match(title, state_dir) is None  # nothing left to match
+
+        # Second offer with all retry state gone: must retire, not restart at 1.
+        rc = asyncio.run(bridge._main_impl())
+        out = capsys.readouterr().out
+        assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR, out
+        assert "retired_state_lost" in out and "missing after 1 recorded attempt" in out, out
+        assert (bridge_state / "handled_req-lost.txt").exists(), "lost state must retire, never re-offer"
+        assert not (bridge_state / "retry_req-lost.json").exists()
+
+        # Third offer: already handled — the loop cannot spin.
+        lose_state()
+        rc = asyncio.run(bridge._main_impl())
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "already_handled" in out
+
     def test_healthy_cycle_is_unchanged(self, tmp_path, monkeypatch):
         """Control: the pre-#1280 path — a subagent that commits real work —
         still records completed, writes the marker, and exits 0."""
@@ -234,3 +286,33 @@ class TestHelpers:
         assert bridge._decide_handled_marker(marker, "req.json", llm_error=True) == "retry"
         assert not marker.exists()
         assert json.loads((tmp_path / "retry_req.json").read_text())["count"] == 1
+
+    def test_decide_handled_marker_lost_state_retires_in_the_readers_direction(self, tmp_path, capsys):
+        """Writer and reader agree: a counter that cannot be read means the
+        budget is spent. Unreadable → retire (someone wrote it). Missing →
+        retire when the ledger witnesses a prior attempt, first attempt when
+        it does not. Each lost-state retirement is printed."""
+        from nanobot.runtime.cycle_ledger import record_cycle_outcome
+
+        marker = tmp_path / "handled_req.txt"
+        counter = tmp_path / "retry_req.json"
+
+        counter.write_text("{not json", encoding="utf-8")
+        assert bridge._decide_handled_marker(marker, "req.json", llm_error=True, state_dir=tmp_path, cycle_id="c1") == "retired_state_lost"
+        assert marker.exists()
+        assert "unreadable" in capsys.readouterr().out
+        marker.unlink()
+        counter.unlink()
+
+        # Missing, no recorded attempt for this cycle: a genuine first attempt.
+        assert bridge._decide_handled_marker(marker, "req.json", llm_error=True, state_dir=tmp_path, cycle_id="c1") == "retry"
+        assert not marker.exists()
+        counter.unlink()
+
+        # Missing, but the ledger says this cycle already died once: retire.
+        record_cycle_outcome(tmp_path, "c1", "failed", "executor_llm_error", [], "selfevo/cycle-c1")
+        assert bridge._recorded_llm_error_attempts(tmp_path, "c1") == 1
+        assert bridge._decide_handled_marker(marker, "req.json", llm_error=True, state_dir=tmp_path, cycle_id="c1") == "retired_state_lost"
+        assert marker.exists()
+        assert "missing after 1 recorded attempt" in capsys.readouterr().out
+        assert bridge._llm_error_retries_exhausted("req") is True  # reader: missing counter → spent

--- a/tests/test_bridge_executor_llm_error.py
+++ b/tests/test_bridge_executor_llm_error.py
@@ -109,15 +109,23 @@ class TestExecutorLLMErrorIsAFailure:
         rc = asyncio.run(bridge._main_impl())
 
         # (1) recorded status: `blocked` with the reason set — both tests
-        # _recent_failure_match applies, so the gate sees this cycle and the
-        # same proposal is suppressed inside the 24 h window.
+        # _recent_failure_match applies. But while the request still has
+        # retry budget the row must NOT feed suppression, or the #716 branch
+        # retires the request on its next offer and the retry never runs
+        # (review finding on PR #1282). Once the budget is spent it counts.
         res = _result_for(state_dir, "req-dead")
         assert res["result_status"] == "blocked"
         assert res["rollback"]["reason"] == "executor_llm_error"
         assert res["commits_pushed"] == 0
         assert res["backlog_title"] == title
         assert any("EXECUTOR LLM ERROR (#1280)" in s and "Connection error" in s for s in res.get("key_learnings") or [])
+        assert bridge._recent_failure_match(title, state_dir) is None
+        assert bridge._llm_error_retries_exhausted("req-dead") is False
+        # Same row, budget spent: the failure proxy sees it like any other.
+        retry_path = state_dir / "subagent_bridge" / "retry_req-dead.json"
+        retry_path.write_text(json.dumps({"count": bridge.LLM_ERROR_MAX_RETRIES}), encoding="utf-8")
         assert bridge._recent_failure_match(title, state_dir) == title
+        retry_path.write_text(json.dumps({"count": 1, "max": bridge.LLM_ERROR_MAX_RETRIES}), encoding="utf-8")
 
         rows = _read_ledger(state_dir)
         outcome = [r for r in rows if r["phase"] == "outcome"][-1]
@@ -141,26 +149,51 @@ class TestExecutorLLMErrorIsAFailure:
         retry = json.loads((bridge_state / "retry_req-dead.json").read_text(encoding="utf-8"))
         assert retry["count"] == 1 and retry["max"] == bridge.LLM_ERROR_MAX_RETRIES
 
-    def test_retry_is_bounded_then_the_request_is_retired(self, tmp_path, monkeypatch):
+    def test_retry_is_bounded_then_the_request_is_retired(self, tmp_path, monkeypatch, capsys):
+        """Production-shaped request: a source_artifact whose
+        next_bounded_candidate.title becomes the result row's backlog_title.
+        The first version of this test seeded no artifact, so backlog_title was
+        empty, the #716 suppression had nothing to match, and the retry passed
+        for the wrong reason; with the artifact the review reproduced the
+        request being retired on attempt 2 of 3 by the suppression branch."""
         state_dir = _wire(tmp_path, monkeypatch, _LLMDeadSubagentManager)
         monkeypatch.setattr(bridge, "LLM_ERROR_MAX_RETRIES", 3)
-        _seed_bridge_request(state_dir, "req-loop", "cycle-loop", task_title="permanently bad request")
+        title = "Add markdown catalog link path resolver to workspace_validation_helpers.py"
+        artifact = tmp_path / "improvements" / "llm-proposed-cycle-loop.json"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text(json.dumps({"next_bounded_candidate": {"title": title}}), encoding="utf-8")
+        _seed_bridge_request(
+            state_dir, "req-loop", "cycle-loop", task_title=title, source_artifact=str(artifact),
+        )
         bridge_state = state_dir / "subagent_bridge"
 
         for attempt in (1, 2):
             rc = asyncio.run(bridge._main_impl())
-            assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR
+            out = capsys.readouterr().out
+            assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR, out
+            assert "matches recent failure/rejection" not in out, out  # suppression must not fire yet
+            assert f"request left pending for retry ({attempt}/3)" in out
             assert not (bridge_state / "handled_req-loop.txt").exists()
             assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == attempt
+            assert _result_for(state_dir, "req-loop")["backlog_title"] == title
+            assert bridge._recent_failure_match(title, state_dir) is None
 
         rc = asyncio.run(bridge._main_impl())
-        assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR
+        out = capsys.readouterr().out
+        assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR, out
+        assert "request retired after 3 failed LLM attempts" in out
         assert (bridge_state / "handled_req-loop.txt").exists(), "third failure must retire the request"
         assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == 3
+        # Budget spent: the title now counts for the 24 h suppression window,
+        # so a re-minted proposal with the same title is held back.
+        assert bridge._llm_error_retries_exhausted("req-loop") is True
+        assert bridge._recent_failure_match(title, state_dir) == title
 
         # Fourth run: the request is already handled — no fourth spawn.
         rc = asyncio.run(bridge._main_impl())
+        out = capsys.readouterr().out
         assert rc == 0
+        assert "already_handled" in out
         assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == 3
 
     def test_healthy_cycle_is_unchanged(self, tmp_path, monkeypatch):

--- a/tests/test_bridge_executor_llm_error.py
+++ b/tests/test_bridge_executor_llm_error.py
@@ -1,0 +1,203 @@
+"""#1280: a cycle whose executor LLM call never returned must not be recorded
+as ``completed``.
+
+On 2026-09-04 the local model was unreachable for ~4.5 h. Twelve subagents
+died with ``LLM execution failed … litellm.InternalServerError … Connection
+error``; eleven of their cycles were recorded ``result_status: completed``,
+ledger ``partial``, ``exit_streak.json`` stayed at ``consecutive_failures: 0``,
+and every request was retired by the unconditional ``handled_`` marker so
+nothing was retried when the model came back.
+
+Drives ``bridge._main_impl`` end to end with a fake SubagentManager whose
+spawn writes exactly the telemetry the real one writes on that failure, and
+asserts all three: the recorded status (and the gate seeing it), the exit
+code that becomes the streak failure, and the absence of the marker with a
+bounded retry.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from nanobot import crash_record
+from nanobot.runtime import bridge
+from tests.test_cycle_ledger import (
+    _FakeSubagentManager,
+    _init_selfevo_repo,
+    _read_ledger,
+    _seed_bridge_request,
+)
+
+TRANSPORT_ERROR = (
+    "Error: LLM execution failed: Error calling LLM: litellm.InternalServerError: "
+    "InternalServerError: OpenAIException - litellm.InternalServerError: "
+    "OpenAIException - Connection error. No fallback model group found for original model group"
+)
+
+
+class _LLMDeadSubagentManager:
+    """The real manager on 2026-09-04: spawn registers a task, the task's LLM
+    call raises, ``_run_subagent`` writes ``status: error`` telemetry and
+    returns without touching the repo."""
+
+    task_id = "0b221168"
+
+    def __init__(self, *, workspace, **_kwargs):
+        self.workspace = workspace
+        self._running_tasks: dict = {}
+
+    async def spawn(self, **_kwargs):
+        telemetry_dir = bridge.STATE_DIR / "subagents"
+        telemetry_dir.mkdir(parents=True, exist_ok=True)
+        (telemetry_dir / f"{self.task_id}.json").write_text(json.dumps({
+            "task_id": self.task_id,
+            "status": "error",
+            "summary": TRANSPORT_ERROR,
+            "result": TRANSPORT_ERROR,
+            "started_at": "2026-09-04T04:01:31Z",
+            "finished_at": "2026-09-04T04:04:45Z",
+        }), encoding="utf-8")
+
+        async def _done():
+            return None
+
+        # bridge captures next(iter(mgr._running_tasks)) right after spawn.
+        self._running_tasks[self.task_id] = asyncio.ensure_future(_done())
+        return "fake subagent spawned (LLM dead)"
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
+
+
+def _wire(tmp_path, monkeypatch, manager_cls):
+    base = tmp_path
+    state_dir = base / "state"
+    state_dir.mkdir(exist_ok=True)
+    _init_selfevo_repo(base)
+    monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+    monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+    monkeypatch.setattr(bridge, "TARGET_WORKSPACE", base / "target_workspace")
+    monkeypatch.setattr(bridge, "SubagentManager", manager_cls)
+    monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+    return state_dir
+
+
+def _result_for(state_dir, request_id):
+    matches = list((state_dir / "subagents").rglob(f"result-{request_id}.json"))
+    assert len(matches) == 1, matches
+    return json.loads(matches[0].read_text(encoding="utf-8"))
+
+
+class TestExecutorLLMErrorIsAFailure:
+    def test_dead_llm_cycle_is_blocked_failed_unmarked_and_exits_nonzero(self, tmp_path, monkeypatch):
+        state_dir = _wire(tmp_path, monkeypatch, _LLMDeadSubagentManager)
+        # Production requests point at a proposal artifact; the result row's
+        # backlog_title (what _recent_failure_match matches on) comes from its
+        # next_bounded_candidate.title — seed one exactly like the proposer does.
+        title = "Add markdown catalog link path resolver to workspace_validation_helpers.py"
+        artifact = tmp_path / "improvements" / "llm-proposed-cycle-dead.json"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text(json.dumps({"next_bounded_candidate": {"title": title}}), encoding="utf-8")
+        _seed_bridge_request(
+            state_dir, "req-dead", "cycle-dead", task_title=title, source_artifact=str(artifact),
+        )
+
+        rc = asyncio.run(bridge._main_impl())
+
+        # (1) recorded status: `blocked` with the reason set — both tests
+        # _recent_failure_match applies, so the gate sees this cycle and the
+        # same proposal is suppressed inside the 24 h window.
+        res = _result_for(state_dir, "req-dead")
+        assert res["result_status"] == "blocked"
+        assert res["rollback"]["reason"] == "executor_llm_error"
+        assert res["commits_pushed"] == 0
+        assert res["backlog_title"] == title
+        assert any("EXECUTOR LLM ERROR (#1280)" in s and "Connection error" in s for s in res.get("key_learnings") or [])
+        assert bridge._recent_failure_match(title, state_dir) == title
+
+        rows = _read_ledger(state_dir)
+        outcome = [r for r in rows if r["phase"] == "outcome"][-1]
+        assert outcome["outcome"] == "failed"
+        assert outcome["reason"] == "executor_llm_error"
+
+        # (2) the streak: the process exits non-zero, and the __main__ guard's
+        # own expression turns that into a `failure` row.
+        assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR != 0
+        streak = crash_record.record_exit(
+            state_dir, outcome="success" if rc == 0 else "failure", exit_status=rc,
+        )
+        assert streak["consecutive_failures"] == 1
+        assert streak["last_outcome"] == "failure"
+        assert streak["last_exit_status"] == bridge.EXIT_EXECUTOR_LLM_ERROR
+
+        # (3) no handled_ marker: the request is re-offered; a retry counter
+        # records the attempt.
+        bridge_state = state_dir / "subagent_bridge"
+        assert not (bridge_state / "handled_req-dead.txt").exists()
+        retry = json.loads((bridge_state / "retry_req-dead.json").read_text(encoding="utf-8"))
+        assert retry["count"] == 1 and retry["max"] == bridge.LLM_ERROR_MAX_RETRIES
+
+    def test_retry_is_bounded_then_the_request_is_retired(self, tmp_path, monkeypatch):
+        state_dir = _wire(tmp_path, monkeypatch, _LLMDeadSubagentManager)
+        monkeypatch.setattr(bridge, "LLM_ERROR_MAX_RETRIES", 3)
+        _seed_bridge_request(state_dir, "req-loop", "cycle-loop", task_title="permanently bad request")
+        bridge_state = state_dir / "subagent_bridge"
+
+        for attempt in (1, 2):
+            rc = asyncio.run(bridge._main_impl())
+            assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR
+            assert not (bridge_state / "handled_req-loop.txt").exists()
+            assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == attempt
+
+        rc = asyncio.run(bridge._main_impl())
+        assert rc == bridge.EXIT_EXECUTOR_LLM_ERROR
+        assert (bridge_state / "handled_req-loop.txt").exists(), "third failure must retire the request"
+        assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == 3
+
+        # Fourth run: the request is already handled — no fourth spawn.
+        rc = asyncio.run(bridge._main_impl())
+        assert rc == 0
+        assert json.loads((bridge_state / "retry_req-loop.json").read_text())["count"] == 3
+
+    def test_healthy_cycle_is_unchanged(self, tmp_path, monkeypatch):
+        """Control: the pre-#1280 path — a subagent that commits real work —
+        still records completed, writes the marker, and exits 0."""
+        state_dir = _wire(tmp_path, monkeypatch, _FakeSubagentManager)
+        _seed_bridge_request(state_dir, "req-ok", "cycle-ok", task_title="add feature")
+
+        rc = asyncio.run(bridge._main_impl())
+
+        assert rc == 0
+        res = _result_for(state_dir, "req-ok")
+        assert res["result_status"] == "completed"
+        assert res["rollback"]["reason"] in ("", None)
+        assert (state_dir / "subagent_bridge" / "handled_req-ok.txt").exists()
+        assert not (state_dir / "subagent_bridge" / "retry_req-ok.json").exists()
+        assert [r for r in _read_ledger(state_dir) if r["phase"] == "outcome"][-1]["outcome"] == "success"
+
+
+class TestHelpers:
+    def test_executor_llm_error_reads_only_the_failure_shape(self, tmp_path):
+        sub = tmp_path / "subagents"
+        sub.mkdir()
+        (sub / "ok.json").write_text(json.dumps({"status": "completed", "summary": "done"}))
+        (sub / "other-error.json").write_text(json.dumps({"status": "error", "summary": "Error: disk full"}))
+        (sub / "dead.json").write_text(json.dumps({"status": "error", "summary": TRANSPORT_ERROR}))
+        assert bridge._executor_llm_error(tmp_path, "ok") == ""
+        assert bridge._executor_llm_error(tmp_path, "other-error") == ""
+        assert bridge._executor_llm_error(tmp_path, "dead").startswith("Error: LLM execution failed")
+        assert bridge._executor_llm_error(tmp_path, "missing") == ""
+        assert bridge._executor_llm_error(tmp_path, None) == ""
+
+    def test_decide_handled_marker_writes_marker_unless_llm_error(self, tmp_path):
+        marker = tmp_path / "handled_req.txt"
+        assert bridge._decide_handled_marker(marker, "req.json", llm_error=False) == "handled"
+        assert marker.exists()
+        marker.unlink()
+        assert bridge._decide_handled_marker(marker, "req.json", llm_error=True) == "retry"
+        assert not marker.exists()
+        assert json.loads((tmp_path / "retry_req.json").read_text())["count"] == 1


### PR DESCRIPTION
Closes #1280. Companion finding filed as #1281 (a failed subagent can still integrate via auto-commit).

## What was wrong

The subagent already wrote the verdict — telemetry `status: "error"`, `summary: "Error: LLM execution failed: … litellm.InternalServerError … Connection error"` — and the bridge never read it. `_bridge_status` started at `completed` and only smoke-block could change it; the ledger mapped zero commits to `partial`; the process exited 0 so `exit_streak.json` recorded a success; and `handled_marker.write_text` ran unconditionally right after the spawn, retiring the request. Twelve outage cycles on 2026-09-04, eleven `completed`.

## Change (bridge.py, +~170/−12)

**Read the verdict.** `_executor_llm_error(state_dir, task_id)` returns the failure text when the spawn's telemetry says `status: error` with `LLM execution failed`; `""` otherwise, fail-open.

**Status — an existing one, on purpose.** With zero commits: `rollback.reason = executor_llm_error`, `result_status = blocked`. `blocked` is one of the two statuses `_recent_failure_match` already treats as failure, and `rollback.reason` being set is the other test, so the row matches on both and enters the 24 h suppression window and the proposer's recent-failures context. The code comment says exactly this; a fresh status would have been invisible to every reader — the bug in a new spelling. `executor_llm_error` is added to `_INCONCLUSIVE_REASONS` (never upgraded to accept/reject). Ledger outcome `failed`, not `partial`. The provider error text is appended to `key_learnings` so a reader sees *why* nothing was produced.

**Streak.** `main()` returns `EXIT_EXECUTOR_LLM_ERROR = 3` for such a cycle. The existing `__main__` guard turns any non-zero code into a `failure` row in `bridge/exit_streak.json` — one writer, no double record — so a sustained outage moves `consecutive_failures`. Consequences, stated: systemd shows the unit failed for that run; the deploy health gate reads both the journal exit status and `exit_streak` and will roll back a release deployed *during* a model outage. Deliberate: a release whose executor cannot reach its model cannot be verified, and "cannot certify" must not read as green.

**Marker, bounded.** `_decide_handled_marker()` replaces the unconditional write. An LLM failure with nothing produced leaves the request pending and increments `retry_<id>.json`; on the `LLM_ERROR_MAX_RETRIES`th failure (3, `SUBAGENT_BRIDGE_LLM_ERROR_MAX_RETRIES`) the marker is written and the request retired like any other. Every other outcome writes the marker exactly as before. Fail-open to writing the marker.

**Real work survives.** If the subagent had edited files before its call died, the #666/#717 auto-commit captures them and the normal gate decides — the error text still lands in learnings. That is what happened to `3cbcc1f77d25`, and whether it *should* is #1281.

## The `3cbcc1f77d25` anomaly, identified

Its subagent was `0652e0eb`, not `0b221168` (that one belongs to `5318708cc6ff`, 04:01–04:04Z). `0652e0eb` edited `scripts/scaffold_script_entrypoint.py`, then died at **03:20:13Z** (06:20:13 MSK — the first outage failure). Auto-commit produced `e7ecea84` ("selfevo: auto-commit uncommitted subagent work — Update scaffold_script_entrypoint.py …") at 03:20:13Z, smoke passed, merged as `e1ff2405` at 03:20:36Z, outcome `success` 03:20:40Z. Real work before the call died; not bookkeeping. Filed as #1281 rather than folded in.

## Not in scope

No fallback model group (operator's call, has a cost, and would still have logged `completed` if it also failed).

## Tests — `tests/test_bridge_executor_llm_error.py` (5)

A fake `SubagentManager` whose `spawn` writes exactly the 2026-09-04 failure telemetry and registers a finished task, driving `bridge._main_impl()` end to end on a real temp git repo:

- **dead LLM** → `result_status blocked`, `rollback.reason executor_llm_error`, `commits_pushed 0`, `backlog_title` set from the seeded proposal artifact (as production requests carry it), `key_learnings` carries the provider error, `_recent_failure_match(title)` returns the title; ledger `failed` / `executor_llm_error`; return code 3, and `crash_record.record_exit(outcome="failure", exit_status=3)` — the `__main__` guard's own expression — yields `consecutive_failures 1`; no `handled_` marker, `retry_ … count 1`.
- **bounded retry** → two failures leave it pending (count 1, 2); the third writes the marker; a fourth run does not spawn.
- **healthy control** → `completed`, marker written, no retry file, ledger `success`, exit 0 — unchanged.
- helper unit tests: `_executor_llm_error` reads only the failure shape; `_decide_handled_marker` marker-vs-retry.

Full suite result posted as a comment when the run finishes (baseline 4 by id). `ruff`: 23 findings on bridge.py, identical to `main`.

Deploy and live verification are the operator's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
