### PR TITLE
fix(deploy): a transport-failed first cycle is not a broken release (#1303)

### DIFF
--- a/host/eeepc/scripts/deploy_release.sh
+++ b/host/eeepc/scripts/deploy_release.sh
@@ -19,6 +19,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# #1303: the bridge's exit-status classes, shared with the remote activation
+# check (which sources the same file from the extracted release).
+. "$(dirname "${BASH_SOURCE[0]}")/lib_bridge_exit.sh"
 HOST="eeepc"
 DRY_RUN=0
 REF=""
@@ -630,9 +633,41 @@ fi
 
 # Ensure bridge service is restarted correctly. Keep the activation rollback trap
 # installed through this restart so a bridge failure restores the previous release.
+#
+# --- #1303 bridge activation begin ---
+# The bridge is Type=oneshot, so `systemctl restart` blocks until its first
+# post-flip cycle ends and returns that cycle's exit status. Since #1280 a cycle
+# whose model call never returned exits EXIT_EXECUTOR_LLM_ERROR (3) so the
+# failure streak stays honest; on 2026-09-05 06:38 a transient gateway 404 in
+# that first cycle turned into "Failed to start … status=3", the ERR trap rolled
+# `a64470e5` back, and the release carrying #1280 became un-deployable by the
+# mechanism its own fix trips.
+#
+# Arm 1 of #1303, deliberately: distinguish the exit status here. Status 3 is
+# "this cycle could not reach the gateway" — the process imported, started, ran
+# a cycle and recorded it `blocked` — not "this release cannot run"; every other
+# non-zero status or signal still is, and still rolls back. Not arm 2 (retry the
+# activation once): it costs a full cycle and a second model call, and the
+# health gate below would still need this same distinction for the journal and
+# streak it reads. Not arm 3 (exit 0 and read the outcome instead): that moves
+# the signal #1280 put on the exit status, and the streak semantics stay exactly
+# as they are. The lib is the single home of the value, pinned to
+# bridge.EXIT_EXECUTOR_LLM_ERROR by test.
 if [ "$VERIFY_ONLY" -eq 0 ]; then
-  sudo systemctl restart eeepc-self-evolving-subagent-bridge.service
+  . "$RELEASE_DIR/host/eeepc/scripts/lib_bridge_exit.sh"
+  BRIDGE_RESTART_RC=0
+  sudo systemctl restart eeepc-self-evolving-subagent-bridge.service || BRIDGE_RESTART_RC=$?
+  BRIDGE_RESULT="$(systemctl show -p Result --value eeepc-self-evolving-subagent-bridge.service 2>/dev/null || true)"
+  BRIDGE_EXIT_STATUS="$(systemctl show -p ExecMainStatus --value eeepc-self-evolving-subagent-bridge.service 2>/dev/null || true)"
+  case "$(classify_bridge_run "$BRIDGE_RESTART_RC" "$BRIDGE_RESULT" "$BRIDGE_EXIT_STATUS")" in
+    ok) ;;
+    transport)
+      echo "[remote] bridge first post-flip cycle exited EXIT_EXECUTOR_LLM_ERROR ($BRIDGE_EXIT_EXECUTOR_LLM_ERROR): transport failure recorded as blocked, not an activation failure (#1303); release stays active" ;;
+    *)
+      die "bridge activation failed (restart rc=$BRIDGE_RESTART_RC Result=$BRIDGE_RESULT ExecMainStatus=$BRIDGE_EXIT_STATUS)" ;;
+  esac
 fi
+# --- #1303 bridge activation end ---
 trap - ERR
 
 REMOTE
@@ -708,12 +743,24 @@ while :; do
   # "15" in "15/TERM", so once #1155 made these queries readable the pattern
   # matched routine operation and rolled back every deploy. Count only a
   # non-zero exit, a core dump, or a kill by a fault signal.
