### PR TITLE
fix(reflector): record parse failures and llm telemetry

### DIFF
--- a/docs/specs/observability/spec.md
+++ b/docs/specs/observability/spec.md
@@ -50,6 +50,24 @@ remains the explanatory reference (signal map, anti-patterns, walkthroughs).
   A change that cannot be observed after the fact from state SHALL NOT ship until
   it has that observability.
 
+### Reflector response diagnostics (#1291)
+
+Reflector error rows in `state/reflector/reflections.jsonl` carry a structured
+`parse_reason`, raw `response_chars`, and bounded `response_head` (200 characters)
+and `response_tail` (80 characters). Transport failures have `not_attempted` and
+empty response diagnostics, never a previous attempt's values.
+
+Malformed text distinguishes `fenced_unclosed`, `fenced_trailing_text`,
+`prose_then_fence`, `json_truncated`, and `not_json`. Complete plain/JSON fences
+are repaired; successes retain `fenced_json`, while invalid enclosed JSON gets
+`fenced_not_json`. `json_truncated` is a text-shape heuristic, not proof of a token
+limit. The telemetry recorder retains the authoritative `finish_reason`; the
+LLM content-return contract is unchanged. Schema diagnostics distinguish missing
+cycle IDs, mismatches, required fields, invalid kinds, and empty details.
+
+The reflector unit permits writes to the state tree, matching the strategist,
+so `state/llm_calls` recording is possible while systemd hardening remains intact.
+
 ## Scenarios
 
 ### Scenario: operator answers all seven questions from state

--- a/host/eeepc/systemd/eeebot-reflector.service
+++ b/host/eeepc/systemd/eeebot-reflector.service
@@ -21,4 +21,4 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=false
 ProtectSystem=strict
-ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/reflector
+ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -287,26 +287,32 @@ def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, 
     return [{"role": "system", "content": system}, {"role": "user", "content": user}]
 
 
-def _parse_output(value: Any, cycle_id: str) -> dict[str, Any] | None:
+def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str]:
     if isinstance(value, str):
         try:
             value = json.loads(value)
         except Exception:
-            return None
-    if not isinstance(value, dict) or str(value.get("cycle_id") or "") != cycle_id:
-        return None
-    if not isinstance(value.get("summary"), str) or not isinstance(value.get("findings"), list) or not isinstance(value.get("recommendations"), list):
-        return None
+            return None, "not_json"
+    if not isinstance(value, dict):
+        return None, "not_object"
+    if str(value.get("cycle_id") or "") != cycle_id:
+        return None, "cycle_id_mismatch"
+    if not isinstance(value.get("summary"), str):
+        return None, "missing_or_invalid:summary"
+    if not isinstance(value.get("findings"), list):
+        return None, "missing_or_invalid:findings"
+    if not isinstance(value.get("recommendations"), list):
+        return None, "missing_or_invalid:recommendations"
     findings = []
     for item in value["findings"]:
         if not isinstance(item, dict) or item.get("kind") not in _VALID_FINDINGS or not str(item.get("detail") or "").strip():
-            return None
+            return None, f"invalid_finding:{item.get('kind') if isinstance(item, dict) else 'not_object'}"
         findings.append({"kind": item["kind"], "detail": str(item["detail"])[:1000]})
     recommendations = []
     for item in value["recommendations"][:_MAX_RECOMMENDATIONS]:
         if not isinstance(item, dict) or item.get("kind") not in _VALID_RECOMMENDATIONS or not str(item.get("detail") or "").strip():
-            return None
-        recommendations.append({"kind": item["kind"], "detail": str(item["detail"])[:1000], "evidence": str(item.get("evidence") or "")[:1000]})
+            return None, f"invalid_recommendation:{item.get('kind') if isinstance(item, dict) else 'not_object'}"
+        recommendations.append({"kind": item["kind"], "detail": str(item.get("detail") or "")[:1000], "evidence": str(item.get("evidence") or "")[:1000]})
     result = {
         "cycle_id": cycle_id,
         "summary": value["summary"][:2000],
@@ -316,7 +322,7 @@ def _parse_output(value: Any, cycle_id: str) -> dict[str, Any] | None:
     }
     if isinstance(value.get("mermaid"), str):
         result["mermaid"] = value["mermaid"][:4000]
