### PR TITLE
fix(runtime): expose and reclaim prompt reserve (#1313)

### DIFF
--- a/docs/adr/ADR-003-operator-owned-agents-consolidation.md
+++ b/docs/adr/ADR-003-operator-owned-agents-consolidation.md
@@ -1,0 +1,68 @@
+---
+title: Keep AGENTS.md operator-owned and consolidate only declared-droppable sections
+status: proposed
+date: 2026-09-05
+authors: [eeebot maintainers]
+related: ["#1188", "#1193", "#1300", "#1313"]
+tags: [runtime, prompt, operations]
+---
+
+# Status
+
+Proposed — implemented in the change governed by #1313, pending merge and rollout.
+
+# Context
+
+#1188 measured 20 autonomous integrations in five days whose only substantive change was appending to the instance `AGENTS.md`, against six deleted lines. #1193 then made the file operator-owned. #1300/#1302 replaced positional truncation with declared-droppable sections and a loud overflow. On 2026-09-05, #1313 measured only 732 prompt characters of slack plus 2,948 characters of still-droppable reserve.
+
+The remaining decision is who may remove accumulated guidance. Giving the autonomous loop deletion authority over the file would also let it delete charter, staging, and forbidden-path instructions that the prose-blind gate cannot evaluate.
+
+# Decision
+
+`AGENTS.md` remains operator-owned. Autonomous proposals and diffs targeting it remain rejected as `operator_owned_path`.
+
+Removal is an explicit operator action through `scripts/agents_md_consolidate.py`. The operator names each `## ` section. The tool removes a section only when there is exactly one matching heading and that section carries the exact `<!-- prompt-fit: droppable -->` declaration. It is dry-run by default, requires `--apply`, and replaces the file atomically. Missing, duplicate, or unmarked headings reject the whole operation without a partial write.
+
+The loop never imports or invokes this tool, and `agents_md_consolidate.py` is itself in the runtime's `_BLOCKED_EXACT_PATHS`: both proposal sizing and the integration gate reject an autonomous edit to the operator's removal mechanism. Raising the system-prompt cap is not part of the decision.
+
+The product gate's `if f == 'AGENTS.md'` check governs only a repository-root path. The growth measured by #1188 occurred in the separate instance repository; that instance `AGENTS.md` is governed by the instance-side path rules delivered with #1193, not by treating every nested `AGENTS.md` in this product repository as operator-owned.
+
+# Consequences
+
+## What gets easier
+
+The prompt ledger reports the remaining droppable reserve directly, and an operator can convert declared reserve into permanent file reduction without hand-editing section boundaries.
+
+## What gets harder
+
+Consolidation requires an operator to choose sections deliberately. The tool cannot decide semantic redundancy and will not remove a critical section even when the operator believes it is obsolete; the marker must first be reviewed and added in the instance repository.
+
+## What does not change
+
+Critical sections are never dropped by prompt fitting or removed by the consolidation tool. The autonomous loop keeps learning through skills, lessons, and memory, but cannot mutate `AGENTS.md`.
+
+# Alternatives considered
+
+- **Autonomous age- or size-based deletion:** rejected because age and size do not encode importance and the gate cannot distinguish redundant prose from a security invariant.
+- **Automatic deletion of every section dropped from a prompt:** rejected because prompt-fit choice is a runtime budget decision, not authorization to mutate the source file.
+- **Raise `NANOBOT_SYSTEM_PROMPT_MAX_CHARS`:** rejected because it moves the failure date while leaving append-only growth and invisible reserve consumption intact.
+- **Do nothing:** rejected because the measured reserve has a finite exhaustion date.
+
+# Test Contract
+
+| Claim | Test | Status |
+|---|---|---|
+| Remaining declared-droppable characters are recorded after no, partial, and complete exhaustion | `tests/test_context_prompt_fit.py` reserve tests | passing |
+| Both successful and overflow ledger rows carry `droppable_reserve_chars` | `tests/test_bridge_system_prompt_overflow.py` | passing |
+| Dry-run never writes and `--apply` removes only explicitly named marked sections | `tests/test_agents_md_consolidate.py` | passing |
+| Missing, duplicate, or unmarked headings reject without partial mutation | `tests/test_agents_md_consolidate.py` refusal tests | passing |
+| Autonomous root `AGENTS.md` mutation remains rejected | `tests/test_mutation_surfaces.py`, `tests/test_llm_proposer.py` | passing |
+| Autonomous edits to `agents_md_consolidate.py` are rejected by proposal sizing and integration policy | `tests/test_mutation_surfaces.py::test_agents_md_consolidate_script_is_immutable`, `tests/test_llm_proposer.py::TestValidateSizing::test_rejects_agents_md_consolidate_script`, `tests/test_runtime_slice.py::test_bridge_policy_mirrors_stay_synced_with_gate` | passing |
+
+# Rollback
+
+Revert the product commit to remove the metric and operator tool. An applied instance consolidation is separately reversible through the instance repository's git history.
+
+# References
+
+#1188, #1193, #1300, #1313; `docs/specs/subagent-bridge/spec.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ Conventions:
 |---|---|---|
 | [ADR-001](ADR-001-agent-architecture.md) | Agent architecture — roles, tools, models, and budgets of the eeebot runtime | accepted |
 | [ADR-002](ADR-002-bounded-state-access.md) | Bounded state access | accepted |
+| [ADR-003](ADR-003-operator-owned-agents-consolidation.md) | Keep AGENTS.md operator-owned and consolidate only declared-droppable sections | proposed |

--- a/docs/specs/subagent-bridge/spec.md
+++ b/docs/specs/subagent-bridge/spec.md
@@ -172,9 +172,19 @@ passes — so a broken or unverified cycle never reaches `main`.
 
 ### Skill mutation and first-hand usage fitness (#939)
 
-The script tier SHALL allow `skills/**` and the instance-root `AGENTS.md` while
-continuing to reject the immutable `goals.md` charter. Proposer and bridge gate
-mirrors SHALL agree on these paths.
+The script tier SHALL allow `skills/**` while continuing to reject the
+immutable `goals.md` charter. Proposer and bridge gate mirrors SHALL agree on
+these paths.
+
+**Stale text corrected (#1313):** an earlier revision of this paragraph also
+allowed the instance-root `AGENTS.md`. That changed with #1193 (closed
+2026-09-02): `AGENTS.md` is operator-owned, not a loop-mutable target.
+`nanobot/runtime/gate.py` `_ALLOWED_EXACT_PATHS` and
+`nanobot/runtime/llm_proposer.py` `_ALLOWED_EXACT_PATHS` are both
+`frozenset()` — a proposal or diff whose only file is `AGENTS.md` is rejected
+with `reason: operator_owned_path`. See "Prompt budget and reserve (#1313)"
+below for the mechanism that replaced "the loop edits `AGENTS.md`": the
+operator marks sections droppable and, separately, removes them.
 
 Successful executor `read_file` calls for an exact workspace path
 `skills/<name>/SKILL.md` SHALL be observed in-process by the harness. Reads from
@@ -875,6 +885,36 @@ executor run does not stop early or hand off instead of acting:
 - R7. When the cycle is isolated on a branch, the prompt SHALL include a
   mandatory branch-discipline addendum instructing the subagent to commit on the
   current branch and to NOT run `git checkout`/`switch`/`branch` or `git push`.
+
+### Prompt budget and reserve (#1313)
+
+`ContextBuilder.build_system_prompt` (loop profile, strict — #1300/#1302) may
+only drop bootstrap `## ` sections the operator marked
+`<!-- prompt-fit: droppable -->`, whole and largest first; a critical
+(unmarked) section that does not fit raises `SystemPromptOverflowError`
+instead. #1188 measured that `AGENTS.md` only grows and nothing ever removes;
+#1313 answers the two gaps that leaves:
+
+- **The reserve is a recorded number, not a hand computation.** Every
+  `phase: "system_prompt"` ledger row (`bridge.py`, both the successful-fit
+  append and the `SystemPromptOverflowError` append) carries
+  `droppable_reserve_chars`:
+  the chars of declared-droppable sections still standing in the prompt as
+  finally assembled — the full droppable total when nothing was dropped, the
+  exact remainder after strict mode drops some, and `0` once every
+  declared-droppable section is gone (the state overflow is always raised
+  from). `ContextBuilder.last_fit` and
+  `SystemPromptOverflowError.droppable_reserve_chars`
+  carry the same value the ledger row does.
+- **Something removes.** `scripts/agents_md_consolidate.py` is a minimal,
+  explicit, operator-only CLI (not imported by, or reachable from, any
+  runtime/loop code path — `AGENTS.md` stays operator-owned per #1193). It
+  removes only `## ` sections named explicitly on the command line, and only
+  if every one of them already carries the exact droppable marker; a named
+  section that is missing, or present but critical/unmarked, refuses the
+  whole run — no partial removal, no write. Dry-run (report only) is the
+  default; `--apply` is required to write, and the write is atomic (temp file
+  in the same directory, then `os.replace`).
 
 ### Cycle isolation
 - R8. Before spawning, the bridge SHALL isolate the cycle on a fresh branch

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -24,8 +24,16 @@ class SystemPromptOverflowError(RuntimeError):
     the cycle as failed and say so on a surface that is watched.
     """
 
-    def __init__(self, *, over_by: int, cap: int, sections: dict[str, int], dropped: list[dict[str, Any]]):
+    def __init__(
+        self, *, over_by: int, cap: int, sections: dict[str, int], dropped: list[dict[str, Any]],
+        droppable_reserve_chars: int = 0,
+    ):
         self.over_by, self.cap, self.sections, self.dropped = over_by, cap, sections, dropped
+        #: #1313: declared-droppable chars still standing at the moment the
+        #: cap gave up. Always 0 on the real strict-overflow path — the fit
+        #: loop only stops once every droppable section is gone or the
+        #: prompt fits — but kept explicit for the ledger contract.
+        self.droppable_reserve_chars = droppable_reserve_chars
         detail = ", ".join(f"{name}={chars}" for name, chars in sections.items())
         super().__init__(
             f"system prompt exceeds cap by {over_by} chars (cap {cap}; sections {detail}; "
@@ -223,6 +231,21 @@ Skills with available="false" need dependencies installed first - you can try in
             sections = sections[:index] + [("bootstrap", kept)] + sections[index + 1:]
         return sections, dropped
 
+    def _droppable_reserve_chars(self, sections: list[tuple[str, str]]) -> int:
+        """#1313: chars of bootstrap ``## `` sections still carrying
+        :data:`DROPPABLE_MARKER` in *sections* as finally assembled — how
+        much more the cap could remove before it would have to touch a
+        critical section. This is the operator's fuse-length reading: it is
+        the full declared-droppable total when nothing has been dropped yet,
+        shrinks by exactly what strict mode removes, and is 0 once every
+        declared-droppable section is gone (including at overflow, where the
+        fit loop only gives up after exhausting them)."""
+        index = next((i for i, (name, _) in enumerate(sections) if name == "bootstrap"), None)
+        if index is None:
+            return 0
+        units = self._split_bootstrap_sections(sections[index][1])
+        return sum(len(text) for _, text in units if self.DROPPABLE_MARKER in text)
+
     def _fit_system_prompt(self, sections: list[tuple[str, str]], strict: bool = False) -> str:
         """Fit sections under the cap and record the outcome in :attr:`last_fit`.
 
@@ -241,18 +264,24 @@ Skills with available="false" need dependencies installed first - you can try in
         joined = self._join_sections(sections)
         fit: dict[str, Any] = {"cap": cap, "chars": len(joined), "strict": strict, "dropped": []}
         if len(joined) <= cap:
+            fit["droppable_reserve_chars"] = self._droppable_reserve_chars(sections)
             self.last_fit = fit
             return joined
 
         if strict:
             sections, dropped = self._drop_droppable_bootstrap_sections(sections, cap)
             prompt = self._join_sections(sections)
-            fit.update(chars=len(prompt), dropped=dropped)
+            droppable_reserve_chars = self._droppable_reserve_chars(sections)
+            fit.update(
+                chars=len(prompt), dropped=dropped,
+                droppable_reserve_chars=droppable_reserve_chars,
+            )
             self.last_fit = fit
             if len(prompt) > cap:
                 raise SystemPromptOverflowError(
                     over_by=len(prompt) - cap, cap=cap,
                     sections={name: len(content) for name, content in sections}, dropped=dropped,
+                    droppable_reserve_chars=droppable_reserve_chars,
                 )
             if dropped:
                 logger.warning("System prompt cap dropped declared-droppable sections: {}",
@@ -284,7 +313,11 @@ Skills with available="false" need dependencies installed first - you can try in
         if dropped_chars:
             details = ", ".join(f"{name}={count} chars" for name, count in dropped_chars.items())
             logger.warning("System prompt cap dropped content: {}", details)
-        fit.update(chars=len(prompt), dropped=[{"section": n, "chars": c, "how": "line-trim"} for n, c in dropped_chars.items()])
+        fit.update(
+            chars=len(prompt),
+            dropped=[{"section": n, "chars": c, "how": "line-trim"} for n, c in dropped_chars.items()],
+            droppable_reserve_chars=self._droppable_reserve_chars(sections),
+        )
         self.last_fit = fit
         return prompt
 

--- a/nanobot/runtime/bridge.py
+++ b/nanobot/runtime/bridge.py
@@ -2770,6 +2770,10 @@ async def _main_impl_body():
                     'phase': 'system_prompt', 'cycle_id': _cycle_id,
                     'chars': _prompt_fit.get('chars'), 'cap': _prompt_fit.get('cap'),
                     'dropped': list(_prompt_fit.get('dropped') or []),
+                    # #1313: how many chars of declared-droppable AGENTS.md
+                    # sections are still standing — the fuse length the
+                    # operator would otherwise have to compute by hand.
+                    'droppable_reserve_chars': _prompt_fit.get('droppable_reserve_chars'),
                 })
             msg = await mgr.spawn(
                 task=task,
@@ -3474,6 +3478,10 @@ async def _main_impl_body():
                 'phase': 'system_prompt', 'cycle_id': _cycle_id, 'overflow': True,
                 'over_by': exc.over_by, 'cap': exc.cap, 'sections': exc.sections,
                 'dropped': list(exc.dropped),
+                # #1313: 0 on the real strict-overflow path (every
+                # declared-droppable section is already gone by the time the
+                # cap gives up) — recorded explicitly, not omitted.
+                'droppable_reserve_chars': exc.droppable_reserve_chars,
             })
         except Exception as exc:
             print(f'bridge: unexpected error during cycle {cycle_branch}: {exc}')
@@ -3880,7 +3888,9 @@ _BLOCKED_FILE_PATTERNS = ('.env', '.git', '.npmrc', 'package-lock', 'yarn.lock',
 _BLOCKED_WORD_PATTERNS = frozenset({'secret', 'credential', 'token'})
 _SENSITIVE_WORDS = _BLOCKED_WORD_PATTERNS
 _ALLOWED_SENSITIVE_BASENAMES = frozenset({'token_report.py', 'summarize_token_costs.py', 'token_budget_check.py', 'analyze_token_usage.py', 'check_token_budget.py', 'validate_no_secrets.py', 'count_tokens.py'})
-_BLOCKED_EXACT_PATHS = frozenset({'goals.md', 'IDENTITY.md'})
+_BLOCKED_EXACT_PATHS = frozenset({
+    'goals.md', 'IDENTITY.md', 'agents_md_consolidate.py',
+})
 _ALLOWED_PATH_PREFIXES = ('surfaces/', 'scripts/', 'memory/', 'lessons/', 'docs/', 'tests/', 'skills/')
 _ALLOWED_EXACT_PATHS = frozenset()
 _GATE_EXT_ALLOWLIST = frozenset(('.py', '.md', '.json', '.yaml', '.yml', '.toml', '.txt', '.sh', '.service', '.timer', '.conf', '.cron', '.html', '.css', '.ts', '.js', '.example'))

--- a/nanobot/runtime/gate.py
+++ b/nanobot/runtime/gate.py
@@ -39,7 +39,9 @@ _ALLOWED_SENSITIVE_BASENAMES = frozenset({
 # instance regardless of path-prefix rules. goals.md is the immutable
 # operator charter — it ships read-only in the release tree and must not
 # appear on ANY mutation surface.
-_BLOCKED_EXACT_PATHS = frozenset({'goals.md', 'IDENTITY.md'})
+_BLOCKED_EXACT_PATHS = frozenset({
+    'goals.md', 'IDENTITY.md', 'agents_md_consolidate.py',
+})
 
 
 def _is_blocked_filename(

--- a/nanobot/runtime/llm_proposer.py
+++ b/nanobot/runtime/llm_proposer.py
@@ -71,7 +71,9 @@ _ALLOWED_EXACT_PATHS = frozenset()
 # #944: explicitly blocked paths (immutable files that proposals may never
 # target), mirroring bridge._BLOCKED_EXACT_PATHS. goals.md is the immutable
 # operator charter shipped in the release tree.
-_BLOCKED_EXACT_PATHS = frozenset({'goals.md', 'IDENTITY.md'})
+_BLOCKED_EXACT_PATHS = frozenset({
+    'goals.md', 'IDENTITY.md', 'agents_md_consolidate.py',
+})
 # #947 (fix-pass): mirror of bridge structural filename policy. Keep this
 # module-level copy behaviorally identical because bridge imports proposer.
 # Backward-compat tuple used by test extraction:

--- a/scripts/agents_md_consolidate.py
+++ b/scripts/agents_md_consolidate.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+agents_md_consolidate.py — operator-only AGENTS.md consolidation (#1313).
+
+#1188 measured a file that only ever grows; #1300/#1302 gave the loop a
+declared-droppable marker (``<!-- prompt-fit: droppable -->``) so the cap
+never silently deletes standing instructions; #1313 measured that marking a
+section droppable buys reserve once but does not bound the file, and that
+nothing ever removes. This script is the removal path — run by the operator,
+never by the loop (#1193 already made ``AGENTS.md`` operator-owned; this
+script is not imported by, or reachable from, any runtime/loop code path).
+
+It removes ONLY the ``## `` sections named explicitly on the command line,
+and ONLY if every one of them already carries the exact droppable marker.
+Anything else — a section that does not exist, or exists but is critical
+(unmarked) — refuses the WHOLE run: no partial removal, no write. Dry-run
+(no write) is the default; ``--apply`` is required to actually change the
+file, and the write is atomic (temp file in the same directory, then
+``os.replace``).
+
+Usage:
+    python3 scripts/agents_md_consolidate.py --file AGENTS.md \\
+        --section "Big optional appendix" --section "Small optional note"
+    python3 scripts/agents_md_consolidate.py --file AGENTS.md \\
+        --section "Big optional appendix" --apply
+
+``--section`` accepts the heading with or without its leading ``## ``.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from nanobot.agent.context import ContextBuilder
+
+DROPPABLE_MARKER = ContextBuilder.DROPPABLE_MARKER
+
+
+def _normalize_heading(raw: str) -> str:
+    raw = raw.strip()
+    return raw if raw.startswith("## ") else f"## {raw}"
+
+
+def _split(text: str) -> list[tuple[str, str]]:
+    """Reuse the one place this repo defines "how a bootstrap file splits
+    into ## sections" — do not re-implement it here."""
+    return ContextBuilder._split_bootstrap_sections(text)
+
+
+class ConsolidationRefusedError(Exception):
+    """A named section could not be safely removed; nothing was written."""
+
+
+def plan_removal(text: str, requested_headings: list[str]) -> dict:
+    """Validate the request against *text* and return a plan describing what
+    would be removed and what would remain. Raises :class:`ConsolidationRefusedError`
+    (naming every offending section) instead of removing anything partially."""
+    units = _split(text)
+    by_heading: dict[str, list[int]] = {}
+    for i, (heading, _) in enumerate(units):
+        by_heading.setdefault(heading, []).append(i)
+
+    missing = [h for h in requested_headings if h not in by_heading]
+    if missing:
+        raise ConsolidationRefusedError(
+            "section(s) not found (no matching '## ' heading): " + ", ".join(missing)
+        )
+
+    ambiguous = [h for h in requested_headings if len(by_heading[h]) != 1]
+    if ambiguous:
+        raise ConsolidationRefusedError(
+            "duplicate heading(s) are ambiguous and cannot be removed safely: "
+            + ", ".join(ambiguous)
+        )
+
+    unmarked = [
+        h for h in requested_headings
+        if DROPPABLE_MARKER not in units[by_heading[h][0]][1]
+    ]
+    if unmarked:
+        raise ConsolidationRefusedError(
+            "refusing critical/unmarked section(s) — missing "
+            f"'{DROPPABLE_MARKER}': " + ", ".join(unmarked)
+        )
+
+    remove_indices = {i for h in requested_headings for i in by_heading[h]}
+    removed_chars = {units[i][0]: len(units[i][1]) for i in sorted(remove_indices)}
+    kept_units = [(h, t) for i, (h, t) in enumerate(units) if i not in remove_indices]
+    new_text = "".join(t for _, t in kept_units)
+    droppable_reserve_chars = sum(len(t) for _, t in kept_units if DROPPABLE_MARKER in t)
+    return {
+        "removed": removed_chars,
+        "removed_total": sum(removed_chars.values()),
+        "new_chars": len(new_text),
+        "droppable_reserve_chars": droppable_reserve_chars,
+        "new_text": new_text,
+    }
+
+
+def _print_report(plan: dict, *, applied: bool) -> None:
+    verb = "Removed" if applied else "Would remove"
+    for heading, chars in plan["removed"].items():
+        print(f"{verb}: {heading} ({chars} chars)")
+    print(f"Total removed: {plan['removed_total']} chars")
+    print(f"Resulting file size: {plan['new_chars']} chars")
+    print(f"Remaining declared-droppable reserve: {plan['droppable_reserve_chars']} chars")
+    if not applied:
+        print("Dry run — no file written. Pass --apply to write.")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Replace the real file atomically without replacing a symlink itself."""
+    target = path.resolve(strict=True)
+    tmp_path = target.with_name(target.name + ".tmp")
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+        os.replace(tmp_path, target)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--file", default="AGENTS.md", help="path to the AGENTS.md-shaped file (default: AGENTS.md)")
+    parser.add_argument(
+        "--section", action="append", dest="sections", default=[],
+        help="a '## ' heading to remove (with or without the '## ' prefix); repeatable",
+    )
+    parser.add_argument("--apply", action="store_true", help="actually write the file (default: dry-run)")
+    args = parser.parse_args(argv)
+
+    if not args.sections:
+        print("error: at least one --section is required (nothing to consolidate)", file=sys.stderr)
+        return 2
+
+    path = Path(args.file)
+    if not path.is_file():
+        print(f"error: no such file: {path}", file=sys.stderr)
+        return 2
+
+    requested = [_normalize_heading(s) for s in args.sections]
+    text = path.read_text(encoding="utf-8")
+
+    try:
+        plan = plan_removal(text, requested)
+    except ConsolidationRefusedError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.apply:
+        _atomic_write(path, plan["new_text"])
+    _print_report(plan, applied=args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agents_md_consolidate.py
+++ b/tests/test_agents_md_consolidate.py
@@ -1,0 +1,183 @@
+"""#1313: #1188's unanswered half — something must remove, not only mark.
+
+Marking a section droppable (#1300/#1302) buys reserve once but never bounds
+the file; nothing else removes. ``scripts/agents_md_consolidate.py`` is the
+minimal, explicit, operator-only removal path: it only removes ``## ``
+sections named on the command line, and only if every one of them already
+carries the exact ``<!-- prompt-fit: droppable -->`` marker. Dry-run is the
+default; ``--apply`` is required to write, and the write is atomic.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from nanobot.agent.context import ContextBuilder
+
+SCRIPT_DIR = Path("scripts").resolve()
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+agents_md_consolidate = importlib.import_module("agents_md_consolidate")
+
+MARK = ContextBuilder.DROPPABLE_MARKER
+
+
+def _agents_md(tmp_path: Path) -> Path:
+    content = (
+        "# Instance AGENTS.md\n\n"
+        "intro paragraph.\n\n"
+        "## Working knowledge\n\n"
+        "critical standing guidance.\n\n"
+        f"## Big optional appendix\n\n{MARK}\n"
+        "loses turns, not correctness, line one.\n"
+        "loses turns, not correctness, line two.\n\n"
+        f"## Small optional note\n\n{MARK}\n"
+        "a short optional note.\n\n"
+        "## Standard test runner\n\n"
+        "critical, unmarked, sits last.\n"
+    )
+    path = tmp_path / "AGENTS.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_dry_run_is_the_default_and_leaves_the_file_untouched(tmp_path, capsys):
+    path = _agents_md(tmp_path)
+    original = path.read_text(encoding="utf-8")
+
+    rc = agents_md_consolidate.main(["--file", str(path), "--section", "Big optional appendix"])
+
+    assert rc == 0
+    assert path.read_text(encoding="utf-8") == original, "dry-run must never write"
+    out = capsys.readouterr().out
+    assert "Would remove" in out and "Big optional appendix" in out
+    assert "Dry run" in out and "--apply" in out
+    assert not path.with_suffix(".md.tmp").exists()
+
+
+def test_apply_removes_exactly_the_named_sections_and_round_trips(tmp_path, capsys):
+    path = _agents_md(tmp_path)
+    original = path.read_text(encoding="utf-8")
+
+    rc = agents_md_consolidate.main([
+        "--file", str(path),
+        "--section", "## Big optional appendix",  # explicit prefix form also accepted
+        "--section", "Small optional note",
+        "--apply",
+    ])
+
+    assert rc == 0
+    new_content = path.read_text(encoding="utf-8")
+    assert "## Big optional appendix" not in new_content
+    assert "## Small optional note" not in new_content
+    assert "## Working knowledge" in new_content and "critical standing guidance" in new_content
+    assert "## Standard test runner" in new_content and "critical, unmarked, sits last" in new_content
+
+    # round-trip: every unit of the ORIGINAL is either still in new_content
+    # (untouched, in order) or was one of the two named removals — nothing
+    # else was touched, and nothing is lost (#1300's split contract: joining
+    # every unit's text reconstructs the source exactly).
+    original_units = ContextBuilder._split_bootstrap_sections(original)
+    kept_units = [text for heading, text in original_units
+                  if heading not in ("## Big optional appendix", "## Small optional note")]
+    assert new_content == "".join(kept_units)
+
+    out = capsys.readouterr().out
+    assert "Removed" in out and "Big optional appendix" in out and "Small optional note" in out
+    assert not path.with_suffix(".md.tmp").exists(), "atomic write must not leave a temp file behind"
+
+
+def test_apply_preserves_a_symlink_and_updates_its_target(tmp_path):
+    target = _agents_md(tmp_path)
+    link = tmp_path / "linked-AGENTS.md"
+    try:
+        link.symlink_to(target.name)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    rc = agents_md_consolidate.main([
+        "--file", str(link), "--section", "Big optional appendix", "--apply",
+    ])
+
+    assert rc == 0
+    assert link.is_symlink(), "atomic replacement must update the target, not destroy the symlink"
+    assert "## Big optional appendix" not in target.read_text(encoding="utf-8")
+
+
+def test_refuses_a_critical_unmarked_section_and_writes_nothing(tmp_path, capsys):
+    path = _agents_md(tmp_path)
+    original = path.read_text(encoding="utf-8")
+
+    rc = agents_md_consolidate.main([
+        "--file", str(path),
+        "--section", "Big optional appendix",
+        "--section", "Standard test runner",  # critical, unmarked
+        "--apply",
+    ])
+
+    assert rc != 0
+    assert path.read_text(encoding="utf-8") == original, "an unmarked section in the request refuses the WHOLE run"
+    err = capsys.readouterr().err
+    assert "critical/unmarked" in err and "Standard test runner" in err
+
+
+def test_refuses_a_section_that_does_not_exist(tmp_path, capsys):
+    path = _agents_md(tmp_path)
+    original = path.read_text(encoding="utf-8")
+
+    rc = agents_md_consolidate.main(["--file", str(path), "--section", "Nonexistent heading", "--apply"])
+
+    assert rc != 0
+    assert path.read_text(encoding="utf-8") == original
+    err = capsys.readouterr().err
+    assert "not found" in err and "Nonexistent heading" in err
+
+
+def test_refuses_with_no_sections_named(tmp_path):
+    path = _agents_md(tmp_path)
+    rc = agents_md_consolidate.main(["--file", str(path)])
+    assert rc != 0
+
+
+def test_refuses_a_missing_file(tmp_path):
+    rc = agents_md_consolidate.main(["--file", str(tmp_path / "nope.md"), "--section", "X"])
+    assert rc != 0
+
+
+def test_droppable_reserve_chars_matches_what_remains(tmp_path):
+    path = _agents_md(tmp_path)
+    plan = agents_md_consolidate.plan_removal(
+        path.read_text(encoding="utf-8"), ["## Big optional appendix"]
+    )
+    # "Small optional note" is still droppable and still present -> the reserve.
+    assert plan["droppable_reserve_chars"] == len(f"## Small optional note\n\n{MARK}\na short optional note.\n\n")
+
+
+def test_refuses_duplicate_heading_even_when_one_copy_is_marked(tmp_path):
+    path = _agents_md(tmp_path)
+    original = path.read_text(encoding="utf-8")
+    path.write_text(
+        original + f"\n## Big optional appendix\n\n{MARK}\nduplicate optional copy.\n",
+        encoding="utf-8",
+    )
+    duplicated = path.read_text(encoding="utf-8")
+
+    rc = agents_md_consolidate.main([
+        "--file", str(path), "--section", "Big optional appendix", "--apply",
+    ])
+
+    assert rc != 0
+    assert path.read_text(encoding="utf-8") == duplicated
+
+
+def test_plan_removal_refuses_are_raised_not_swallowed(tmp_path):
+    path = _agents_md(tmp_path)
+    text = path.read_text(encoding="utf-8")
+    with pytest.raises(agents_md_consolidate.ConsolidationRefusedError):
+        agents_md_consolidate.plan_removal(text, ["## Standard test runner"])
+    with pytest.raises(agents_md_consolidate.ConsolidationRefusedError):
+        agents_md_consolidate.plan_removal(text, ["## Nope"])

--- a/tests/test_bridge_system_prompt_overflow.py
+++ b/tests/test_bridge_system_prompt_overflow.py
@@ -27,6 +27,7 @@ OVERFLOW = SystemPromptOverflowError(
     over_by=11_434, cap=24_000,
     sections={"identity": 1446, "bootstrap": 22986, "skills_catalogue": 6951, "memory": 4030},
     dropped=[{"section": "## Optional appendix", "chars": 512, "how": "declared-droppable"}],
+    droppable_reserve_chars=0,
 )
 
 
@@ -49,7 +50,8 @@ class _FittingManager(_FakeSubagentManager):
 
     def _build_subagent_prompt(self) -> str:
         self.last_prompt_fit = {"cap": 24_000, "chars": 23_500, "strict": True,
-                                "dropped": [{"section": "## Optional appendix", "chars": 900, "how": "declared-droppable"}]}
+                                "dropped": [{"section": "## Optional appendix", "chars": 900, "how": "declared-droppable"}],
+                                "droppable_reserve_chars": 1_200}
         return "system prompt"
 
 
@@ -99,6 +101,7 @@ def test_overflow_is_a_failed_unspawned_cycle_with_its_own_exit_code(tmp_path, m
     assert fit_rows[0]["overflow"] is True and fit_rows[0]["over_by"] == 11_434 and fit_rows[0]["cap"] == 24_000
     assert fit_rows[0]["sections"]["bootstrap"] == 22_986
     assert fit_rows[0]["dropped"] == OVERFLOW.dropped
+    assert fit_rows[0]["droppable_reserve_chars"] == 0, "#1313: every declared-droppable section is gone by the time the cap gives up"
 
     # exit status → the streak the health dimension and the deploy gate read
     assert rc == bridge.EXIT_SYSTEM_PROMPT_OVERFLOW != 0
@@ -125,5 +128,6 @@ def test_fitting_prompt_journals_what_the_cap_dropped(tmp_path, monkeypatch):
     assert fit_rows[0]["cycle_id"] == "cycle-fit"
     assert fit_rows[0]["chars"] == 23_500 and fit_rows[0]["cap"] == 24_000
     assert fit_rows[0]["dropped"] == [{"section": "## Optional appendix", "chars": 900, "how": "declared-droppable"}]
+    assert fit_rows[0]["droppable_reserve_chars"] == 1_200, "#1313: what remains droppable is a ledger-visible number, not a re-derived estimate"
     assert "overflow" not in fit_rows[0]
     assert [r for r in rows if r["phase"] == "outcome"][-1]["outcome"] == "success"

--- a/tests/test_context_prompt_fit.py
+++ b/tests/test_context_prompt_fit.py
@@ -124,6 +124,48 @@ def test_cap_env_override_is_the_operator_lever(tmp_path, monkeypatch):
     assert builder._cap() == 3_000, "a malformed override falls back to the default, never to unbounded"
 
 
+def test_droppable_reserve_chars_is_full_total_when_nothing_dropped(tmp_path):
+    """#1313: under the cap, the reserve is every declared-droppable section
+    still standing — the fuse length an operator can read without waiting
+    for the cap to bite."""
+    optional = _section("Optional", 2, droppable=True)
+    builder = _builder(tmp_path, _section("Working knowledge", 3) + optional)
+    for strict in (True, False):
+        builder.build_system_prompt(loop_profile=strict)
+        assert builder.last_fit["droppable_reserve_chars"] == len(optional)
+
+
+def test_droppable_reserve_chars_shrinks_by_exact_drop(tmp_path, monkeypatch):
+    """#1313: one of two declared-droppable sections goes; the reserve left is
+    the other one's exact size, not a re-derived estimate."""
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 6_000)
+    small_optional = _section("Small optional note", 5, droppable=True)
+    bootstrap = (
+        _section("Working knowledge", 6)
+        + _section("Big optional appendix", 60, droppable=True)
+        + small_optional
+        + _section("Standard test runner", 8)
+    )
+    builder = _builder(tmp_path, bootstrap)
+    builder.build_system_prompt(loop_profile=True)
+    fit = builder.last_fit
+    assert fit["dropped"] == [{"section": "## Big optional appendix", "chars": pytest.approx(len(_section("Big optional appendix", 60, droppable=True))), "how": "declared-droppable"}]
+    assert fit["droppable_reserve_chars"] == len(small_optional), "reserve is what is LEFT to drop, not what already went"
+
+
+def test_droppable_reserve_chars_is_zero_after_exhaustion(tmp_path, monkeypatch):
+    """#1313: at the moment the cap gives up, every declared-droppable section
+    has already been removed — the reserve that motivated this issue is gone,
+    and the ledger must say so as 0, not omit the key."""
+    monkeypatch.setattr(ContextBuilder, "MAX_SYSTEM_PROMPT_CHARS", 4_000)
+    bootstrap = _section("Working knowledge", 40) + _section("Optional", 4, droppable=True) + _section("Standard test runner", 40)
+    builder = _builder(tmp_path, bootstrap)
+    with pytest.raises(SystemPromptOverflowError) as info:
+        builder.build_system_prompt(loop_profile=True)
+    assert info.value.droppable_reserve_chars == 0
+    assert builder.last_fit["droppable_reserve_chars"] == 0, "the record left for the caller matches the exception, even on failure"
+
+
 def test_subagent_prompt_is_strict_and_exposes_the_fit(tmp_path, monkeypatch):
     from nanobot.agent import subagent as subagent_module
 

--- a/tests/test_llm_proposer.py
+++ b/tests/test_llm_proposer.py
@@ -969,6 +969,13 @@ class TestValidateSizing:
         assert ok is False
         assert "immutable" in reason
 
+    def test_rejects_agents_md_consolidate_script(self):
+        ok, reason = llm_proposer.validate_sizing(
+            self._good(target_path="scripts/agents_md_consolidate.py")
+        )
+        assert ok is False
+        assert "immutable" in reason
+
     def test_rejects_operator_owned_agents_and_accepts_skill_surface(self):
         ok, reason = llm_proposer.validate_sizing(self._good(target_path="AGENTS.md"))
         assert ok is False

--- a/tests/test_mutation_surfaces.py
+++ b/tests/test_mutation_surfaces.py
@@ -108,6 +108,14 @@ def test_goals_md_is_explicitly_immutable():
     assert violations == ['immutable file blocked from mutation: goals.md']
 
 
+def test_agents_md_consolidate_script_is_immutable():
+    fn = _get_validate()
+    violations = fn(['scripts/agents_md_consolidate.py'])
+    assert violations == [
+        'immutable file blocked from mutation: scripts/agents_md_consolidate.py'
+    ]
+
+
 def test_root_agents_is_operator_owned_and_skill_files_are_allowed():
     fn = _get_validate()
     violations = fn(['AGENTS.md'])

--- a/tests/test_runtime_slice.py
+++ b/tests/test_runtime_slice.py
@@ -46,6 +46,7 @@ def test_bridge_policy_mirrors_stay_synced_with_gate():
     assert bridge._SENSITIVE_WORDS == gate._SENSITIVE_WORDS
     assert bridge._ALLOWED_SENSITIVE_BASENAMES == gate._ALLOWED_SENSITIVE_BASENAMES
     assert bridge._BLOCKED_EXACT_PATHS == gate._BLOCKED_EXACT_PATHS
+    assert "agents_md_consolidate.py" in bridge._BLOCKED_EXACT_PATHS
     assert bridge._ALLOWED_PATH_PREFIXES == gate._ALLOWED_PATH_PREFIXES
     assert bridge._ALLOWED_EXACT_PATHS == gate._ALLOWED_EXACT_PATHS
     assert bridge._GATE_EXT_ALLOWLIST == gate._GATE_EXT_ALLOWLIST


### PR DESCRIPTION
Closes #1313

## What changed

- Records `droppable_reserve_chars` on every successful and overflow `phase: system_prompt` ledger row. The value is the exact character total of declared-droppable bootstrap sections still standing after prompt fitting.
- Covers the real strict boundary: all droppable sections are exhausted, critical content still exceeds the cap, `SystemPromptOverflowError` carries reserve `0`, the bridge spawns nothing and returns exit `4`.
- Preserves #1193 rather than adding a second guard: root `AGENTS.md` remains operator-owned and autonomous proposals/diffs continue to reject as `operator_owned_path`.
- Adds an explicit operator-only removal path, `scripts/agents_md_consolidate.py`. It is dry-run by default, requires named `## ` sections and `--apply`, removes only uniquely matched sections carrying the exact droppable marker, refuses the whole operation for missing/duplicate/unmarked headings, preserves symlinks, and replaces the real file atomically. It is not imported or invoked by the loop.
- Corrects the stale subagent-bridge spec that still said the script tier allowed `AGENTS.md`, and records the decision in ADR-003.

## Why this arm

The autonomous loop must not gain deletion authority over the file containing its charter, staging rules, and forbidden-path guardrails; the prose-blind gate cannot distinguish consolidation from deleting a safety invariant. #1193 already stopped new autonomous growth. Removal is therefore explicit and operator-owned, and is limited to sections the operator has already declared droppable.

Rejected alternatives: automatic age/size deletion, deleting every section omitted from a prompt, and raising `NANOBOT_SYSTEM_PROMPT_MAX_CHARS`. The first two can remove critical meaning; the cap increase only moves the failure date.

## Test-first evidence

The reserve/bridge test was added before production changes and executed against the unmodified implementation. Collection failed as expected:

```text
TypeError: SystemPromptOverflowError.__init__() got an unexpected keyword argument 'reserve_chars'
```

The public field was then deliberately named `droppable_reserve_chars` to keep the ledger contract unambiguous.

## Validation

- Focused acceptance set: `234 passed`.
- Full Windows suite: `4 failed, 3108 passed, 17 skipped`; failures are exactly the established baseline:
  - `tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended`
  - `tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock`
- Focused Ruff on new/changed standalone surfaces: passed. Existing whole-file Ruff debt in `bridge.py`/`context.py` is unchanged.
- `git diff --check`: passed.
- Independent Opus review found and blocked a symlink-replacement flaw; the CLI now resolves the real target and has a regression test. Re-review verdict: OK.

## Rollout verification owed

After deployment, quote the latest live `phase: system_prompt` row as two numbers: `cap - chars` slack and `droppable_reserve_chars`. Then run the consolidation CLI first in dry-run mode against the operator-selected instance sections; apply only through the separately reviewed instance-repository change.

No cap was raised. `nanobot/runtime/reflector.py` was not touched. No host state or live symlink was mutated.