### PR TITLE
fix(strategist): cut prompt sections by declared priority, not key position (#1284)

### DIFF
--- a/nanobot/runtime/strategist.py
+++ b/nanobot/runtime/strategist.py
@@ -28,12 +28,37 @@ _MAX_JSON_BYTES = 256_000
 _MAX_LINES_FILE_BYTES = 256_000
 # Decision reason when the archive view is too empty to advise on (#1182).
 REASON_INPUTS_UNAVAILABLE = "inputs_unavailable"
-# Prompt budget: while the payload is over the cap, the largest of these
-# sections is halved (goals, the tree digest, the futility sidecar and
-# inputs_status are never shrunk); every halving is recorded in inputs_status.
+# Prompt budget (#1182, #1284): while the payload is over the cap, the largest
+# of these sections loses one step (goals, the tree digest, the futility
+# sidecar and inputs_status are never shrunk). Position in a dict is a proxy
+# for nothing, so WHAT a step removes is declared per leaf in _CUT_POLICY,
+# cheapest first:
+#   - a tuple names dict keys from cheapest to load-bearing; undeclared keys go
+#     before any declared one and the load-bearing tail survives longest
+#   - _HEAD_CHEAP: rows arrive oldest-first, the head is expendable
+#   - _TAIL_CHEAP: the producer ranked the member best-first, the tail is expendable
+# A path not in the policy is a container: the step descends into its largest
+# member. Every step is recorded under inputs_status.dropped with the keys or
+# the row count it removed, so the record says what the model did not see.
 _HALVING_SECTIONS = ("lessons", "prior_decisions", "recent_cycles", "insights", "funnel", "scorecard")
 _HALVING_STEPS = 48  # 6 sections x 8 halvings (1/256 each) before the truncated fallback
-_HALVING_KEEP = {"columns"}  # table headers inside a section, not data
+_HALVING_KEEP = {"columns", "samples"}  # table headers and axes inside a section, not data
+_HEAD_CHEAP, _TAIL_CHEAP = "head", "tail"
+_CUT_POLICY: dict[str, tuple[str, ...] | str] = {
+    "lessons": _TAIL_CHEAP,  # insights_input sorts legacy rows newest first
+    "prior_decisions": _HEAD_CHEAP,  # decisions.jsonl tail, oldest first
+    "recent_cycles": _HEAD_CHEAP,  # cycles.jsonl tail, oldest first
+    "insights.cards": _TAIL_CHEAP,  # newest first
+    "insights.errors": _HEAD_CHEAP,  # errors.yaml tail, oldest first
+    "insights.indexes": ("docs/index.md", "memory/index.md"),
+    "funnel.by_demand_id": _TAIL_CHEAP,  # most recently proposed id first
+    "scorecard.history_7d.series": _TAIL_CHEAP,  # series that moved sort first
+    "scorecard.latest": (
+        "schema_version", "computed_at_utc", "window_days",  # metadata, 44 bytes together
+        "control_plane", "reader_status", "bridge", "knowledge_lift", "heldout", "integrity",
+        "cost", "quality", "feeds", "value", "loop", "gaps_status", "gaps",  # what the advice is about
+    ),
+}
 
 def _now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -153,6 +178,7 @@ def collect_inputs(state_root: Path, repo_root: Path) -> dict[str, Any]:
             "evolution_tree": tree_meta,
             "recent_cycles": len(recent),
             "halved": [],  # filled by build_strategist_prompt when it shrinks sections
+            "dropped": [],  # what each step removed: keys for dicts, row count and end for sequences
         },
     }
 
@@ -182,14 +208,21 @@ def build_strategist_prompt(inputs: dict[str, Any], watermark: dict[str, Any]) -
         archive = payload["archive"]
         status = archive.get("inputs_status")
         halved = status.setdefault("halved", []) if isinstance(status, dict) else []
+        dropped = status.setdefault("dropped", []) if isinstance(status, dict) else []
         for _ in range(_HALVING_STEPS):
             if len(encoded) <= _MAX_PROMPT_CHARS:
                 break