-    return result
+    return result, "ok"
 
 
 def _default_llm(messages: list[dict[str, str]], model: str, cycle_id: str) -> str:
@@ -399,15 +405,15 @@ def run_reflector(
             messages = _messages(cycle_id, transcript, context_rows, _journal_tail(state_dir))
             model = resolve_model("reflector", strip_openai=True)
             response = llm(messages, model) if llm else _default_llm(messages, model, cycle_id)
-            parsed = _parse_output(response, cycle_id)
+            parsed, parse_reason = _parse_output(response, cycle_id)
             if parsed is None:
-                raise ValueError("malformed reflector output")
+                raise ValueError(f"malformed reflector output: {parse_reason}")
             _append_journal(state_dir, {**parsed, "timestamp": _now()})
             _save_watermark(state_dir, cycle_id)
             result["processed"] += 1
             consecutive_errs = 0
         except Exception as exc:
-            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500]})
+            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500], "response_head": str(response)[:200] if "response" in locals() else ""})
             result["errors"] += 1
             consecutive_errs += 1
             result["consecutive_errors"] = consecutive_errs

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -298,6 +298,7 @@ def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str
                     value = json.loads(value)
                 except Exception:
                     return None, "fenced_not_json"
+                parsed_from_fence = True
             else:
                 try:
                     value = json.loads(raw)
@@ -337,7 +338,7 @@ def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str
     }
     if isinstance(value.get("mermaid"), str):
         result["mermaid"] = value["mermaid"][:4000]
-    return result, "ok"
+    return result, "fenced_json" if locals().get("parsed_from_fence") else "ok"
 
 
 def _default_llm(messages: list[dict[str, str]], model: str, cycle_id: str) -> str:
@@ -416,6 +417,7 @@ def run_reflector(
         context_rows = [row for row in rows if str(row.get("cycle_id") or "") == cycle_id]
         if cycle_id in proposed:
             context_rows.insert(0, proposed[cycle_id])
+        response: Any = None
         try:
             messages = _messages(cycle_id, transcript, context_rows, _journal_tail(state_dir))
             model = resolve_model("reflector", strip_openai=True)
@@ -423,12 +425,16 @@ def run_reflector(
             parsed, parse_reason = _parse_output(response, cycle_id)
             if parsed is None:
                 raise ValueError(f"malformed reflector output: {parse_reason}")
-            _append_journal(state_dir, {**parsed, "timestamp": _now()})
+            _append_journal(state_dir, {
+                **parsed,
+                "timestamp": _now(),
+                **({"parse_reason": parse_reason} if parse_reason != "ok" else {}),
+            })
             _save_watermark(state_dir, cycle_id)
             result["processed"] += 1
             consecutive_errs = 0
         except Exception as exc:
-            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500], "response_head": "".join(ch for ch in str(response)[:200] if ch >= " " or ch in "\t\n\r") if "response" in locals() else ""})
+            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500], "response_head": "".join(ch for ch in str(response)[:200] if ch >= " " or ch in "\t\n\r") if response is not None else ""})
             result["errors"] += 1
             consecutive_errs += 1
             result["consecutive_errors"] = consecutive_errs

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -289,10 +289,25 @@ def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, 
 
 def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str]:
     if isinstance(value, str):
-        try:
-            value = json.loads(value)
-        except Exception:
-            return None, "not_json"
+        raw = value.strip()
+        if raw.startswith("```"):
+            first_line, _, remainder = raw.partition("\n")
+            if first_line.strip().lower() in {"```", "```json"} and remainder.rstrip().endswith("```"):
+                value = remainder.rstrip()[:-3].strip()
+                try:
+                    value = json.loads(value)
+                except Exception:
+                    return None, "fenced_not_json"
+            else:
+                try:
+                    value = json.loads(raw)
+                except Exception:
+                    return None, "not_json"
+        else:
+            try:
+                value = json.loads(raw)
+            except Exception:
+                return None, "not_json"
     if not isinstance(value, dict):
         return None, "not_object"
     if str(value.get("cycle_id") or "") != cycle_id:
