### PR TITLE
fix(dashboard): retire writerless artifact readers

### DIFF
--- a/nanobot/runtime/state_paths.py
+++ b/nanobot/runtime/state_paths.py
@@ -48,8 +48,8 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
     # control_plane/ and self_evolution/ lost their autoevolve reader (#1224).
     # evolution reports froze with the coordinator, but dashboard/preflight
     # readers survived: #1312 retires them explicitly, not as healthy emptiness.
-    # This orphan names evolution-*.json only; external proof reports stay live.
-    "reports": ("orphan:#1312",),
+    # Their final artifact readers were removed by #1312. No orphan is carried;
+    # reports stays outside this registry (external proof reports remain live).
     "curator": (
         "nanobot.runtime.knowledge_curator:_write_decision",
         "nanobot.runtime.knowledge_curator:_stage_promotions",
@@ -85,7 +85,7 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
         "nanobot.runtime.hypothesis_backlog:append_hypotheses",
     ),
     # llm-proposed requests remain live; materialized-cycle evidence is retired.
-    "improvements": ("nanobot.runtime.llm_proposer:write_request", "orphan:#1312"),
+    "improvements": ("nanobot.runtime.llm_proposer:write_request",),
     "ledger": ("nanobot.runtime.cycle_ledger:append_event",),
     "llm_calls": (
         "nanobot.observability.llm_telemetry:record_llm_call",
@@ -121,5 +121,5 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
 # Every ``orphan:#N`` reference must name an issue listed here, with the
 # one-line reason the orphan is being carried rather than fixed in place.
 ORPHAN_ISSUES: dict[str, str] = {
-    "#1312": "Materialized-cycle and evolution writers are retired; dashboard and preflight retain explicit retired labels, not artifact reads.",
+    # Empty: #1312 removes the artifact readers, rather than carrying orphans.
 }

--- a/nanobot/runtime/state_paths.py
+++ b/nanobot/runtime/state_paths.py
@@ -45,11 +45,11 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
     ),
     # apply.ok is written by the operator (runbook), read by the bridge gate.
     "approvals": ("repo:docs/EEEPC_APPLY_OK_OPERATOR_RUNBOOK.md",),
-    # control_plane/, reports/ and self_evolution/ left this registry with their
-    # last reader, autoevolve (#1224): current_summary.json and evolution-*.json
-    # froze 2026-08-21/22 with the deleted coordinator, self_evolution/ was
-    # never written on the host. proof-*.json in reports/ is live but written
-    # and read outside nanobot/.
+    # control_plane/ and self_evolution/ lost their autoevolve reader (#1224).
+    # evolution reports froze with the coordinator, but dashboard/preflight
+    # readers survived: #1312 retires them explicitly, not as healthy emptiness.
+    # This orphan names evolution-*.json only; external proof reports stay live.
+    "reports": ("orphan:#1312",),
     "curator": (
         "nanobot.runtime.knowledge_curator:_write_decision",
         "nanobot.runtime.knowledge_curator:_stage_promotions",
@@ -84,7 +84,8 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
         "nanobot.runtime.hypothesis_backlog:_save_lifecycle",
         "nanobot.runtime.hypothesis_backlog:append_hypotheses",
     ),
