### PR TITLE
fix(curator): quarantine a lesson larger than the input budget instead of stalling (#1309)

### DIFF
--- a/nanobot/runtime/knowledge_curator.py
+++ b/nanobot/runtime/knowledge_curator.py
@@ -633,6 +633,38 @@ def fit_lessons_to_input_budget(
     }
 
 
+def _quarantine_oversized_head(
+    lessons: list[dict[str, Any]],
+    max_chars: int = MAX_INPUT_CHARS,
+) -> tuple[list[dict[str, Any]], list[tuple[dict[str, Any], int]], str]:
+    """Split off leading items that exceed ``max_chars`` on their own (#1309).
+
+    Only the head of the chronological stream can be passed over by the scalar
+    watermark without skipping unseen entries, so only leading oversized items
+    are quarantined; an oversized item behind a retained prefix is deferred by
+    :func:`fit_lessons_to_input_budget` and becomes the head next run. An
+    oversized head item with no id or timestamp cannot be acknowledged by a
+    scalar cursor at all; it is left in place and named in ``blocked_reason``
+    — the one honest stall that remains.
+
+    Returns ``(remaining, [(item, serialized_chars), ...], blocked_reason)``.
+    """
+    quarantined: list[tuple[dict[str, Any], int]] = []
+    index = 0
+    while index < len(lessons):
+        size = len(json.dumps([lessons[index]], ensure_ascii=False, separators=(",", ":")))
+        if size <= max_chars:
+            break
+        if not _entry_key(lessons[index]):
+            return lessons[index:], quarantined, (
+                f"head item is {size} chars over a {max_chars}-char budget and has no id or "
+                "timestamp, so the scalar watermark cannot pass it"
+            )
+        quarantined.append((lessons[index], size))
+        index += 1
+    return lessons[index:], quarantined, ""
+
+
 def _messages(lessons: list[dict[str, Any]], index: str, facts: str) -> list[dict[str, str]]:
     body = json.dumps(lessons, ensure_ascii=False, separators=(",", ":"))
     if len(body) > MAX_INPUT_CHARS:
@@ -1722,13 +1754,42 @@ def run_curation(
             "last_success_ts": _now(), **result["stages"],
         })
         return result
+    # #1309: an item that is over the budget on its own can never be the head
+    # of a retained prefix, so under #1307's rule it would stall the stream
+    # forever (honestly, run after run). Quarantine it instead: record it with
+    # its id and size, advance the watermark past it, continue. Arm 1 of the
+    # three in #1309, chosen against the measurement: the largest item in the
+    # 993-item live stream on 2026-09-05 was 2,113 chars (4.4% of 48,000, p99
+    # 1,883), so this is a guard against a theoretical shape and the cheapest
+    # correct one wins. Not arm 2 (field truncation: more code, the model sees
+    # a lossy item) and not arm 3 (escalate: nothing reads the curator's
+    # status file — the same file said `ok` for weeks over torn input — so an
+    # escalation would be arm 1 without the benefit). The quarantine file is
+    # the countable record; nothing revisits it today, by design — the
+    # operator or a future reader can.
+    entries, quarantined, blocked_reason = _quarantine_oversized_head(entries, MAX_INPUT_CHARS)
+    quarantine_report: dict[str, Any] = {"blocked_reason": blocked_reason} if blocked_reason else {}
+    if quarantined:
+        for item, size in quarantined:
+            _append_jsonl(state_dir / "curator" / "quarantine.jsonl", {
+                "timestamp": _now(), "lesson_id": _entry_key(item), "chars": size,
+                "budget": MAX_INPUT_CHARS, "reason": "single item exceeds MAX_INPUT_CHARS",
+            })
+        last_q = _entry_key(quarantined[-1][0])
+        _atomic_json(wm_path, {"last_processed": last_q, "last_processed_id": last_q, "timestamp": _now(),
+                               "quarantined": [_entry_key(item) for item, _ in quarantined]})
+        quarantine_report = {"quarantined": len(quarantined),
+                             "quarantined_ids": [_entry_key(item) for item, _ in quarantined[:10]]}
     # The scalar watermark can safely acknowledge only a contiguous oldest
     # prefix. Newer items that do not fit are explicitly deferred and remain
     # eligible after the watermark advances through the selected prefix.
     entries, input_fit = fit_lessons_to_input_budget(entries, MAX_INPUT_CHARS)