@@ -413,7 +428,7 @@ def run_reflector(
             result["processed"] += 1
             consecutive_errs = 0
         except Exception as exc:
-            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500], "response_head": str(response)[:200] if "response" in locals() else ""})
+            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500], "response_head": "".join(ch for ch in str(response)[:200] if ch >= " " or ch in "\t\n\r") if "response" in locals() else ""})
             result["errors"] += 1
             consecutive_errs += 1
             result["consecutive_errors"] = consecutive_errs

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -288,30 +288,37 @@ def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, 
 
 
 def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str]:
+    parsed_from_fence = False
     if isinstance(value, str):
         raw = value.strip()
         if raw.startswith("```"):
-            first_line, _, remainder = raw.partition("\n")
-            if first_line.strip().lower() in {"```", "```json"} and remainder.rstrip().endswith("```"):
-                value = remainder.rstrip()[:-3].strip()
-                try:
-                    value = json.loads(value)
-                except Exception:
-                    return None, "fenced_not_json"
-                parsed_from_fence = True
-            else:
-                try:
-                    value = json.loads(raw)
-                except Exception:
-                    return None, "not_json"
-        else:
-            try:
-                value = json.loads(raw)
-            except Exception:
-                return None, "not_json"
+            closing = raw.find("```", 3)
+            if closing == -1:
+                return None, "fenced_unclosed"
+            if raw[closing + 3:].strip():
+                return None, "fenced_trailing_text"
+            first_line, _, inner = raw[:closing].partition("\n")
+            if first_line.strip().lower() not in {"```", "```json"}:
+                return None, "fenced_not_json"
+            raw = inner.strip()
+            parsed_from_fence = True
+        try:
+            value = json.loads(raw)
+        except (ValueError, TypeError):
+            if parsed_from_fence:
+                return None, "fenced_not_json"
+            if "```" in raw:
+                return None, "prose_then_fence"
+            # A text-shape heuristic, not proof of a token-limit finish reason.
+            if raw.startswith(("{", "[")):
+                return None, "json_truncated"
+            return None, "not_json"
     if not isinstance(value, dict):
         return None, "not_object"
-    if str(value.get("cycle_id") or "") != cycle_id:
+    raw_cid = str(value.get("cycle_id") or "")
+    if raw_cid == "":
+        return None, "cycle_id_missing"
+    if raw_cid != cycle_id:
         return None, "cycle_id_mismatch"
     if not isinstance(value.get("summary"), str):
         return None, "missing_or_invalid:summary"
@@ -321,14 +328,22 @@ def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str
         return None, "missing_or_invalid:recommendations"
     findings = []
     for item in value["findings"]:
-        if not isinstance(item, dict) or item.get("kind") not in _VALID_FINDINGS or not str(item.get("detail") or "").strip():
-            return None, f"invalid_finding:{item.get('kind') if isinstance(item, dict) else 'not_object'}"
+        if not isinstance(item, dict):
+            return None, "invalid_finding:not_object"
+        if item.get("kind") not in _VALID_FINDINGS:
+            return None, f"invalid_finding:bad_kind:{item.get('kind')}"
+        if not str(item.get("detail") or "").strip():
+            return None, "invalid_finding:empty_detail"
         findings.append({"kind": item["kind"], "detail": str(item["detail"])[:1000]})
     recommendations = []
     for item in value["recommendations"][:_MAX_RECOMMENDATIONS]:
