### PR TITLE
fix(agent): never let the prompt cap pick surviving instructions by position (#1300)

### DIFF
--- a/docs/EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md
+++ b/docs/EEEPC_DEPLOY_VERIFY_ROLLBACK_RUNBOOK.md
@@ -149,6 +149,30 @@ Expected:
 
 This proves the verification release can read the same live proof fields coherently.
 
+### Step 8b — precondition for any release at or after #1300 (strict executor prompt)
+
+Since eeebot #1300 the executor's system prompt is built strict: only instance
+`AGENTS.md` sections marked `<!-- prompt-fit: droppable -->` may be dropped
+under the 24,000-char cap, and a prompt that cannot hold every unmarked
+section fails the cycle with exit status 4 (`EXIT_SYSTEM_PROMPT_OVERFLOW`).
+`deploy_release.sh` classifies 4 as a genuine activation failure and rolls the
+release back, naming the cause in its output.
+
+Before deploying such a release, confirm the host's instance workspace already
+carries the markers (ozand/eeebot-self-evolving#186 or later):
+
+```bash
+ssh ozand@eeepc-lan "sudo grep -c 'prompt-fit: droppable' \
+  /var/lib/eeepc-agent/self-evolving-agent/eeebot-self-evolving/AGENTS.md"
+# expected: 13 (or more); 0 means the deploy will roll itself back
+```
+
+Order of operations when both land together: merge the instance markers PR,
+wait one bridge cycle (the bridge fetches the instance `origin/main` at cycle
+start), re-run the check above, then deploy. The alternative lever —
+`NANOBOT_SYSTEM_PROMPT_MAX_CHARS` in the bridge env chain — is an operator
+decision recorded on #1300, not a default.
+
 ## Activation Workflow (optional)
 
 Only do this if the verification release must become the active pinned runtime.

--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -664,7 +664,9 @@ if [ "$VERIFY_ONLY" -eq 0 ]; then
     transport)
       echo "[remote] bridge first post-flip cycle exited EXIT_EXECUTOR_LLM_ERROR ($BRIDGE_EXIT_EXECUTOR_LLM_ERROR): transport failure recorded as blocked, not an activation failure (#1303); release stays active" ;;
     *)
-      die "bridge activation failed (restart rc=$BRIDGE_RESTART_RC Result=$BRIDGE_RESULT ExecMainStatus=$BRIDGE_EXIT_STATUS)" ;;
+      # #1300: a known status names itself and its remedy here, so the deployer
+      # reads the cause in the deploy output instead of in the bridge journal.
+      die "bridge activation failed (restart rc=$BRIDGE_RESTART_RC Result=$BRIDGE_RESULT ExecMainStatus=$BRIDGE_EXIT_STATUS) $(describe_bridge_exit_status "$BRIDGE_EXIT_STATUS")" ;;
   esac
 fi
 # --- #1303 bridge activation end ---

--- a/host/eeepc/scripts/lib_bridge_exit.sh
+++ b/host/eeepc/scripts/lib_bridge_exit.sh
@@ -16,6 +16,23 @@
 # Keep the value equal to nanobot/runtime/bridge.py::EXIT_EXECUTOR_LLM_ERROR;
 # tests/test_deploy_activation_exit_class.py pins the two together.
 BRIDGE_EXIT_EXECUTOR_LLM_ERROR=3
+# #1300: the strict ContextBuilder could not fit every critical AGENTS.md
+# section under the system-prompt cap. A property of the release plus the
+# instance's AGENTS.md, not a transient: stays a genuine activation failure
+# and rolls back — but the rollback must name itself and its remedy.
+BRIDGE_EXIT_SYSTEM_PROMPT_OVERFLOW=4
+
+# describe_bridge_exit_status <ExecMainStatus>
+# One line naming a known status and what to do about it; empty for others.
+describe_bridge_exit_status() {
+  case "${1:-}" in
+    "$BRIDGE_EXIT_EXECUTOR_LLM_ERROR")
+      echo "EXIT_EXECUTOR_LLM_ERROR: the executor could not reach its model this cycle (#1280)" ;;
+    "$BRIDGE_EXIT_SYSTEM_PROMPT_OVERFLOW")
+      echo "EXIT_SYSTEM_PROMPT_OVERFLOW: the executor prompt cannot hold every critical AGENTS.md section (#1300) — the instance AGENTS.md must carry '<!-- prompt-fit: droppable -->' markers (ozand/eeebot-self-evolving#186) before this release can run; details in the cycle's system_prompt ledger row and the bridge journal" ;;
+    *) echo "" ;;
+  esac
+}
 
 # classify_bridge_run <systemctl-restart-rc> <Result> <ExecMainStatus>
 # Prints exactly one word:

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -2,6 +2,7 @@
 
 import base64
 import mimetypes
+import os
 import platform
 from pathlib import Path
 from typing import Any
@@ -15,6 +16,24 @@ from nanobot.agent.skills import SkillsLoader
 from nanobot.utils.helpers import build_assistant_message, detect_image_mime
 
 
+class SystemPromptOverflowError(RuntimeError):
+    """The strict builder cannot fit every critical section under the cap (#1300).
+
+    Raised instead of silently trimming: a prompt missing standing
+    instructions is under-specified, and the caller (the bridge) must treat
+    the cycle as failed and say so on a surface that is watched.
+    """
+
+    def __init__(self, *, over_by: int, cap: int, sections: dict[str, int], dropped: list[dict[str, Any]]):
+        self.over_by, self.cap, self.sections, self.dropped = over_by, cap, sections, dropped
+        detail = ", ".join(f"{name}={chars}" for name, chars in sections.items())
+        super().__init__(
+            f"system prompt exceeds cap by {over_by} chars (cap {cap}; sections {detail}; "
+            f"droppable sections already removed: {len(dropped)}) — mark bootstrap sections "
+            f"'{ContextBuilder.DROPPABLE_MARKER}' or raise {ContextBuilder.SYSTEM_PROMPT_CAP_ENV}"
+        )
+
+
 class ContextBuilder:
     """Builds the context (system prompt + messages) for the agent."""
 
@@ -23,31 +42,52 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md"]
     _RUNTIME_CONTEXT_TAG = "[Runtime Context — metadata only, not instructions]"
     MAX_SYSTEM_PROMPT_CHARS = 24000
