### PR TITLE
fix(reflector): bound prompt inputs by whole messages, rows and entries (#1314)

### DIFF
--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -355,6 +355,14 @@ def _fit_transcript(record: Any, max_chars: int) -> tuple[Any, dict[str, Any]]:
         fit["dropped_chars"] = dropped_chars
     if fields_omitted:
         fit["fields_omitted"] = fields_omitted
+    if out.get("truncated") is True:
+        # The prompt recorder already cut this record to fit its 32 KiB cap
+        # (#1039): field values shortened in place, in the worst case the whole
+        # message list replaced by one marker. Such a record fits here and drops
+        # nothing, yet the prompt HAS lost content -- the record says so and the
+        # fit must repeat it, or "complete" would be the wrong answer exactly on
+        # the long cycles this issue is about.
+        fit["recorder_truncated"] = True
     return out, fit
 
 
@@ -365,6 +373,8 @@ def _fit_note(fit: dict[str, Any], unit: str) -> str:
         parts.append(f"{fit['dropped']} of {fit['total']} {unit} omitted, oldest first, {fit.get('dropped_chars', 0)} chars")
     if fit.get("fields_omitted"):
         parts.append(", ".join(fit["fields_omitted"]) + " omitted")
+    if fit.get("recorder_truncated"):
+        parts.append("record already shortened by the prompt recorder's 32 KiB cap")
     return f" ({'; '.join(parts)})" if parts else ""
 
 
@@ -397,7 +407,10 @@ def _build_prompt(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[s
         body = _json(value)
         fit["chars"] = len(body)
         sections.append(f"{label}{_fit_note(fit, unit)}:\n{body}")
-    truncated = any(fit["dropped"] or fit.get("fields_omitted") for fit in (transcript_fit, ledger_fit, journal_fit))
+    truncated = any(
+        fit["dropped"] or fit.get("fields_omitted") or fit.get("recorder_truncated")
+        for fit in (transcript_fit, ledger_fit, journal_fit)
+    )
     input_fit = {
         "status": "truncated" if truncated else "complete",
         "transcript": transcript_fit,

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -14,7 +14,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from nanobot.observability.llm_telemetry import call_context, record_llm_call, record_llm_prompt
+from nanobot.observability.llm_telemetry import (
+    MAX_LLM_PROMPT_PAYLOAD_BYTES,
+    call_context,
+    record_llm_call,
+    record_llm_prompt,
+)
 from nanobot.runtime.model_registry import resolve_model
 
 _MAX_CYCLES = 3
@@ -33,9 +38,31 @@ _MAX_JOURNAL_BYTES = 512 * 1024
 _ARCHIVE_RETENTION_DAYS = 90
 _ARCHIVE_READ_FILES = 2
 _ARCHIVE_RE = re.compile(r"^reflections-(\d{4}-\d{2}-\d{2})(?:-(\d+))?\.jsonl\.gz$")
-_MAX_TRANSCRIPT_CHARS = 48_000
+# #1314: the three prompt inputs are bounded structurally in _build_prompt --
+# whole executor messages, whole ledger rows, whole journal entries -- so the
+# document the model receives always parses. Until #1314 the serialized JSON
+# was sliced at these offsets, the curator tear of #1307 in another file.
+# Each budget is chosen against the host measurement of 2026-09-05:
+#  - transcript: the prompt recorder already caps one record at 32 KiB
+#    (MAX_LLM_PROMPT_PAYLOAD_BYTES, #1039), so the reflector can never be
+#    handed more than that; the old 48,000 was unreachable (largest record
+#    seen: 32,652). Pinning the budget to the recorder cap means the message
+#    drop only acts if the two caps ever diverge.
+#  - ledger: per-cycle context is at most 3,059 chars / 12 rows, largest row
+#    1,278 (a system_prompt row); 12,000 is ~4x the largest cycle and holds
+#    nine rows of the largest shape -- headroom for the row types #1302,
+#    #1303 and #1313 keep adding.
+#  - journal: _JOURNAL_TAIL rows at the observed p95 row size (2,896; max
+#    3,690). The old 12,000 was crossed by 349 of 1,031 ten-row windows on
+#    the host (today's tail: 16,319 chars), so the PRIOR REFLECTIONS section
+#    was already being torn every run.
+# _MAX_JOURNAL_BYTES above bounds only the live file: readers span the newest
+# archives plus the live file, so rotation never changes the tail the model
+# sees. What reaches the model is _JOURNAL_TAIL rows, then _MAX_JOURNAL_CHARS.
+_MAX_TRANSCRIPT_CHARS = MAX_LLM_PROMPT_PAYLOAD_BYTES
 _MAX_LEDGER_CHARS = 12_000
-_MAX_JOURNAL_CHARS = 12_000
+_MAX_JOURNAL_CHARS = 30_000
+_OMITTED = "…[omitted: reflector input fit]"
 _VALID_FINDINGS = {"wasted_steps", "error_pattern", "tool_misuse", "good_practice"}
 _VALID_RECOMMENDATIONS = {"skill_candidate", "instruction_change", "approach_hint"}
 
@@ -270,7 +297,85 @@ def _completed_cycles(rows: list[dict[str, Any]], watermark: str) -> list[dict[s
     return outcomes[-1:]
 
 
-def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, Any]], journal: list[dict[str, Any]]) -> list[dict[str, str]]:
+def _json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _fit_rows(rows: list[Any], max_chars: int, *, protect_head: int = 0) -> tuple[list[Any], dict[str, Any]]:
+    """Drop whole rows, oldest first after ``protect_head`` leading rows, until the list fits (#1314).
+
+    The protected head is dropped last, so a section is only ever emptied,
+    never torn. Oldest-first because every caller's list is chronological and
+    the newest rows carry the outcome (ledger) or the recommendations the
+    model is asked to check against (journal).
+    """
+    kept = list(rows)
+    dropped_chars = 0
+    while kept and len(_json(kept)) > max_chars:
+        victim = kept.pop(protect_head if len(kept) > protect_head else 0)
+        dropped_chars += len(_json(victim))
+    fit: dict[str, Any] = {"budget": max_chars, "total": len(rows), "kept": len(kept), "dropped": len(rows) - len(kept)}
+    if dropped_chars:
+        fit["dropped_chars"] = dropped_chars
+    return kept, fit
+
+
+def _fit_transcript(record: Any, max_chars: int) -> tuple[Any, dict[str, Any]]:
+    """Bound one prompt record by dropping whole executor turns, oldest first (#1314).
+
+    Leading ``system`` messages and the first ``user`` message (the task) are
+    protected and go last. ``reasoning_content`` / ``content`` are replaced
+    whole by :data:`_OMITTED` only when the record cannot fit with no turns
+    at all -- dropping turns could never rescue such a record, so the field
+    goes first and the turns stay.
+    """
+    if not isinstance(record, dict):
+        return record, {"budget": max_chars, "total": 0, "kept": 0, "dropped": 0}
+    out = dict(record)
+    messages = list(out["messages"]) if isinstance(out.get("messages"), list) else []
+    if isinstance(out.get("messages"), list):
+        out["messages"] = messages
+    protect = 0
+    while protect < len(messages) and isinstance(messages[protect], dict) and messages[protect].get("role") == "system":
+        protect += 1
+    if protect < len(messages) and isinstance(messages[protect], dict) and messages[protect].get("role") == "user":
+        protect += 1
+    fields_omitted: list[str] = []
+    for key in ("reasoning_content", "content"):
+        if isinstance(out.get(key), str) and len(_json({**out, "messages": []})) > max_chars:
+            fields_omitted.append(key)
+            out[key] = _OMITTED
+    total = len(messages)
+    dropped_chars = 0
+    while messages and len(_json(out)) > max_chars:
+        victim = messages.pop(protect if len(messages) > protect else 0)
+        dropped_chars += len(_json(victim))
+    fit: dict[str, Any] = {"budget": max_chars, "total": total, "kept": len(messages), "dropped": total - len(messages)}
+    if dropped_chars:
+        fit["dropped_chars"] = dropped_chars
+    if fields_omitted:
+        fit["fields_omitted"] = fields_omitted
+    return out, fit
+
+
+def _fit_note(fit: dict[str, Any], unit: str) -> str:
+    """The label suffix that tells the model what was left out; empty when nothing was."""
+    parts = []
+    if fit["dropped"]:
+        parts.append(f"{fit['dropped']} of {fit['total']} {unit} omitted, oldest first, {fit.get('dropped_chars', 0)} chars")
+    if fit.get("fields_omitted"):
+        parts.append(", ".join(fit["fields_omitted"]) + " omitted")
+    return f" ({'; '.join(parts)})" if parts else ""
+
+
+def _build_prompt(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, Any]], journal: list[dict[str, Any]]) -> tuple[list[dict[str, str]], dict[str, Any]]:
+    """The reflector prompt plus an ``input_fit`` record of what each section kept and dropped (#1314).
+
+    Every section is complete JSON: inputs are bounded before serialization,
+    and a section that lost content says so on its label line. The fit
+    record is journaled with the reflection so an audit can answer "did this
+    prompt lose content" from the row alone.
+    """
     system = (
         "Analyze every message, skill, command, tool call/result, error, retry, and detour in this completed cycle. "
         "Return ONLY strict JSON with keys cycle_id, summary, findings, recommendations, followed_previous, and optional mermaid. "
@@ -279,12 +384,32 @@ def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, 
         "Each finding has kind/detail; each recommendation has kind/detail/evidence; return at most three recommendations. "
         "Recommendations are steering only: do not edit files, invent evidence, or claim scorecard value."
     )
-    user = (
-        f"CYCLE_ID: {cycle_id}\nTRANSCRIPT:\n{json.dumps(transcript, ensure_ascii=False)[:_MAX_TRANSCRIPT_CHARS]}\n"
-        f"LEDGER:\n{json.dumps(ledger, ensure_ascii=False)[:_MAX_LEDGER_CHARS]}\n"
-        f"PRIOR REFLECTIONS:\n{json.dumps(journal, ensure_ascii=False)[:_MAX_JOURNAL_CHARS]}"
-    )
-    return [{"role": "system", "content": system}, {"role": "user", "content": user}]
+    transcript_kept, transcript_fit = _fit_transcript(transcript, _MAX_TRANSCRIPT_CHARS)
+    protect = 1 if ledger and isinstance(ledger[0], dict) and ledger[0].get("phase") == "proposed" else 0
+    ledger_kept, ledger_fit = _fit_rows(ledger, _MAX_LEDGER_CHARS, protect_head=protect)
+    journal_kept, journal_fit = _fit_rows(journal, _MAX_JOURNAL_CHARS)
+    sections = []
+    for label, value, fit, unit in (
+        ("TRANSCRIPT", transcript_kept, transcript_fit, "messages"),
+        ("LEDGER", ledger_kept, ledger_fit, "rows"),
+        ("PRIOR REFLECTIONS", journal_kept, journal_fit, "entries"),
+    ):
+        body = _json(value)
+        fit["chars"] = len(body)
+        sections.append(f"{label}{_fit_note(fit, unit)}:\n{body}")
+    truncated = any(fit["dropped"] or fit.get("fields_omitted") for fit in (transcript_fit, ledger_fit, journal_fit))
+    input_fit = {
+        "status": "truncated" if truncated else "complete",
+        "transcript": transcript_fit,
+        "ledger": ledger_fit,
+        "journal": journal_fit,
+    }
+    user = f"CYCLE_ID: {cycle_id}\n" + "\n".join(sections)
+    return [{"role": "system", "content": system}, {"role": "user", "content": user}], input_fit
+
+
+def _messages(cycle_id: str, transcript: dict[str, Any], ledger: list[dict[str, Any]], journal: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return _build_prompt(cycle_id, transcript, ledger, journal)[0]
 
 
 def _parse_output(value: Any, cycle_id: str) -> tuple[dict[str, Any] | None, str]:
@@ -403,6 +528,7 @@ def run_reflector(
         "skipped_pruned": 0,
         "errors": 0,
         "consecutive_errors": 0,
+        "input_truncated": 0,
     }
     skipped_ids = {
         str(row.get("cycle_id") or "")
@@ -438,8 +564,11 @@ def run_reflector(
             context_rows.insert(0, proposed[cycle_id])
         response: Any = None
         parse_reason = "not_attempted"
+        input_fit: dict[str, Any] = {}
         try:
-            messages = _messages(cycle_id, transcript, context_rows, _journal_tail(state_dir))
+            messages, input_fit = _build_prompt(cycle_id, transcript, context_rows, _journal_tail(state_dir))
+            if input_fit["status"] != "complete":
+                result["input_truncated"] += 1
             model = resolve_model("reflector", strip_openai=True)
             response = llm(messages, model) if llm else _default_llm(messages, model, cycle_id)
             parsed, parse_reason = _parse_output(response, cycle_id)
@@ -449,6 +578,7 @@ def run_reflector(
                 **parsed,
                 "timestamp": _now(),
                 **({"parse_reason": parse_reason} if parse_reason != "ok" else {}),
+                "input_fit": input_fit,
             })
             _save_watermark(state_dir, cycle_id)
             result["processed"] += 1
@@ -468,6 +598,7 @@ def run_reflector(
                 "parse_reason": parse_reason,
                 "response_chars": len(_resp_str),
                 "response_tail": "".join(ch for ch in _resp_str[-80:] if ch >= " " or ch in "\t\n\r"),
+                **({"input_fit": input_fit} if input_fit else {}),
             }
             _append_journal(state_dir, _err_row)
             result["errors"] += 1

--- a/tests/test_reflector_input_fit.py
+++ b/tests/test_reflector_input_fit.py
@@ -1,0 +1,174 @@
+"""#1314: the reflector bounds its three prompt inputs structurally, never by slicing JSON text."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from nanobot.observability import llm_telemetry
+from nanobot.runtime import reflector
+
+_SECTION_RE = re.compile(
+    r"\ATRANSCRIPT[^\n]*:\n(?P<transcript>.*)\nLEDGER[^\n]*:\n(?P<ledger>.*)\nPRIOR REFLECTIONS[^\n]*:\n(?P<journal>.*)\Z",
+    re.DOTALL,
+)
+
+
+def _sections(messages: list[dict[str, str]]) -> dict[str, str]:
+    """Split the user message into its three sections by label, tolerant of a note on the label line."""
+    user = messages[1]["content"]
+    header, _, body = user.partition("\n")
+    assert header == "CYCLE_ID: c1"
+    match = _SECTION_RE.match(body)
+    assert match, body[:200]
+    return match.groupdict()
+
+
+def _header_lines(messages: list[dict[str, str]]) -> list[str]:
+    return [line for line in messages[1]["content"].splitlines() if line.startswith(("TRANSCRIPT", "LEDGER", "PRIOR REFLECTIONS"))]
+
+
+def _record(turns: int, chars: int, *, content: str = "done") -> dict:
+    """A prompt record shaped like ``record_llm_prompt`` writes: system, task, then alternating turns."""
+    messages: list[dict] = [
+        {"role": "system", "content": "You are the executor."},
+        {"role": "user", "content": "Task: fix the thing."},
+    ]
+    for index in range(turns):
+        role = "assistant" if index % 2 == 0 else "tool"
+        messages.append({"role": role, "content": f"turn-{index:03d} " + ("x" * chars)})
+    return {"ts": "2026-08-26T00:00:00Z", "cycle_id": "c1", "seq": 3, "messages": messages, "content": content, "reasoning_content": None, "truncated": False}
+
+
+def _ledger(rows: int, chars: int) -> list[dict]:
+    body = [{"phase": "proposed", "cycle_id": "c1", "task_title": "Do work", "ts": "2026-08-26T00:00:00Z"}]
+    for index in range(rows):
+        body.append({"phase": f"step-{index:03d}", "cycle_id": "c1", "ts": f"2026-08-26T00:{index:02d}:00Z", "detail": "y" * chars})
+    body.append({"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": "2026-08-26T01:00:00Z"})
+    return body
+
+
+def _journal(rows: int, chars: int) -> list[dict]:
+    return [{"cycle_id": f"old-{index:03d}", "timestamp": f"2026-08-{index + 1:02d}T00:00:00Z", "summary": "z" * chars, "findings": [], "recommendations": []} for index in range(rows)]
+
+
+def test_transcript_over_budget_is_bounded_by_whole_messages():
+    record = _record(turns=60, chars=1_000)  # ~61K chars, well over the recorder-sized budget
+    assert len(json.dumps(record, ensure_ascii=False)) > reflector._MAX_TRANSCRIPT_CHARS
+    messages = reflector._messages("c1", record, _ledger(2, 10), [])
+    section = _sections(messages)["transcript"]
+    parsed = json.loads(section)  # the whole point: the section must be JSON
+    assert len(section) <= reflector._MAX_TRANSCRIPT_CHARS
+    kept = parsed["messages"]
+    assert kept[0]["role"] == "system" and kept[1]["content"] == "Task: fix the thing."  # protected head
+    assert kept[-1]["content"].startswith("turn-059")  # newest turn survives; oldest turns were dropped
+    assert 2 < len(kept) < 62
+    assert parsed["content"] == "done"
+    header = _header_lines(messages)[0]
+    assert header.startswith("TRANSCRIPT (") and "messages omitted" in header and header.endswith(":")
+
+
+def test_transcript_fields_are_replaced_not_sliced_when_messages_alone_cannot_fit():
+    record = _record(turns=2, chars=10, content="c" * 60_000)
+    messages = reflector._messages("c1", record, _ledger(1, 10), [])
+    parsed = json.loads(_sections(messages)["transcript"])
+    assert parsed["content"] == reflector._OMITTED
+    assert parsed["messages"], "small messages are kept once the oversized field is gone"
+    assert "content omitted" in _header_lines(messages)[0]
+
+
+def test_ledger_over_budget_keeps_proposed_and_outcome_rows():
+    ledger = _ledger(rows=40, chars=500)  # ~21K chars against 12K
+    messages = reflector._messages("c1", _record(1, 10), ledger, [])
+    parsed = json.loads(_sections(messages)["ledger"])
+    assert parsed[0]["phase"] == "proposed"
+    assert parsed[-1]["phase"] == "outcome"
+    assert 2 < len(parsed) < len(ledger)
+    dropped = [row["phase"] for row in ledger if row not in parsed]
+    assert dropped == sorted(dropped) and dropped[0] == "step-000"  # oldest first
+    assert "rows omitted" in _header_lines(messages)[1]
+
+
+def test_journal_over_budget_keeps_newest_entries():
+    journal = _journal(rows=10, chars=4_000)  # ~40K chars against 30K
+    messages = reflector._messages("c1", _record(1, 10), _ledger(1, 10), journal)
+    parsed = json.loads(_sections(messages)["journal"])
+    assert parsed[-1]["cycle_id"] == "old-009"
+    assert parsed[0]["cycle_id"] != "old-000"
+    assert 0 < len(parsed) < 10
+    assert "entries omitted" in _header_lines(messages)[2]
+
+
+def test_inputs_under_budget_are_untouched_and_headers_are_bare():
+    record, ledger, journal = _record(3, 50), _ledger(3, 50), _journal(3, 50)
+    messages, fit = reflector._build_prompt("c1", record, ledger, journal)
+    sections = _sections(messages)
+    assert json.loads(sections["transcript"]) == record
+    assert json.loads(sections["ledger"]) == ledger
+    assert json.loads(sections["journal"]) == journal
+    assert _header_lines(messages) == ["TRANSCRIPT:", "LEDGER:", "PRIOR REFLECTIONS:"]
+    assert fit["status"] == "complete"
+    assert all(fit[key]["dropped"] == 0 and fit[key]["chars"] <= fit[key]["budget"] for key in ("transcript", "ledger", "journal"))
+
+
+def test_budgets_are_derived_from_measured_inputs():
+    # The recorder already caps a prompt record at 32 KiB (#1039); anything above that is unreachable.
+    assert reflector._MAX_TRANSCRIPT_CHARS == llm_telemetry.MAX_LLM_PROMPT_PAYLOAD_BYTES
+    # Ten journal rows at the observed p95 row size (2,896 chars on 2026-09-05) must fit whole.
+    assert reflector._MAX_JOURNAL_CHARS >= reflector._JOURNAL_TAIL * 2_900
+    assert reflector._MAX_LEDGER_CHARS == 12_000
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _seed_oversized_ledger(state: Path) -> None:
+    rows = [{"phase": "proposed", "cycle_id": "c1", "task_title": "Do work"}]
+    rows += [{"phase": f"step-{index}", "cycle_id": "c1", "detail": "y" * 900} for index in range(20)]
+    rows.append({"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": "2026-08-26T00:00:00Z"})
+    _write(state / "ledger/cycles.jsonl", rows)
+    _write(state / "llm_calls/prompts/2026-08-26.jsonl", [{"cycle_id": "c1", "seq": 1, "messages": [{"role": "user", "content": "task"}]}])
+
+
+def _answer() -> str:
+    return json.dumps({"cycle_id": "c1", "summary": "good", "findings": [], "recommendations": [], "followed_previous": []})
+
+
+def test_truncation_is_journaled_on_the_success_row(tmp_path: Path):
+    _seed_oversized_ledger(tmp_path)
+    seen: list[list[dict[str, str]]] = []
+
+    def llm(messages, model):
+        seen.append(messages)
+        return _answer()
+
+    result = reflector.run_reflector(tmp_path, llm=llm)
+    assert result["processed"] == 1 and result["input_truncated"] == 1
+    json.loads(_sections(seen[0])["ledger"])
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    fit = row["input_fit"]
+    assert fit["status"] == "truncated"
+    # 23, not 22: run_reflector re-inserts the proposed row at index 0 on top of the cycle's own rows (pre-existing).
+    assert fit["ledger"]["dropped"] >= 1 and fit["ledger"]["dropped_chars"] > 0 and fit["ledger"]["total"] == 23
+    assert fit["transcript"]["dropped"] == 0 and fit["journal"]["dropped"] == 0
+
+
+def test_truncation_is_journaled_on_the_error_row_too(tmp_path: Path):
+    _seed_oversized_ledger(tmp_path)
+    result = reflector.run_reflector(tmp_path, llm=lambda *_: "not json")
+    assert result["errors"] == 1 and result["input_truncated"] == 1
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    assert row["status"] == "error"
+    assert row["input_fit"]["status"] == "truncated" and row["input_fit"]["ledger"]["dropped"] >= 1
+
+
+def test_complete_fit_is_recorded_so_absence_is_distinguishable(tmp_path: Path):
+    _write(tmp_path / "ledger/cycles.jsonl", [{"phase": "outcome", "cycle_id": "c1", "outcome": "success", "ts": "2026-08-26T00:00:00Z"}])
+    _write(tmp_path / "llm_calls/prompts/2026-08-26.jsonl", [{"cycle_id": "c1", "seq": 1, "messages": [{"role": "user", "content": "task"}]}])
+    result = reflector.run_reflector(tmp_path, llm=lambda *_: _answer())
+    assert result["processed"] == 1 and result["input_truncated"] == 0
+    row = json.loads((tmp_path / "reflector/reflections.jsonl").read_text().splitlines()[0])
+    assert row["input_fit"]["status"] == "complete"
+    assert set(row["input_fit"]) == {"status", "transcript", "ledger", "journal"}

--- a/tests/test_reflector_input_fit.py
+++ b/tests/test_reflector_input_fit.py
@@ -77,6 +77,20 @@ def test_transcript_fields_are_replaced_not_sliced_when_messages_alone_cannot_fi
     assert "content omitted" in _header_lines(messages)[0]
 
 
+def test_recorder_truncated_record_is_reported_as_lost_content():
+    """A record the recorder already cut (#1039) fits and drops nothing here, but the prompt did lose content."""
+    record = _record(turns=2, chars=10)
+    record["messages"] = [{"role": "info", "content": "…[payload truncated to fit 32KB budget]"}]
+    record["truncated"] = True
+    messages, fit = reflector._build_prompt("c1", record, _ledger(1, 10), [])
+    assert json.loads(_sections(messages)["transcript"]) == record
+    assert fit["status"] == "truncated"
+    assert fit["transcript"]["recorder_truncated"] is True and fit["transcript"]["dropped"] == 0
+    assert "prompt recorder" in _header_lines(messages)[0]
+    _, fit = reflector._build_prompt("c1", _record(turns=2, chars=10), _ledger(1, 10), [])
+    assert fit["status"] == "complete" and "recorder_truncated" not in fit["transcript"]
+
+
 def test_ledger_over_budget_keeps_proposed_and_outcome_rows():
     ledger = _ledger(rows=40, chars=500)  # ~21K chars against 12K
     messages = reflector._messages("c1", _record(1, 10), ledger, [])


### PR DESCRIPTION
Closes #1314.

## The measurement first: one of the three caps is being crossed today

Read-only on the host as `eeepc-agent` (2026-09-05, release `632bffbb` state), serializing exactly as `_messages` did (`json.dumps(value, ensure_ascii=False)`):

| input | what reaches the model | observed | old cap | crossed? |
|---|---|---|---|---|
| transcript | latest `llm_calls/prompts` record of the cycle | max 32,652 (443 records, p50 4,370; 54 messages max; largest single message 17,043) | 48,000 | never — and it cannot: the recorder caps a record at 32 KiB (`MAX_LLM_PROMPT_PAYLOAD_BYTES`, #1039) |
| ledger | the cycle's rows, proposed row first | max 3,059 chars / 12 rows over the last 60 cycles; largest row 1,278 (`system_prompt`) | 12,000 | never |
| journal | last 10 reflection rows across archives + live | **today's tail 16,319**; rows p50 266 / p95 2,896 / max 3,690; **349 of 1,031 ten-row windows exceed 12,000**, max window 25,989 | 12,000 | **yes, every run** |

#1305 measured the journal tail at 11,293 on 2026-09-04 and called it under budget. One day of appended rows moved the same window over the cap. Run over today's real inputs (fetched read-only, evaluated locally) the old slice fails on the PRIOR REFLECTIONS section for every cycle:

```
old journal:    len=16319 cap=12000 -> TORN (Unterminated string starting at at char 11481)
```

**This is a live-defect fix, not a hardening.** The `PRIOR REFLECTIONS` section has been arriving as broken JSON on roughly a third of reflector runs (349 of 1,031 ten-row windows; every run today), stopping mid-string with no marker, while the model is asked to fill `followed_previous` from it. Everything built on those reflections — the demand items, the curator's reflector-derived lessons, the `AGENTS.md` additions #1313 is about — degraded silently. #1305's "0 of 96" answered a narrower question: it sampled candidate prompt records, and the journal tail is assembled separately in `_journal_tail`, so it never entered that sample. The issue text has been corrected accordingly.

**And the transcript cap was dead code, not headroom.** `record_llm_prompt` caps every record at 32 KiB upstream (`_cap_payload_record`, #1039) before it is written, so no record the reflector can read was ever within 15,000 chars of the 48,000 slice. The three largest records on the host (32,652 / 32,631 / 32,461) are the recorder's cap showing through, not the transcripts' natural size.

## What changes (`nanobot/runtime/reflector.py`)

Every input is bounded **before** serialization, so the document is always JSON; a section that lost content says so on its label line, and every journal row records what happened.

- `_fit_rows(rows, max_chars, protect_head)` drops whole rows oldest-first after a protected head; the head goes last, so a section can be emptied but never torn. Ledger: protected head is the `proposed` row, so the outcome row survives longest. Journal: plain oldest-first, the newest reflections (the recommendations the model is asked to check) survive.
- `_fit_transcript(record, max_chars)` drops whole executor turns oldest-first, protecting leading `system` messages and the first `user` message (the task). `reasoning_content` / `content` are replaced whole by `_OMITTED` only when the record cannot fit even with zero turns — dropping turns could never rescue such a record, so the field goes and the turns stay.
- `_build_prompt(...) -> (messages, input_fit)` assembles the prompt; labels become e.g. `LEDGER (14 of 23 rows omitted, oldest first, 12684 chars):` when something was dropped, and stay bare (`LEDGER:`) otherwise, so the model knows where the record is incomplete. `_messages` is kept as a thin wrapper for compatibility.
- `run_reflector` journals `input_fit` on **every** reflection row, success and error: `{"status": "complete"|"truncated", "transcript": {budget, total, kept, dropped, chars[, dropped_chars][, fields_omitted][, recorder_truncated]}, "ledger": {...}, "journal": {...}}`, and counts `input_truncated` in the run result. Recorded when complete too, so a row without the key is a row from before this change, not a row that happened not to drop.
- **Upstream truncation is carried through (review finding).** A record the recorder already cut to 32 KiB arrives with `truncated: true`, field values shortened in place — in the worst case the whole message list replaced by `…[payload truncated to fit 32KB budget]`. Such a record fits the budget and drops nothing here, but the prompt *has* lost content. `_fit_transcript` now copies that flag into `transcript_fit.recorder_truncated`, it flips `input_fit.status` to `truncated`, and the label line says `record already shortened by the prompt recorder's 32 KiB cap`. Without this, the row this PR exists for would answer "no" to "did this prompt lose content" exactly on the long cycles where the answer is "yes".

### Budgets, chosen per input against the table above

- **transcript = `MAX_LLM_PROMPT_PAYLOAD_BYTES` (32,768)**. The recorder already caps a record at 32 KiB, so the reflector can never be handed more; 48,000 was dead code. Pinning to the recorder's constant means the message drop acts only if the two caps ever diverge, and `input_fit.transcript.dropped` will say so. The largest record today (32,652 chars) fits whole with 116 to spare; chars ≤ bytes, so a record under the recorder cap always fits.
- **ledger = 12,000**, kept but now derived: ~4× the largest cycle observed (3,059) and nine rows of the largest shape (1,278). Row types were added by #1302 and #1303 this week and #1313 proposes another; the headroom is for that, and the fit makes the cap safe rather than fatal.
- **journal = 30,000** = `_JOURNAL_TAIL` (10) × 3,000, the observed p95 row (2,896) rounded up. Covers every ten-row window observed on the host (max 25,989); ten rows at the maximum observed size (3,690) would drop two, visibly. This is the one budget that changes behaviour, so the rejected arm is recorded here: **keep 12,000 and drop whole entries**, which the new mechanism makes free and labelled. Rejected because it would hand the model 5–7 of the 10 reflections on every run — today's tail would lose 3 — while `_JOURNAL_TAIL = 10` is the declared window `followed_previous` is checked against; dropping a third of it permanently would be #1183's promotion blind-spot in a smaller form (a declared window that the code quietly reads narrower). Cost of raising: +18,000 chars (~4.5k tokens) per reflector call at 9–13 cycles/hour on `cl/gemini-3.5-flash-low`, whose context is not the constraint. If the cost is the wrong side of the trade, the right lever is `_JOURNAL_TAIL`, not a silent char cap: shrink the window explicitly and the budget follows as 10 × 3,000 → N × 3,000.

### `_MAX_JOURNAL_BYTES` vs the prompt slice — settled

`_MAX_JOURNAL_BYTES = 512 KiB` bounds only the live **file**. `_journal_tail` reads `iter_reflection_rows`, which spans the newest two archives plus the live file, so rotation does not change the ten rows the model sees at all. What reaches the model is bounded by `_JOURNAL_TAIL = 10` rows, then by `_MAX_JOURNAL_CHARS`. Today the char cap was the active bound and it tore; after this PR the row count is the active bound and the char cap is a whole-entry guard. Stated in the constants comment.

## Tests (`tests/test_reflector_input_fit.py`, 10) — all fail on `main`, verified

Run against the unmodified module before the fix (log kept): the four structural tests die in `json.loads` on the emitted section —

```
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 47215 (char 47214)   # transcript
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 11878 (char 11877)   # ledger
json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 8306 (char 8305)     # journal
```

the rest with `AttributeError: _build_prompt`, `assert 48000 == 32768`, `KeyError: 'input_truncated'`. After the fix: 9 passed.

- transcript over budget → section parses, system + task message kept, newest turn kept, label says `N of M messages omitted`
- oversized `content` field → replaced whole, small messages kept, label says `content omitted`
- recorder-truncated record (`truncated: true`, marker message) → passes through byte-identical, `status: truncated`, `recorder_truncated: true`, `dropped: 0`, label names the recorder; an untruncated twin stays `complete` without the key
- ledger over budget → parses, `proposed` first and `outcome` last, drops oldest-first
- journal over budget → parses, newest entries kept
- under budget → all three sections byte-identical to the inputs, bare labels, `input_fit.status == "complete"`
- budgets pinned: transcript == recorder cap, journal ≥ 10 × 2,900, ledger 12,000
- `run_reflector`: `input_fit` on the success row and on the error row; `input_truncated` counted; complete fit recorded so absence is distinguishable

`tests/test_reflector.py` unchanged, 29 green. Ruff clean.

Full Windows suite at `2fcd07ca` (on `52267426`):

```
4 failed, 3106 passed, 17 skipped, 11 warnings in 1553.39s (0:25:53)
FAILED tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock
```

Exactly the four Windows-baseline failures, matched by name, not by count.

## Real-input check

Today's newest reflected cycle and the largest retained record, fetched read-only and run through `_build_prompt` locally: all three sections parse, `input_fit.status == "complete"`, nothing dropped (journal 16,319 of 30,000; transcript 32,652 of 32,768; ledger 3,567 of 12,000). The same inputs through the old slice tear the journal at char 11,481.

## Not done, on purpose

- **The duplicated `proposed` row.** `run_reflector` filters the cycle's rows (which already include `proposed`) and then inserts the `proposed` row again at index 0, so the ledger section carries it twice (`total: 23` in the test for 22 rows). Pre-existing, ≤692 chars, not this issue's mechanism; noted, not changed.
- **Projecting journal rows for the model.** `parse_reason`, `response_head`, and now `input_fit` ride along in PRIOR REFLECTIONS. Stripping telemetry keys from the model-facing tail would change what the model sees beyond the ask; left as is, ~220 chars per row.
- **Reflector telemetry blindness** (no `component: reflector` rows since 2026-07-07): separate defect, untouched; verification here used the journal rows, not `llm_calls`.
- `nanobot/agent/context.py` and the AGENTS.md write path: untouched (pi-1 on #1313).

## Live check owed after deploy

First reflector run: every new row in `state/reflector/reflections.jsonl` carries `input_fit`; expected `status: complete` with `journal.chars` in the 15–20K range. A `truncated` row names the section and count; the label line in the prompt dump says the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