-        if not isinstance(item, dict) or item.get("kind") not in _VALID_RECOMMENDATIONS or not str(item.get("detail") or "").strip():
-            return None, f"invalid_recommendation:{item.get('kind') if isinstance(item, dict) else 'not_object'}"
-        recommendations.append({"kind": item["kind"], "detail": str(item.get("detail") or "")[:1000], "evidence": str(item.get("evidence") or "")[:1000]})
+        if not isinstance(item, dict):
+            return None, "invalid_recommendation:not_object"
+        if item.get("kind") not in _VALID_RECOMMENDATIONS:
+            return None, f"invalid_recommendation:bad_kind:{item.get('kind')}"
+        if not str(item.get("detail") or "").strip():
+            return None, "invalid_recommendation:empty_detail"
+        recommendations.append({"kind": item["kind"], "detail": str(item["detail"])[:1000], "evidence": str(item.get("evidence") or "")[:1000]})
     result = {
         "cycle_id": cycle_id,
         "summary": value["summary"][:2000],
@@ -338,7 +353,7 @@ def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str
     }
     if isinstance(value.get("mermaid"), str):
         result["mermaid"] = value["mermaid"][:4000]
-    return result, "fenced_json" if locals().get("parsed_from_fence") else "ok"
+    return result, "fenced_json" if parsed_from_fence else "ok"
 
 
 def _default_llm(messages: list[dict[str, str]], model: str, cycle_id: str) -> str:
