### PR TITLE
test(dashboard): stop pinning a POSIX separator in the queue-reference test

### DIFF
--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -362,11 +362,18 @@ def test_queue_path_redaction_preserves_action_metadata() -> None:
 
 
 def test_queue_reference_keeps_raw_internal_value_until_public_sanitization() -> None:
-    reference = DASHBOARD.format_stale_request_reference(42.0, Path("/secret/a.json"))
-    assert reference == ("42.0h", "/secret/a.json")
+    # The subject is that the raw path survives until sanitization, not how the
+    # platform spells a separator: str(Path("/secret/a.json")) is
+    # "\secret\a.json" on Windows and "/secret/a.json" elsewhere. Pinning the
+    # POSIX form made this a Windows-only failure and silently moved the
+    # documented four-failure Windows baseline to five.
+    raw_path = Path("/secret/a.json")
+    raw_text = str(raw_path)
+    reference = DASHBOARD.format_stale_request_reference(42.0, raw_path)
+    assert reference == ("42.0h", raw_text)
     sanitized = DASHBOARD.sanitize_public_metrics({
-        "oldest_stale_request_path": Path("/secret/a.json"),
-        "oldest_stale_request_path_text": "/secret/a.json",
+        "oldest_stale_request_path": raw_path,
+        "oldest_stale_request_path_text": raw_text,
         "queue_action": f"archive oldest 42.0h @ {reference[1]}",
         "queue_archive_target": f"{reference[1]} (42.0h)",
     })


### PR DESCRIPTION
One-line test fix with a disproportionate effect on how the fleet reads its own results.

`test_queue_reference_keeps_raw_internal_value_until_public_sanitization` (added with #1275) asserted:

```python
reference = DASHBOARD.format_stale_request_reference(42.0, Path("/secret/a.json"))
assert reference == ("42.0h", "/secret/a.json")
```

On Windows `str(Path("/secret/a.json"))` is `\secret\a.json`, so this failed locally and passed on the Linux CI:

```
AssertionError: assert ('42.0h', '\secret\a.json') == ('42.0h', '/secret/a.json')
```

The test's subject is that the raw path survives until `sanitize_public_metrics` redacts it — the two assertions that check that are unchanged. The separator spelling was incidental to it.

**Why this is worth its own PR rather than a drive-by.** Every agent brief in this repo quotes the Windows full-suite baseline as exactly four named failures, and treats a fifth as theirs to explain. This test silently made it five. One agent spent a round investigating a "fifth failure" before the real cause was found elsewhere, and the wrong explanation nearly went into a PR body as fact. A baseline that is stated as exact has to actually be exact, or it stops being a useful contract and becomes a source of confident wrong answers.

Verified: `tests/test_eeebot_dashboard_truth.py` is 25 passed on `main` with this change, 24 passed + 1 failed without it.