### PR TITLE
fix(reflector): parse inner fenced content safely (#1306)

### DIFF
--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -289,11 +289,15 @@ def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, 
 
 def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str]:
     parsed_from_fence = False
+
+    def _fail(reason: str) -> tuple[None, str]:
+        return None, f"fenced:{reason}" if parsed_from_fence else reason
+
     if isinstance(value, str):
         raw = value.strip()
         if raw.startswith("```"):
-            closing = raw.find("```", 3)
-            if closing == -1:
+            closing = raw.rfind("```")
+            if closing <= 0:
                 return None, "fenced_unclosed"
             if raw[closing + 3:].strip():
                 return None, "fenced_trailing_text"
@@ -314,35 +318,35 @@ def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str
                 return None, "json_truncated"
             return None, "not_json"
     if not isinstance(value, dict):
-        return None, "not_object"
+        return _fail("not_object")
     raw_cid = str(value.get("cycle_id") or "")
     if raw_cid == "":
-        return None, "cycle_id_missing"
+        return _fail("cycle_id_missing")
     if raw_cid != cycle_id:
-        return None, "cycle_id_mismatch"
+        return _fail("cycle_id_mismatch")
     if not isinstance(value.get("summary"), str):
-        return None, "missing_or_invalid:summary"
+        return _fail("missing_or_invalid:summary")
     if not isinstance(value.get("findings"), list):
-        return None, "missing_or_invalid:findings"
+        return _fail("missing_or_invalid:findings")
     if not isinstance(value.get("recommendations"), list):
-        return None, "missing_or_invalid:recommendations"
+        return _fail("missing_or_invalid:recommendations")
     findings = []
     for item in value["findings"]:
         if not isinstance(item, dict):
-            return None, "invalid_finding:not_object"
+            return _fail("invalid_finding:not_object")
         if item.get("kind") not in _VALID_FINDINGS:
-            return None, f"invalid_finding:bad_kind:{item.get('kind')}"
+            return _fail(f"invalid_finding:bad_kind:{item.get('kind')}")
         if not str(item.get("detail") or "").strip():
-            return None, "invalid_finding:empty_detail"
+            return _fail("invalid_finding:empty_detail")
         findings.append({"kind": item["kind"], "detail": str(item["detail"])[:1000]})
     recommendations = []
     for item in value["recommendations"][:_MAX_RECOMMENDATIONS]:
         if not isinstance(item, dict):
-            return None, "invalid_recommendation:not_object"
+            return _fail("invalid_recommendation:not_object")
         if item.get("kind") not in _VALID_RECOMMENDATIONS:
-            return None, f"invalid_recommendation:bad_kind:{item.get('kind')}"
+            return _fail(f"invalid_recommendation:bad_kind:{item.get('kind')}")
         if not str(item.get("detail") or "").strip():