@@ -418,6 +433,7 @@ def run_reflector(
         if cycle_id in proposed:
             context_rows.insert(0, proposed[cycle_id])
         response: Any = None
+        parse_reason = "not_attempted"
         try:
             messages = _messages(cycle_id, transcript, context_rows, _journal_tail(state_dir))
             model = resolve_model("reflector", strip_openai=True)
@@ -434,7 +450,22 @@ def run_reflector(
             result["processed"] += 1
             consecutive_errs = 0
         except Exception as exc:
-            _append_journal(state_dir, {"cycle_id": cycle_id, "timestamp": _now(), "summary": "Reflector error; cycle will be retried.", "findings": [], "recommendations": [], "followed_previous": [], "status": "error", "error": f"{type(exc).__name__}: {exc}"[:500], "response_head": "".join(ch for ch in str(response)[:200] if ch >= " " or ch in "\t\n\r") if response is not None else ""})
+            _resp_str = str(response) if response is not None else ""
+            _err_row: dict[str, Any] = {
+                "cycle_id": cycle_id,
+                "timestamp": _now(),
+                "summary": "Reflector error; cycle will be retried.",
+                "findings": [],
+                "recommendations": [],
+                "followed_previous": [],
+                "status": "error",
+                "error": f"{type(exc).__name__}: {exc}"[:500],
+                "response_head": "".join(ch for ch in _resp_str[:200] if ch >= " " or ch in "\t\n\r"),
+                "parse_reason": parse_reason,
+                "response_chars": len(_resp_str),
+                "response_tail": "".join(ch for ch in _resp_str[-80:] if ch >= " " or ch in "\t\n\r"),
+            }
+            _append_journal(state_dir, _err_row)
             result["errors"] += 1
             consecutive_errs += 1
             result["consecutive_errors"] = consecutive_errs

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -43,7 +43,18 @@ def test_malformed_output_watermark_unmoved(tmp_path: Path):
     _seed(tmp_path)
     assert reflector.run_reflector(tmp_path, llm=lambda *_: "bad")["errors"] == 1
     assert not (tmp_path / "reflector/watermark.json").exists()
-    assert json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])["status"] == "error"
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    assert row["status"] == "error"
+    assert "not_json" in row["error"]
+    assert row["response_head"] == "bad"
+
+
+def test_parse_output_reports_distinct_validation_reasons():
+    assert reflector._parse_output("bad", "c1") == (None, "not_json")
+    parsed, reason = reflector._parse_output({"cycle_id": "wrong", "summary": "x", "findings": [], "recommendations": []}, "c1")
+    assert parsed is None and reason == "cycle_id_mismatch"
+    parsed, reason = reflector._parse_output({"cycle_id": "c1", "summary": "x", "findings": [{"kind": "bad", "detail": "x"}], "recommendations": []}, "c1")
+    assert parsed is None and reason.startswith("invalid_finding:")
 
 
 def test_pruned_transcript_is_journaled_and_watermarked(tmp_path: Path):

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -190,3 +190,178 @@ def test_reflector_wall_clock_guard_stops_before_next_cycle(tmp_path: Path, monk
     monkeypatch.setattr(reflector.time, "monotonic", lambda: next(ticks))
     result = reflector.run_reflector(tmp_path, llm=lambda *_: _answer("c1"), max_runtime_seconds=1)
     assert result["processed"] == 1
+
+
+# Response-shape diagnostics must remain independently countable.
+
+def test_classify_not_json_fenced_unclosed():
+    """A fence that opens but never closes → fenced_unclosed."""
+    raw = "```json\n{\"cycle_id\": \"c1\""
+    _, reason = reflector._parse_output(raw, "c1")
+    assert reason == "fenced_unclosed"
+
+
+def test_classify_not_json_fenced_trailing_text():
+    """Fence with closing marker but trailing prose → fenced_trailing_text."""
+    raw = "```json\n" + _answer("c1") + "\n```\nHope this helps!"
+    _, reason = reflector._parse_output(raw, "c1")
+    assert reason == "fenced_trailing_text"
+
+
+def test_classify_not_json_prose_then_fence():
+    """Prose then a fence (chatty model) → prose_then_fence."""
+    raw = "Sure, here is the reflection:\n```json\n" + _answer("c1") + "\n```"
+    _, reason = reflector._parse_output(raw, "c1")
+    assert reason == "prose_then_fence"
+
+
+def test_classify_not_json_json_truncated():
+    """Bare object or array that json.loads rejects (truncated) → json_truncated."""
+    _, reason = reflector._parse_output('{"cycle_id": "c1", "summ', "c1")
+    assert reason == "json_truncated"
+    _, reason2 = reflector._parse_output('["partial', "c1")
+    assert reason2 == "json_truncated"
+
+
+def test_classify_not_json_plain_prose():
+    """Plain prose (no JSON, no fence) → not_json."""
+    _, reason = reflector._parse_output("The model returned prose.", "c1")
+    assert reason == "not_json"
+
+
+def test_cycle_id_missing_vs_mismatch():
+    """cycle_id absent → cycle_id_missing; wrong value → cycle_id_mismatch."""
+    _, reason = reflector._parse_output(
+        {"summary": "x", "findings": [], "recommendations": []}, "c1"
+    )
+    assert reason == "cycle_id_missing"
+
+    _, reason2 = reflector._parse_output(
+        {"cycle_id": "wrong", "summary": "x", "findings": [], "recommendations": []}, "c1"
+    )
+    assert reason2 == "cycle_id_mismatch"
+
+
+def test_invalid_finding_bad_kind_vs_empty_detail():
+    """Valid kind + empty detail → empty_detail; invalid kind → bad_kind:<kind>."""
+    base = {"cycle_id": "c1", "summary": "x", "recommendations": []}
+
+    # invalid kind
+    _, reason = reflector._parse_output(
+        {**base, "findings": [{"kind": "unknown_kind", "detail": "something"}]}, "c1"
+    )
+    assert reason == "invalid_finding:bad_kind:unknown_kind"
+
+    # valid kind, empty detail
+    _, reason2 = reflector._parse_output(
+        {**base, "findings": [{"kind": "error_pattern", "detail": ""}]}, "c1"
+    )
+    assert reason2 == "invalid_finding:empty_detail"
+
+    # not a dict at all
+    _, reason3 = reflector._parse_output(
+        {**base, "findings": ["not_a_dict"]}, "c1"
+    )
+    assert reason3 == "invalid_finding:not_object"
+
+
+def test_invalid_recommendation_bad_kind_vs_empty_detail():
+    """Valid kind + empty detail → empty_detail; invalid kind → bad_kind:<kind>."""
+    base = {"cycle_id": "c1", "summary": "x", "findings": []}
+
+    # invalid kind
+    _, reason = reflector._parse_output(
+        {**base, "recommendations": [{"kind": "not_a_kind", "detail": "something"}]}, "c1"
+    )
+    assert reason == "invalid_recommendation:bad_kind:not_a_kind"
+
+    # valid kind, empty detail
+    _, reason2 = reflector._parse_output(
+        {**base, "recommendations": [{"kind": "skill_candidate", "detail": ""}]}, "c1"
+    )
+    assert reason2 == "invalid_recommendation:empty_detail"
+
+    # not a dict at all
+    _, reason3 = reflector._parse_output(
+        {**base, "recommendations": [42]}, "c1"
+    )
+    assert reason3 == "invalid_recommendation:not_object"
+
+
+def test_error_row_has_structured_fields(tmp_path: Path):
+    """Error journal rows carry parse_reason, response_chars, and response_tail as top-level keys."""
+    _seed(tmp_path)
+    truncated = '{"cycle_id": "c1", "summ'  # json_truncated shape
+    reflector.run_reflector(tmp_path, llm=lambda *_: truncated)
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    assert row["status"] == "error"
+    assert row["parse_reason"] == "json_truncated"
+    assert row["response_chars"] == len(truncated)
+    assert isinstance(row["response_tail"], str)
+    assert truncated[-10:] in row["response_tail"]  # tail contains the end of response
+    assert isinstance(row["response_head"], str)
+
+
+def test_error_row_fields_not_stale_across_consecutive_attempts(tmp_path: Path):
+    """Consecutive errors each get their own response/reason; no cross-contamination."""
+    _write(tmp_path / "ledger/cycles.jsonl", [
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "failed", "ts": "2026-08-26T00:00:00Z"},
+        {"phase": "outcome", "cycle_id": "c2", "outcome": "failed", "ts": "2026-08-26T00:01:00Z"},
+    ])
+    _write(tmp_path / "llm_calls/prompts/2026-08-26.jsonl", [
+        {"cycle_id": "c1", "seq": 1, "messages": []},
+        {"cycle_id": "c2", "seq": 1, "messages": []},
+    ])
+    responses = iter(["prose only", '{"cycle_id": "c2"'])
+    result = reflector.run_reflector(tmp_path, llm=lambda *_: next(responses), max_cycles=2, max_consecutive_errors=2)
+    assert result["errors"] == 2
+    rows = [json.loads(line) for line in (tmp_path / "reflector/reflections.jsonl").read_text().splitlines() if line.strip()]
+    err_rows = [r for r in rows if r.get("status") == "error"]
+    assert len(err_rows) == 2
+    # Each row records its own cycle_id
+    assert err_rows[0]["cycle_id"] == "c1"
+    assert err_rows[1]["cycle_id"] == "c2"
+    # Reasons are distinct and correspond to their response shape
+    assert err_rows[0]["parse_reason"] == "not_json"
+    assert err_rows[1]["parse_reason"] == "json_truncated"
+    # response_head and response_chars are not stale (each cycle's own)
+    assert err_rows[0]["response_head"] == "prose only"
+    assert err_rows[1]["response_chars"] == len('{"cycle_id": "c2"')
+
+
+def test_repaired_fence_count_is_visible_in_journal(tmp_path: Path):
+    """fenced_json repairs are countable: each success row has parse_reason=fenced_json."""
+    _write(tmp_path / "ledger/cycles.jsonl", [
+        {"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": "2026-08-26T00:00:00Z"},
+        {"phase": "outcome", "cycle_id": "c2", "outcome": "success", "ts": "2026-08-26T00:01:00Z"},
+    ])
+    _write(tmp_path / "llm_calls/prompts/2026-08-26.jsonl", [
+        {"cycle_id": "c1", "seq": 1, "messages": []},
+        {"cycle_id": "c2", "seq": 1, "messages": []},
+    ])
+
+    def fenced_llm(messages, model):
+        cid = messages[1]["content"].split("CYCLE_ID: ")[1].split("\n")[0].strip()
+        return "```json\n" + json.dumps({"cycle_id": cid, "summary": "ok", "findings": [], "recommendations": [], "followed_previous": []}) + "\n```"
+
+    result = reflector.run_reflector(tmp_path, llm=fenced_llm, max_cycles=2)
+    assert result["processed"] == 2
+    rows = [json.loads(line) for line in (tmp_path / "reflector/reflections.jsonl").read_text().splitlines() if line.strip()]
+    fenced_count = sum(1 for r in rows if r.get("parse_reason") == "fenced_json")
+    assert fenced_count == 2
+
+
+def test_llm_exception_produces_error_row_with_empty_parse_reason(tmp_path: Path):
+    """A transport failure explicitly records that parsing was not attempted."""
+    _seed(tmp_path)
+
+    def failing_llm(messages, model):
+        raise RuntimeError("connection refused")
+
+    reflector.run_reflector(tmp_path, llm=failing_llm)
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    assert row["status"] == "error"
+    assert row["parse_reason"] == "not_attempted"
+    assert row["response_chars"] == 0
+    assert row["response_head"] == ""
+    assert row["response_tail"] == ""

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -51,10 +51,24 @@ def test_malformed_output_watermark_unmoved(tmp_path: Path):
 
 def test_parse_output_reports_distinct_validation_reasons():
     assert reflector._parse_output("bad", "c1") == (None, "not_json")