-            sizes = {key: len(json.dumps(archive.get(key), ensure_ascii=False)) for key in _HALVING_SECTIONS}
-            label = _halve_section(archive, max(sizes, key=sizes.get))
-            if label is None:
+            # largest section first; a section with nothing left to cut yields to the next
+            by_size = sorted(_HALVING_SECTIONS, key=lambda key: -len(json.dumps(archive.get(key), ensure_ascii=False)))
+            record = None
+            for section in by_size:
+                record = _cut_step(archive, section)
+                if record is not None:
+                    break
+            if record is None:
                 break
-            halved.append(label)
+            halved.append(record["section"])
+            dropped.append(record)
             encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         if len(encoded) > _MAX_PROMPT_CHARS:
             encoded = json.dumps({"schema": SCHEMA, "watermark": _cap(watermark, 200), "archive": {"truncated": True}}, ensure_ascii=False)
@@ -197,26 +230,37 @@ def build_strategist_prompt(inputs: dict[str, Any], watermark: dict[str, Any]) -
             encoded = encoded[:_MAX_PROMPT_CHARS]
     return system, encoded
 
-def _halve_section(archive: dict[str, Any], key: str) -> str | None:
-    """Halve one prompt section in place. Lists and strings keep their first
-    half; a dict halves its largest list/dict/str member (so a one-key section
-    such as ``funnel.by_demand_id`` still shrinks, newest ids first). Returns
-    the label recorded under ``inputs_status.halved``, ``None`` if nothing
-    shrinkable is left."""
-    value = archive.get(key)
-    if isinstance(value, (list, str)):
-        if len(value) <= 1:
+def _cut_step(archive: dict[str, Any], section: str) -> dict[str, Any] | None:
+    """Remove the cheapest half of one leaf under ``section`` in place, per
+    :data:`_CUT_POLICY`. Descends through undeclared dicts to their largest
+    member. Returns the record for ``inputs_status.dropped`` — ``section`` (the
+    leaf path), ``dropped`` (count) and either ``keys`` (the dict keys removed)
+    or ``end`` (which end of a ranked sequence went) — or ``None`` when nothing
+    under ``section`` is left to cut."""
+    parent, key, path = archive, section, section
+    value = archive.get(section)
+    while path not in _CUT_POLICY and isinstance(value, dict):
+        members = [(k, v) for k, v in value.items() if k not in _HALVING_KEEP and isinstance(v, (list, dict, str)) and len(v) > 1]
+        if not members:
             return None