-  MAIN_PID_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'main process exited, (code=exited, status=[1-9]|code=dumped|code=killed, status=(4|6|8|11)/)' || true")
+  # #1303: `code=exited, status=3/` is EXIT_EXECUTOR_LLM_ERROR — a cycle that
+  # could not reach its model, recorded `blocked` (#1280). Transport, not a
+  # crash of the release; say so once and keep polling for a clean run. The
+  # `grep -v` runs on the host inside the same pipeline so the test replay of
+  # this command exercises exactly this filter.
+  MAIN_PID_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'main process exited, (code=exited, status=[1-9]|code=dumped|code=killed, status=(4|6|8|11)/)' | grep -vE 'code=exited, status=${BRIDGE_EXIT_EXECUTOR_LLM_ERROR}/' || true")
   if [ -n "$MAIN_PID_EXIT" ]; then
     log "FAIL: Bridge process crashed:"
     echo "$MAIN_PID_EXIT"
     rollback_release
     exit 1
+  fi
+  if [ -z "${TRANSPORT_EXIT_LOGGED:-}" ]; then
+    TRANSPORT_EXIT=$(ssh "ozand@${HOST}" "sudo journalctl -u eeepc-self-evolving-subagent-bridge.service --utc --since \"$FLIP_JOURNAL_TS\" --no-pager | grep -iE 'main process exited, code=exited, status=${BRIDGE_EXIT_EXECUTOR_LLM_ERROR}/' || true")
+    if [ -n "$TRANSPORT_EXIT" ]; then
+      log "Health gate: bridge exited EXIT_EXECUTOR_LLM_ERROR (${BRIDGE_EXIT_EXECUTOR_LLM_ERROR}) after the flip — a transport failure recorded as blocked (#1280), not a release failure (#1303); release stays active, waiting for a clean run: $TRANSPORT_EXIT"
+      TRANSPORT_EXIT_LOGGED=1
+    fi
   fi
 
   # ORDER MATTERS. Both FAIL branches above run before every positive verdict
@@ -749,11 +796,26 @@ while :; do
     STREAK_FAIL_TS=$(echo "$STREAK_RAW" | grep -o '"last_failure_ts": "[^"]*"' | cut -d'"' -f4 || true)
     STREAK_OK_TS=$(echo "$STREAK_RAW" | grep -o '"last_success_ts": "[^"]*"' | cut -d'"' -f4 || true)
     STREAK_N=$(echo "$STREAK_RAW" | grep -o '"consecutive_failures": [0-9]*' | grep -o '[0-9]*$' || true)
-    if [ -n "$STREAK_FAIL_TS" ] && [[ "$STREAK_FAIL_TS" > "$FLIP_TS" ]]; then
-      log "FAIL: bridge exit recorder shows a failure after the flip (consecutive_failures=${STREAK_N:-?}, last_failure_ts=$STREAK_FAIL_TS):"
-      echo "$STREAK_RAW" | grep -E '"last_(error|where|exit_status)"' || true
-      rollback_release
-      exit 1
+    STREAK_EXIT=$(echo "$STREAK_RAW" | grep -o '"last_exit_status": [0-9]*' | grep -o '[0-9]*$' || true)
+    # #1303: a failure row is only a live verdict while consecutive_failures is
+    # non-zero; the recorder resets it on the next clean run, and a transport
+    # failure followed by a clean cycle is the expected post-flip sequence now.
+    # A real crash in the window is still caught by the journal grep above.
+    if [ -n "$STREAK_FAIL_TS" ] && [[ "$STREAK_FAIL_TS" > "$FLIP_TS" ]] && [ "${STREAK_N:-0}" != "0" ]; then
+      # #1303: the recorder is meant to advance on a transport failure (#1280)
+      # — that is the streak being honest, not the release being broken. Only
+      # a failure recorded with any OTHER exit status rolls back.
+      if [ "$STREAK_EXIT" = "$BRIDGE_EXIT_EXECUTOR_LLM_ERROR" ]; then
+        if [ -z "${TRANSPORT_STREAK_LOGGED:-}" ]; then
+          log "Health gate: exit recorder shows a transport failure after the flip (last_exit_status=$STREAK_EXIT = EXIT_EXECUTOR_LLM_ERROR, consecutive_failures=${STREAK_N:-?}); the streak advanced as #1280 intends, not a release failure (#1303); waiting for a clean run."
+          TRANSPORT_STREAK_LOGGED=1
+        fi
+      else
+        log "FAIL: bridge exit recorder shows a failure after the flip (consecutive_failures=${STREAK_N:-?}, last_failure_ts=$STREAK_FAIL_TS):"
+        echo "$STREAK_RAW" | grep -E '"last_(error|where|exit_status)"' || true
+        rollback_release
+        exit 1
+      fi
     fi
     if [ -n "$STREAK_OK_TS" ] && [[ "$STREAK_OK_TS" > "$FLIP_TS" ]] && [ "${STREAK_N:-0}" = "0" ]; then
       log "Health gate: CLEAN-EXIT. Bridge run recorded exit 0 after the flip (exit_streak.json last_success_ts=$STREAK_OK_TS, consecutive_failures=0)."