+    fenced = "```json\n" + _answer("c1") + "\n```"
+    parsed, reason = reflector._parse_output(fenced, "c1")
+    assert parsed is not None and reason == "ok"
     parsed, reason = reflector._parse_output({"cycle_id": "wrong", "summary": "x", "findings": [], "recommendations": []}, "c1")
     assert parsed is None and reason == "cycle_id_mismatch"
+    parsed, reason = reflector._parse_output({"cycle_id": "c1", "findings": [], "recommendations": []}, "c1")
+    assert parsed is None and reason == "missing_or_invalid:summary"
     parsed, reason = reflector._parse_output({"cycle_id": "c1", "summary": "x", "findings": [{"kind": "bad", "detail": "x"}], "recommendations": []}, "c1")
     assert parsed is None and reason.startswith("invalid_finding:")
+    parsed, reason = reflector._parse_output({"cycle_id": "c1", "summary": "x", "findings": [], "recommendations": [{"kind": "bad", "detail": "x"}]}, "c1")
+    assert parsed is None and reason.startswith("invalid_recommendation:")
+    parsed, reason = reflector._parse_output([], "c1")
+    assert parsed is None and reason == "not_object"
+
+
+def test_parse_output_reports_fenced_invalid_json():
+    parsed, reason = reflector._parse_output("```json\nnot-json\n```", "c1")
+    assert parsed is None and reason == "fenced_not_json"
 
 
 def test_pruned_transcript_is_journaled_and_watermarked(tmp_path: Path):