+    input_fit.update(quarantine_report)
     if not entries:
         curation_stage = {
-            "status": "partial",
+            # A head item without any key cannot be passed by a scalar
+            # watermark; that is the one remaining honest stall, and it is named.
+            "status": "quarantined" if quarantined and not input_fit["omitted"] else "partial",
             "processed": 0,
             "writes": 0,
             "staged": [],

--- a/tests/test_knowledge_curator_quarantine.py
+++ b/tests/test_knowledge_curator_quarantine.py
@@ -1,0 +1,144 @@
+"""#1309: a single lesson larger than the curator's input budget must not block
+the queue forever.
+
+Under #1307 the curator keeps the oldest complete prefix that fits and keys the
+watermark off the last retained item. An item that is over the budget on its
+own can never head a retained prefix, so `fit_lessons_to_input_budget` returned
+`[]`, `run_curation` took the empty early return, and the watermark never
+moved: every run picked the same item and stopped, honestly. Measured on the
+live stream on 2026-09-05: 993 items, max 2,113 chars against 48,000 — a guard
+against a theoretical shape, so the cheapest correct arm: quarantine the item
+(durable row with id and size), advance the watermark past it, continue.
+"""
+from __future__ import annotations
+
+import json
+
+from nanobot.runtime import knowledge_curator as curator
+from nanobot.runtime.knowledge_curator import run_curation
+
+BUDGET = curator.MAX_INPUT_CHARS
+
+
+def _lesson(i: int, size: int) -> dict:
+    return {"id": f"L{i:02d}", "timestamp": f"2026-09-05T00:{i:02d}:00Z", "approach": "x" * size}
+
+
+def _wire(monkeypatch, lessons: list[dict]):
+    """A watermark-honouring lessons_after over an in-memory stream, and an LLM
+    that acknowledges every item it is shown and records what it saw."""
+    def fake_lessons_after(_workspace, watermark, *, limit, state_dir):
+        start = 0
+        if watermark:
+            start = next((i + 1 for i, item in enumerate(lessons) if curator._entry_key(item) == watermark), 0)
+        return lessons[start:start + limit]
+
+    seen: list[list[str]] = []
+
+    def llm(messages, _model):
+        body = messages[1]["content"].split("NEW LESSONS:\n", 1)[1].split("\n\nKB INDEXES:", 1)[0]
+        batch = json.loads(body)
+        seen.append([item["id"] for item in batch])
+        return json.dumps([{"action": "unimportant", "lesson_id": item["id"], "reason": "t"} for item in batch])
+
+    monkeypatch.setattr(curator, "lessons_after", fake_lessons_after)
+    monkeypatch.setattr(curator, "promote_reflector_recommendations_to_v2", lambda *_a, **_k: {})
+    return llm, seen
+
+
+def _read(state, name):
+    return json.loads((state / "curator" / name).read_text(encoding="utf-8"))
+
+
+def test_quarantine_helper_takes_only_the_oversized_head():
+    big, small = _lesson(0, BUDGET + 10), _lesson(1, 100)
+    remaining, quarantined, blocked = curator._quarantine_oversized_head([big, big | {"id": "L09"}, small, _lesson(3, BUDGET + 10)], BUDGET)
+    assert [item["id"] for item, _ in quarantined] == ["L00", "L09"]
+    assert all(size > BUDGET for _, size in quarantined)
+    assert [item["id"] for item in remaining] == ["L01", "L03"], "an oversized item behind a fitting one is deferred, not quarantined"
+    assert blocked == ""
+    assert curator._quarantine_oversized_head([small], BUDGET) == ([small], [], "")
+
+
+def test_oversized_head_is_quarantined_and_the_rest_is_curated(tmp_path, monkeypatch):
+    """Fails on main: the LLM is never called, watermark.json is never written."""
+    lessons = [_lesson(0, BUDGET + 500), _lesson(1, 200), _lesson(2, 200)]
+    llm, seen = _wire(monkeypatch, lessons)
+    state = tmp_path / "state"
+
+    result = run_curation(tmp_path, state, llm=llm)
+
+    assert seen == [["L01", "L02"]], "the two fitting lessons reached the model in one batch"
+    assert result["processed"] == 2 and result["ok"] is True
+    assert _read(state, "watermark.json")["last_processed_id"] == "L02"
+    rows = [json.loads(line) for line in (state / "curator" / "quarantine.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["lesson_id"] == "L00" and rows[0]["chars"] > BUDGET == rows[0]["budget"]
+    assert rows[0]["reason"] == "single item exceeds MAX_INPUT_CHARS" and rows[0]["timestamp"]
+    status = _read(state, "status.json")["curation"]
+    assert status["status"] == "ok" and status["quarantined"] == 1 and status["quarantined_ids"] == ["L00"]
+
+    second = run_curation(tmp_path, state, llm=llm)
+    assert second["processed"] == 0 and len(seen) == 1, "nothing left; the quarantined item is not re-offered"
+
+
+def test_only_oversized_items_advance_the_watermark_without_an_llm_call(tmp_path, monkeypatch):
+    lessons = [_lesson(0, BUDGET + 1), _lesson(1, BUDGET + 1)]
+    llm, seen = _wire(monkeypatch, lessons)
+    state = tmp_path / "state"
+
+    result = run_curation(tmp_path, state, llm=llm)
+
+    assert seen == [] and result["processed"] == 0 and result["ok"] is True
+    assert _read(state, "watermark.json")["last_processed_id"] == "L01"
+    assert _read(state, "watermark.json")["quarantined"] == ["L00", "L01"]
+    rows = (state / "curator" / "quarantine.jsonl").read_text(encoding="utf-8").splitlines()
+    assert [json.loads(r)["lesson_id"] for r in rows] == ["L00", "L01"]
+    status = _read(state, "status.json")["curation"]
+    assert status["status"] == "quarantined" and status["quarantined"] == 2 and status["omitted"] == 0
+    assert run_curation(tmp_path, state, llm=llm)["processed"] == 0 and len(rows) == 2, "a second run does not re-quarantine"
+
+
+def test_quarantine_is_recorded_before_the_llm_call_and_survives_its_failure(tmp_path, monkeypatch):
+    lessons = [_lesson(0, BUDGET + 1), _lesson(1, 200)]
+    _wire(monkeypatch, lessons)
+    state = tmp_path / "state"
+
+    def dead_llm(*_a):
+        raise RuntimeError("gateway 500")
+
+    result = run_curation(tmp_path, state, llm=dead_llm)
+
+    assert result["ok"] is False
+    assert _read(state, "watermark.json")["last_processed_id"] == "L00", "past the quarantined item, not past the unseen L01"
+    assert json.loads((state / "curator" / "quarantine.jsonl").read_text(encoding="utf-8"))["lesson_id"] == "L00"
+
+
+def test_oversized_head_without_any_key_is_the_one_honest_stall(tmp_path, monkeypatch):
+    lessons = [{"approach": "x" * (BUDGET + 1)}, _lesson(1, 200)]
+    llm, seen = _wire(monkeypatch, lessons)
+    state = tmp_path / "state"
+
+    result = run_curation(tmp_path, state, llm=llm)
+
+    assert seen == [] and result["processed"] == 0
+    assert not (state / "curator" / "watermark.json").exists(), "a keyless item cannot be passed by a scalar cursor"
+    assert not (state / "curator" / "quarantine.jsonl").exists()
+    status = _read(state, "status.json")["curation"]
+    assert status["status"] == "partial" and "no id or timestamp" in status["blocked_reason"]
+
+
+def test_deferred_oversized_item_is_quarantined_on_the_next_run(tmp_path, monkeypatch):
+    """Behind a fitting prefix the oversized item is deferred (#1307); it heads the next run and is quarantined then."""
+    lessons = [_lesson(0, 200), _lesson(1, BUDGET + 1), _lesson(2, 200)]
+    llm, seen = _wire(monkeypatch, lessons)
+    state = tmp_path / "state"
+
+    first = run_curation(tmp_path, state, llm=llm)
+    assert seen[0] == ["L00"] and first["omitted"] == 2 and "quarantined" not in _read(state, "status.json")["curation"]
+    assert _read(state, "watermark.json")["last_processed_id"] == "L00"
+
+    second = run_curation(tmp_path, state, llm=llm)
+    assert seen[1] == ["L02"] and second["processed"] == 1
+    assert [json.loads(r)["lesson_id"] for r in (state / "curator" / "quarantine.jsonl").read_text(encoding="utf-8").splitlines()] == ["L01"]
+    assert _read(state, "watermark.json")["last_processed_id"] == "L02"


### PR DESCRIPTION
Closes #1309.

## The measurement, first

Deployed `knowledge_curator.lessons_after(workspace, "", limit=1_000_000, state_dir)` run read-only on the host as `eeepc-agent` (release `20260904T212321Z-canonical-632bffbb`, 2026-09-05 ~09:00 MSK), each item serialized exactly as `fit_lessons_to_input_budget` does (`json.dumps(item, ensure_ascii=False, separators=(",", ":"))`):

```
items in stream: 993 | max 2113 | p50 738 | p95 1736 | p99 1883 | mean 962
count >=12000: 0 | >=24000: 0 | >=48000: 0
top: LESS-20260904-90931e43 2113 (largest field solution=438) · REFL-ead413e7a8d9-0 2046 (result=790) ·
     LESS-20260904-d44ed220 2031 · REFL-137ea494d7ec-0 1990 · ERR-2026-06-20-001 1981 (fix_applied=653) …
curator status.json now: status ok, processed 40, writes 2 · watermark REFL-53e67c3f1d78 @ 2026-09-04T21:01:48Z
```

The largest item ever written is **4.4% of the 48,000-char budget**; nothing has come within a tenth of it. The stall is real but theoretical today, so the cheapest arm that closes it correctly wins.

## Arm chosen: 1 — skip and quarantine

Reason recorded in the code next to the change (`run_curation`, `_quarantine_oversized_head`). Not **arm 2** (truncate the item's fields): more code, and the model receives a lossy item whose truncation it has to be told about. Not **arm 3** (escalate): nothing reads the curator's `status.json` — the same file said `ok` for weeks over torn input — so an escalation would be arm 1 without the benefit. Who revisits the quarantine: nobody today, by design; `curator/quarantine.jsonl` is the countable record (id, size, budget, reason, timestamp) that the operator or a future reader can consume.

## What changes

- `_quarantine_oversized_head(lessons, max_chars)` splits off **leading** items that exceed the budget on their own. Only the head of the chronological stream can be passed by the scalar watermark without skipping unseen entries, so only leading items are quarantined; an oversized item behind a retained prefix is deferred by #1307's rule and quarantined when it becomes the head next run. A head item with **no id or timestamp** cannot be acknowledged by a scalar cursor at all: it is left in place and named in `status.json` `blocked_reason` — the one honest stall that remains, now with a reason instead of a bare `partial`.
- `run_curation`: for each quarantined item, one row in `curator/quarantine.jsonl` (`timestamp, lesson_id, chars, budget, reason`); the watermark is advanced past them **before** the LLM call (so a model failure cannot re-quarantine them); `status.json`, `watermark.json` (`quarantined: [ids]`) and the run result carry `quarantined` / `quarantined_ids`. If only oversized items were present, `status: quarantined` with no LLM call. Fitting then proceeds exactly as #1307 left it.
- No change to `fit_lessons_to_input_budget`, `_messages`, or the state-path registry (`curator/` is already declared by its live writers; granularity is the segment).

## Tests (`tests/test_knowledge_curator_quarantine.py`, 6 — all six fail on `main`, verified)

- helper takes only the oversized head, records the serialized size, defers an oversized item behind a fitting one
- oversized head quarantined, the two fitting lessons reach the model in one batch, watermark at the last retained, quarantine row has id/chars/budget/reason, status `ok` with `quarantined 1`, second run has nothing to do
- only-oversized stream → watermark advances, quarantine rows, `status: quarantined`, no LLM call, no re-quarantine on the next run
- quarantine row and watermark survive an LLM failure (watermark past the quarantined item, not past the unseen one)
- keyless oversized head → no watermark, no quarantine row, `status: partial` with `blocked_reason`
- oversized item behind a fitting prefix is deferred (#1307), then quarantined on the next run

Existing `tests/test_knowledge_curator.py` unchanged, 18 green. Ruff clean.

Full Windows suite at `7737c94a` (on `1f4ba878`): `4 failed, 3093 passed, 17 skipped` in 21 min — exactly the baseline by name (`test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle` and the three `test_bridge_locking.py::TestAcquireBridgeLock` cases).

## Live check owed after deploy

None expected to fire: no live item is near the budget. Observable if it ever does: a row in `state/curator/quarantine.jsonl` with the lesson id and size, `status.json.curation.quarantined ≥ 1`, and the watermark past that id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