--- a/host/eeepc/scripts/lib_bridge_exit.sh
+++ b/host/eeepc/scripts/lib_bridge_exit.sh
@@ -1,0 +1,37 @@
+# Exit-status classes of the oneshot bridge, shared by the deploy script's two
+# rollback points (#1303): the remote activation `systemctl restart` and the
+# local post-deploy health gate. Sourced, never executed.
+#
+# The bridge says with its exit status what kind of run it had (#1280):
+#   0  ran a cycle to a recorded outcome
+#   3  EXIT_EXECUTOR_LLM_ERROR — the process imported, started, ran a cycle,
+#      could not reach its model, recorded the cycle `blocked` and left the
+#      request pending. This is "this one cycle could not reach the gateway",
+#      a transient with a few-percent base rate per cycle, NOT "this release
+#      cannot run". It must still advance the failure streak (that is the
+#      honesty #1280 added), and it must NOT roll a deploy back.
+#   anything else non-zero (1 internal error, 4 system-prompt overflow, 203
+#   missing interpreter, signals) — the release, its unit or its host is broken.
+#
+# Keep the value equal to nanobot/runtime/bridge.py::EXIT_EXECUTOR_LLM_ERROR;
+# tests/test_deploy_activation_exit_class.py pins the two together.
+BRIDGE_EXIT_EXECUTOR_LLM_ERROR=3
+
+# classify_bridge_run <systemctl-restart-rc> <Result> <ExecMainStatus>
+# Prints exactly one word:
+#   ok         the run exited 0
+#   transport  the run exited EXIT_EXECUTOR_LLM_ERROR (Result=exit-code)
+#   failed     any other failure, including signals and an unreadable status
+classify_bridge_run() {
+  local rc="${1:-1}" result="${2:-}" status="${3:-}"
+  if [ "$rc" = "0" ]; then
+    echo ok
+    return 0
+  fi
+  if [ "$result" = "exit-code" ] && [ "$status" = "$BRIDGE_EXIT_EXECUTOR_LLM_ERROR" ]; then
+    echo transport
+    return 0
+  fi
+  echo failed
+  return 0
+}