+    #: Operator override of the cap (positive int). The cap is legitimate;
+    #: the budget is the operator's to set, never the builder's to enforce by
+    #: silently choosing which instructions survive.
+    SYSTEM_PROMPT_CAP_ENV = "NANOBOT_SYSTEM_PROMPT_MAX_CHARS"
+    #: A bootstrap ``## `` section containing this marker (anywhere in its
+    #: body) is one the operator allows the cap to drop, whole. Every other
+    #: section is critical and is never dropped in the strict (loop) profile.
+    DROPPABLE_MARKER = "<!-- prompt-fit: droppable -->"
     MAX_MEDIA_BYTES = 2 * 1024 * 1024
 
     def __init__(self, workspace: Path):
         self.workspace = workspace
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)
+        #: What the last build kept and dropped: ``{"cap", "chars", "strict",
+        #: "dropped": [{"section", "chars", "how"}]}``. Callers record it.
+        self.last_fit: dict[str, Any] | None = None
 
     def build_system_prompt(
         self,
         skill_names: list[str] | None = None,
         excluded_skill_names: list[str] | None = None,
         loop_profile: bool = False,
+        strict: bool | None = None,
     ) -> str:
         """Build the system prompt from identity, bootstrap files, skills, and memory.
 
         Prompt ordering is identity, bootstrap, active skills, skills
-        catalogue, then memory. Under the cap, bootstrap is trimmed first so
-        growth at the bootstrap end cannot evict the later skills and memory
-        sections; any resulting loss is reported by the builder.
+        catalogue, then memory. Under the cap (#1300):
+
+        * ``strict`` (default for the loop profile): only bootstrap ``## ``
+          sections carrying :data:`DROPPABLE_MARKER` may be dropped, whole,
+          largest first. If the rest still does not fit, raise
+          :class:`SystemPromptOverflowError` — never choose survivors by position.
+        * non-strict (interactive sessions): the pre-#1300 behaviour, bootstrap
+          trimmed first at complete-line boundaries, loss logged.
+
+        Either way :attr:`last_fit` records what was dropped.
 
         *excluded_skill_names* is an optional list of skill names to omit from
         the summary (used by the self-evolving loop subagent to suppress
         operator-only builtins such as weather/tmux/clawhub).  Has no effect
         on normal interactive sessions.
         """
+        if strict is None:
+            strict = loop_profile
         sections = [("identity", self._get_identity(loop_profile=loop_profile))]
 
         bootstrap = self._load_bootstrap_files()
@@ -77,7 +117,7 @@ Skills with available="false" need dependencies installed first - you can try in
         memory = self.memory.get_memory_context(loop=loop_profile)
         if memory:
             sections.append(("memory", f"# Memory\n\n{memory}"))
-        return self._fit_system_prompt(sections)
+        return self._fit_system_prompt(sections, strict=strict)
 
     @staticmethod
     def _join_sections(sections: list[tuple[str, str]]) -> str:
@@ -99,17 +139,28 @@ Skills with available="false" need dependencies installed first - you can try in
             used += len(line)
         return "".join(kept)
 
+    def _cap(self) -> int:
+        """The cap: :data:`SYSTEM_PROMPT_CAP_ENV` when it is a positive int, else the class default."""
+        raw = os.environ.get(self.SYSTEM_PROMPT_CAP_ENV, "").strip()
+        try:
+            value = int(raw) if raw else 0
+        except ValueError:
+            value = 0
+        return value if value > 0 else self.MAX_SYSTEM_PROMPT_CHARS
+
     def _trim_section_to_fit(
         self,
         sections: list[tuple[str, str]],
         name: str,
+        cap: int | None = None,
     ) -> tuple[list[tuple[str, str]], int]:
         """Trim one section to the cap and return its dropped character count."""
+        cap = self._cap() if cap is None else cap
         index = next((i for i, (section_name, _) in enumerate(sections) if section_name == name), None)
         if index is None:
             return sections, 0
         current = sections[index][1]
-        if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+        if len(self._join_sections(sections)) <= cap:
             return sections, 0
 
         low, high = 0, len(current)
@@ -118,7 +169,7 @@ Skills with available="false" need dependencies installed first - you can try in
             middle = (low + high) // 2
             candidate = self._trim_lines(current, middle)
             trial = sections[:index] + [(name, candidate)] + sections[index + 1:]
