### PR TITLE
test(dashboard): enforce html context key contract

### DIFF
--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 from io import BytesIO
 from pathlib import Path
@@ -263,6 +264,47 @@ def test_status_tokens_meet_wcag_aa_contrast() -> None:
     for background, foreground in pairs:
         ratio = (max(luminance(background), luminance(foreground)) + 0.05) / (min(luminance(background), luminance(foreground)) + 0.05)
         assert ratio >= 4.5, (background, foreground, ratio)
+def test_html_context_keys_are_produced_by_metrics_builder(monkeypatch) -> None:
+    """Keep direct indexing loud and derive the builder/context contract.
+
+    Presentation keys intentionally use direct indexing: a missing value should
+    fail loudly instead of rendering a plausible but incomplete dashboard.
+    """
+    source = DASHBOARD_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(DASHBOARD_PATH))
+    context_fn = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_build_html_context"
+    )
+    metrics_param = context_fn.args.args[0].arg
+    direct_keys = {
+        sub.slice.value
+        for sub in ast.walk(context_fn)
+        if isinstance(sub, ast.Subscript)
+        and isinstance(sub.value, ast.Name)
+        and sub.value.id == metrics_param
+        and isinstance(sub.slice, ast.Constant)
+        and isinstance(sub.slice.value, str)
+    }
+    dynamic_keys = {
+        DASHBOARD._HTML_KEY_MAP[html_key]
+        for html_key in DASHBOARD._HTML_ESCAPE_KEYS
+    }
+    indexed_keys = direct_keys | dynamic_keys
+    assert len(dynamic_keys) > len(direct_keys), "dynamic HTML key map must be part of this contract"
+
+    # The builder is deliberately exercised with its normal source adapters
+    # patched to a tiny deterministic fixture; this remains the real builder,
+    # not a copied list of expected keys.
+    monkeypatch.setattr(DASHBOARD, "load_json", lambda *_args: {})
+    monkeypatch.setattr(DASHBOARD, "load_latest_materialized", lambda: (None, {}))
+    monkeypatch.setattr(DASHBOARD, "scan_report_artifacts", lambda: (None, {}, []))
+    monkeypatch.setattr(DASHBOARD, "load_host_capabilities", lambda: {})
+    monkeypatch.setattr(DASHBOARD, "scan_subagent_tree_stats", lambda: (0, 0, None, 0, None))
+    monkeypatch.setattr(DASHBOARD, "scan_all_report_rewards", lambda **_kwargs: [])
+    produced = DASHBOARD.collect_metrics_uncached()
+    assert indexed_keys <= produced.keys(), sorted(indexed_keys - produced.keys())
 
 
 def test_fresh_report_status_is_still_bounded() -> None:


### PR DESCRIPTION
## Summary

Closes #1289.

Adds a structural contract test for `_build_html_context()` without changing dashboard behavior.

## Contract derivation

The test derives the required metrics keys from both mechanisms used by the renderer:

1. AST scan of `_build_html_context()` for direct string-constant `m["..."]` subscripts.
2. Imported module truth for the dynamic loop:
   `for html_key in _HTML_ESCAPE_KEYS: m[_HTML_KEY_MAP[html_key]]`.

The final set is the union of both. This deliberately covers the dynamic key map rather than stopping at the four direct subscripts.

The test calls the real `collect_metrics_uncached()` builder with only source adapters patched to a deterministic empty fixture. It does not reproduce or hand-maintain the builder's output key set.

## Direct indexing decision

Presentation keys remain direct-indexed. A missing presentation value must fail loudly instead of rendering a plausible but incomplete dashboard; `.get()` defaults would hide the same class of contract break that caused #1206. The new test is the structural guard for that deliberate choice.

## Failure demonstration

The guard was exercised with a temporary in-memory mutation: one key from the dynamic set (`queue_freshness`) was removed from the builder result before the assertion. The resulting failure was:

```text
AssertionError: HTML context indexes keys absent from metrics builder: ['queue_freshness']
```

The source and builder were restored before commit; no production code was changed.

## Verification

- Focused dashboard suite: **26 passed**.
- Full pytest from the dedicated worktree: **3013 passed, 17 skipped, 5 failed**.
- Five failures are the current Windows baseline before #1295 merges:
  - `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`
  - `tests/test_eeebot_dashboard_truth.py::test_queue_reference_keeps_raw_internal_value_until_public_sanitization`

No semantic status-colour code was changed. No deployment or host mutation was performed.
