### PR TITLE
fix(runtime): complete hypothesis identity plumbing

### DIFF
--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -474,7 +474,6 @@ def _make_item(
     affected_path: str = "",
     vector: str = "",
     direction: str = "",
-    hypothesis_ref: str = "",
 ) -> dict[str, str]:
     summary = (summary or "").strip()[:_MAX_SUMMARY_CHARS]
     return {
@@ -496,7 +495,6 @@ def _make_item(
         # correspondence; see its own docstring). Additive-only: existing
         # callers that omit this arg get "" and are unaffected.
         "direction": (direction or "").strip(),
-        "hypothesis_ref": (hypothesis_ref or "").strip()[:200],
     }
 
 

--- a/nanobot/runtime/demand.py
+++ b/nanobot/runtime/demand.py
@@ -474,6 +474,7 @@ def _make_item(
     affected_path: str = "",
     vector: str = "",
     direction: str = "",
+    hypothesis_ref: str = "",
 ) -> dict[str, str]:
     summary = (summary or "").strip()[:_MAX_SUMMARY_CHARS]
     return {
@@ -495,6 +496,7 @@ def _make_item(
         # correspondence; see its own docstring). Additive-only: existing
         # callers that omit this arg get "" and are unaffected.
         "direction": (direction or "").strip(),
+        "hypothesis_ref": (hypothesis_ref or "").strip()[:200],
     }
 
 
@@ -1670,7 +1672,10 @@ def _hypothesis_items(
                 continue
             seen.add(title)
             evidence = str(entry.get("evidence") or entry.get("metric") or entry.get("data_to_collect") or entry.get("insight_criterion") or entry.get("acceptance") or "")
-            items.append(_make_item("hypothesis", title, evidence))
+            hypothesis_ref = str(entry.get("hypothesis_id") or "").strip()
+            demand_item = _make_item("hypothesis", title, evidence)
+            demand_item["hypothesis_ref"] = hypothesis_ref
+            items.append(demand_item)
         # #1219: ``research/hypotheses.json`` is no longer a source here. Its
         # writer (``cycle_planning._write_research_feed``) was deleted with the
         # planner (#924) and the file froze on 2026-08-22; durable + backlog

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -668,6 +668,8 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
         entries = []
 
     # Map existing titles / keys to avoid duplicate additions
+    import hashlib
+
     existing_titles = {
         str(e.get("title") or e.get("task_title") or e.get("hypothesis") or "").strip().lower()
         for e in entries
@@ -687,8 +689,13 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
         if lookup_key in existing_titles:
             continue
 
+        hypothesis_id = str(item.get("hypothesis_id") or "").strip()
+        if not hypothesis_id:
+            hypothesis_id = "hyp-" + hashlib.sha256(
+                f"{title}\n{hypothesis_text}".encode("utf-8")
+            ).hexdigest()[:16]
         entry_record: dict[str, Any] = {
-            "hypothesis_id": str(item.get("hypothesis_id") or f"hyp-{len(entries) + 1:04d}"),
+            "hypothesis_id": hypothesis_id,
             "task_title": title or hypothesis_text[:80],
             "title": title or hypothesis_text[:80],
             "hypothesis": hypothesis_text,

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -358,10 +358,15 @@ def reconcile(state_dir: Path, *, now: datetime | None = None) -> None:
         answered_keys: dict[str, str] = {}
         for cid, prow in proposed_by_cycle.items():
             ref = _serves_hypothesis_ref(str(prow.get("serves") or ""))
-            if not ref:
+            explicit_ref = str(prow.get("hypothesis_ref") or "").strip()
+            if not ref and not explicit_ref:
                 continue
             for cand in candidates:
-                if not _ref_matches_candidate(ref, cand):
+                if explicit_ref:
+                    matches = explicit_ref == cand["key"]
+                else:
+                    matches = _ref_matches_candidate(ref, cand)
+                if not matches:
                     continue
                 touched_keys.add(cand["key"])
                 outcome_row = outcome_by_cycle.get(cid)

--- a/nanobot/runtime/hypothesis_backlog.py
+++ b/nanobot/runtime/hypothesis_backlog.py
@@ -55,6 +55,7 @@ verification gate).
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -667,9 +668,29 @@ def append_hypotheses(state_dir: Path | str, new_entries: list[dict[str, Any]]) 
         backlog_data = {"schema": "hypothesis-durable-v1", "entries": []}
         entries = []
 
-    # Map existing titles / keys to avoid duplicate additions
-    import hashlib
+    # Repair duplicate FIFO-era ids before exact identity links can act on
+    # them. Unique legacy ids stay unchanged; each duplicate receives the
+    # same content identity used for new entries. Lifecycle rows under the old
+    # id remain historical rather than being guessed onto one duplicate.
+    id_counts: dict[str, int] = {}
+    for entry in entries:
+        if isinstance(entry, dict):
+            hypothesis_id = str(entry.get("hypothesis_id") or "").strip()
+            if hypothesis_id:
+                id_counts[hypothesis_id] = id_counts.get(hypothesis_id, 0) + 1
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        hypothesis_id = str(entry.get("hypothesis_id") or "").strip()
+        if id_counts.get(hypothesis_id, 0) <= 1:
+            continue
+        title = str(entry.get("title") or entry.get("task_title") or "").strip()
+        hypothesis_text = str(entry.get("hypothesis") or "").strip()
+        entry["hypothesis_id"] = "hyp-" + hashlib.sha256(
+            f"{title}\n{hypothesis_text}".encode("utf-8")
+        ).hexdigest()[:16]
 
+    # Map existing titles / keys to avoid duplicate additions
     existing_titles = {
         str(e.get("title") or e.get("task_title") or e.get("hypothesis") or "").strip().lower()
         for e in entries

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2585,6 +2585,7 @@ def write_request(
     rationale = str(proposal.get("rationale") or "").strip()
     target_path = str(proposal.get("target_path") or "").strip()
     serves = str(proposal.get("serves") or "").strip()
+    hypothesis_ref = str(proposal.get("hypothesis_ref") or "").strip()
 
     improvements_dir = state_dir / "improvements"
     improvements_dir.mkdir(parents=True, exist_ok=True)
@@ -2661,6 +2662,7 @@ def write_request(
         "target_path": target_path,
         "serves": serves,
         "source_artifact": "llm_proposer",
+        **({"hypothesis_ref": hypothesis_ref} if hypothesis_ref else {}),
     }
     # #760: demand traceability — when serves is 'demand <id>', the proposed
     # row also carries the id, so proposal→demand-item is queryable.

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2847,6 +2847,18 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         def _proposal_demand_id(p: Any) -> str:
             return _demand_id_from_serves(p.get("serves")) if isinstance(p, dict) else ""
 
+        def _stamp_assigned_hypothesis_ref(p: Any) -> None:
+            if not assigned or not demand_items or not isinstance(demand_items[0], dict):
+                return
+            if not isinstance(p, dict):
+                return
+            assigned_item = demand_items[0]
+            if _proposal_demand_id(p) != str(assigned_item.get("id") or "").strip():
+                return
+            hypothesis_ref = str(assigned_item.get("hypothesis_ref") or "").strip()
+            if hypothesis_ref:
+                p["hypothesis_ref"] = hypothesis_ref
+
         def _is_noop_reply(p: Any) -> bool:
             # #760 roll-out fix: the weak host model emits no_valuable_task
             # as the string "true" (or 1) rather than a JSON boolean; such a
@@ -2869,8 +2881,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
 
         proposal = _call_propose()
         calls_made += 1
-        if assigned and demand_items and isinstance(demand_items[0], dict) and isinstance(proposal, dict):
-            proposal["hypothesis_ref"] = str(demand_items[0].get("hypothesis_ref") or "").strip()
+        _stamp_assigned_hypothesis_ref(proposal)
 
         if allow_no_op and _is_noop_reply(proposal):
             _record_noop_skip(state_dir, _noop_skip_reason(str(proposal.get("reason") or "")))
@@ -2880,8 +2891,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if not ok and calls_made < _MAX_LLM_CALLS:
             proposal = _call_propose(rejection_reason=reason)
             calls_made += 1
-            if assigned and demand_items and isinstance(demand_items[0], dict) and isinstance(proposal, dict):
-                proposal["hypothesis_ref"] = str(demand_items[0].get("hypothesis_ref") or "").strip()
+            _stamp_assigned_hypothesis_ref(proposal)
             if allow_no_op and _is_noop_reply(proposal):
                 _record_noop_skip(state_dir, _noop_skip_reason(str(proposal.get("reason") or "")))
                 return None
@@ -2918,8 +2928,7 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if dup and calls_made < _MAX_LLM_CALLS:
             proposal = _call_propose(rejection_reason=dup_reason)
             calls_made += 1
-            if assigned and demand_items and isinstance(demand_items[0], dict) and isinstance(proposal, dict):
-                proposal["hypothesis_ref"] = str(demand_items[0].get("hypothesis_ref") or "").strip()
+            _stamp_assigned_hypothesis_ref(proposal)
             # #760 follow-up (live 2026-07-15 20:42-21:02Z): a model told
             # "your proposal duplicates X" may honestly answer
             # no_valuable_task — this path lacked the no-op check, so three

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -2649,6 +2649,7 @@ def write_request(
         "profile": "bounded_execution",
         "budget": "standard",
         "source_artifact": str(artifact_path),
+        **({"hypothesis_ref": hypothesis_ref} if hypothesis_ref else {}),
         "feedback_decision": None,
         "lessons_context": lessons_context,
     }
@@ -2868,6 +2869,8 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
 
         proposal = _call_propose()
         calls_made += 1
+        if assigned and demand_items and isinstance(demand_items[0], dict) and isinstance(proposal, dict):
+            proposal["hypothesis_ref"] = str(demand_items[0].get("hypothesis_ref") or "").strip()
 
         if allow_no_op and _is_noop_reply(proposal):
             _record_noop_skip(state_dir, _noop_skip_reason(str(proposal.get("reason") or "")))
@@ -2877,6 +2880,8 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if not ok and calls_made < _MAX_LLM_CALLS:
             proposal = _call_propose(rejection_reason=reason)
             calls_made += 1
+            if assigned and demand_items and isinstance(demand_items[0], dict) and isinstance(proposal, dict):
+                proposal["hypothesis_ref"] = str(demand_items[0].get("hypothesis_ref") or "").strip()
             if allow_no_op and _is_noop_reply(proposal):
                 _record_noop_skip(state_dir, _noop_skip_reason(str(proposal.get("reason") or "")))
                 return None
@@ -2913,6 +2918,8 @@ def maybe_propose(state_dir: Path, selfevo_repo: Path | None) -> str | None:
         if dup and calls_made < _MAX_LLM_CALLS:
             proposal = _call_propose(rejection_reason=dup_reason)
             calls_made += 1
+            if assigned and demand_items and isinstance(demand_items[0], dict) and isinstance(proposal, dict):
+                proposal["hypothesis_ref"] = str(demand_items[0].get("hypothesis_ref") or "").strip()
             # #760 follow-up (live 2026-07-15 20:42-21:02Z): a model told
             # "your proposal duplicates X" may honestly answer
             # no_valuable_task — this path lacked the no-op check, so three

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -177,6 +177,22 @@ class TestLifecycleReconciliation:
         assert hypothesis_backlog.top_candidates(state_dir) == []
         assert hypothesis_backlog.context_section(state_dir) == ""
 
+    def test_duplicate_fifo_ids_are_reminted_before_append(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_durable(state_dir, [
+            {"hypothesis_id": "hyp-0022", "title": "First", "hypothesis": "claim one"},
+            {"hypothesis_id": "hyp-0022", "title": "Second", "hypothesis": "claim two"},
+        ])
+
+        hypothesis_backlog.append_hypotheses(state_dir, [])
+
+        entries = json.loads(
+            (state_dir / "hypotheses" / "durable.json").read_text(encoding="utf-8")
+        )["entries"]
+        assert len({entry["hypothesis_id"] for entry in entries}) == 2
+        assert all(entry["hypothesis_id"].startswith("hyp-") for entry in entries)
+        assert all(entry["hypothesis_id"] != "hyp-0022" for entry in entries)
+
     def test_generated_hypothesis_ids_remain_unique_after_fifo_eviction(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_durable(state_dir, [])

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -46,6 +46,15 @@ def _write_lifecycle(state_dir: Path, entries: dict) -> None:
     )
 
 
+def _write_durable(state_dir: Path, entries: list[dict]) -> None:
+    hypotheses_dir = state_dir / "hypotheses"
+    hypotheses_dir.mkdir(parents=True, exist_ok=True)
+    (hypotheses_dir / "durable.json").write_text(
+        json.dumps({"schema": "hypothesis-durable-v1", "entries": entries}),
+        encoding="utf-8",
+    )
+
+
 def _read_lifecycle(state_dir: Path) -> dict:
     path = state_dir / "hypotheses" / "lifecycle.json"
     return json.loads(path.read_text(encoding="utf-8"))
@@ -167,6 +176,20 @@ class TestLifecycleReconciliation:
         # Answered candidates no longer surface as context candidates.
         assert hypothesis_backlog.top_candidates(state_dir) == []
         assert hypothesis_backlog.context_section(state_dir) == ""
+
+    def test_generated_hypothesis_ids_remain_unique_after_fifo_eviction(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_durable(state_dir, [])
+        for i in range(22):
+            hypothesis_backlog.append_hypotheses(
+                state_dir,
+                [{"title": f"Hypothesis {i}", "hypothesis": f"claim {i}"}],
+            )
+        entries = json.loads(
+            (state_dir / "hypotheses" / "durable.json").read_text(encoding="utf-8")
+        )["entries"]
+        ids = [entry["hypothesis_id"] for entry in entries]
+        assert len(ids) == len(set(ids)) == hypothesis_backlog.DURABLE_MAX_ENTRIES
 
     def test_strategist_hypothesis_ref_answers_via_demand_id(self, tmp_path):
         state_dir = _state_dir(tmp_path)

--- a/tests/test_hypothesis_backlog.py
+++ b/tests/test_hypothesis_backlog.py
@@ -168,6 +168,29 @@ class TestLifecycleReconciliation:
         assert hypothesis_backlog.top_candidates(state_dir) == []
         assert hypothesis_backlog.context_section(state_dir) == ""
 
+    def test_strategist_hypothesis_ref_answers_via_demand_id(self, tmp_path):
+        state_dir = _state_dir(tmp_path)
+        _write_backlog(state_dir, [{"hypothesis_id": "hyp-0022", "task_title": "Fix widget"}])
+        cycle_ledger.append_event(
+            state_dir,
+            {
+                "phase": "proposed",
+                "cycle_id": "c1",
+                "task_title": "Fix widget",
+                "serves": "demand hypothesis-cab86c3e9ed8",
+                "hypothesis_ref": "hyp-0022",
+            },
+        )
+        cycle_ledger.append_event(
+            state_dir, {"phase": "outcome", "cycle_id": "c1", "outcome": "success"}
+        )
+
+        hypothesis_backlog.reconcile(state_dir)
+
+        entry = _read_lifecycle(state_dir)["entries"]["hyp-0022"]
+        assert entry["status"] == "answered"
+        assert entry["answered_evidence"] == "c1"
+
     def test_referenced_but_not_yet_successful_stays_active(self, tmp_path):
         state_dir = _state_dir(tmp_path)
         _write_backlog(state_dir, [{"hypothesis_id": "hypothesis-h1", "task_title": "Fix widget"}])

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2713,6 +2713,31 @@ class TestDemandDrivenMode:
         assert proposed[0]["demand_id"] == demand_id
         assert proposed[0]["serves"] == f"demand {demand_id}"
 
+    def test_assigned_hypothesis_ref_reaches_proposed_ledger(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "mission text with no priority-targets section")
+        item = {
+            "kind": "hypothesis",
+            "id": "hypothesis-cab86c3e9ed8",
+            "summary": "Fix widget",
+            "evidence": "metric",
+            "hypothesis_ref": "hyp-0022",
+        }
+        monkeypatch.setattr(llm_proposer, "_select_assigned_demand", lambda _state, _items: [item])
+        monkeypatch.setattr(llm_proposer.demand, "collect_demand", lambda *_args, **_kwargs: [item])
+        monkeypatch.setattr(llm_proposer, "propose", lambda *_args, **_kwargs: {
+            "task_title": "Fix widget implementation",
+            "rationale": "Test assigned hypothesis identity.",
+            "target_path": "scripts/widget.py",
+            "serves": "demand hypothesis-cab86c3e9ed8",
+        })
+
+        llm_proposer.maybe_propose(state_dir, None)
+
+        proposed = [r for r in _ledger_rows(state_dir) if r.get("phase") == "proposed"]
+        assert len(proposed) == 1
+        assert proposed[0]["hypothesis_ref"] == "hyp-0022"
+
     def test_demand_mode_uses_demand_system_prompt(self, tmp_path, monkeypatch):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -2738,6 +2738,31 @@ class TestDemandDrivenMode:
         assert len(proposed) == 1
         assert proposed[0]["hypothesis_ref"] == "hyp-0022"
 
+    def test_assigned_hypothesis_ref_not_stamped_for_different_serves(self, tmp_path, monkeypatch):
+        state_dir = _state_dir(tmp_path)
+        _write_goal_text(state_dir, "mission text with no priority-targets section")
+        item = {
+            "kind": "hypothesis",
+            "id": "hypothesis-cab86c3e9ed8",
+            "summary": "Fix widget",
+            "evidence": "metric",
+            "hypothesis_ref": "hyp-0022",
+        }
+        monkeypatch.setattr(llm_proposer, "_select_assigned_demand", lambda _state, _items: [item])
+        monkeypatch.setattr(llm_proposer.demand, "collect_demand", lambda *_args, **_kwargs: [item])
+        monkeypatch.setattr(llm_proposer, "propose", lambda *_args, **_kwargs: {
+            "task_title": "Implement another priority",
+            "rationale": "Model did not serve the assigned item.",
+            "target_path": "scripts/other.py",
+            "serves": "demand priority-other",
+        })
+
+        llm_proposer.maybe_propose(state_dir, None)
+
+        proposed = [r for r in _ledger_rows(state_dir) if r.get("phase") == "proposed"]
+        assert len(proposed) == 1
+        assert "hypothesis_ref" not in proposed[0]
+
     def test_demand_mode_uses_demand_system_prompt(self, tmp_path, monkeypatch):
         state_dir = _state_dir(tmp_path)
         _write_goal_text(state_dir, json.loads(GOAL_TEXT_JSON)["text"])


### PR DESCRIPTION
## Summary

Fixes #1285 by carrying a unique strategist hypothesis identity through demand selection and proposal materialization, then reconciling by exact identity instead of text or generated demand id.

- `_hypothesis_items` carries the source `hypothesis_id` as `hypothesis_ref` on the demand item.
- The assigned-demand path injects that ref into the model proposal after the model response; the model does not need to echo internal bookkeeping.
- `write_request` preserves `hypothesis_ref` in both the request payload and proposed ledger event.
- `hypothesis_backlog.reconcile` uses exact `hypothesis_ref == candidate key` when present; legacy rows without it retain the old matcher.
- Newly minted hypotheses without an explicit id use a short content hash (`title + hypothesis`) rather than the old FIFO `hyp-NNNN` position, so FIFO eviction cannot reuse an identity.
- Added tests for production-path proposal plumbing, strategist-shaped reconciliation, and uniqueness across FIFO eviction.

## State-access deny-set

`nanobot/runtime/hypothesis_backlog.py` is **not** listed in `nanobot/runtime/runtime_deny.py`; this change does not add it because the module is ordinary runtime bookkeeping, not a mutation-surface module.

## Verification

- Focused tests: **416 passed** (`test_hypothesis_backlog.py`, `test_demand.py`, `test_llm_proposer.py`).
- Full suite after rebasing onto current `origin/main` (`2e9937bd`): **3024 passed, 17 skipped, 4 failed**.
- The exact four remaining failures are the established Windows bridge baseline:
  - `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`
- Ruff's changed-runtime checks and `git diff --check` passed.
- No host access, deployment, current switch, service restart, or merge was performed.