@@ -69,6 +83,15 @@ def test_recommendations_are_demand_items(tmp_path: Path):
     reflector.run_reflector(tmp_path, llm=lambda *_: _answer())
     items = demand._reflection_items(tmp_path)
     assert items and items[0]["kind"] == "reflection" and "cycle c1" in items[0]["evidence"]
+
+
+def test_reflector_unit_allows_state_telemetry_without_widening_hardening():
+    unit = (Path(__file__).parents[1] / "host/eeepc/systemd/eeebot-reflector.service").read_text(encoding="utf-8")
+    assert "ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state\n" in unit
+    assert "ReadWritePaths=/var/lib/eeepc-agent/self-evolving-agent/state/reflector" not in unit
+    assert "ProtectSystem=strict" in unit
+    assert "NoNewPrivileges=true" in unit
+    assert "PrivateTmp=true" in unit
 
 
 def test_reflector_model_override(monkeypatch):

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -53,7 +53,7 @@ def test_parse_output_reports_distinct_validation_reasons():
     assert reflector._parse_output("bad", "c1") == (None, "not_json")
     fenced = "```json\n" + _answer("c1") + "\n```"
     parsed, reason = reflector._parse_output(fenced, "c1")
-    assert parsed is not None and reason == "ok"
+    assert parsed is not None and reason == "fenced_json"
     parsed, reason = reflector._parse_output({"cycle_id": "wrong", "summary": "x", "findings": [], "recommendations": []}, "c1")
     assert parsed is None and reason == "cycle_id_mismatch"
     parsed, reason = reflector._parse_output({"cycle_id": "c1", "findings": [], "recommendations": []}, "c1")