-            if len(self._join_sections(trial)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+            if len(self._join_sections(trial)) <= cap:
                 best = candidate
                 low = middle + 1
             else:
@@ -126,41 +177,115 @@ Skills with available="false" need dependencies installed first - you can try in
         updated = sections[:index] + ([(name, best)] if best else []) + sections[index + 1:]
         return updated, len(current) - len(best)
 
-    def _fit_system_prompt(self, sections: list[tuple[str, str]]) -> str:
-        """Fit sections without silently evicting memory or skills.
+    @staticmethod
+    def _split_bootstrap_sections(text: str) -> list[tuple[str, str]]:
+        """Split the bootstrap text into ``(heading, text)`` units at ``## ``
+        lines, keeping every character so ``"".join(texts) == text``. The
+        first unit is the wrapper heading plus anything before the file's
+        first ``## `` section."""
+        units: list[tuple[str, str]] = []
+        heading, buffer = "", []
+        for line in text.splitlines(keepends=True):
+            if line.startswith("## ") and buffer:
+                units.append((heading, "".join(buffer)))
+                heading, buffer = line.strip(), [line]
+            else:
+                if not buffer:
+                    heading = line.strip() if line.startswith("## ") else "(preamble)"
+                buffer.append(line)
+        if buffer:
+            units.append((heading, "".join(buffer)))
+        return units
 
-        Bootstrap is the pressure source observed in #1191, so it is trimmed
-        first at complete-line boundaries. Any dropped content is reported with
-        its section name and character count; no opaque trailing marker is used.
+    def _drop_droppable_bootstrap_sections(
+        self, sections: list[tuple[str, str]], cap: int,
+    ) -> tuple[list[tuple[str, str]], list[dict[str, Any]]]:
+        """Strict fit (#1300): remove bootstrap sections the operator declared
+        droppable, whole and largest first, until the prompt fits or none are
+        left. Critical (unmarked) sections are never touched. Returns the
+        sections and the record of what went."""
+        index = next((i for i, (name, _) in enumerate(sections) if name == "bootstrap"), None)
+        dropped: list[dict[str, Any]] = []
+        if index is None:
+            return sections, dropped
+        units = self._split_bootstrap_sections(sections[index][1])
+        droppable = sorted(
+            (i for i, (_, text) in enumerate(units) if self.DROPPABLE_MARKER in text),
+            key=lambda i: -len(units[i][1]),
+        )
+        removed: set[int] = set()
+        for i in droppable:
+            if len(self._join_sections(sections)) <= cap:
+                break
+            removed.add(i)
+            dropped.append({"section": units[i][0], "chars": len(units[i][1]), "how": "declared-droppable"})
+            kept = "".join(text for j, (_, text) in enumerate(units) if j not in removed)
+            sections = sections[:index] + [("bootstrap", kept)] + sections[index + 1:]
+        return sections, dropped
+
+    def _fit_system_prompt(self, sections: list[tuple[str, str]], strict: bool = False) -> str:
+        """Fit sections under the cap and record the outcome in :attr:`last_fit`.
+
+        Strict (#1300): the only content the cap may remove is a bootstrap
+        section the operator marked :data:`DROPPABLE_MARKER`, removed whole,
+        largest first. Position never decides. If critical content still does
+        not fit, :class:`SystemPromptOverflowError` is raised — an under-specified
+        prompt is a failed build, not a quieter one. The decision recorded
+        here: the cap never drops a critical section.
+
+        Non-strict (interactive sessions): the pre-#1300 behaviour — bootstrap
+        is trimmed first at complete-line boundaries (#1191), then the later
+        sections, and the loss is logged.
         """
-        if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
-            return self._join_sections(sections)
+        cap = self._cap()
+        joined = self._join_sections(sections)
+        fit: dict[str, Any] = {"cap": cap, "chars": len(joined), "strict": strict, "dropped": []}
+        if len(joined) <= cap:
+            self.last_fit = fit
+            return joined
 
-        dropped: dict[str, int] = {}
+        if strict:
+            sections, dropped = self._drop_droppable_bootstrap_sections(sections, cap)
+            prompt = self._join_sections(sections)
+            fit.update(chars=len(prompt), dropped=dropped)
+            self.last_fit = fit
+            if len(prompt) > cap:
+                raise SystemPromptOverflowError(
+                    over_by=len(prompt) - cap, cap=cap,
+                    sections={name: len(content) for name, content in sections}, dropped=dropped,
+                )
+            if dropped:
+                logger.warning("System prompt cap dropped declared-droppable sections: {}",
+                               ", ".join(f"{d['section']}={d['chars']} chars" for d in dropped))
+            return prompt
+
+        dropped_chars: dict[str, int] = {}
         # Defend the later sections from bootstrap growth first. If the
         # protected sections are themselves too large, report each additional
         # section that must lose complete lines rather than hiding the loss.
         for name in ("bootstrap", "memory", "skills_catalogue", "active_skills", "identity"):
-            if len(self._join_sections(sections)) <= self.MAX_SYSTEM_PROMPT_CHARS:
+            if len(self._join_sections(sections)) <= cap:
                 break
-            sections, count = self._trim_section_to_fit(sections, name)
+            sections, count = self._trim_section_to_fit(sections, name, cap)
             if count:
-                dropped[name] = count
+                dropped_chars[name] = count
 
         prompt = self._join_sections(sections)
-        if len(prompt) > self.MAX_SYSTEM_PROMPT_CHARS:
+        if len(prompt) > cap:
             # A section without line breaks cannot be partially retained. Drop
             # it explicitly so the hard cap remains a real bound.
             for name, content in list(sections):
-                if len(prompt) <= self.MAX_SYSTEM_PROMPT_CHARS:
+                if len(prompt) <= cap:
                     break
                 sections = [(section_name, value) for section_name, value in sections if section_name != name]
-                dropped[name] = dropped.get(name, 0) + len(content)
+                dropped_chars[name] = dropped_chars.get(name, 0) + len(content)
                 prompt = self._join_sections(sections)
 
-        if dropped:
-            details = ", ".join(f"{name}={count} chars" for name, count in dropped.items())
+        if dropped_chars:
+            details = ", ".join(f"{name}={count} chars" for name, count in dropped_chars.items())
             logger.warning("System prompt cap dropped content: {}", details)
+        fit.update(chars=len(prompt), dropped=[{"section": n, "chars": c, "how": "line-trim"} for n, c in dropped_chars.items()])
+        self.last_fit = fit
         return prompt
 
 

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -661,10 +661,19 @@ Summarize this naturally for the user. Keep it brief (1-2 sentences). Do not men
         """
         from nanobot.agent.context import ContextBuilder
 
-        prompt = ContextBuilder(self.workspace).build_system_prompt(
-            excluded_skill_names=self._excluded_skill_names or None,
-            loop_profile=True,
-        )
+        builder = ContextBuilder(self.workspace)
+        # #1300: the loop profile is strict — a prompt that cannot hold every
+        # critical AGENTS.md section raises SystemPromptOverflow here, and the
+        # bridge records the cycle as failed instead of spawning on a prompt
+        # missing its standing instructions. What was kept/dropped is left on
+        # ``last_prompt_fit`` for the bridge to journal.
+        try:
+            prompt = builder.build_system_prompt(
+                excluded_skill_names=self._excluded_skill_names or None,
+                loop_profile=True,
+            )
+        finally:
+            self.last_prompt_fit = builder.last_fit
         if self.system_context:
             prompt += "\n\n---\n\n" + self.system_context
         return prompt

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -31,6 +31,7 @@ try:  # pragma: no cover - fcntl is POSIX-only; the host is always Linux
 except ImportError:  # pragma: no cover - exercised only on non-POSIX platforms
     fcntl = None  # type: ignore[assignment]
 
+from nanobot.agent.context import SystemPromptOverflowError
 from nanobot.agent.subagent import SubagentManager
 from nanobot.bus.queue import MessageBus
 from nanobot.cli.commands import _make_provider
@@ -119,6 +120,13 @@ BRIDGE_STATE_DIR = Path(os.environ.get('SUBAGENT_BRIDGE_STATE_DIR', str(STATE_DI
 # run of successes. Distinct from 1 (internal error) so the journal and the
 # streak's last_exit_status name the class.
 EXIT_EXECUTOR_LLM_ERROR = 3
+# #1300: the strict ContextBuilder could not fit every critical AGENTS.md
+# section under the system-prompt cap. No subagent is spawned on a prompt
+# missing its standing instructions; the cycle is `blocked`/`failed` with
+# rollback.reason `system_prompt_overflow`, the request is left pending (it is
+# not the request's fault), and the process exits with this code so
+# exit_streak / the bridge health dimension / the deploy gate all see it.
+EXIT_SYSTEM_PROMPT_OVERFLOW = 4
 # How many times a request whose subagent died on the LLM call is re-offered
 # before it is retired with the handled_ marker like any other request. Bounded
 # so a permanently-bad request (bad model name, oversize prompt) cannot spin
@@ -2730,6 +2738,9 @@ async def _main_impl_body():
         # #789: names of fitness sidecars changed during the spawn window (empty =
         # clean). Populated by the pre/post hash compare below.
         _integrity_changed: 'list[str]' = []
+        # #1300: set when the strict prompt builder refused to build (see the
+        # SystemPromptOverflowError clause below); rides into the result's learnings.
+        _system_prompt_overflow_text = ''
         try:
             # #789: hash the fitness sidecars IMMEDIATELY before the spawn — every
             # bridge-own sidecar write (demand fold, exhaustion updates, scorecard
@@ -2749,6 +2760,17 @@ async def _main_impl_body():
                 else ('# Immutable operator charter\n\n' + charter_text if charter_text else '')
             )
             dump_spawn_prompts(STATE_DIR, _cycle_id, _dump_system, task)
+            # #1300: journal what the cap kept and dropped for THIS spawn, so a
+            # dropped section is a ledger row anyone can query, not a journal
+            # WARNING nobody reads. Only declared-droppable sections can appear
+            # here; a critical one that does not fit raises above instead.
+            _prompt_fit = getattr(mgr, 'last_prompt_fit', None)
+            if isinstance(_prompt_fit, dict):
+                append_event(STATE_DIR, {
+                    'phase': 'system_prompt', 'cycle_id': _cycle_id,
+                    'chars': _prompt_fit.get('chars'), 'cap': _prompt_fit.get('cap'),
+                    'dropped': list(_prompt_fit.get('dropped') or []),
+                })
             msg = await mgr.spawn(
                 task=task,
                 label=f'selfevo-{goal_id[:8]}',
@@ -3438,6 +3460,21 @@ async def _main_impl_body():
                                     )
                 except Exception:
                     pass  # never block on archiver failure
+        except SystemPromptOverflowError as exc:
+            # #1300: the strict builder refused to assemble a prompt that cannot
+            # hold every critical AGENTS.md section. Nothing was spawned, the
+            # request keeps its pending state (no handled_ marker is written on
+            # this path), and the cycle is recorded as a failure with its own
+            # reason and exit code so the halt is visible where cycles are read.
+            print(f'bridge: SYSTEM PROMPT OVERFLOW (#1300) — no subagent spawned: {exc}')
+            _rollback_reason = 'system_prompt_overflow'
+            _system_prompt_overflow_text = str(exc)[:500]
+            commits_pushed = 0
+            append_event(STATE_DIR, {
+                'phase': 'system_prompt', 'cycle_id': _cycle_id, 'overflow': True,
+                'over_by': exc.over_by, 'cap': exc.cap, 'sections': exc.sections,
+                'dropped': list(exc.dropped),
+            })
         except Exception as exc:
             print(f'bridge: unexpected error during cycle {cycle_branch}: {exc}')
             _rollback_reason = _rollback_reason or 'internal_error'
@@ -3472,6 +3509,7 @@ async def _main_impl_body():
             'cycle_tier': locals().get('_cycle_tier', 'script'),
             'subagent_task_id': locals().get('_subagent_task_id', None),
             'executor_llm_error': locals().get('_executor_llm_error_text', ''),
+            'system_prompt_overflow': locals().get('_system_prompt_overflow_text', ''),
             'origin_main_observed': locals().get('_origin_main_observed', locals().get('main_sha_before', ''))
         }
 
@@ -3572,6 +3610,7 @@ async def _main_impl_body():
     _cycle_tier = _res.get('cycle_tier', 'script')
     _subagent_task_id = _res.get('subagent_task_id')
     _executor_llm_error_text = str(_res.get('executor_llm_error') or '')
+    _system_prompt_overflow_text = str(_res.get('system_prompt_overflow') or '')
     commits_pushed = cycle_commit_count if _integrated else 0
     import subprocess as _sp
 
@@ -3588,9 +3627,11 @@ async def _main_impl_body():
     _bridge_status = 'completed'
     if _revision_record and _revision_record['outcome'] == 'blocked':
         _bridge_status = 'blocked'
-    if _rollback_reason == 'executor_llm_error':
-        # #1280: the executor's LLM call never returned and nothing was
-        # committed — this is `blocked`, not a new spelling. `blocked` is one
+    if _rollback_reason in ('executor_llm_error', 'system_prompt_overflow'):
+        # #1280 / #1300: the executor's LLM call never returned, or no
+        # executor was spawned because the prompt could not hold its critical
+        # sections, and nothing was committed — this is `blocked`, not a new
+        # spelling. `blocked` is one
         # of the two statuses `_recent_failure_match` already treats as a
         # failure (with rollback.reason set it matches on either test), so
         # the 24 h suppression window and the proposer's "recent failures"
@@ -3640,6 +3681,11 @@ async def _main_impl_body():
                 [f'EXECUTOR LLM ERROR (#1280): {_executor_llm_error_text}']
                 if _executor_llm_error_text else []
             )
+            + (
+                # #1300: why no executor ran — the sections and the overshoot.
+                [f'SYSTEM PROMPT OVERFLOW (#1300): {_system_prompt_overflow_text}']
+                if _system_prompt_overflow_text else []
+            )
             or None
         ),
     )
@@ -3654,10 +3700,12 @@ async def _main_impl_body():
     # accounting above rather than a distinct outcome.
     if _integrated:
         _cycle_outcome = 'success'
-    elif _rollback_reason in ('internal_error', 'executor_llm_error'):
+    elif _rollback_reason in ('internal_error', 'executor_llm_error', 'system_prompt_overflow'):
         # #1280: an executor whose LLM call never returned is a failure with
         # zero commits, not a `partial` no-op — `partial` is what eleven
         # outage cycles read on 2026-09-04 and it kept every reader calm.
+        # #1300: likewise a cycle that never spawned because its prompt could
+        # not hold every critical section.
         _cycle_outcome = 'failed'
     elif _cycle_tier == 'runtime' and _smoke_passed and cycle_commit_count > 0:
         # #812: a green runtime-slice cycle produced a valid promotion candidate.
@@ -3805,6 +3853,11 @@ async def _main_impl_body():
         except Exception:
             pass  # fail-open
 
+    if _rollback_reason == 'system_prompt_overflow':
+        # #1300: same mechanism as #1280 below — the exit status carries the
+        # class, so exit_streak, the bridge health dimension and the deploy
+        # gate all see a loop that cannot build its own prompt.
+        return EXIT_SYSTEM_PROMPT_OVERFLOW
     if _rollback_reason == 'executor_llm_error':
         # #1280: say it with the exit status. The __main__ guard records any
         # non-zero code as a `failure` in bridge/exit_streak.json, so an

--- a/tests/test_bridge_system_prompt_overflow.py
+++ b/tests/test_bridge_system_prompt_overflow.py
@@ -1,0 +1,129 @@
+"""#1300: a cycle whose system prompt cannot hold every critical AGENTS.md
+section is a failed cycle that spawns nothing — and says so where cycles are
+read (result status + reason, ledger outcome, exit status → exit_streak). On
+success, what the cap kept and dropped is a ledger row, not a journal line.
+
+Drives ``bridge._main_impl`` end to end with fake SubagentManagers, the same
+way tests/test_bridge_executor_llm_error.py does for #1280.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from nanobot import crash_record
+from nanobot.agent.context import SystemPromptOverflowError
+from nanobot.runtime import bridge
+from tests.test_cycle_ledger import (
+    _FakeSubagentManager,
+    _init_selfevo_repo,
+    _read_ledger,
+    _seed_bridge_request,
+)
+
+OVERFLOW = SystemPromptOverflowError(
+    over_by=11_434, cap=24_000,
+    sections={"identity": 1446, "bootstrap": 22986, "skills_catalogue": 6951, "memory": 4030},
+    dropped=[{"section": "## Optional appendix", "chars": 512, "how": "declared-droppable"}],
+)
+
+
+class _OverflowingManager(_FakeSubagentManager):
+    """The strict builder refuses; spawn must never be reached."""
+
+    spawned = False
+
+    def _build_subagent_prompt(self) -> str:
+        self.last_prompt_fit = {"cap": 24_000, "chars": 35_434, "strict": True, "dropped": OVERFLOW.dropped}
+        raise OVERFLOW
+
+    async def spawn(self, **kwargs):
+        type(self).spawned = True
+        return await super().spawn(**kwargs)
+
+
+class _FittingManager(_FakeSubagentManager):
+    """A prompt that fits after one declared-droppable section went."""
+
+    def _build_subagent_prompt(self) -> str:
+        self.last_prompt_fit = {"cap": 24_000, "chars": 23_500, "strict": True,
+                                "dropped": [{"section": "## Optional appendix", "chars": 900, "how": "declared-droppable"}]}
+        return "system prompt"
+
+
+@pytest.fixture(autouse=True)
+def _core_smoke_set_matches_fixture_repo(monkeypatch):
+    monkeypatch.setattr(bridge, "_CORE_SMOKE_TESTS", ("tests/test_smoke.py",))
+
+
+def _wire(tmp_path, monkeypatch, manager_cls):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(exist_ok=True)
+    _init_selfevo_repo(tmp_path)
+    monkeypatch.setattr(bridge, "STATE_DIR", state_dir)
+    monkeypatch.setattr(bridge, "BRIDGE_STATE_DIR", state_dir / "subagent_bridge")
+    monkeypatch.setattr(bridge, "TARGET_WORKSPACE", tmp_path / "target_workspace")
+    monkeypatch.setattr(bridge, "SubagentManager", manager_cls)
+    monkeypatch.setattr(bridge, "_make_provider", lambda _config: object())
+    monkeypatch.setenv("SELFEVO_DUMP_PROMPTS", "0")
+    return state_dir
+
+
+def _result_for(state_dir, request_id):
+    matches = list((state_dir / "subagents").rglob(f"result-{request_id}.json"))
+    assert len(matches) == 1, matches
+    return json.loads(matches[0].read_text(encoding="utf-8"))
+
+
+def test_overflow_is_a_failed_unspawned_cycle_with_its_own_exit_code(tmp_path, monkeypatch):
+    state_dir = _wire(tmp_path, monkeypatch, _OverflowingManager)
+    _OverflowingManager.spawned = False
+    _seed_bridge_request(state_dir, "req-over", "cycle-over", task_title="Extend a skill")
+
+    rc = asyncio.run(bridge._main_impl())
+
+    assert _OverflowingManager.spawned is False, "no executor runs on a prompt missing its standing instructions"
+    res = _result_for(state_dir, "req-over")
+    assert res["result_status"] == "blocked"
+    assert res["rollback"]["reason"] == "system_prompt_overflow"
+    assert res["commits_pushed"] == 0
+    assert any("SYSTEM PROMPT OVERFLOW (#1300)" in s and "11434" in s for s in res.get("key_learnings") or [])
+
+    rows = _read_ledger(state_dir)
+    outcome = [r for r in rows if r["phase"] == "outcome"][-1]
+    assert outcome["outcome"] == "failed" and outcome["reason"] == "system_prompt_overflow"
+    fit_rows = [r for r in rows if r["phase"] == "system_prompt"]
+    assert len(fit_rows) == 1
+    assert fit_rows[0]["overflow"] is True and fit_rows[0]["over_by"] == 11_434 and fit_rows[0]["cap"] == 24_000
+    assert fit_rows[0]["sections"]["bootstrap"] == 22_986
+    assert fit_rows[0]["dropped"] == OVERFLOW.dropped
+
+    # exit status → the streak the health dimension and the deploy gate read
+    assert rc == bridge.EXIT_SYSTEM_PROMPT_OVERFLOW != 0
+    assert bridge.EXIT_SYSTEM_PROMPT_OVERFLOW != bridge.EXIT_EXECUTOR_LLM_ERROR
+    streak = crash_record.record_exit(state_dir, outcome="success" if rc == 0 else "failure", exit_status=rc)
+    assert streak["consecutive_failures"] == 1 and streak["last_exit_status"] == bridge.EXIT_SYSTEM_PROMPT_OVERFLOW
+
+    # the request is not retired and not counted as an LLM retry: it is not its fault
+    bridge_state = state_dir / "subagent_bridge"
+    assert not (bridge_state / "handled_req-over.txt").exists()
+    assert not (bridge_state / "retry_req-over.json").exists()
+
+
+def test_fitting_prompt_journals_what_the_cap_dropped(tmp_path, monkeypatch):
+    state_dir = _wire(tmp_path, monkeypatch, _FittingManager)
+    _seed_bridge_request(state_dir, "req-fit", "cycle-fit", task_title="Extend a skill")
+
+    rc = asyncio.run(bridge._main_impl())
+
+    assert rc == 0
+    rows = _read_ledger(state_dir)
+    fit_rows = [r for r in rows if r["phase"] == "system_prompt"]
+    assert len(fit_rows) == 1
+    assert fit_rows[0]["cycle_id"] == "cycle-fit"
+    assert fit_rows[0]["chars"] == 23_500 and fit_rows[0]["cap"] == 24_000
+    assert fit_rows[0]["dropped"] == [{"section": "## Optional appendix", "chars": 900, "how": "declared-droppable"}]
+    assert "overflow" not in fit_rows[0]
+    assert [r for r in rows if r["phase"] == "outcome"][-1]["outcome"] == "success"

--- a/tests/test_context_prompt_fit.py
+++ b/tests/test_context_prompt_fit.py
@@ -1,0 +1,137 @@
+"""#1300: the system-prompt cap must never choose surviving instructions by
+position, and its choices must never be silent.
+
+Pre-fix, ``_fit_system_prompt`` trimmed the bootstrap (AGENTS.md) from the end
+at line boundaries. On the host that removed 11,688 of 22,972 chars — eleven
+``##`` sections including ``## Working knowledge`` — from every executor
+prompt from 2026-09-01 on, with a journal WARNING as the only trace. Here the
+loop profile is strict: only sections the operator marked droppable may go,
+whole and largest first; anything else that does not fit raises.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nanobot.agent import context as context_module
+from nanobot.agent.context import ContextBuilder, SystemPromptOverflowError
+
+MARK = ContextBuilder.DROPPABLE_MARKER
+
+
+def _section(title: str, lines: int, *, droppable: bool = False) -> str:
+    body = "".join(f"{title} line {i} is standing guidance for the executor.\n" for i in range(lines))
+    return f"## {title}\n\n" + (f"{MARK}\n" if droppable else "") + body + "\n"
+
+
+def _builder(tmp_path, bootstrap_body: str, *, catalogue_lines: int = 40, memory_lines: int = 20) -> ContextBuilder:
+    """A builder whose only variable is the bootstrap text; the other sections
+    are fixed-size stand-ins so the cap arithmetic is legible."""
+    builder = ContextBuilder(tmp_path)
+    builder._get_identity = lambda loop_profile=False: "# identity\n\nYou are the loop executor."
+    builder._load_bootstrap_files = lambda: "## AGENTS.md\n\n# Instance AGENTS.md\n\nintro paragraph.\n\n" + bootstrap_body
+    builder.skills.get_always_skills = lambda: []
+    builder.skills.load_skills_for_context = lambda names: ""
+    builder.skills.build_skills_summary = lambda excluded_names=None: "<skills>\n" + "  <skill><name>s</name></skill>\n" * catalogue_lines + "</skills>"
+    builder.memory.get_memory_context = lambda loop=False: "## Long-term Memory\n" + "remembered fact\n" * memory_lines
+    return builder
+
+
+def test_split_keeps_every_character_and_names_sections():
+    text = "## AGENTS.md\n\n# Title\n\nintro\n\n" + _section("Alpha", 2) + _section("Beta", 3, droppable=True)
+    units = ContextBuilder._split_bootstrap_sections(text)
+    assert "".join(t for _, t in units) == text
+    assert [h for h, _ in units] == ["## AGENTS.md", "## Alpha", "## Beta"]
+
+
+def test_strict_drops_only_declared_sections_largest_first_and_records_them(tmp_path, monkeypatch):
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 6_000)
+    bootstrap = (
+        _section("Working knowledge", 6)                    # critical, small, sits BEFORE the droppables
+        + _section("Big optional appendix", 60, droppable=True)
+        + _section("Small optional note", 5, droppable=True)
+        + _section("Standard test runner", 8)               # critical, LAST in the file — pre-fix casualty
+    )
+    builder = _builder(tmp_path, bootstrap)
+    prompt = builder.build_system_prompt(loop_profile=True)
+
+    assert len(prompt) <= 6_000
+    assert "## Working knowledge" in prompt and "## Standard test runner" in prompt, "critical sections survive regardless of position"
+    assert "## Big optional appendix" not in prompt, "the largest declared-droppable section goes first"
+    assert "## Small optional note" in prompt, "a droppable section is not dropped when the prompt already fits"
+    assert "# Memory" in prompt and "<skills>" in prompt
+    fit = builder.last_fit
+    assert fit["strict"] is True and fit["cap"] == 6_000 and fit["chars"] == len(prompt)
+    assert fit["dropped"] == [{"section": "## Big optional appendix", "chars": pytest.approx(len(_section("Big optional appendix", 60, droppable=True))), "how": "declared-droppable"}]
+
+
+def test_strict_refuses_when_critical_sections_do_not_fit(tmp_path, monkeypatch):
+    """The decision recorded for #1300: the cap never drops a critical section."""
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 4_000)
+    bootstrap = _section("Working knowledge", 40) + _section("Optional", 4, droppable=True) + _section("Standard test runner", 40)
+    builder = _builder(tmp_path, bootstrap)
+    with pytest.raises(SystemPromptOverflowError) as info:
+        builder.build_system_prompt(loop_profile=True)
+    exc = info.value
+    assert exc.cap == 4_000 and exc.over_by > 0
+    assert set(exc.sections) == {"identity", "bootstrap", "skills_catalogue", "memory"}
+    assert [d["section"] for d in exc.dropped] == ["## Optional"], "the droppable one was removed before giving up"
+    assert ContextBuilder.DROPPABLE_MARKER in str(exc) and ContextBuilder.SYSTEM_PROMPT_CAP_ENV in str(exc)
+    assert builder.last_fit["dropped"] == exc.dropped, "the record is left for the caller even on failure"
+
+
+def test_strict_never_trims_lines_inside_a_section(tmp_path, monkeypatch):
+    """Position-based line trimming is the defect; strict mode must not fall back to it."""
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 3_000)
+    builder = _builder(tmp_path, _section("Working knowledge", 80))
+    with pytest.raises(SystemPromptOverflowError):
+        builder.build_system_prompt(loop_profile=True)
+
+
+def test_non_strict_keeps_the_interactive_behaviour_and_records_it(tmp_path, monkeypatch):
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 3_000)
+    messages: list[str] = []
+    monkeypatch.setattr(context_module.logger, "warning", lambda message, *args: messages.append(message.format(*args)))
+    builder = _builder(tmp_path, _section("Working knowledge", 80))
+    prompt = builder.build_system_prompt(loop_profile=False)
+    assert len(prompt) <= 3_000 and "# Memory" in prompt
+    assert builder.last_fit["strict"] is False
+    assert builder.last_fit["dropped"][0]["section"] == "bootstrap" and builder.last_fit["dropped"][0]["how"] == "line-trim"
+    assert any("bootstrap" in m and "dropped" in m for m in messages)
+
+
+def test_under_cap_nothing_is_dropped_in_either_mode(tmp_path):
+    builder = _builder(tmp_path, _section("Working knowledge", 3) + _section("Optional", 2, droppable=True))
+    for strict in (True, False):
+        prompt = builder.build_system_prompt(loop_profile=strict)
+        assert "## Optional" in prompt and builder.last_fit["dropped"] == []
+
+
+def test_cap_env_override_is_the_operator_lever(tmp_path, monkeypatch):
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 3_000)
+    builder = _builder(tmp_path, _section("Working knowledge", 80))
+    with pytest.raises(SystemPromptOverflowError):
+        builder.build_system_prompt(loop_profile=True)
+    monkeypatch.setenv(ContextBuilder.SYSTEM_PROMPT_CAP_ENV, "40000")
+    prompt = builder.build_system_prompt(loop_profile=True)
+    assert "## Working knowledge" in prompt and builder.last_fit["cap"] == 40000 and builder.last_fit["dropped"] == []
+    monkeypatch.setenv(ContextBuilder.SYSTEM_PROMPT_CAP_ENV, "not-a-number")
+    assert builder._cap() == 3_000, "a malformed override falls back to the default, never to unbounded"
+
+
+def test_subagent_prompt_is_strict_and_exposes_the_fit(tmp_path, monkeypatch):
+    from nanobot.agent import subagent as subagent_module
+
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 3_000)
+    (tmp_path / "AGENTS.md").write_text("# Instance\n\n" + _section("Working knowledge", 80), encoding="utf-8")
+    mgr = subagent_module.SubagentManager.__new__(subagent_module.SubagentManager)
+    mgr.workspace = tmp_path
+    mgr._excluded_skill_names = []
+    mgr.system_context = "# Immutable operator charter\n\ncharter"
+    with pytest.raises(SystemPromptOverflowError):
+        mgr._build_subagent_prompt()
+    assert isinstance(mgr.last_prompt_fit, dict) and mgr.last_prompt_fit["strict"] is True
+
+    monkeypatch.setenv(ContextBuilder.SYSTEM_PROMPT_CAP_ENV, "60000")
+    prompt = mgr._build_subagent_prompt()
+    assert prompt.endswith("# Immutable operator charter\n\ncharter") and "## Working knowledge" in prompt
+    assert mgr.last_prompt_fit["dropped"] == []

