### PR TITLE
chore: ignore agent scratch logs in the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ workspace/
 lessons/errors/ERR-*.md
 lessons/lessons/LESS-*.md
 
+
+# Agent scratch output written into the repo root.
+# Test runs are redirected to a file rather than piped, because a pipe can lose
+# a long run's entire output; those logs land here and must never be committed.
+# `NUL` is a Windows device-name artifact from a redirect that reached cmd.exe.
+*.log
+/NUL


### PR DESCRIPTION
Small hardening, found during a hygiene pass rather than from a failure.

The repo root currently holds about twenty untracked `*.log` files — `full-1287.log`, `durable-1279-*.log`, `focused-dashboard-fix-*.log` and so on. They are there by design: agents redirect test runs to a file instead of piping them, because a pipe can lose a long run's entire output and leaves nothing to read while the run is still going. We lost a deploy log and a twelve-minute pytest run that way, which is why the redirect is the standing instruction.

What was missing is the other half. `.gitignore` has no `*.log` entry and no `.log` file is tracked, so nothing prevented those logs from being committed — and all four agents share `T:\Code\eeebot` as their shell working directory, so a single `git add -A` there would have taken the lot. Checked before writing this: nothing junk has actually been committed in the last day, so this closes a class rather than fixing an incident.

`/NUL` is ignored for the same reason. It is the artifact of a redirect that reached cmd.exe instead of the POSIX shell; it cannot be removed by ordinary means on Windows and there is no reason for it to be committable.

No behaviour change, no test change.