-            return None, "invalid_recommendation:empty_detail"
+            return _fail("invalid_recommendation:empty_detail")
         recommendations.append({"kind": item["kind"], "detail": str(item["detail"])[:1000], "evidence": str(item.get("evidence") or "")[:1000]})
     result = {
         "cycle_id": cycle_id,

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -71,6 +71,40 @@ def test_parse_output_reports_fenced_invalid_json():
     assert parsed is None and reason == "fenced_not_json"
 
 
+def test_parse_output_handles_inner_markdown_fence():
+    # Inner Markdown fence inside a JSON string value should parse successfully
+    # when closing delimiter is located via rfind rather than find (#1306).
+    inner = {
+        "cycle_id": "c1",
+        "summary": "Fix includes ```python\nprint('hello')\n``` snippet.",
+        "findings": [{"kind": "good_practice", "detail": "Document with ```block```"}],
+        "recommendations": [{"kind": "approach_hint", "detail": "Use ```fence``` in docs", "evidence": "c1"}],
+        "followed_previous": [],
+    }
+    fenced = "```json\n" + json.dumps(inner) + "\n```"
+    parsed, reason = reflector._parse_output(fenced, "c1")
+    assert parsed is not None
+    assert reason == "fenced_json"
+    assert parsed["summary"] == inner["summary"]
+    assert parsed["findings"][0]["detail"] == inner["findings"][0]["detail"]
+
+
+def test_parse_output_preserves_fence_provenance_on_content_validation_failure():
+    # If the JSON was inside a fence, but content validation fails, the reason
+    # must be prefixed with fenced: (#1306).
+    fenced_bad_cycle = "```json\n" + json.dumps({"cycle_id": "wrong", "summary": "x", "findings": [], "recommendations": []}) + "\n```"
+    parsed, reason = reflector._parse_output(fenced_bad_cycle, "c1")
+    assert parsed is None and reason == "fenced:cycle_id_mismatch"
+
+    fenced_bad_finding = "```json\n" + json.dumps({"cycle_id": "c1", "summary": "x", "findings": [{"kind": "bad", "detail": "x"}], "recommendations": []}) + "\n```"
+    parsed, reason = reflector._parse_output(fenced_bad_finding, "c1")
+    assert parsed is None and reason == "fenced:invalid_finding:bad_kind:bad"
+
+    fenced_missing_summary = "```json\n" + json.dumps({"cycle_id": "c1", "findings": [], "recommendations": []}) + "\n```"
+    parsed, reason = reflector._parse_output(fenced_missing_summary, "c1")
+    assert parsed is None and reason == "fenced:missing_or_invalid:summary"
+
+
 def test_fenced_json_is_repaired_and_reason_is_journaled(tmp_path: Path):
     _seed(tmp_path)
     fenced = "```json\n" + _answer("c1") + "\n```"

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -89,6 +89,22 @@ def test_parse_output_handles_inner_markdown_fence():
     assert parsed["findings"][0]["detail"] == inner["findings"][0]["detail"]
 
 
+def test_parse_output_rejects_trailing_prose_ending_in_a_fence() -> None:
+    """The last-fence repair must not accept prose after a valid fenced payload.
+
+    The final fence in the prose becomes the extraction boundary, leaving the
+    genuine closing fence and prose inside the candidate JSON. That safely
+    rejects as ``fenced_not_json``. This diagnostic bucket is shared with
+    genuinely invalid enclosed JSON; response head/tail distinguish the shapes,
+    and the deferred #1306 classification bundles remain out of scope.
+    """
+    raw = "```json\n" + _answer("c1") + "\n```\nHope this helps! ```"
+
+    parsed, reason = reflector._parse_output(raw, "c1")
+
+    assert parsed is None and reason == "fenced_not_json"
+
+
 def test_parse_output_preserves_fence_provenance_on_content_validation_failure():
     # If the JSON was inside a fence, but content validation fails, the reason
     # must be prefixed with fenced: (#1306).


### PR DESCRIPTION
Closes #1306.

## Scope

Implements only the authorized immediate correctness bundle. The three day-one-data classification bundles and every cap are unchanged.

## Fix

- Use the **last** closing Markdown fence (`rfind`) for an opening fenced JSON response, so a legitimate ` ``` ` sequence inside a JSON string does not terminate extraction early.
- Preserve extraction provenance when decoded fenced JSON fails content validation by prefixing the existing reason with `fenced:` (for example `fenced:cycle_id_mismatch` and `fenced:invalid_finding:bad_kind:bad`). This is an observability prefix, not a new validation category.

Bare JSON, prose/fence, BOM, truncated-response classifications, response/token caps, and reflector input caps are untouched.

## Pre-fix failure demonstration

The new valid-inner-fence regression was run with production parser code restored to `find`. It failed before the change:

```text
FAILED test_parse_output_handles_inner_markdown_fence
assert parsed is not None
E assert None is not None
```

The old parser classified the valid response as `fenced_trailing_text`, because the first inner fence was mistaken for the closing delimiter. With `rfind`, it parses and returns `fenced_json` while preserving the exact summary/finding strings.

## Tests

Added coverage for:

- a valid fenced response whose summary and details contain Markdown fences;
- fenced content failures retaining provenance for cycle mismatch, invalid finding kind, and missing summary.

Verification:

- focused reflector suite: **28 passed**;
- Ruff on changed files: passed;
- `git diff --check`: passed;
- full Windows pytest, redirected to `full-pytest-1306.log`: **4 failed, 3087 passed, 17 skipped**.

The failures are exactly the established Windows baseline:

1. `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
2. `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
3. `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
4. `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`

Branch was rebased onto current `origin/main` (`1f4ba878`, including #1308). No host or deployment mutation was performed.
