### PR TITLE
fix(curator): retain complete prompt input batches (#1307)

### DIFF
--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -604,9 +604,39 @@ def _parse_output(value: Any) -> list[dict[str, Any]] | None:
     return clean
 
 
+def fit_lessons_to_input_budget(
+    lessons: list[dict[str, Any]],
+    max_chars: int = MAX_INPUT_CHARS,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Keep the oldest complete prefix that fits the JSON budget (#1307).
+
+    ``lessons_after`` is chronological and the watermark is one scalar cursor,
+    so only a contiguous oldest prefix may be acknowledged safely. Newer items
+    are deferred, not dropped: advancing through a newest-only suffix would
+    permanently skip the omitted older entries. Each candidate is serialized
+    whole, so the model never receives torn JSON.
+    """
+    retained: list[dict[str, Any]] = []
+    for item in lessons:
+        candidate = [*retained, item]
+        body = json.dumps(candidate, ensure_ascii=False, separators=(",", ":"))
+        if len(body) > max_chars:
+            break
+        retained.append(item)
+    omitted = lessons[len(retained):]
+    return retained, {
+        "input_status": "complete" if not omitted else "partial",
+        "selected": len(retained),
+        "omitted": len(omitted),
+        "omitted_ids": [_entry_key(item) for item in omitted[:10]],
+        "selection": "oldest-prefix-newest-deferred",
+    }
+
+
 def _messages(lessons: list[dict[str, Any]], index: str, facts: str) -> list[dict[str, str]]:
     body = json.dumps(lessons, ensure_ascii=False, separators=(",", ":"))
-    body = body[:MAX_INPUT_CHARS]
+    if len(body) > MAX_INPUT_CHARS:
+        raise ValueError("curator lesson batch was not fitted to complete items")
     system = (
         "You are the eeebot knowledge curator. Return ONLY a JSON array. "
         "Each item must be one of: "
@@ -1692,6 +1722,26 @@ def run_curation(
             "last_success_ts": _now(), **result["stages"],
         })
         return result
+    # The scalar watermark can safely acknowledge only a contiguous oldest
+    # prefix. Newer items that do not fit are explicitly deferred and remain
+    # eligible after the watermark advances through the selected prefix.
+    entries, input_fit = fit_lessons_to_input_budget(entries, MAX_INPUT_CHARS)
+    if not entries:
+        curation_stage = {
+            "status": "partial",
+            "processed": 0,
+            "writes": 0,
+            "staged": [],
+            **input_fit,
+        }
+        result = {"ok": True, "processed": 0, "writes": 0, "staged": [], "stages": {
+            "reflector_mint": reflector_stage,
+            "curation": curation_stage,
+        }}
+        _atomic_json(state_dir / "curator" / "status.json", {
+            "last_success_ts": _now(), **result["stages"],
+        })
+        return result
     try:
         model = resolve_model("curator", strip_openai=True)
         messages = _messages(entries, _read_index(workspace), "")
@@ -1745,10 +1795,15 @@ def run_curation(
         staged_paths = [e["path"] for e in staged]
         unsupported = sum(1 for e in staged if e.get("overlap_flag"))
         curation_stage = {
-            "status": "ok", "processed": len(entries), "writes": writes, "staged": staged_paths,
+            "status": "ok" if input_fit["input_status"] == "complete" else "partial",
+            "processed": len(entries),
+            "writes": writes,
+            "staged": staged_paths,
+            **input_fit,
         }
         result_dict: dict[str, Any] = {
             "ok": True, "processed": len(entries), "writes": writes, "staged": staged_paths,
+            "input_status": input_fit["input_status"], "omitted": input_fit["omitted"],
             "stages": {"reflector_mint": reflector_stage, "curation": curation_stage},
         }
         _atomic_json(state_dir / "curator" / "status.json", {

--- a/tests/test_issue_1216_curator_signal.py
+++ b/tests/test_issue_1216_curator_signal.py
@@ -92,6 +92,8 @@ def test_run_curation_reports_fact_stage_success(tmp_path: Path) -> None:
     assert result["stages"]["curation"] == {
         "status": "ok", "processed": 1, "writes": 1,
         "staged": ["memory/facts/insight.md"],
+        "input_status": "complete", "selected": 1, "omitted": 0,
+        "omitted_ids": [], "selection": "oldest-prefix-newest-deferred",
     }
 
 

--- a/tests/test_knowledge_curator.py
+++ b/tests/test_knowledge_curator.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from nanobot.runtime.knowledge_curator import (
     _ACTION_INDEX_SEGMENTS,
     _fact_path,
+    _messages,
     clear_staged_manifest,
+    fit_lessons_to_input_budget,
     lessons_after,
     load_staged_manifest,
     migrate_loose_lessons,
@@ -96,6 +98,7 @@ def test_action_index_fallback_opens_only_bounded_newest_segments(tmp_path, monk
     """#1107: a large index/archive cannot cause an unbounded fallback scan."""
     import builtins
     import gzip
+
     from nanobot.runtime.knowledge_curator import _read_action_index_cycle_text
 
     index_dir = tmp_path / "action_index"
@@ -143,6 +146,104 @@ def test_curator_stages_promotions_not_workspace(tmp_path):
     # Decisions sidecar records staged + duplicate (#1209: promoted only after the bridge pushes)
     rows = [json.loads(x) for x in (state / "curator/decisions.jsonl").read_text().splitlines()]
     assert {r["decision"] for r in rows} == {"staged", "duplicate"}
+
+
+def test_oversized_lesson_batch_keeps_valid_oldest_prefix_and_defers_newest() -> None:
+    """#1307 live shape: 40 complete items exceed 48K; no JSON object is torn."""
+    lessons = [
+        {
+            "id": f"L{i:02d}",
+            "timestamp": f"2026-09-05T00:{i:02d}:00Z",
+            "approach": f"lesson {i} " + "x" * 1_300,
+        }
+        for i in range(40)
+    ]
+    full_body = json.dumps(lessons, ensure_ascii=False, separators=(",", ":"))
+    assert len(full_body) > 48_000
+
+    retained, fit = fit_lessons_to_input_budget(lessons)
+    body = _messages(retained, "", "")[1]["content"].split(
+        "NEW LESSONS:\n", 1
+    )[1].split("\n\nKB INDEXES:", 1)[0]
+
+    assert json.loads(body) == retained
+    assert len(body) <= 48_000
+    assert [item["id"] for item in retained] == [
+        item["id"] for item in lessons[: len(retained)]
+    ]
+    assert fit == {
+        "input_status": "partial",
+        "selected": len(retained),
+        "omitted": len(lessons) - len(retained),
+        "omitted_ids": [item["id"] for item in lessons[len(retained):][:10]],
+        "selection": "oldest-prefix-newest-deferred",
+    }
+
+
+def test_partial_batch_watermark_leaves_deferred_suffix_for_next_run(
+    tmp_path, monkeypatch
+) -> None:
+    """A partial input advances only through the contiguous prefix sent to the LLM."""
+    from nanobot.runtime import knowledge_curator as curator
+
+    lessons = [
+        {
+            "id": f"L{i:02d}",
+            "timestamp": f"2026-09-05T00:{i:02d}:00Z",
+            "approach": f"lesson {i} " + "x" * 1_300,
+        }
+        for i in range(40)
+    ]
+
+    def fake_lessons_after(_workspace, watermark, *, limit, state_dir):
+        start = next(
+            (i + 1 for i, item in enumerate(lessons) if item["id"] == watermark),
+            0,
+        )
+        return lessons[start : start + limit]
+
+    seen_batches: list[list[str]] = []
+
+    def deciding_llm(messages, _model):
+        body = messages[1]["content"].split("NEW LESSONS:\n", 1)[1].split(
+            "\n\nKB INDEXES:", 1
+        )[0]
+        batch = json.loads(body)
+        seen_batches.append([item["id"] for item in batch])
+        return json.dumps([
+            {"action": "unimportant", "lesson_id": item["id"], "reason": "bounded test"}
+            for item in batch
+        ])
+
+    monkeypatch.setattr(curator, "lessons_after", fake_lessons_after)
+    monkeypatch.setattr(
+        curator, "promote_reflector_recommendations_to_v2", lambda *_args, **_kwargs: {}
+    )
+    state = tmp_path / "state"
+
+    first = run_curation(tmp_path, state, llm=deciding_llm)
+    first_watermark = json.loads(
+        (state / "curator" / "watermark.json").read_text(encoding="utf-8")
+    )["last_processed_id"]
+    first_status = json.loads(
+        (state / "curator" / "status.json").read_text(encoding="utf-8")
+    )["curation"]
+
+    assert first["input_status"] == "partial"
+    assert first["processed"] == len(seen_batches[0]) < len(lessons)
+    assert first["omitted"] == len(lessons) - first["processed"]
+    assert first_watermark == seen_batches[0][-1] != lessons[-1]["id"]
+    assert first_status["status"] == "partial"
+    assert first_status["processed"] == first_status["selected"] == first["processed"]
+    assert first_status["omitted_ids"][0] == lessons[first["processed"]]["id"]
+
+    second = run_curation(tmp_path, state, llm=deciding_llm)
+
+    assert seen_batches[1] == [item["id"] for item in lessons[first["processed"] :]]
+    assert second["processed"] == len(seen_batches[1])
+    assert json.loads(
+        (state / "curator" / "watermark.json").read_text(encoding="utf-8")
+    )["last_processed_id"] == lessons[-1]["id"]
 
 
 def test_watermark_skips_prior_and_failure_does_not_advance(tmp_path):


### PR DESCRIPTION
Closes #1307.

## Defect

The curator serialized up to 40 lessons and then sliced the JSON string at 48,000 characters. The live 2026-09-05 batch serialized to 49,617 characters; the slice ended inside an `approach` string and was invalid JSON. The run nevertheless reported `status: ok, processed: 40`, and advanced the watermark through all 40 entries.

## Fix

- Fit the lesson batch at complete JSON item boundaries. `_messages` now rejects an unfitted oversized batch instead of slicing it.
- Retain the **oldest contiguous prefix** and defer the newest suffix. This ordering is deliberate: `lessons_after` is chronological and the watermark is one scalar cursor, so only an oldest prefix can be acknowledged without permanently skipping omitted entries. The next run starts at the deferred suffix.
- Report input completeness directly: `input_status`, `selected`, `omitted`, bounded `omitted_ids`, and `selection: oldest-prefix-newest-deferred`.
- `processed` counts only complete items actually sent to the model.
- The watermark advances only through the retained prefix after staging succeeds.

No cap increase was made. No `ContextBuilder` or reflector code was changed.

## Regression evidence

The live-shape test creates 40 complete lesson objects whose serialized body exceeds 48K and proves valid JSON, complete-item retention, prefix-only watermark advancement, and exact deferred-suffix pickup on the next run.

Manual fixture: raw 54,871 chars; sent 46,639 valid JSON chars; selected 34; deferred 6 (`L34`..`L39`); `input_status=partial`.

## Verification

- focused curator tests: **24 passed**;
- Ruff and `git diff --check`: passed;
- full Windows pytest (redirected): **4 failed, 3087 passed, 17 skipped**.

Failures are exactly the established baseline: one `test_bridge_cycle_tags` case and the three `TestAcquireBridgeLock` cases. Branch is based on current `origin/main` (`5a222e78`, including #1298 `8cd5217b`). Host was read-only; no deployment or runtime mutation.