--- a/tests/test_context_prompt_fit.py
+++ b/tests/test_context_prompt_fit.py
@@ -36,6 +36,12 @@ def _builder(tmp_path, bootstrap_body: str, *, catalogue_lines: int = 40, memory
     return builder
 
 
+def test_marker_literal_is_the_one_the_instance_repo_carries():
+    """ozand/eeebot-self-evolving#186 wrote this exact string into AGENTS.md;
+    changing it here silently makes every declared section critical again."""
+    assert ContextBuilder.DROPPABLE_MARKER == "<!-- prompt-fit: droppable -->"
+
+
 def test_split_keeps_every_character_and_names_sections():
     text = "## AGENTS.md\n\n# Title\n\nintro\n\n" + _section("Alpha", 2) + _section("Beta", 3, droppable=True)
     units = ContextBuilder._split_bootstrap_sections(text)

--- a/tests/test_deploy_activation_exit_class.py
+++ b/tests/test_deploy_activation_exit_class.py
@@ -52,6 +52,25 @@ def test_lib_constant_is_pinned_to_the_bridge_exit_code():
     text = LIB.read_text(encoding="utf-8")
     value = int(re.search(r"^BRIDGE_EXIT_EXECUTOR_LLM_ERROR=(\d+)$", text, re.M).group(1))
     assert value == bridge.EXIT_EXECUTOR_LLM_ERROR == 3
+    overflow = int(re.search(r"^BRIDGE_EXIT_SYSTEM_PROMPT_OVERFLOW=(\d+)$", text, re.M).group(1))
+    assert overflow == bridge.EXIT_SYSTEM_PROMPT_OVERFLOW == 4
+
+
+def test_describe_bridge_exit_status_names_known_codes_and_the_remedy():
+    lib = str(LIB).replace("\\", "/")
+    for status, needle in (("3", "EXIT_EXECUTOR_LLM_ERROR"), ("4", "EXIT_SYSTEM_PROMPT_OVERFLOW"), ("4", "prompt-fit: droppable"), ("1", ""), ("", "")):
+        res = _bash(f'. "{lib}"; describe_bridge_exit_status "{status}"')
+        assert res.returncode == 0, res.stderr
+        assert needle in res.stdout.strip() if needle else res.stdout.strip() == ""
+
+
+def test_activation_overflow_rollback_names_itself_and_the_remedy(tmp_path):
+    """#1300 deployed before the instance markers: the rollback still happens (exit 4 is a
+    release-plus-data failure, not a transient) and the deploy output says why and what to do."""
+    res, rolled_back = _drive_activation(tmp_path, restart_rc=4, result="exit-code", status="4")
+    assert res.returncode != 0 and rolled_back is True
+    assert "CRITICAL: bridge activation failed" in res.stderr
+    assert "EXIT_SYSTEM_PROMPT_OVERFLOW" in res.stderr and "prompt-fit: droppable" in res.stderr and "#1300" in res.stderr
 
 
 @pytest.mark.parametrize("rc, result, status, expected", [


### PR DESCRIPTION
Closes #1300. Same class and same remedy shape as #1284 (PR #1288): a bound that chose what survives by position is replaced by a declared choice, and the choice is recorded.

**Ships with its data:** the declaration lives in the instance repo — **ozand/eeebot-self-evolving#186** — and must be merged (and fetched by the bridge) **before** this PR is deployed. Deployed the other way round, the first cycle fails `system_prompt_overflow`, exits 4, and the deploy gate rolls the release back: by design, harmless, wasted.

## Defect

`ContextBuilder._fit_system_prompt` caps the builder's part of the executor system prompt at 24,000 chars and trimmed the bootstrap (`AGENTS.md`) first, whole lines from the end. On 2026-09-01 19:34 the instance `AGENTS.md` reached 22,972 chars and the total crossed (`22986 + 1446 + 6951 + 4030 = 35434`). Every executor prompt since carried ~210 of 417 lines and lost eleven `##` sections, `## Working knowledge` among them; the only trace was a journal `WARNING`. Measured effect on one casualty: KB uptake 6-of-10 skill cycles with the pointer present, 0-of-8 without. **Trimming from the end is the defect, not the cap.**

## Fix — mechanism (this PR)

- Loop profile is **strict** (`build_system_prompt(..., strict=None)` → `loop_profile`). The only content the cap may remove is a bootstrap `## ` section whose body contains **`<!-- prompt-fit: droppable -->`** (`ContextBuilder.DROPPABLE_MARKER`), removed **whole, largest first**. Every unmarked section is critical.
- **Decision, stated:** the cap never drops a critical section. If critical content still does not fit, `build_system_prompt` raises `SystemPromptOverflowError(over_by, cap, sections, dropped)`. No line-trimming in strict mode. Interactive sessions keep the pre-#1300 behaviour (stated).
- Both profiles leave `builder.last_fit`; `NANOBOT_SYSTEM_PROMPT_MAX_CHARS` overrides the cap (malformed → default, never unbounded). **No cap override is shipped in the bridge unit or preset, deliberately**: the lever this PR chooses is the declaration, not a bigger budget.
- Bridge: on `SystemPromptOverflowError` no subagent is spawned, result `blocked` / `rollback.reason = system_prompt_overflow`, ledger `outcome: failed`, request left pending (no `handled_` marker, no retry counter), process exits **`EXIT_SYSTEM_PROMPT_OVERFLOW = 4`** → `exit_streak` → bridge health → deploy gate (#1304 keeps 4 fatal at activation; only 3 is transport).
- Every spawn appends a ledger row `{"phase": "system_prompt", "cycle_id", "chars", "cap", "dropped": [...]}`; an overflow appends it with `overflow: true, over_by, sections`. Consumers filter by named phases, so the row is invisible to them.

## Fix — data (ozand/eeebot-self-evolving#186), and the judgement behind it

The reviewer's finding was correct and is what this revision answers: at `1372ddd8` the live `AGENTS.md` has zero markers, so strict mode raises (`exceeds cap by 1243` in the reviewer's environment; by ~11,400 with the host's catalogue and memory). #186 marks **13 loop-authored efficiency sections** droppable (turn budgeting, what to read first, output bounding, test-runner tips — losing one costs turns) and leaves **14 critical**: the five operator sections from #175 (`Identity`, `Charter`, `Cycle contract`, `Working knowledge`, `Script contract`) and the loop-authored rules the gate or the repo's safety depend on (`Forbidden operational paths`, `Staging protocol`, `Execution protocol`, `Cycle termination`, `Immediate skip protocol`, `Out-of-scope handoff`, `Lesson markdown schema`, `Canonical skill path layout`) plus a new `## Prompt budget (droppable sections)` explaining the marker without containing it. Authorship was the first cut; each loop-authored section was then placed by what breaks if the executor never sees it.

Verified with this branch's builder on the marked file: live sizes → **OK at 23,291 / 24,000, 10 droppable sections removed, every critical one kept** (`## Working knowledge` included); reviewer's environment → OK, 2 dropped.

**Marker survival / new sections — decided, not assumed.** The marker is a comment line inside the section body and survives appends and rewrites of the body; only deleting the section removes it. **New sections arrive unmarked, and unmarked means critical** — the correctness-safe default (nothing the operator wrote can vanish) and the overflow-dangerous one. The counterweight is in the instance's own structural tests (#186): a `## ` section that is neither on `CRITICAL_SECTIONS` nor marked fails `test_every_section_is_critical_or_marked_droppable`; a marked critical section fails `test_critical_sections_are_never_marked_droppable`; a critical set that exceeds the live budget fails `test_critical_sections_fit_the_executor_prompt_budget`. A loop-authored addition cannot silently grow the critical set; and if it does slip through, the failure is a loud exit-4 cycle, not a silent cut. (AGENTS.md has been an operator-owned path for the loop since #1193; its last loop commit is 2026-09-01.) This repo pins the literal: `test_marker_literal_is_the_one_the_instance_repo_carries`.

## Tests

`tests/test_context_prompt_fit.py` (9): marker literal pinned; split round-trips every character; strict drops only declared sections, largest first, and keeps a critical section that sits *after* the droppables; strict raises with `sections`/`dropped`/`over_by`; strict never line-trims; non-strict keeps the interactive behaviour; nothing dropped under the cap; env override + malformed fallback; subagent builder strict and exposes `last_prompt_fit`.
`tests/test_bridge_system_prompt_overflow.py` (2), end to end on the #1280 harness: overflow → not spawned, `blocked`/`system_prompt_overflow`, ledger `failed`, `system_prompt` row with `overflow: true`, `rc == EXIT_SYSTEM_PROMPT_OVERFLOW != EXIT_EXECUTOR_LLM_ERROR`, streak failure, no marker, no retry counter; fitting prompt → `rc 0` and a `system_prompt` row listing the dropped section.
Existing `test_context_prompt_budget.py` (#1191) and `test_bridge_executor_llm_error.py` unchanged, green. Rebased onto `ec8721a8` (#1304 merged). Full Windows suite at the final head `3aecf71a` (on `ec8721a8`): `4 failed, 3069 passed, 17 skipped` in 22.5 min — exactly the baseline by name (`test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle` and the three `test_bridge_locking.py::TestAcquireBridgeLock` cases).

## Deployability — the question, answered before merge

Today's live instance `AGENTS.md` carries **zero** droppable markers. Deployed as-is, the first cycle raises `SystemPromptOverflowError`, exits `EXIT_SYSTEM_PROMPT_OVERFLOW = 4`, and #1304's classifier treats 4 as a genuine activation failure and rolls the release back — correctly. Three ways out were on the table; the choice and the reasons:

**Chosen — 1. Markers first, through the instance repo's gated path; this PR merged but not deployed until the host has them.** The declaration is **ozand/eeebot-self-evolving#186** (open). It marks the **13 loop-authored efficiency sections** droppable — turn budgeting, what to read first, output bounding, test-runner tips: losing any of them costs turns, not correctness — and keeps **14 critical**: the five operator sections from #175 (`Identity`, `Charter`, `Cycle contract`, `Working knowledge`, `Script contract`) and the loop-authored rules the gate or the repo's safety depend on (`Forbidden operational paths`, `Staging protocol`, `Execution protocol`, `Cycle termination`, `Immediate skip protocol`, `Out-of-scope handoff`, `Lesson markdown schema`, `Canonical skill path layout`), plus a new `## Prompt budget` section that explains the marker without containing it. Authorship was the first cut; each loop-authored section was then placed by what breaks if the executor never sees it — a gate failure or an unsafe edit → critical; extra turns → droppable. Verified with this branch's builder on the marked file: live sizes → 23,291 / 24,000, 10 sections dropped, every critical one kept; the reviewer's environment → 2 dropped. New sections arrive unmarked (critical) by default; #186's structural tests fail any section that is neither critical-listed nor marked, so the critical set cannot grow silently.

**Rejected — 2. Set `NANOBOT_SYSTEM_PROMPT_MAX_CHARS` high enough to fit today's content.** It turns the refusal into a guard that fires only after the *next* few thousand chars of growth, and nothing re-tightens it: the cap would sit at a number chosen to match one day's file, and the first person to hit it again would raise it again. The override stays available as an operator decision recorded on #1300; it is not the default and this PR ships none.

**Rejected — 3. Classify exit 4 as non-fatal at activation, like 3.** No. Exit 3 is "this one cycle could not reach the gateway" — a transient with a per-cycle base rate, not a property of the release. Exit 4 is "this release, with this instance file, cannot build the prompt it needs" — it will fail every cycle until the data or the code changes, which is exactly what an activation check exists to catch. Agreeing with the reviewer here; the classifier's `failed` for 4 is pinned by test.

**So that the next deployer does not learn this from a journal:**

- The exit-4 rollback now names itself in the deploy output. `lib_bridge_exit.sh` gains `BRIDGE_EXIT_SYSTEM_PROMPT_OVERFLOW=4` and `describe_bridge_exit_status`; the activation `die` line prints `EXIT_SYSTEM_PROMPT_OVERFLOW: the executor prompt cannot hold every critical AGENTS.md section (#1300) — the instance AGENTS.md must carry '<!-- prompt-fit: droppable -->' markers (ozand/eeebot-self-evolving#186) before this release can run`. Driven by test: status 4 still rolls back, and the CRITICAL line carries the remedy.
- The runbook gets **Step 8b**: the one-line host check (`grep -c 'prompt-fit: droppable' …/AGENTS.md` → expect 13) and the order of operations — merge #186, wait one bridge cycle (the bridge fetches the instance `origin/main` at cycle start), re-check, then deploy.
- A pre-flip preflight that runs the new builder against the live workspace was considered and not built: it would duplicate the bridge's workspace path, interpreter and excluded-skill list in bash, and a conservative version (no exclusions) would falsely refuse today's marked file (margin 709 chars vs ~2.2 K of excluded catalogue). The self-naming rollback plus the documented check covers the failure the reviewer is worried about without a second copy of the bridge's configuration.

## Live check owed after deploy (in this order: #186 merged → bridge has fetched → deploy this)

First cycle on the release: a `system_prompt` ledger row (`chars`, `cap`, `dropped` — expect ~10 declared sections), a prompt dump whose `## AGENTS.md` section equals the file minus exactly those sections, `## Working knowledge` present. If #186 was not in place: `outcome: failed, reason: system_prompt_overflow`, `exit_streak.last_exit_status: 4`, deploy rolled back — the fix working, not failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
