### PR TITLE
fix(dashboard): complete semantic color follow-ups (#1299)

### DIFF
--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -2314,13 +2314,6 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
             font-size: 12px;
             font-weight: 600;
         }}
-        .status-badge[data-status="fresh"], .status-badge[data-status="valid"], .status-badge[data-status="nominal"] {{ background: var(--state-nominal); color: var(--state-nominal-fg); }}
-        .status-badge[data-status="stale"], .status-badge[data-status="caution"] {{ background: var(--state-caution); color: var(--state-caution-fg); }}
-        .status-badge[data-status="malformed"], .status-badge[data-status="error"], .status-badge[data-status="failed"], .status-badge[data-status="critical"] {{ background: var(--state-critical); color: var(--state-critical-fg); }}
-        .status-badge[data-status="unavailable"], .status-badge[data-status="offline"] {{ background: var(--state-offline); color: var(--state-offline-fg); }}
-        .trend-badge.trend-good {{ background: var(--trend-good); }}
-        .trend-badge.trend-neutral {{ background: var(--trend-neutral); }}
-        .trend-badge.trend-bad {{ background: var(--trend-bad); }}
         .status-badge[data-status="fresh"],
         .status-badge[data-status="valid"],
         .status-badge[data-status="nominal"] {{ background: var(--state-nominal); color: var(--state-nominal-fg); }}
@@ -2332,10 +2325,11 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
         .status-badge[data-status="critical"] {{ background: var(--state-critical); color: var(--state-critical-fg); }}
         .status-badge[data-status="unavailable"],
         .status-badge[data-status="offline"] {{ background: var(--state-offline); color: var(--state-offline-fg); }}
+        /* context-only intentionally shares the offline palette: both convey non-authoritative state, distinguished by attributes */
         .status-badge[data-status="context-only"] {{ background: var(--state-offline); color: var(--state-offline-fg); }}
-        .trend-badge.trend-good {{ background: var(--trend-good); }}
-        .trend-badge.trend-neutral {{ background: var(--trend-neutral); }}
-        .trend-badge.trend-bad {{ background: var(--trend-bad); }}
+        .trend-badge.trend-good {{ background: var(--trend-good); color: var(--text); }}
+        .trend-badge.trend-neutral {{ background: var(--trend-neutral); color: var(--text); }}
+        .trend-badge.trend-bad {{ background: var(--trend-bad); color: var(--text); }}
         .path {{
             font-family: monospace;
             font-size: 12px;

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -28,7 +28,6 @@ def _render_ready(metrics: dict) -> dict:
     for key in ("host_capability_badges_html", "host_capability_details_html",
                 "oldest_stale_request_age"):
         filled.setdefault(key, "")
-    filled.setdefault("reward_trend", [])
     return filled
 
 
@@ -259,11 +258,45 @@ def test_status_tokens_meet_wcag_aa_contrast() -> None:
         linear = [c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4 for c in channels]
         return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
 
-    pairs = (("#065f46", "#6ee7b7"), ("#92400e", "#fcd34d"),
-             ("#7f1d1d", "#fecaca"), ("#1e3a8a", "#bfdbfe"))
+    pairs = (
+        ("#065f46", "#6ee7b7"),
+        ("#92400e", "#fcd34d"),
+        ("#7f1d1d", "#fecaca"),
+        ("#1e3a8a", "#bfdbfe"),
+        ("#166534", "#f8fafc"),
+        ("#1d4ed8", "#f8fafc"),
+        ("#b91c1c", "#f8fafc"),
+    )
     for background, foreground in pairs:
         ratio = (max(luminance(background), luminance(foreground)) + 0.05) / (min(luminance(background), luminance(foreground)) + 0.05)
         assert ratio >= 4.5, (background, foreground, ratio)
+
+
+def test_rendered_status_and_trend_badge_rules_emitted_exactly_once() -> None:
+    html = DASHBOARD.render_html(_render_ready(_health_metrics(
+        report_status="fresh",
+        materialized_status="fresh",
+    )))
+    for selector in (
+        '.status-badge[data-status="fresh"]',
+        '.status-badge[data-status="valid"]',
+        '.status-badge[data-status="nominal"]',
+        '.status-badge[data-status="stale"]',
+        '.status-badge[data-status="caution"]',
+        '.status-badge[data-status="malformed"]',
+        '.status-badge[data-status="error"]',
+        '.status-badge[data-status="failed"]',
+        '.status-badge[data-status="critical"]',
+        '.status-badge[data-status="unavailable"]',
+        '.status-badge[data-status="offline"]',
+        '.status-badge[data-status="context-only"]',
+        '.trend-badge.trend-good',
+        '.trend-badge.trend-neutral',
+        '.trend-badge.trend-bad',
+    ):
+        assert html.count(selector) == 1, f"Expected {selector} exactly once in rendered HTML"
+
+
 def test_html_context_keys_are_produced_by_metrics_builder(monkeypatch) -> None:
     """Keep direct indexing loud and derive the builder/context contract.
 


### PR DESCRIPTION
Closes #1299.

## Summary

- remove the duplicate emitted status/trend badge CSS rule block and assert each rendered selector occurs exactly once;
- remove the inert `reward_trend` fixture default: public sanitization clears that field before HTML context construction;
- explicitly use the existing `--text` foreground for all trend badges and cover all three background/foreground pairs at the WCAG AA 4.5:1 floor;
- document that `context-only` intentionally shares the offline palette because both are non-authoritative and remain distinguished by badge text and semantic attributes.

The critical/offline hues and lightness from #1287 are unchanged.

## Verification

- focused dashboard truth suite: `29 passed`;
- `ruff check tests/test_eeebot_dashboard_truth.py`: passed;
- `git diff --check`: passed;
- static HTML export: 18,070 bytes, above the 1,024-byte deploy floor;
- full Windows pytest, output redirected to `full-pytest-1299.log`: `4 failed, 3025 passed, 17 skipped`.

The four failures are exactly the established Windows baseline:

1. `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
2. `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
3. `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
4. `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`

Branch was created from and rebased onto current `origin/main` (`3dbaa3a4`, which includes #1287 `08114a75`). No deployment or host mutation was performed.
