### PR TITLE
fix(validator-harness): widen findings parser to read failed_count (#1208 step 2)

### DIFF
--- a/nanobot/runtime/validator_harness.py
+++ b/nanobot/runtime/validator_harness.py
@@ -136,15 +136,23 @@ defect when a script did not anticipate it:
 - Non-zero exit = a finding worth surfacing: it becomes ``defect`` demand
   with your stderr/stdout as evidence (see
   ``demand._validator_defect_items``).
-- ``--json`` output is read for a findings count ONLY from a top-level
-  object carrying one of :data:`_FINDINGS_KEYS` as a list/dict. Any other
-  shape yields ``findings_count: None`` (exit code decides alone) and the
-  sidecar row says why — ``findings_parse`` is ``matched`` /
-  ``not_json`` / ``not_object`` / ``unrecognised_keys`` (with the
-  ``stdout_keys`` seen), ``json_flag`` says whether the flag was passed,
-  ``stdout_truncated`` whether the :data:`_MAX_OUTPUT_BYTES` cap cut the
-  document (#1208 step 1: measured live, six validators emitted JSON daily
-  under keys this parser never read, invisibly).
+- ``--json`` output is read for a findings count from a top-level object
+  carrying one of :data:`_FINDINGS_KEYS` as a list/dict, OR an int
+  :data:`_FINDINGS_COUNT_KEYS` field (``failed_count`` — #1208 step 2, the
+  schema decision: the harness widens to the scripts' own established
+  convention rather than rewriting 15+ scripts to a name none of them
+  chose). Any other shape yields ``findings_count: None`` (exit code
+  decides alone) and the sidecar row says why — ``findings_parse`` is
+  ``matched`` / ``not_json`` / ``not_object`` / ``unrecognised_keys`` (with
+  the ``stdout_keys`` seen), ``json_flag`` says whether the flag was
+  passed, ``stdout_truncated`` whether the :data:`_MAX_OUTPUT_BYTES` cap
+  cut the document (#1208 step 1: measured live, validators emitted JSON
+  daily under keys this parser never read, invisibly; #1208 step 2: 15 of
+  those share ``failed_count``, an int already meaning exactly the same
+  thing this parser was already counting for the four list/dict fields —
+  widened; a script's ``results``/``issues``/``all_issues`` array of
+  per-item audit rows, whose length equals items CHECKED rather than items
+  FAILED, is deliberately left unrecognised rather than risked as a count).
 - Decay self-declaration is detected from printed output (#936): when a
    script's captured stdout+stderr contains :data:`_DECAY_DECL_RE` AND the
    script's own repo-relative path (``scripts/<filename>``), the run is
@@ -289,6 +297,35 @@ _SANDBOX_DENIAL_RE = re.compile(
 # JSON object with one of these list/dict fields counts; anything else
 # yields None (no findings parsed), never a crash or a guess.
 _FINDINGS_KEYS = ("findings", "alerts", "missing", "failures")
+
+# #1208 step 2 (the schema decision): a second, narrower field the harness
+# reads directly as a COUNT rather than a container length. Live measurement
+# (issue #1208, 2026-09-05) found 15 of 23 previously-``unrecognised_keys``
+# validators share one shape: ``{"success", "checked_count",
+# "failed_count": <int>, "results": [<one row per item CHECKED, pass or
+# fail>]}``. ``failed_count`` is already exactly a findings count under a
+# different name in every script that emits it -- confirmed by reading the
+# deployed sources of ``validate_deprecation_status.py`` and
+# ``validate_unused_imports.py`` directly: it is incremented once per item
+# that FAILED, never once per item checked. ``results`` is deliberately NOT
+# added here: its length equals ``checked_count`` on every script observed,
+# clean or not (confirmed live: a 970-item clean run reports
+# ``len(results)==970``, ``failed_count==0``), so reading it as a findings
+# count would report a clean run's total scanned-file count as N findings --
+# the exact silent-mismatch shape #1208 step 1 was built to catch, not one to
+# reproduce under a new key. The direction of this fix (the harness widens
+# to the scripts' existing convention, not the other way) was chosen because
+# it touches ONE read site here rather than 15 separate script files, each of
+# which would need to rename an established field their own tests and any
+# other caller already depend on -- and because five of the 23 unclassified
+# validators (``check_git_clean_branch``'s ``modified``,
+# ``check_last_cycle_repeat``'s ``is_repeat``,
+# ``check_lesson_markdown_sections``'s ``violations``,
+# ``check_stale_feeds``'s ``stale``, ``validate_markdown_format``'s
+# ``issues``/``warning_count``) use FIVE DIFFERENT field names for the same
+# concept, so no single script-side rename could unify them either -- the
+# harness is the one place all 53 scripts already funnel through.
+_FINDINGS_COUNT_KEYS = ("failed_count",)
 
 
 def _parse_ts(value: Any) -> datetime | None:
@@ -546,23 +583,38 @@ _MAX_RECORDED_KEYS = 24  # top-level keys kept in ``stdout_keys`` for an unrecog
 
 def _classify_findings(stdout: str) -> tuple[int | None, str, list[str]]:
     """Deliberately tiny findings heuristic, now with its verdict spelled
-    out (#1208 step 1). Returns ``(findings_count, findings_parse, stdout_keys)``:
+    out (#1208 step 1) and widened by one exact field (#1208 step 2). Returns
+    ``(findings_count, findings_parse, stdout_keys)``:
 
-    - ``"matched"``: a top-level JSON object with a
+    - ``"matched"``: a top-level JSON object with EITHER a
       ``findings``/``alerts``/``missing``/``failures`` list or dict —
-      ``findings_count`` is that field's length.
+      ``findings_count`` is that field's length — OR an int
+      ``failed_count`` (:data:`_FINDINGS_COUNT_KEYS`), read directly as the
+      count, checked only when none of the container fields matched.
+      ``failed_count`` is checked as ``isinstance(value, int) and not
+      isinstance(value, bool)`` — bool is an int subclass in Python, and a
+      script that repurposed the name for a flag must not silently become a
+      count of 0 or 1.
     - ``"not_json"``: stdout did not parse (plain text, empty, or a JSON
       document truncated at :data:`_MAX_OUTPUT_BYTES`).
     - ``"not_object"``: valid JSON whose top level is not an object.
     - ``"unrecognised_keys"``: a valid object with none of
-      :data:`_FINDINGS_KEYS` — ``stdout_keys`` carries the top-level keys
-      actually seen (sorted, first :data:`_MAX_RECORDED_KEYS`).
+      :data:`_FINDINGS_KEYS` or :data:`_FINDINGS_COUNT_KEYS` — ``stdout_keys``
+      carries the top-level keys actually seen (sorted, first
+      :data:`_MAX_RECORDED_KEYS`).
 
     Every state but ``"matched"`` yields ``findings_count`` ``None``; the
     caller then falls back to the raw exit code alone, never a fabricated
-    count. Before #1208 the three ``None`` states were one value, which is
-    how six live validators emitted JSON daily to keys nobody read without
-    anything recording it."""
+    count. Before #1208 step 1 the three ``None`` states were one value,
+    which is how six live validators emitted JSON daily to keys nobody read
+    without anything recording it. Before #1208 step 2, ``failed_count``
+    (an int already meaning exactly "number of findings" in every script
+    that emits it — confirmed against 15 live validators sharing this
+    shape) fell into ``unrecognised_keys`` alongside the five validators
+    that genuinely use unrelated shapes; deliberately NOT reading
+    ``results`` for the same reason — its length is the count of items
+    CHECKED, not the count that failed, and is identical on a clean run and
+    a failing one."""
     try:
         data = json.loads(stdout)
     except Exception:
@@ -573,6 +625,10 @@ def _classify_findings(stdout: str) -> tuple[int | None, str, list[str]]:
         value = data.get(key)
         if isinstance(value, (list, dict)):
             return len(value), "matched", []
+    for key in _FINDINGS_COUNT_KEYS:
+        value = data.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value, "matched", []
     keys = sorted(str(k) for k in data.keys())[:_MAX_RECORDED_KEYS]
     return None, "unrecognised_keys", keys
 

--- a/tests/test_validator_harness.py
+++ b/tests/test_validator_harness.py
@@ -558,26 +558,32 @@ class TestExecution:
         assert rows[0]["findings_parse"] == "not_object"
         assert "stdout_keys" not in rows[0]
 
-    def test_unrecognised_json_keys_are_recorded_and_do_not_change_demand(self, tmp_path):
-        """#1208 step 1: the live shape — six validators emit
-        ``{"success", "checked_count", "failed_count", "results"}`` under
-        ``--json`` and the parser reads none of those keys. The row must now
-        SAY so and name the keys, while what becomes demand is unchanged:
-        exit 0 + None → no item (same as before), exit 1 + None → the same
-        exit-code item as before. Recording changed; deciding did not."""
+    def test_unrecognised_json_keys_without_failed_count_are_recorded_and_do_not_change_demand(self, tmp_path):
+        """#1208 step 1: an object shape the parser reads NONE of (no
+        ``_FINDINGS_KEYS`` container and no ``_FINDINGS_COUNT_KEYS`` int, as
+        of #1208 step 2) is recorded as ``unrecognised_keys`` and changes no
+        demand: exit 0 + None -> no item (same as before), exit 1 + None ->
+        the same exit-code item as before. Recording changed; deciding did
+        not. (The ``checked_count``/``failed_count``/``results``/``success``
+        shape this test covered before #1208 step 2 is now ``matched`` via
+        ``failed_count`` -- see
+        ``TestExecution.test_failed_count_int_is_now_a_recognised_findings_field``
+        for that shape; this test now covers a shape with none of the
+        recognised fields at all, to keep proving the ``unrecognised_keys``
+        path still exists and still changes nothing.)"""
         script = (
             "import argparse, json, sys\n"
             "p = argparse.ArgumentParser()\n"
             "p.add_argument('--json', action='store_true')\n"
             "p.parse_args()\n"
-            "print(json.dumps({'success': %s, 'checked_count': 67, 'failed_count': %d, 'results': [{'file': 'a.py'}]}))\n"
+            "print(json.dumps({'checked_count': 67, 'summary': 'ok', 'notes': [{'file': 'a.py'}]}))\n"
             "sys.exit(%d)\n"
         )
         # exit 0 with unrecognised keys: recorded, no demand.
         (tmp_path / "clean").mkdir()
         (tmp_path / "failing").mkdir()
         repo = _init_repo(tmp_path / "clean")
-        _add_script(repo, "check_shape.py", script % ("True", 0, 0), days_ago=2)
+        _add_script(repo, "check_shape.py", script % (0,), days_ago=2)
         state_dir = _state_dir(tmp_path / "clean")
         validator_harness.run_validator_harness(state_dir, repo)
         row = _last_runs(state_dir)[0]
@@ -585,12 +591,12 @@ class TestExecution:
         assert row["findings_count"] is None
         assert row["json_flag"] is True
         assert row["findings_parse"] == "unrecognised_keys"
-        assert row["stdout_keys"] == ["checked_count", "failed_count", "results", "success"]
+        assert row["stdout_keys"] == ["checked_count", "notes", "summary"]
         assert demand._validator_defect_items(state_dir) == []
 
         # exit 1 with the same shape: still the exit-code defect, nothing more.
         repo2 = _init_repo(tmp_path / "failing")
-        _add_script(repo2, "check_shape.py", script % ("False", 2, 1), days_ago=2)
+        _add_script(repo2, "check_shape.py", script % (1,), days_ago=2)
         state_dir2 = _state_dir(tmp_path / "failing")
         validator_harness.run_validator_harness(state_dir2, repo2)
         row2 = _last_runs(state_dir2)[0]
@@ -601,6 +607,91 @@ class TestExecution:
         assert len(items) == 1
         assert items[0]["affected_path"] == "scripts/check_shape.py"
         assert "findings" not in items[0]["summary"]  # the exit-code wording, not a count
+
+    def test_failed_count_int_is_now_a_recognised_findings_field(self, tmp_path):
+        """#1208 step 2 (the schema decision): the harness reads what the
+        SCRIPTS emit, not the reverse -- live measurement (issue #1208,
+        2026-09-05) found 15 of 23 unclassified validators share
+        ``{"success", "checked_count", "failed_count": <int>, "results":
+        [per-file audit rows]}``, a shape none of the four list/dict
+        ``_FINDINGS_KEYS`` ever matched because ``failed_count`` is a plain
+        int, not a list. This is the ONE key widened, deliberately: it is
+        already exactly a findings count by another name in every script
+        that emits it (checked directly against the deployed sources of
+        ``validate_deprecation_status.py``, ``validate_unused_imports.py``,
+        and 13 others -- ``failed_count`` increments once per item that
+        FAILED its check, never once per item checked). ``results`` itself is
+        NOT widened: its length equals ``checked_count`` regardless of pass
+        or fail (confirmed live: a 970-item clean run reports
+        ``len(results)==970``, ``failed_count==0``) -- reading it as a
+        findings count would report every clean run's total scanned-file
+        count as N findings, the exact trap #1208 step 1 was measuring
+        against. A zero ``failed_count`` must still parse as ``matched``
+        with ``findings_count: 0`` (a real, present zero — NOT the same as
+        ``findings_count: None``, which means "no verdict, fall back to
+        exit code"), so an already-passing validator like
+        ``validate_deprecation_status.py`` moves from `unrecognised_keys`
+        (silently dropped) to a truthful zero rather than staying invisible."""
+        script = (
+            "import argparse, json, sys\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "p.parse_args()\n"
+            "print(json.dumps({'success': %s, 'checked_count': 67, 'failed_count': %d, 'results': [{'file': 'a.py', 'valid': %s}] * 67}))\n"
+            "sys.exit(0)\n"
+        )
+        # A live-shaped clean run: failed_count 0, 67 per-file audit rows in
+        # `results` (NOT read as a count) -> findings_count 0, matched, no demand.
+        (tmp_path / "clean").mkdir()
+        (tmp_path / "failing").mkdir()
+        (tmp_path / "odd").mkdir()
+        clean_repo = _init_repo(tmp_path / "clean")
+        _add_script(clean_repo, "check_shape.py", script % ("True", 0, "True"), days_ago=2)
+        clean_state = _state_dir(tmp_path / "clean")
+        validator_harness.run_validator_harness(clean_state, clean_repo)
+        clean_row = _last_runs(clean_state)[0]
+        assert clean_row["exit_code"] == 0
+        assert clean_row["findings_count"] == 0, "a present zero, not the absence of a verdict"
+        assert clean_row["findings_parse"] == "matched"
+        assert "stdout_keys" not in clean_row
+        assert demand._validator_defect_items(clean_state) == []
+
+        # A live-shaped run with real failures, exit 0 (the validate_unused_imports.py
+        # live case: the script's OWN --strict gate is not engaged by the
+        # harness's bare invocation, so it reports failures via JSON while
+        # exiting 0) -> findings_count 2 must now raise real demand that a
+        # correct parse makes visible for the first time.
+        failing_repo = _init_repo(tmp_path / "failing")
+        _add_script(failing_repo, "check_shape.py", script % ("False", 2, "False"), days_ago=2)
+        failing_state = _state_dir(tmp_path / "failing")
+        validator_harness.run_validator_harness(failing_state, failing_repo)
+        failing_row = _last_runs(failing_state)[0]
+        assert failing_row["exit_code"] == 0
+        assert failing_row["findings_count"] == 2
+        assert failing_row["findings_parse"] == "matched"
+        items = demand._validator_defect_items(failing_state)
+        assert len(items) == 1
+        assert items[0]["summary"] == "validator scripts/check_shape.py reports 2 findings"
+
+        # A shape `failed_count` does NOT cover (a bool, not an int, e.g. a
+        # script that reused the name for something else) still falls back
+        # to unrecognised_keys rather than being coerced -- widening is exact,
+        # not fuzzy.
+        odd_repo = _init_repo(tmp_path / "odd")
+        _add_script(
+            odd_repo, "check_odd.py",
+            "import argparse, json\n"
+            "p = argparse.ArgumentParser()\n"
+            "p.add_argument('--json', action='store_true')\n"
+            "p.parse_args()\n"
+            "print(json.dumps({'failed_count': True, 'other': 1}))\n",
+            days_ago=2,
+        )
+        odd_state = _state_dir(tmp_path / "odd")
+        validator_harness.run_validator_harness(odd_state, odd_repo)
+        odd_row = _last_runs(odd_state)[0]
+        assert odd_row["findings_count"] is None
+        assert odd_row["findings_parse"] == "unrecognised_keys"
 
     def test_stdout_cut_at_cap_is_recorded_as_truncated_not_json(self, tmp_path, monkeypatch):
         """A JSON document longer than the capture cap (the live


### PR DESCRIPTION
## #1208 step 2 — the schema decision

Step 1 (PR #1258, merged `8fac1549`, deployed) instrumented every validator-harness run with `findings_parse`, `stdout_keys`, and `stdout_truncated` — turning "the parser probably discards some output" into a measured fact. This PR is step 2: decide the canonical schema and implement it.

### 1. Predicted demand direction — before any code change

The operator's own paragraph is correct, confirmed independently by reading `nanobot/runtime/demand.py:1115-1170` directly: `isinstance(exit_code, int) and exit_code != 0` is checked **unconditionally before** the findings branch — not an if/elif keyed on findings first. A schema fix can therefore only move a candidate from "no verdict" (`findings_count=None`, exit 0) to "findings=0, no demand" (flat) or "findings>0, new demand" (up). **It cannot suppress an already-raised exit-code-driven item**, because exit-code demand is checked first and unconditionally, and it cannot suppress a currently-invisible item either — there is nothing to suppress from `None`.

Concretely: of the population this PR's widening newly classifies as `matched` (see below), one live case at write time flips from invisible to a genuine new candidate — `validate_unused_imports.py` exits 0 under the harness's bare (no-argument) invocation but its own JSON reports `failed_count: 2`, because its `--strict` gate (the thing that would make it exit 1) needs a flag the harness never passes. That is exactly the operator's predicted shape: repairing the parse can raise demand, never lower it. No candidate in the newly-matched population goes from raising to suppressing.

### 2. The canonical schema — decided and recorded

**Direction: the harness widens to read what the scripts already emit, not the reverse.** Live measurement (this session, re-run against the deployed sidecar) found the `unrecognised_keys` population is not uniform:

- **15 of 23** unrecognised paths share one exact shape: `{"success": bool, "checked_count": int, "failed_count": int, "results": [<one row per item CHECKED, pass or fail>]}`. `failed_count` is already exactly a findings count under a different name — verified by reading the deployed sources of `validate_deprecation_status.py` and `validate_unused_imports.py` directly (`failed_count` increments once per item that failed its check, never once per item checked).
- **5 of 23** use five *different* field names for the same concept: `check_git_clean_branch`'s `modified` (list), `check_last_cycle_repeat`'s `is_repeat` (bool), `check_lesson_markdown_sections`'s `violations` (list), `check_stale_feeds`'s `stale` (list), `validate_markdown_format`'s `issues` (list) + `warning_count`. No single shared field name unifies these five, so a harness-side widening cannot reach them without becoming a five-way special case — left unrecognised, deliberately.
- **1 of 23** (`check_disk.py`) was already `matched`.
- **2 of 23** are `not_json` due to output truncation (see #4).

Widening `_classify_findings` to additionally recognise an int `failed_count` field fixes the 15-validator majority with **one read site**, versus rewriting 15 separate script files (several of which have their own tests and callers already depending on the current field names) to a name none of them chose. Rejected direction and reason: making the scripts emit the harness's four names (`findings`/`alerts`/`missing`/`failures`) instead — rejected because it multiplies the edit surface by 15+ files for a single-consumer benefit, and doesn't even unify the other 5 divergent shapes.

**Deliberately not widened: `results`/`issues`/`all_issues` array length as a count.** That array holds one row per item *checked*, not per item *failed* — confirmed live: a 970-item clean run (`validate_filename_compatibility.py`) reports `len(results)==970`, `failed_count==0`. Reading the array length as a findings count would report every clean run's total scanned-file count as N findings — the exact silent mismatch #1208 step 1 was built to catch, reproduced under a different key. This is the trap named in the issue's own "trap" section, caught before it shipped.

A `failed_count` that is a `bool` (a subclass of `int` in Python) is explicitly excluded (`isinstance(value, int) and not isinstance(value, bool)`) so a script that repurposed the name for a flag can't silently become a count of 0 or 1.

### 3. The 23-with-no-`findings_parse`-row population

Re-measured live at write time (not from the issue's stale count): the population with no `findings_parse` on their latest row is **18**, not 23 — the number keeps shrinking as the 4-runs/day rotation catches up since `8fac1549` deployed (2026-09-03T19:07Z). Checked all 18 against `rotation.json`'s `served` map: **every one is present with a `last served` timestamp on or before the deploy** — none is bypassed, skipped, or unreachable. At 5 validators served per run / 4 runs per day against 53 total paths, full coverage takes ~2.6 days; this is a timing fact confirmed by evidence, not a defect, and no code change applies. (The earlier session's 30-vs-330-row coverage confusion, self-corrected on the issue thread, was exactly this distinction — path-has-a-row vs. path-has-a-*classifiable*-row.)

### 4. `stdout_truncated: true` — what the cap protects, and what's behind it

One live case as of this measurement: `validate_filename_compatibility.py`, 168,732 bytes of stdout against the 64 KiB (`_MAX_OUTPUT_BYTES`) cap — reproduced directly: truncating its real output at 65,536 bytes yields `JSONDecodeError: Unterminated string`, confirming the cap genuinely cuts valid JSON mid-document rather than coincidentally aligning with a parse boundary.

The cap protects against a runaway/malicious/OOM-inducing subprocess printer (module docstring #928: "a runaway printer was bounded only by the unit's `MemoryMax`... i.e. an OOM kill, not by this cap"). The thing behind it here is **not** unbounded or malicious — it emits exactly one row per repository file under the same `results`-array convention as the 15 `failed_count` scripts (970 files today), and both historically-cited large emitters (`check_style.py`, 184,676 bytes; `verify_imports.py`, 2,175,307 bytes) reproduce the identical pattern live. This is a **document-size** problem (one bounded-but-growing dimension — repo file count — outgrowing a fixed byte cap), not a **key-naming** problem, and fixing it (a streaming/summarized JSON shape from the scripts, or a per-script output budget scaled to file count) is a different, separable change with its own risk profile. Scoped out of this PR deliberately rather than bundled; named as a follow-up. Practically low-severity today: `failed_count: 0` on the one live truncated case, so the exit-code fallback already agrees with the (unreachable) true count.

## What changed

- `nanobot/runtime/validator_harness.py`: `_classify_findings` now also matches an int `failed_count` field (`_FINDINGS_COUNT_KEYS`), in addition to the four existing list/dict `_FINDINGS_KEYS` fields. Module docstring and INVOCATION CONTRACT section updated to document the widened contract and the rejected `results`-length alternative.
- `tests/test_validator_harness.py`: new `test_failed_count_int_is_now_a_recognised_findings_field` (written first, confirmed to fail against pre-fix code — see below); the one step-1 test whose fixture happened to use `failed_count` was renamed/adjusted to a shape with none of the recognised fields, since its old assertion (`findings_count is None` for that exact shape) is now the opposite of correct behavior.

## Non-vacuity

Ran the new test against pre-fix `_classify_findings` directly (`(None, 'unrecognised_keys', [...])` for the live 15-validator shape) — confirmed it currently discards `failed_count` before writing the test. Full new test then run and confirmed to fail for the right reason (`assert clean_row["findings_count"] == 0` → `AssertionError: None == 0`) before implementing the widening.

## grep every read site of `findings_count` (per the issue's trap)

Only one: `nanobot/runtime/demand.py:1116` (`_validator_defect_items`), which turns a positive count into `defect` demand and a zero into nothing. No dashboard, no other runtime module, no script reads `findings_count`, `findings_parse`, or `stdout_keys` — confirmed by grep across `nanobot/`, `scripts/`, and the instance repo before writing this PR. The widened field feeds the same single consumer step 1 already measured; this PR does not create a new, unread machinery.

## Verification

- `pytest tests/test_validator_harness.py tests/test_demand.py -v` — 291 passed, 5 skipped (pre-existing POSIX-only skips).
- Full suite: `pytest tests/ -q` — 3097 passed, 17 skipped, 4 failed — exactly the established Windows baseline (`test_bridge_cycle_tags`, three `TestAcquireBridgeLock` cases). No fifth failure.
- `ruff check nanobot/runtime/validator_harness.py tests/test_validator_harness.py` — clean.
- Live re-measurement against the deployed `validator_harness/last_runs.jsonl` and the instance repo's actual script sources (read-only, no host mutation) underlies every population count and shape claim above — none of it is inherited unverified from the issue thread.

## Roll-out

Read-only measurement only in this session; the fix itself is a pure parser widening with no schema-breaking change (existing `matched`/`not_json`/`not_object` states unchanged; only a subset of `unrecognised_keys` rows move to `matched`). After deploy, the next several `eeebot-validator-harness.timer` fires (00:00/06:00/12:00/18:00 MSK) should show the 15-validator population's rows carry `findings_parse: matched` with real `findings_count` values, and `demand._validator_defect_items` should surface the `validate_unused_imports.py` candidate predicted above (unless it has since been fixed on its own). Re-checking this against the prediction in §1 is the intended follow-up, not this PR's job to force.

Closes step 2 of #1208; the issue's overall verdict (used/unused, displaced capacity, suppression-worthiness) was already answered in the issue thread before this PR — this PR is the schema-decision implementation the thread called for.