-        archive[key] = value[: len(value) // 2]
-        return key
-    if not isinstance(value, dict):
+        name, member = max(members, key=lambda item: len(json.dumps(item[1], ensure_ascii=False)))
+        parent, key, path, value = value, name, f"{path}.{name}", member
+    if not isinstance(value, (list, dict, str)) or len(value) <= 1:
         return None
-    members = [(k, v) for k, v in value.items() if k not in _HALVING_KEEP and isinstance(v, (list, dict, str)) and len(v) > 1]
-    if not members:
-        return None
-    name, member = max(members, key=lambda item: len(json.dumps(item[1], ensure_ascii=False)))
-    value[name] = dict(list(member.items())[: len(member) // 2]) if isinstance(member, dict) else member[: len(member) // 2]
-    return f"{key}.{name}"
+    policy = _CUT_POLICY.get(path, _TAIL_CHEAP)
+    keep = len(value) // 2
+    if isinstance(value, dict) and isinstance(policy, tuple):
+        rank = {name: index for index, name in enumerate(policy)}  # undeclared keys rank below every declared one
+        cheapest = sorted(value, key=lambda name: rank.get(name, -1))[: len(value) - keep]
+        parent[key] = {name: member for name, member in value.items() if name not in cheapest}
+        return {"section": path, "dropped": len(cheapest), "keys": cheapest}
+    end = _HEAD_CHEAP if policy == _HEAD_CHEAP else _TAIL_CHEAP
+    if isinstance(value, dict):
+        items = list(value.items())
+        parent[key] = dict(items[len(items) - keep:] if end == _HEAD_CHEAP else items[:keep])
+    else:
+        parent[key] = value[len(value) - keep:] if end == _HEAD_CHEAP else value[:keep]
+    return {"section": path, "dropped": len(value) - keep, "end": end}
 
 def _text_field(value: Any, limit: int = 1_000) -> bool:
     return isinstance(value, str) and bool(value.strip()) and len(value) <= limit

--- a/tests/test_strategist_inputs.py
+++ b/tests/test_strategist_inputs.py
@@ -240,13 +240,13 @@ def test_decision_row_carries_inputs_status(roots):
     assert result["success"] is True
     row = json.loads((state_root / "strategist" / "decisions.jsonl").read_text(encoding="utf-8").splitlines()[0])
     status = row["inputs_status"]
-    assert set(status) == {"goals", "scorecard", "funnel", "insights", "evolution_tree", "recent_cycles", "halved"}
+    assert set(status) == {"goals", "scorecard", "funnel", "insights", "evolution_tree", "recent_cycles", "halved", "dropped"}
     assert status["goals"]["chars"] > 0
     assert status["scorecard"] == {"latest_keys": 1, "history_rows": 7, "history_samples": 7, "status": "complete"}
     assert status["funnel"]["ids"] == 2 and status["funnel"]["ledger"]["status"] == "complete"
     assert status["insights"]["cards"] == 1
     assert status["evolution_tree"]["fitness_values"] == 6
-    assert status["recent_cycles"] == 4 and status["halved"] == []
+    assert status["recent_cycles"] == 4 and status["halved"] == [] and status["dropped"] == []
 
 
 def test_refuses_the_llm_call_when_two_inputs_are_empty(roots, monkeypatch, capsys):
@@ -296,6 +296,133 @@ def test_prompt_stays_within_cap_and_records_halved_sections(roots):
     assert "truncated" not in archive and archive["goals"].startswith("# Charter")
     assert inputs["inputs_status"]["halved"] == ["lessons", "lessons"], "the largest section is halved until the payload fits"
     assert archive["inputs_status"]["halved"] == inputs["inputs_status"]["halved"]
+    # #1284: the record says what went, not only which section was cut
+    assert inputs["inputs_status"]["dropped"] == [{"section": "lessons", "dropped": 300, "end": "tail"},
+                                                  {"section": "lessons", "dropped": 150, "end": "tail"}]
+    assert archive["lessons"][0] == inputs["lessons"][0] and len(archive["lessons"]) == 150, "newest-first list keeps its head"
+
+
+# scorecard/latest.json on the host 2026-09-04 (key order and JSON bytes) — the
+# run that cut this dict by position kept the first eight keys (#1284).
+_LIVE_LATEST_ORDER = ("schema_version", "computed_at_utc", "window_days", "loop", "cost", "quality", "value", "heldout",
+                      "integrity", "feeds", "bridge", "knowledge_lift", "control_plane", "reader_status", "gaps_status", "gaps")
+_LIVE_LATEST_BYTES = (14, 29, 1, 478, 121, 93, 194, 91, 64, 894, 294, 127, 2427, 559, 10, 367)
+
+
+def _live_latest(scale: int = 1) -> dict:
+    return {key: {"payload": "x" * max(1, size * scale - 16)} for key, size in zip(_LIVE_LATEST_ORDER, _LIVE_LATEST_BYTES)}
+
+
+def test_cut_step_drops_declared_cheap_keys_first_and_names_them():
+    """Pre-fix (#1284): scorecard.latest kept schema_version/computed_at_utc/window_days and lost gaps."""
+    archive = {"scorecard": {"latest": _live_latest(), "history_7d": {"samples": ["t0", "t1"], "series": {"a": [1, 2]}}}}
+    record = strategist._cut_step(archive, "scorecard")
+    assert record == {"section": "scorecard.latest", "dropped": 8, "keys": [
+        "schema_version", "computed_at_utc", "window_days", "control_plane", "reader_status", "bridge", "knowledge_lift", "heldout"]}
+    assert set(archive["scorecard"]["latest"]) == {"integrity", "cost", "quality", "feeds", "value", "loop", "gaps_status", "gaps"}
+    # a second step on the same section keeps cutting from the cheap end
+    assert strategist._cut_step(archive, "scorecard") == {"section": "scorecard.latest", "dropped": 4,
+                                                          "keys": ["integrity", "cost", "quality", "feeds"]}
+    assert set(archive["scorecard"]["latest"]) == {"value", "loop", "gaps_status", "gaps"}
+
+
+def test_cut_step_order_is_what_pins_the_survivors(monkeypatch):
+    """The same input under the reversed declaration loses gaps: the pin is the order, not the fixture."""
+    archive = {"scorecard": {"latest": _live_latest(), "history_7d": {"samples": [], "series": {}}}}
+    reversed_policy = {**strategist._CUT_POLICY, "scorecard.latest": tuple(reversed(strategist._CUT_POLICY["scorecard.latest"]))}
+    monkeypatch.setattr(strategist, "_CUT_POLICY", reversed_policy)
+    record = strategist._cut_step(archive, "scorecard")
+    assert "gaps" in record["keys"] and "loop" in record["keys"]
+    assert "schema_version" in archive["scorecard"]["latest"], "reversed order keeps the metadata — exactly the pre-fix outcome"
+
+
+def test_cut_step_drops_undeclared_keys_before_any_declared_one():
+    latest = {"experimental_block": {"payload": "y" * 5000}, **_live_latest()}
+    archive = {"scorecard": {"latest": latest, "history_7d": {"samples": [], "series": {}}}}
+    record = strategist._cut_step(archive, "scorecard")
+    assert record["keys"][0] == "experimental_block" and "gaps" in archive["scorecard"]["latest"]
+
+
+def test_cut_step_takes_the_cheap_end_of_each_sequence():
+    """Ledger tails are oldest-first, so their head is the cheap end; ranked members lose their tail."""
+    archive = {
+        "recent_cycles": [{"ts": f"2026-09-0{d}"} for d in range(1, 9)],  # oldest first
+        "prior_decisions": [{"timestamp": f"2026-08-2{d}"} for d in range(1, 5)],
+        "lessons": [f"newest-first {i}" for i in range(4)],
+        "funnel": {"columns": ["proposed"], "by_demand_id": {f"id-{i}": [i] for i in range(6)}},  # newest id first
+        "insights": {"cards": [{"id": f"L{i}"} for i in range(4)], "errors": [{"title": f"E{i}"} for i in range(4)],
+                     "indexes": {"memory/index.md": "m" * 300, "docs/index.md": "d" * 400}},
+        "scorecard": {"latest": {"loop": {}}, "history_7d": {"samples": ["t0", "t1"], "series": {f"s{i}": [i, i] for i in range(4)}}},
+    }
+    assert strategist._cut_step(archive, "recent_cycles") == {"section": "recent_cycles", "dropped": 4, "end": "head"}
+    assert [row["ts"] for row in archive["recent_cycles"]] == ["2026-09-05", "2026-09-06", "2026-09-07", "2026-09-08"]
+    assert strategist._cut_step(archive, "prior_decisions") == {"section": "prior_decisions", "dropped": 2, "end": "head"}
+    assert [row["timestamp"] for row in archive["prior_decisions"]] == ["2026-08-23", "2026-08-24"]
+    assert strategist._cut_step(archive, "lessons") == {"section": "lessons", "dropped": 2, "end": "tail"}
+    assert archive["lessons"] == ["newest-first 0", "newest-first 1"]
+    assert strategist._cut_step(archive, "funnel") == {"section": "funnel.by_demand_id", "dropped": 3, "end": "tail"}
+    assert list(archive["funnel"]["by_demand_id"]) == ["id-0", "id-1", "id-2"] and archive["funnel"]["columns"] == ["proposed"]
+    # insights: the largest member goes first (indexes), and its declared-cheap key is docs/index.md
+    assert strategist._cut_step(archive, "insights") == {"section": "insights.indexes", "dropped": 1, "keys": ["docs/index.md"]}
+    assert list(archive["insights"]["indexes"]) == ["memory/index.md"]
+    archive["insights"]["indexes"] = {}
+    assert strategist._cut_step(archive, "insights") == {"section": "insights.errors", "dropped": 2, "end": "head"}
+    assert [e["title"] for e in archive["insights"]["errors"]] == ["E2", "E3"], "errors.yaml tail keeps the newest"
+    # history axis (samples) is never cut; series lose the tail (least-moved) half
+    assert strategist._cut_step(archive, "scorecard") == {"section": "scorecard.history_7d.series", "dropped": 2, "end": "tail"}
+    assert archive["scorecard"]["history_7d"]["samples"] == ["t0", "t1"] and list(archive["scorecard"]["history_7d"]["series"]) == ["s0", "s1"]
+
+
+def test_cut_step_yields_when_nothing_is_left():
+    archive = {"lessons": ["one"], "funnel": {"columns": ["proposed"], "by_demand_id": {"id-0": [1]}}}
+    assert strategist._cut_step(archive, "lessons") is None
+    assert strategist._cut_step(archive, "funnel") is None
+    assert strategist._cut_step(archive, "missing") is None
+
+
+def test_every_prompt_leaf_declares_its_cheap_end(roots):
+    """A member the policy does not know would fall back to position — the #1284 defect. Walk the
+    live-shaped archive and demand a declaration for every list/str/dict-of-scalars a step could reach."""
+    state_root, repo_root, release_root = roots
+    _live_shape(state_root, repo_root, release_root)
+    inputs = collect_inputs(state_root, repo_root)
+    undeclared: list[str] = []
+
+    def walk(path: str, value) -> None:
+        if path in strategist._CUT_POLICY:
+            return
+        if isinstance(value, dict) and any(isinstance(v, (dict, list)) for k, v in value.items() if k not in strategist._HALVING_KEEP):
+            for name, member in value.items():
+                if name not in strategist._HALVING_KEEP and isinstance(member, (dict, list, str)):
+                    walk(f"{path}.{name}", member)
+            return
+        undeclared.append(path)
+
+    for section in strategist._HALVING_SECTIONS:
+        walk(section, inputs[section])
+    assert undeclared == []
+    assert set(strategist._CUT_POLICY) >= {"scorecard.latest", "funnel.by_demand_id", "recent_cycles", "prior_decisions"}
+
+
+def test_live_shape_over_budget_keeps_gaps_and_drops_control_plane_first(roots):
+    """The 2026-09-04 run, replayed: scorecard.latest over budget must lose control_plane and the
+    metadata keys, never gaps/loop/value/feeds, and the row must name what went."""
+    state_root, repo_root, release_root = roots
+    _live_shape(state_root, repo_root, release_root)
+    inputs = collect_inputs(state_root, repo_root)
+    inputs["scorecard"]["latest"] = _live_latest()
+    inputs["scorecard"]["latest"]["control_plane"] = {"payload": "c" * 40_000}  # push the prompt over the cap
+    _, user = strategist.build_strategist_prompt(inputs, {"total_runs": 9})
+    assert len(user) <= strategist._MAX_PROMPT_CHARS
+    archive = json.loads(user)["archive"]
+    assert "truncated" not in archive
+    status = inputs["inputs_status"]
+    assert status["halved"][0] == "scorecard.latest" and status["dropped"][0]["section"] == "scorecard.latest"
+    assert "control_plane" in status["dropped"][0]["keys"] and "schema_version" in status["dropped"][0]["keys"]
+    for key in ("gaps", "gaps_status", "loop", "value", "feeds", "quality", "cost"):
+        assert key in archive["scorecard"]["latest"], key
+    assert "control_plane" not in archive["scorecard"]["latest"]
+    assert archive["inputs_status"]["dropped"] == status["dropped"], "the record travels with the prompt and the decision row"
 
 
 def _live_shape(state_root: Path, repo_root: Path, release_root: Path) -> None:


### PR DESCRIPTION
Closes #1284.

## Defect

`_halve_section` shrank an over-budget prompt section by keeping the first half of a dict **by key position**. On the 2026-09-04 03:00 run that cut `scorecard.latest` to `schema_version, computed_at_utc, window_days, loop, cost, quality, value, heldout` and dropped `integrity, feeds, bridge, knowledge_lift, control_plane, reader_status, gaps_status, gaps` — three metadata keys worth 44 bytes survived, the gap table the strategist exists to reason about did not. The same function cut `recent_cycles` and `prior_decisions` (oldest-first ledger tails) by keeping their **oldest** half.

## Fix

Position is a proxy for nothing, so each leaf declares its own cheap end in `_CUT_POLICY` (`nanobot/runtime/strategist.py`):

- a tuple names dict keys from cheapest to load-bearing (`scorecard.latest`: metadata, then `control_plane`, `reader_status`, `bridge`, `knowledge_lift`, `heldout`, `integrity`, then `cost`, `quality`, `feeds`, `value`, `loop`, `gaps_status`, `gaps`); keys the policy does not know go before any declared one;
- `head`: rows arrive oldest-first, the head is expendable (`recent_cycles`, `prior_decisions`, `insights.errors`);
- `tail`: the producer ranked the member best-first, the tail is expendable (`funnel.by_demand_id`, `scorecard.history_7d.series`, `lessons`, `insights.cards`).

A path not in the policy is a container and the step descends into its largest member, so the same function serves every halving section. A section with nothing left to cut yields to the next largest instead of falling through to the `{"truncated": true}` payload. `samples` joins `columns` as an axis that is never cut.

Observability: `inputs_status.halved` keeps its section labels; a new `inputs_status.dropped` list records each step as `{"section": "scorecard.latest", "dropped": 8, "keys": [...]}` for dicts or `{"section": "recent_cycles", "dropped": 25, "end": "head"}` for sequences, in the prompt and in the `decisions.jsonl` row.

Not changed: the 48,000 budget, what the strategist reads or writes, `_HALVING_SECTIONS`, the refusal rule.

## Tests (`tests/test_strategist_inputs.py`)

- `test_cut_step_drops_declared_cheap_keys_first_and_names_them` — live 16-key `latest` with host byte sizes; asserts the eight dropped keys by name and that a second step keeps cutting from the cheap end.
- `test_cut_step_order_is_what_pins_the_survivors` — reversed declaration on the same input loses `gaps` and keeps `schema_version`: the pin is the order, the test fails if it is reversed.
- `test_cut_step_drops_undeclared_keys_before_any_declared_one`
- `test_cut_step_takes_the_cheap_end_of_each_sequence` — head/tail per member, axes untouched, `insights.indexes` drops `docs/index.md` first.
- `test_cut_step_yields_when_nothing_is_left`
- `test_every_prompt_leaf_declares_its_cheap_end` — walks the live-shaped archive; any list/str/dict-of-scalars reachable by a step must be in the policy.
- `test_live_shape_over_budget_keeps_gaps_and_drops_control_plane_first` — the 09-04 run replayed; `gaps/gaps_status/loop/value/feeds/quality/cost` survive, `control_plane` and `schema_version` are in the record, record travels with the prompt.
- existing `test_prompt_stays_within_cap_and_records_halved_sections` extended with the `dropped` records; `inputs_status` key-set test updated.

Focused: 73 passed, 2 skipped. Full suite on Windows at `c6053bab`: `5 failed, 3020 passed, 17 skipped` in 21 min. Four are the exact Windows baseline (`test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle` and the three `test_bridge_locking.py::TestAcquireBridgeLock` cases). The fifth, `test_eeebot_dashboard_truth.py::test_queue_reference_keeps_raw_internal_value_until_public_sanitization`, is a path-separator assertion (`'\secret\a.json' != '/secret/a.json'`) added on `main` by #1275 (`632bffbb`, Linux CI green); this branch does not touch the dashboard, so it is a new Windows-only baseline entry, not a regression here.

## Live check owed after deploy

Next natural run whose row has `halved` non-empty: quote `inputs_status.dropped` and confirm `gaps` is among the surviving `scorecard.latest` keys (or that the cut fell on another section per its declared end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