-    "improvements": ("nanobot.runtime.llm_proposer:write_request",),
+    # llm-proposed requests remain live; materialized-cycle evidence is retired.
+    "improvements": ("nanobot.runtime.llm_proposer:write_request", "orphan:#1312"),
     "ledger": ("nanobot.runtime.cycle_ledger:append_event",),
     "llm_calls": (
         "nanobot.observability.llm_telemetry:record_llm_call",
@@ -120,7 +121,5 @@ STATE_PATH_WRITERS: dict[str, tuple[str, ...]] = {
 # Every ``orphan:#N`` reference must name an issue listed here, with the
 # one-line reason the orphan is being carried rather than fixed in place.
 ORPHAN_ISSUES: dict[str, str] = {
-    # Empty since #1225 retired the last orphaned read (goals/cycle_archive.json,
-    # the #877 line-switch trigger). Add an entry here only together with an
-    # ``orphan:#N`` marker above, and remove both in the same change.
+    "#1312": "Materialized-cycle and evolution writers are retired; dashboard and preflight retain explicit retired labels, not artifact reads.",
 }

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -13,7 +13,6 @@ labelled stale or unavailable rather than reported as healthy current state.
 
 from __future__ import annotations
 
-import heapq
 import html
 import http.server
 import json
@@ -326,118 +325,17 @@ def latest_file(directory: Path, pattern: str) -> Path | None:
 
 
 def scan_report_artifacts(limit: int = 5) -> tuple[Path | None, dict[str, Any], list[tuple[str, float]]]:
-    """Scan report artifacts once and reuse the result for latest-report and trend views.
+    """Retired evolution reports (#1312); public fields label this unavailable.
 
-    Uses directory-mtime-based caching to avoid re-scanning 8000+ report files
-    on every call.  Cache is invalidated when the reports directory changes
-    or after REPORT_SCAN_CACHE_TTL_SECONDS.
+    Keep the adapter signature for callers, but never scan frozen files or
+    return previously cached rewards as evidence from a live writer.
     """
-    now = time.monotonic()
-    cached_limit = _REPORT_SCAN_CACHE.get("limit")
-    cached_root_mtime_ns = _REPORT_SCAN_CACHE.get("root_mtime_ns")
-    cached_result = _REPORT_SCAN_CACHE.get("result")
-    loaded_at = float(_REPORT_SCAN_CACHE.get("loaded_at", 0.0) or 0.0)
-    try:
-        root_mtime_ns = REPORTS_DIR.stat().st_mtime_ns if REPORTS_DIR.exists() else None
-    except Exception:
-        root_mtime_ns = None
-    if (
-        cached_result is not None
-        and cached_limit == limit
-        and cached_root_mtime_ns == root_mtime_ns
-        and now - loaded_at < REPORT_SCAN_CACHE_TTL_SECONDS
-    ):
-        return cached_result
-
-    latest_path: Path | None = None
-    latest_mtime = -1.0
-    recent_heap: list[tuple[float, Path]] = []
-
-    try:
-        for path in REPORTS_DIR.glob("evolution-*.json"):
-            mtime = path.stat().st_mtime
-            if mtime > latest_mtime:
-                latest_mtime = mtime
-                latest_path = path
-            item = (mtime, path)
-            if len(recent_heap) < limit:
-                heapq.heappush(recent_heap, item)
-            else:
-                heapq.heappushpop(recent_heap, item)
-    except Exception:
-        result = (None, {}, [])
-        _REPORT_SCAN_CACHE.update({"loaded_at": now, "limit": limit, "root_mtime_ns": root_mtime_ns, "result": result})
-        return result
-
-    if latest_path is None:
-        result = (None, {}, [])
-        _REPORT_SCAN_CACHE.update({"loaded_at": now, "limit": limit, "root_mtime_ns": root_mtime_ns, "result": result})
-        return result
-
-    latest_report: dict[str, Any] = {}
-    recent_rewards: list[tuple[str, float]] = []
-    for _, report in sorted(recent_heap, reverse=True):
-        data = load_json(report, {})
-        reward = data.get("reward_signal", {}).get("value")
-        if isinstance(reward, (int, float)):
-            recent_rewards.append((data.get("cycle_id", report.stem), float(reward)))
-        if report == latest_path:
-            latest_report = data
-
-    if not latest_report:
-        latest_report = load_json(latest_path, {})
-    result = (latest_path, latest_report, recent_rewards)
-    _REPORT_SCAN_CACHE.update({"loaded_at": now, "limit": limit, "root_mtime_ns": root_mtime_ns, "result": result})
-    return result
+    return None, {}, []
 
 
 def scan_all_report_rewards(limit: int = 200) -> list[tuple[str, float, str]]:
-    """Scan report artifacts and return (cycle_id, reward, result_status) tuples.
-
-    Uses a limit to avoid scanning 8000+ files on the weak host.  Defaults to
-    the 200 most recent reports by mtime, which covers the last ~200 cycles.
-
-    Uses directory-mtime-based caching to avoid re-scanning 8000+ report files
-    on every call.  Cache is invalidated when the reports directory changes
-    or after REPORT_SCAN_CACHE_TTL_SECONDS.
-    """
-    now = time.monotonic()
-    cached_limit = _MATERIALIZED_CACHE.get("limit")
-    cached_root_mtime_ns = _MATERIALIZED_CACHE.get("root_mtime_ns")
-    cached_result = _MATERIALIZED_CACHE.get("result")
-    loaded_at = float(_MATERIALIZED_CACHE.get("loaded_at", 0.0) or 0.0)
-    try:
-        root_mtime_ns = REPORTS_DIR.stat().st_mtime_ns if REPORTS_DIR.exists() else None
-    except Exception:
-        root_mtime_ns = None
-    if (
-        cached_result is not None
-        and cached_limit == limit
-        and cached_root_mtime_ns == root_mtime_ns
-        and now - loaded_at < REPORT_SCAN_CACHE_TTL_SECONDS
-    ):
-        return cached_result
-
-    rewards: list[tuple[str, float, str]] = []
-    try:
-        # Use heapq.nlargest for O(n log k) instead of sorted() O(n log n)
-        # when only the newest *limit* reports are needed from 8000+ files.
-        paths = heapq.nlargest(
-            limit,
-            REPORTS_DIR.glob("evolution-*.json"),
-            key=lambda p: p.stat().st_mtime,
-        )
-        for path in paths:
-            data = load_json(path, {})
-            reward = data.get("reward_signal", {}).get("value")
-            if isinstance(reward, (int, float)):
-                cycle_id = data.get("cycle_id", path.stem)
-                result_status = data.get("reward_signal", {}).get("result_status", "unknown")
-                rewards.append((str(cycle_id), float(reward), str(result_status)))
-    except Exception:
-        pass
-    _MATERIALIZED_CACHE.update({"loaded_at": now, "limit": limit, "root_mtime_ns": root_mtime_ns, "result": rewards})
-    return rewards
+    """No reward rows: the evolution report writer is retired (#1312)."""
+    return []
 
 
 def bounded_reward_export(rewards: list[tuple[str, float, str]], source: dict[str, Any]) -> list[tuple[str, float, str]]:
@@ -488,10 +386,8 @@ def render_top_cycles(rewards: list[tuple[str, float, str]], top_n: int = 5) -> 
 
 
 def load_latest_materialized() -> tuple[Path | None, dict[str, Any]]:
-    latest = latest_file(IMPROVEMENT_DIR, "materialized-cycle-*.json")
-    if not latest:
-        return None, {}
-    return latest, load_json(latest, {})
+    # Retired writer (#1312); llm-proposed requests are not approval evidence.
+    return None, {}
 
 
 def load_latest_report() -> tuple[Path | None, dict[str, Any]]:
@@ -1112,16 +1008,20 @@ def select_artifact_source(
     materialized: dict[str, Any],
     report_path: Path | None,
     report: dict[str, Any],
+    *, materialized_retired: bool = False, report_retired: bool = False,
 ) -> tuple[dict[str, Any], Path | None, str]:
-    """Select by source presence, preserving empty/malformed provenance.
+    """Exclude retired families first, then preserve live source provenance.
+
+    Age cannot revive a writerless family (#1312). Explicit retirement, not
+    truthiness or age, permits fallback; a malformed live source stays selected.
 
     A present materialized file is authoritative for source selection even when
     its decoded value is ``{}`` after a malformed or valid-empty read. Truthiness
     would silently substitute the report and erase that source state.
     """
-    if materialized_path is not None:
+    if materialized_path is not None and not materialized_retired:
         return materialized, materialized_path, "materialized"
-    if report_path is not None:
+    if report_path is not None and not report_retired:
         return report, report_path, "report"
     return {}, None, "none"
 
@@ -1370,14 +1270,10 @@ def collect_metrics_uncached() -> dict[str, Any]:
     health = load_json(STATE_DIR / "current_health.json", {})
     materialized_path, materialized = load_latest_materialized()
     latest_report_path, latest_report, recent_rewards = scan_report_artifacts()
-    report_source_status = source_status_for_artifact(
-        latest_report_path, REPORTS_DIR, "evolution-*.json"
-    )
-    materialized_source_status = source_status_for_artifact(
-        materialized_path, IMPROVEMENT_DIR, "materialized-cycle-*.json"
-    )
+    report_source_status = materialized_source_status = "retired"
     selected_source, selected_path, selected_kind = select_artifact_source(
-        materialized_path, materialized, latest_report_path, latest_report
+        materialized_path, materialized, latest_report_path, latest_report,
+        materialized_retired=True, report_retired=True,
     )
     selected_source_status = (
         materialized_source_status if selected_kind == "materialized" else report_source_status
@@ -1461,8 +1357,8 @@ def collect_metrics_uncached() -> dict[str, Any]:
     latest_report_age_hours = _report_age
 
     artifact_freshness = format_artifact_freshness(
-        format_file_recency(materialized_age_hours),
-        format_file_recency(latest_report_age_hours),
+        "retired (#1312)",
+        "retired (#1312)",
     )
 
     dashboard_summary = format_dashboard_summary({

--- a/scripts/eeebot_dashboard.py
+++ b/scripts/eeebot_dashboard.py
@@ -126,18 +126,6 @@ elif _SYSTEM_STATE_DIR.exists():
     STATE_DIR = _SYSTEM_STATE_DIR
 else:
     STATE_DIR = REPO_ROOT / "state"
-IMPROVEMENT_DIR = Path(
-    os.getenv(
-        "EEEBOT_IMPROVEMENTS_DIR",
-        "/var/lib/eeepc-agent/self-evolving-agent/state/improvements",
-    )
-)
-REPORTS_DIR = Path(
-    os.getenv(
-        "EEEBOT_REPORTS_DIR",
-        "/var/lib/eeepc-agent/self-evolving-agent/state/reports",
-    )
-)
 METRICS_CACHE_TTL_SECONDS = 3.0
 TREE_SCAN_CACHE_TTL_SECONDS = 3.0
 HOST_CAPS_CACHE_TTL_SECONDS = 30.0
@@ -1271,10 +1259,8 @@ def collect_metrics_uncached() -> dict[str, Any]:
     materialized_path, materialized = load_latest_materialized()
     latest_report_path, latest_report, recent_rewards = scan_report_artifacts()
     report_source_status = materialized_source_status = "retired"
-    selected_source, selected_path, selected_kind = select_artifact_source(
-        materialized_path, materialized, latest_report_path, latest_report,
-        materialized_retired=True, report_retired=True,
-    )
+    # Both families have no writer (#1312): no source selection is possible.
+    selected_source, selected_path, selected_kind = {}, None, "none"
     selected_source_status = (
         materialized_source_status if selected_kind == "materialized" else report_source_status
     )
@@ -2223,6 +2209,9 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
         .status-badge[data-status="offline"] {{ background: var(--state-offline); color: var(--state-offline-fg); }}
         /* context-only intentionally shares the offline palette: both convey non-authoritative state, distinguished by attributes */
         .status-badge[data-status="context-only"] {{ background: var(--state-offline); color: var(--state-offline-fg); }}
+        /* Retired intentionally shares the offline palette, but has a dashed
+           outline: remove the reader, rather than troubleshoot a live writer. */
+        .status-badge[data-status="retired"] {{ background: var(--state-offline); color: var(--state-offline-fg); outline: 1px dashed currentColor; }}
         .trend-badge.trend-good {{ background: var(--trend-good); color: var(--text); }}
         .trend-badge.trend-neutral {{ background: var(--trend-neutral); color: var(--text); }}
         .trend-badge.trend-bad {{ background: var(--trend-bad); color: var(--text); }}

--- a/scripts/eeepc_privileged_rollout_preflight.py
+++ b/scripts/eeepc_privileged_rollout_preflight.py
@@ -6,7 +6,6 @@ import json
 import shlex
 import subprocess
 import sys
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Sequence
@@ -129,25 +128,9 @@ def _effective_check(host: str, direct_command: str, sudo_command: str, *, sudo_
 
 
 def _read_latest_report(host: str, state_root: str, *, key: str | None = None, sudo_available: bool = False) -> tuple[str | None, dict[str, Any] | None, dict[str, Any] | None]:
-    reports_glob = f"{_quote(state_root)}/reports/evolution-*.json"
-    list_command = f"sh -lc {_quote(f'ls -1t {reports_glob} 2>/dev/null | head -n 1')}"
-    path_result = _ssh(host, _sudo(list_command) if sudo_available else list_command, key=key)
-    report_path = path_result["stdout"].splitlines()[0] if path_result["ok"] and path_result["stdout"] else None
-    if not report_path:
-        return None, None, path_result
-    cat_command = f"cat {_quote(report_path)}"
-    cat_result = _ssh(host, _sudo(cat_command) if sudo_available else cat_command, key=key)
-    if not cat_result["ok"]:
-        return report_path, None, cat_result
-    try:
-        payload = json.loads(cat_result["stdout"])
-        age_seconds = max(0.0, time.time() - float(cat_result.get("mtime", time.time())))
-        if isinstance(payload, dict):
-            payload["age_seconds"] = age_seconds
-            payload["stale"] = age_seconds > 86400
-        return report_path, payload, None
-    except json.JSONDecodeError as exc:
-        return report_path, None, {"ok": False, "message": str(exc), "stage": "parse_latest_report", "path": report_path}
+    # Coordinator evolution reports have no writer. Historical files are not
+    # rollout evidence; do not SSH or substitute a different report family.
+    return None, None, {"ok": False, "status": "retired", "issue": "#1312"}
 
 
 def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str | None = None, nanobot_path: str = DEFAULT_NANOBOT, opencode_home: str = DEFAULT_OPENCODE_HOME, self_evolving_base: str = DEFAULT_SELF_EVOLVING_BASE) -> dict[str, Any]:
@@ -205,17 +188,8 @@ def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str
         blockers.extend(self_evolving_release_venv.get("reasons") or ["self_evolving_release_venv"])
 
     report_path, report_payload, report_error = _read_latest_report(host, state_root, key=key, sudo_available=sudo_available)
-    latest_report = None
-    if report_payload:
-        latest_report = {
-            "path": report_path,
-            "result_status": report_payload.get("result_status") or report_payload.get("status"),
-            "goal_id": report_payload.get("goal_id") or ((report_payload.get("goal") or {}).get("goal_id") if isinstance(report_payload.get("goal"), dict) else None),
-            "feedback_decision_present": report_payload.get("feedback_decision") is not None,
-            "selected_tasks": report_payload.get("selected_tasks"),
-            "task_selection_source": report_payload.get("task_selection_source"),
-        }
-    checks["latest_readable_report"] = {"path": report_path, "ok": bool(report_payload), "error": report_error}
+    latest_report = {"status": "retired", "issue": "#1312"}
+    checks["latest_readable_report"] = {"path": None, "ok": False, "status": "retired", "error": report_error}
 
     state = "ready" if not blockers else ("partial_report_only" if latest_report else "blocked_privileged_access")
     if blockers:
@@ -228,7 +202,7 @@ def build_preflight(*, host: str, state_root: str = DEFAULT_STATE_ROOT, key: str
         "state": state,
         "ready": not blockers,
         "blocked_capabilities": sorted(set(blockers)),
-        "available_partial_proof": "latest_readable_report" if latest_report else None,
+        "available_partial_proof": None,
         "checks": checks,
         "latest_report": latest_report,
         "does_not_mutate_host": True,

--- a/scripts/verify_materialized_improvement.py
+++ b/scripts/verify_materialized_improvement.py
@@ -1,26 +1,16 @@
 #!/usr/bin/env python3
-"""Verify a materialized improvement artifact.
+"""Retired materialized-artifact verifier (#1312).
 
-This is a lightweight, dependency-free smoke checker for the self-evolving
-runtime. It validates the artifact shape, confirms the PASS result, and checks
-that the follow-up semantics are explicit enough for review.
+The writer is gone. Invocation reports retirement, never PASS or a missing-file
+failure that would generate defect demand. Pure historical shape helpers remain
+for compatibility; the entrypoint no longer reads any artifact.
 """
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 from typing import Any
-
-DEFAULT_ARTIFACT = Path(
-    "/var/lib/eeepc-agent/self-evolving-agent/state/improvements/materialized-cycle-43b67e3806de.json"
-)
-
-
-def load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
 
 def validate_artifact(data: dict[str, Any], source_path: Path) -> list[str]:
     errors: list[str] = []
@@ -120,9 +110,6 @@ def validate_artifact(data: dict[str, Any], source_path: Path) -> list[str]:
         elif derived_task_id != str(next_candidate.get("task_id", "")).strip():
             errors.append("derived_candidate.task_id must match next_bounded_candidate.task_id")
 
-    if not source_path.exists():
-        errors.append(f"artifact file does not exist: {source_path}")
-
     return errors
 
 
@@ -138,24 +125,7 @@ def summarize(data: dict[str, Any], source_path: Path) -> str:
 
 
 def main(argv: list[str]) -> int:
-    source_path = Path(argv[1]) if len(argv) > 1 else DEFAULT_ARTIFACT
-    try:
-        data = load_json(source_path)
-    except FileNotFoundError:
-        print(f"ERROR: artifact not found: {source_path}", file=sys.stderr)
-        return 2
-    except json.JSONDecodeError as exc:
-        print(f"ERROR: invalid JSON in {source_path}: {exc}", file=sys.stderr)
-        return 2
-
-    errors = validate_artifact(data, source_path)
-    if errors:
-        print(f"FAIL: {source_path}", file=sys.stderr)
-        for error in errors:
-            print(f" - {error}", file=sys.stderr)
-        return 1
-
-    print(summarize(data, source_path))
+    print("retired (#1312): materialized improvement writer removed; verification unavailable")
     return 0
 
 

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -344,8 +344,8 @@ def test_retired_artifact_families_never_scan_or_render_stale(monkeypatch, tmp_p
     def forbidden(*args, **kwargs):
         raise AssertionError("retired artifact reader accessed filesystem")
 
-    monkeypatch.setattr(DASHBOARD, "REPORTS_DIR", tmp_path)
-    monkeypatch.setattr(DASHBOARD, "IMPROVEMENT_DIR", tmp_path)
+    assert not hasattr(DASHBOARD, "REPORTS_DIR")
+    assert not hasattr(DASHBOARD, "IMPROVEMENT_DIR")
     monkeypatch.setattr(Path, "glob", forbidden)
     monkeypatch.setattr(DASHBOARD, "load_json", lambda *_args: {})
     monkeypatch.setattr(DASHBOARD, "load_host_capabilities", lambda: {})
@@ -357,6 +357,17 @@ def test_retired_artifact_families_never_scan_or_render_stale(monkeypatch, tmp_p
     assert metrics["materialized_source"]["status"] == "retired"
     assert metrics["reward_source"]["status"] == "retired"
     assert DASHBOARD.scan_all_report_rewards() == []
+
+
+def test_materialized_verifier_is_retired_without_reading(monkeypatch, capsys):
+    import runpy
+
+    module = runpy.run_path(str(Path(__file__).parents[1] / "scripts/verify_materialized_improvement.py"))
+    def forbidden(*args, **kwargs):
+        raise AssertionError("retired verifier read an artifact")
+    monkeypatch.setattr(Path, "read_text", forbidden)
+    assert module["main"](["verify_materialized_improvement.py"]) == 0
+    assert "retired (#1312)" in capsys.readouterr().out
 
 
 def test_source_selection_skips_retired_but_preserves_malformed_live():

--- a/tests/test_eeebot_dashboard_truth.py
+++ b/tests/test_eeebot_dashboard_truth.py
@@ -340,6 +340,36 @@ def test_html_context_keys_are_produced_by_metrics_builder(monkeypatch) -> None:
     assert indexed_keys <= produced.keys(), sorted(indexed_keys - produced.keys())
 
 
+def test_retired_artifact_families_never_scan_or_render_stale(monkeypatch, tmp_path):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("retired artifact reader accessed filesystem")
+
+    monkeypatch.setattr(DASHBOARD, "REPORTS_DIR", tmp_path)
+    monkeypatch.setattr(DASHBOARD, "IMPROVEMENT_DIR", tmp_path)
+    monkeypatch.setattr(Path, "glob", forbidden)
+    monkeypatch.setattr(DASHBOARD, "load_json", lambda *_args: {})
+    monkeypatch.setattr(DASHBOARD, "load_host_capabilities", lambda: {})
+    monkeypatch.setattr(DASHBOARD, "scan_subagent_tree_stats", lambda: (0, 0, None, 0, None))
+    metrics = DASHBOARD.collect_metrics_uncached()
+    for key in ("approval_gate_state", "materialized_status", "concrete_statement", "latest_report_status", "artifact_freshness"):
+        assert "retired" in metrics[key], (key, metrics[key])
+        assert "stale" not in metrics[key]
+    assert metrics["materialized_source"]["status"] == "retired"
+    assert metrics["reward_source"]["status"] == "retired"
+    assert DASHBOARD.scan_all_report_rewards() == []
+
+
+def test_source_selection_skips_retired_but_preserves_malformed_live():
+    materialized = Path("materialized.json")
+    report = Path("report.json")
+    assert DASHBOARD.select_artifact_source(
+        materialized, {}, report, {"id": "report"}, materialized_retired=True,
+    ) == ({"id": "report"}, report, "report")
+    assert DASHBOARD.select_artifact_source(
+        materialized, {}, report, {"id": "report"},
+    ) == ({}, materialized, "materialized")
+
+
 def test_fresh_report_status_is_still_bounded() -> None:
     metrics = _health_metrics(report_status="fresh", materialized_status="fresh")
     metrics.update({

--- a/tests/test_eeepc_privileged_rollout_preflight.py
+++ b/tests/test_eeepc_privileged_rollout_preflight.py
@@ -67,13 +67,9 @@ def test_preflight_reports_blocked_privileged_access_with_latest_readable_report
     assert payload['state'] == 'blocked_privileged_access'
     assert payload['ready'] is False
     assert payload['does_not_mutate_host'] is True
-    assert payload['available_partial_proof'] == 'latest_readable_report'
-    assert payload['latest_report']['path'] == latest_report
-    assert payload['latest_report']['result_status'] == 'PASS'
-    assert payload['latest_report']['goal_id'] == 'goal-bootstrap'
-    assert payload['latest_report']['feedback_decision_present'] is False
-    assert payload['latest_report']['selected_tasks'] == 'Record cycle reward [task_id=record-reward]'
-    assert payload['latest_report']['task_selection_source'] == 'recorded_current_task'
+    assert payload['available_partial_proof'] is None
+    assert payload['latest_report'] == {'status': 'retired', 'issue': '#1312'}
+    assert payload['checks']['latest_readable_report']['ok'] is False
     assert set(payload['blocked_capabilities']) == {
         'sudo_noninteractive',
         'execute_opencode_nanobot',
@@ -122,7 +118,7 @@ def test_preflight_reports_ready_when_all_privileged_checks_pass(monkeypatch):
     assert payload['state'] == 'ready'
     assert payload['ready'] is True
     assert payload['blocked_capabilities'] == []
-    assert payload['latest_report']['feedback_decision_present'] is True
+    assert payload['latest_report'] == {'status': 'retired', 'issue': '#1312'}
 
 
 def test_preflight_reports_blocked_unreachable_without_running_privileged_checks(monkeypatch):
@@ -168,7 +164,8 @@ def test_preflight_quotes_user_supplied_remote_paths(monkeypatch):
     )
 
     joined = '\n'.join(commands)
-    assert "'/state; touch /tmp/SHOULD_NOT_EXIST'" in joined
+    assert "'/state; touch /tmp/SHOULD_NOT_EXIST/outbox/report.index.json'" in joined
+    assert 'evolution-' not in joined
     assert "'/bin/nanobot; touch /tmp/SHOULD_NOT_EXIST'" in joined
     assert "'/home/opencode; touch /tmp/SHOULD_NOT_EXIST'" in joined
     assert 'test -r /state; touch /tmp/SHOULD_NOT_EXIST' not in joined


### PR DESCRIPTION
## Scope

Refs #1312. Both writerless artifact families are retired, not replaced with fictional writers. llm-proposed requests are not materialized approval evidence. Dashboard no longer scans frozen evolution/materialized files or returns cached rewards. Dependent fields explicitly say retired. Rollout-preflight does not treat historical reports as partial rollout proof.

## Review corrections (pushed)

- Removed both orphan:#1312 markers AND the ORPHAN_ISSUES entry. reports is outside the registry; improvements names only its live llm_proposer writer. Corrected last-reader history remains in the comment.
- Retired verify_materialized_improvement.py entrypoint: no hardcoded July path or artifact read; emits `retired (#1312): materialized improvement writer removed; verification unavailable`. Exit 0 avoids creating spurious defect demand; this is not a PASS verdict. Historical validation helpers remain for compatibility, without filesystem reads.
- Added explicit retired CSS rule and explanation: offline palette intentionally shared, dashed outline distinguishes retirement.
- Removed dead IMPROVEMENT_DIR / REPORTS_DIR constants and their unused environment configuration.
- Removed the always-True production selector invocation. Both retired families have no selectable evidence. The isolated selector helper and malformed-live provenance test remain; no invented future caller is claimed.

## Test-first evidence

Before the initial production change, tests failed on unchanged main code:
- `AssertionError: retired artifact reader accessed filesystem` (evolution glob).
- `TypeError: select_artifact_source() got an unexpected keyword argument 'materialized_retired'`.

Additional review regressions were run before their production fixes and failed: dead constants still existed; the materialized verifier attempted an artifact read. Logs: red-1312.log and red-review-1312.log in the isolated worktree.

## Verification after review corrections

Focused dashboard/preflight/registry suite: **58 passed in 1.41s**.
Full pytest redirected to full-review-1312.log with explicit worktree cd, no output pipeline:

```
FAILED tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock
4 failed, 3099 passed, 17 skipped, 11 warnings in 1543.16s (0:25:43)
```

Exactly the named Windows baseline, no fifth failure. Full-file Ruff was not globally green due to pre-existing findings; no claim of global lint cleanliness.

## Review / rollout boundary

Owner review corrections are addressed above. Independent Opus review timed out; no independent verdict is claimed and it does not block preservation/publication. Latest pushed-head CI passed on Python 3.11 (7m10s), 3.12 (3m15s), and 3.13 (2m59s), Actions run 33968607253.

No merge/deploy/restart/host-state mutation. After merge and deployment, read-only curl of the live dashboard must quote Approval Gate, Latest Improvement, Concrete Statement and Artifact Freshness verbatim in the issue closing comment. Before-deploy HTML is baseline only. No /api/cleanup, fabricated state, or secrets read. Issue remains open pending this acceptance.