--- a/tests/test_deploy_activation_exit_class.py
+++ b/tests/test_deploy_activation_exit_class.py
@@ -1,0 +1,189 @@
+"""#1303: a deploy must tell "this release cannot run" from "this one cycle
+could not reach the gateway".
+
+On 2026-09-05 06:38 the first post-flip bridge cycle of `a64470e5` drew a
+transient gateway 404, exited EXIT_EXECUTOR_LLM_ERROR (3) as #1280 requires,
+systemd reported the oneshot start job failed, and deploy_release.sh rolled the
+release back — un-deploying the fix for the lie it had just recorded honestly.
+
+Arm 1: the exit status is classified at both rollback points. Status 3 keeps
+the release; every other failure still rolls back. Both halves are DRIVEN here,
+not asserted: the remote activation stanza is executed with a scripted
+`systemctl`, and the local health gate is run through the full script with
+journal/streak fixtures, exactly as tests/test_deploy_release.py does.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nanobot.runtime import bridge
+from tests import test_deploy_release as _harness
+from tests.test_deploy_release import (
+    DEPLOY_SCRIPT,
+    _journal_replay_mock,
+    _streak_mock,
+    _write_mock,
+    run_deploy,
+    set_ssh_mock,
+)
+
+# The harness fixtures, re-exported under their own names so pytest finds them
+# here (an assignment, not an import, so the test parameters do not read as a
+# redefinition to the linter).
+repo = _harness.repo
+mock_bin = _harness.mock_bin
+
+LIB = DEPLOY_SCRIPT.with_name("lib_bridge_exit.sh")
+BRIDGE_UNIT_LINE = "Sep 05 03:40:10 eeepc systemd[1]: eeepc-self-evolving-subagent-bridge.service: Main process exited, code=exited, status={status}/{name}"
+
+
+def _bash(script: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    full_env = os.environ.copy()
+    full_env.update(env or {})
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=full_env)
+
+
+def test_lib_constant_is_pinned_to_the_bridge_exit_code():
+    text = LIB.read_text(encoding="utf-8")
+    value = int(re.search(r"^BRIDGE_EXIT_EXECUTOR_LLM_ERROR=(\d+)$", text, re.M).group(1))
+    assert value == bridge.EXIT_EXECUTOR_LLM_ERROR == 3
+
+
+@pytest.mark.parametrize("rc, result, status, expected", [
+    ("0", "success", "0", "ok"),
+    ("3", "exit-code", "3", "transport"),          # the 2026-09-05 case
+    ("1", "exit-code", "1", "failed"),             # internal error
+    ("4", "exit-code", "4", "failed"),             # #1302 system-prompt overflow: a release/config failure, stays fatal
+    ("203", "exit-code", "203", "failed"),         # missing interpreter / venv
+    ("1", "signal", "9", "failed"),                # killed
+    ("1", "exit-code", "", "failed"),              # status unreadable: never assume transport
+    ("1", "", "3", "failed"),                      # status 3 but Result not exit-code: not the #1280 path
+])
+def test_classify_bridge_run(rc, result, status, expected):
+    lib = str(LIB).replace("\\", "/")
+    res = _bash(f'. "{lib}"; classify_bridge_run "{rc}" "{result}" "{status}"')
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == expected
+
+
+def _activation_stanza() -> str:
+    text = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    begin, end = "# --- #1303 bridge activation begin ---", "# --- #1303 bridge activation end ---"
+    assert begin in text and end in text, "the activation stanza must keep its markers so this test drives the real text"
+    return text.split(begin, 1)[1].split(end, 1)[0]
+
+
+def _drive_activation(tmp_path: Path, *, restart_rc: int, result: str, status: str) -> tuple[subprocess.CompletedProcess, bool]:
+    """Run the script's own activation stanza under `set -eEuo pipefail` with the
+    real ERR trap wiring (die → return 1 → trap → rollback_remote) and a scripted
+    systemctl. Returns the process and whether rollback_remote fired."""
+    shims = tmp_path / "shims"
+    shims.mkdir(exist_ok=True)
+    _write_mock(shims / "sudo", 'exec "$@"')
+    _write_mock(shims / "systemctl", f'''
+    if [ "$1" = "restart" ]; then exit {restart_rc}; fi
+    if [ "$1" = "show" ] && [[ "$*" == *"-p Result"* ]]; then echo "{result}"; exit 0; fi
+    if [ "$1" = "show" ] && [[ "$*" == *"-p ExecMainStatus"* ]]; then echo "{status}"; exit 0; fi
+    exit 0
+    ''')
+    marker = tmp_path / "rolled_back"
+    release_dir = str(DEPLOY_SCRIPT.parents[3]).replace("\\", "/")
+    prelude = f'''
+    set -eEuo pipefail
+    die() {{ echo "CRITICAL: $*" >&2; return 1; }}
+    rollback_remote() {{ if [ "${{BASH_SUBSHELL:-0}}" -gt 0 ]; then return; fi; touch "{str(marker).replace(chr(92), "/")}"; echo "[remote] rollback after activation failure" >&2; }}
+    trap rollback_remote ERR
+    VERIFY_ONLY=0
+    RELEASE_DIR="{release_dir}"
+    '''
+    env = {"PATH": str(shims).replace("\\", "/") + ":" + os.environ["PATH"]}
+    res = _bash(prelude + _activation_stanza() + "\necho STANZA-COMPLETED\n", env=env)
+    return res, marker.exists()
+
+
+def test_activation_transport_exit_keeps_the_release(tmp_path):
+    res, rolled_back = _drive_activation(tmp_path, restart_rc=3, result="exit-code", status="3")
+    assert res.returncode == 0, res.stderr
+    assert rolled_back is False
+    assert "STANZA-COMPLETED" in res.stdout
+    assert "not an activation failure (#1303)" in res.stdout and "EXIT_EXECUTOR_LLM_ERROR (3)" in res.stdout
+
+
+@pytest.mark.parametrize("restart_rc, result, status, why", [
+    (1, "exit-code", "1", "import error / internal error"),
+    (203, "exit-code", "203", "missing venv or interpreter"),
+    (1, "exit-code", "4", "#1302 system-prompt overflow"),
+    (1, "signal", "9", "killed"),
+    (1, "exit-code", "", "unit that never produced a status"),
+])
+def test_activation_genuine_failure_still_rolls_back(tmp_path, restart_rc, result, status, why):
+    res, rolled_back = _drive_activation(tmp_path, restart_rc=restart_rc, result=result, status=status)
+    assert res.returncode != 0, why
+    assert rolled_back is True, why
+    assert "STANZA-COMPLETED" not in res.stdout, why
+    assert "CRITICAL: bridge activation failed" in res.stderr, why
+
+
+def test_activation_clean_exit_continues(tmp_path):
+    res, rolled_back = _drive_activation(tmp_path, restart_rc=0, result="success", status="0")
+    assert res.returncode == 0 and rolled_back is False and "STANZA-COMPLETED" in res.stdout
+
+
+# ── the local health gate: journal and exit-streak reads ────────────────────
+
+def test_gate_transport_exit_in_journal_does_not_roll_back(repo, mock_bin):
+    """The exact line systemd logged on 2026-09-05 06:38."""
+    set_ssh_mock(mock_bin, _journal_replay_mock(BRIDGE_UNIT_LINE.format(status=3, name="NOTIMPLEMENTED")))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode == 0, combined
+    assert "rolling back to" not in combined and "bridge process crashed" not in combined
+    assert "transport failure recorded as blocked" in combined and "not a release failure (#1303)" in combined
+    assert "health gate: unknown" in combined, "no clean run yet — the gate says so instead of certifying"
+
+
+@pytest.mark.parametrize("status, name", [(1, "FAILURE"), (4, "NOTIMPLEMENTED"), (203, "EXEC")])
+def test_gate_other_nonzero_exits_still_roll_back(repo, mock_bin, status, name):
+    set_ssh_mock(mock_bin, _journal_replay_mock(BRIDGE_UNIT_LINE.format(status=status, name=name)))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode != 0
+    assert "rolling back" in combined and "bridge process crashed" in combined, combined
+
+
+def test_gate_transport_streak_failure_waits_instead_of_rolling_back(repo, mock_bin):
+    streak = ('{"schema_version": "bridge-exit-streak-v1", "consecutive_failures": 1, '
+              '"last_failure_ts": "2099-01-01T00:00:00Z", "last_exit_status": 3, "last_outcome": "failure"}')
+    set_ssh_mock(mock_bin, _streak_mock(streak))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode == 0, combined
+    assert "rolling back to" not in combined and "exit recorder shows a failure" not in combined
+    assert "transport failure after the flip" in combined and "streak advanced as #1280 intends" in combined
+    assert "health gate: unknown" in combined
+
+
+def test_gate_other_streak_failure_still_rolls_back(repo, mock_bin):
+    streak = ('{"schema_version": "bridge-exit-streak-v1", "consecutive_failures": 1, '
+              '"last_failure_ts": "2099-01-01T00:00:00Z", "last_exit_status": 4, "last_error": "SystemPromptOverflowError"}')
+    set_ssh_mock(mock_bin, _streak_mock(streak))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode != 0
+    assert "rolling back" in combined and "exit recorder shows a failure" in combined, combined
+
+
+def test_transport_then_clean_run_is_clean_exit(repo, mock_bin):
+    """The streak after a transient: consecutive_failures back to 0 with a post-flip success."""
+    streak = ('{"schema_version": "bridge-exit-streak-v1", "consecutive_failures": 0, '
+              '"last_failure_ts": "2099-01-01T00:00:00Z", "last_exit_status": 0, "last_success_ts": "2099-01-01T00:15:00Z"}')
+    set_ssh_mock(mock_bin, _streak_mock(streak, BRIDGE_UNIT_LINE.format(status=3, name="NOTIMPLEMENTED")))
+    res = run_deploy(repo, mock_bin, ["--health-timeout", "0", "--ref", "HEAD"])
+    combined = (res.stdout + res.stderr).lower()
+    assert res.returncode == 0, combined
+    assert "health gate: clean-exit" in combined and "rolling back to" not in combined

--- a/tests/test_deploy_release.py
+++ b/tests/test_deploy_release.py
@@ -39,6 +39,8 @@ def repo(tmp_path):
     # author's worktree passed only on that machine and turned CI red on main.
     test_script = script_dir / "deploy_release.sh"
     shutil.copy(DEPLOY_SCRIPT, test_script)
+    # #1303: the script sources its exit-class lib from its own directory.
+    shutil.copy(DEPLOY_SCRIPT.with_name("lib_bridge_exit.sh"), script_dir / "lib_bridge_exit.sh")
 
     _git("init", cwd=repo_root, check=True)
     (repo_root / "README").write_text("hello")


### PR DESCRIPTION
Closes #1303. Opened on the author's behalf — deploys are blocked and the branch was ready with an independent review already posted on the issue.

## What broke

Deploying `a64470e5` at 06:38 MSK activated cleanly, then rolled back. The bridge's first post-flip cycle drew `litellm.NotFoundError: GeminiException - {"detail":"Not Found"}` and every line after that was #1282 working as designed — recorded `blocked` with `rollback.reason = executor_llm_error`, request left pending at retry 1/3, process exited `EXIT_EXECUTOR_LLM_ERROR` so the failure streak stays honest.

To systemd that is a `Type=oneshot` start-job failure. `systemctl restart` at `deploy_release.sh:634` runs under `set -eE` with `trap rollback_remote ERR` still installed, so the non-zero return fired the trap and flipped `current` back. The release carrying #1280 became un-deployable by the mechanism its own fix trips, and the host returned to recording executor failures as `completed`.

## The fix, and why this arm

Arm 1 of the three on the issue: distinguish the exit status at the activation check. The restart's failure is captured (`|| BRIDGE_RESTART_RC=$?`) so it no longer reaches the trap; the script then reads `Result` and `ExecMainStatus` and passes both to `classify_bridge_run` in a new `lib_bridge_exit.sh`, sourced remotely from `$RELEASE_DIR` so the classification travels with the release that defines the code.

Two corrections during design are worth recording, because both of my original framings were wrong:

- Arm 1 as first described was not implementable — the script never sees `ExecMainStatus` at that point and had to be made to query it.
- **Arm 2 (retry the activation once) is refuted by the incident itself.** All three attempts on that pending request drew the same 404, at 06:40, 06:43 and 06:48, and it was retired at 3/3. A single retry would also have failed.

Arm 3 (exit 0 and read the recorded outcome) was rejected because it moves the signal #1280 deliberately put on the exit status.

## Independent review

Posted on #1303 by an agent that did not write this and had established the diagnosis. Verdict APPROVE, with the two things that actually mattered checked by execution:

- **Bypassing the trap did not un-cover anything.** Every non-transport tuple reaches an explicit `die` while the trap is still installed; it is cleared only after the classification block. Verified for exit 1, exit 203, prompt-overflow exit 4, signal termination and an unreadable `ExecMainStatus` — the rollback callback fires in all five, and does not fire for the transport tuple.
- **A signal cannot alias exit 3.** `classify_bridge_run` requires `Result=exit-code` as well as status 3: `Result=signal, ExecMainStatus=3` classifies `failed`, as does signal 9.

Activation tests: 23 passed, driving the real stanza under `set -eEuo pipefail` rather than asserting on source. Existing deploy suite: 33 passed.

## Verification owed

The deploy that carries this change is its own live test: it must complete rather than roll back if its first cycle draws a 404, and must still roll back on a genuinely broken release. I will run it and report.