@@ -69,6 +69,14 @@ def test_parse_output_reports_distinct_validation_reasons():
 def test_parse_output_reports_fenced_invalid_json():
     parsed, reason = reflector._parse_output("```json\nnot-json\n```", "c1")
     assert parsed is None and reason == "fenced_not_json"
+
+
+def test_fenced_json_is_repaired_and_reason_is_journaled(tmp_path: Path):
+    _seed(tmp_path)
+    fenced = "```json\n" + _answer("c1") + "\n```"
+    assert reflector.run_reflector(tmp_path, llm=lambda *_: fenced)["processed"] == 1
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    assert row["parse_reason"] == "fenced_json"
 
 
 def test_pruned_transcript_is_journaled_and_watermarked(tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes #1291. Reflector telemetry can write to the state tree with existing systemd hardening preserved. Complete JSON fences are repaired and counted as `fenced_json`; malformed response shapes and schema causes now have distinct reasons. Error rows contain structured `parse_reason`, `response_chars`, bounded `response_head` (200) and `response_tail` (80). Transport errors use `not_attempted` with empty response diagnostics. Plain flag initialization and consistent detail access replace the previous nits.

`json_truncated` deliberately denotes a text-shape heuristic (starts with `{` or `[` and fails JSON parsing), not proof of token exhaustion. `finish_reason` remains in LLM telemetry; plumbing it through the content-return contract is unnecessary for this bounded change. Actual dominant production cause remains unverified until post-rollout data exists.

## Independently executed response probe

The parent executed `probe_1298.py` against this worktree. All 15 shapes below have distinct reasons; the probe asserts uniqueness.

| Response shape | Result | parse_reason |
|---|---|---|
| fenced-valid | accepted | `fenced_json` |
| fenced-invalid | rejected | `fenced_not_json` |
| fenced-unclosed | rejected | `fenced_unclosed` |
| closing-fence-then-prose | rejected | `fenced_trailing_text` |
| prose-then-fence | rejected | `prose_then_fence` |
| bare-truncated | rejected | `json_truncated` |
| prose-only | rejected | `not_json` |
| non-object | rejected | `not_object` |
| missing-key | rejected | `missing_or_invalid:summary` |
| cycle-id-missing | rejected | `cycle_id_missing` |
| cycle-id-wrong | rejected | `cycle_id_mismatch` |
| valid-finding-kind-empty-detail | rejected | `invalid_finding:empty_detail` |
| valid-recommendation-kind-empty-detail | rejected | `invalid_recommendation:empty_detail` |
| bad-finding-kind | rejected | `invalid_finding:bad_kind:unknown` |
| bad-recommendation-kind | rejected | `invalid_recommendation:bad_kind:unknown` |

## Verification

- Base verified: `a64470e5`; revision: `2917a84f`.
- `python -m pytest tests/test_reflector.py -q`: **26 passed**.
- `python -m pytest tests/ -q`: **3049 passed, 17 skipped, exactly 4 failed** in 1542.23 seconds. Executed with explicit `cd /t/Code/.worktrees/eeebot-1291`, redirected to `full-final-1298.log`; no pytest pipeline.
- Expected Windows failures only:
  - `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`
- Ruff for both Python files and `git diff --check`: passed.
- Coverage includes the requested response taxonomy, both item validators, missing/mismatched cycle ID, structured journal diagnostics, consecutive malformed attempts, transport exception diagnostics, repaired-fence count visibility, and existing watermark/unit tests.
- Previous five-failure reports are superseded: they were not valid verification of this worktree.
- Latest CI is pending; prior-head green is not evidence for this revision.
- No deployment, restart, host mutation, or merge. Main advanced to `ec8721a8` during verification; tested base remains the requested `a64470e5`. PR three-dot diff contains only four intended files.
