### PR TITLE
fix(telemetry): trim a prompt record to the cap instead of clamping every message to 1,000 chars (#1319)

### DIFF
--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -27,6 +27,7 @@ actually be inspected (see ``scripts/llm_prompt_inspect.py``).
 from __future__ import annotations
 
 import contextlib
+import copy
 import gzip
 import json
 import os
@@ -206,46 +207,116 @@ def _rotate_and_prune(prompts_dir: Path, today: str, retention_days: int) -> Non
 MAX_LLM_PROMPT_PAYLOAD_BYTES = 32 * 1024  # 32KB per-record cap (#1039)
 
 
+# #1319 -- how the cap is met. Until #1319 the first pass clamped every message
+# to a fixed 1,000 chars on any overage, so a record one byte over lost ~97% of
+# its content; on the host that left a median 6.6 KB of the 32 KiB budget and
+# 581 of 582 reflector inputs were cut that way. Passes 2-5 below are unchanged
+# and now fire only when the record's structure alone (message count, keys)
+# exceeds the budget.
+_CAP_FIELDS = ("messages", "content", "reasoning_content")
+_CAP_MIN_KEEP_CHARS = 32  # a string levelled below this is noise; fall through to pass 2 instead
+_CAP_MARKER_RE = re.compile(
+    r"…\[truncated \d+ chars\]|…\[truncated\]|…\[intermediate messages omitted\]|…\[payload truncated to fit 32KB budget\]"
+)
+
+
+def _string_leaves(value: Any, out: list[tuple[Any, Any, str]], container: Any = None, key: Any = None) -> None:
+    """Collect ``(container, key, string)`` for every string leaf so it can be replaced in place."""
+    if isinstance(value, str):
+        if container is not None:
+            out.append((container, key, value))
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            _string_leaves(v, out, value, k)
+    elif isinstance(value, list):
+        for i, v in enumerate(value):
+            _string_leaves(v, out, value, i)
+
+
+def _content_chars(value: Any) -> int:
+    """Characters of string content in ``value``, not counting the recorder's own markers."""
+    if isinstance(value, str):
+        return len(_CAP_MARKER_RE.sub("", value))
+    if isinstance(value, dict):
+        return sum(_content_chars(v) for v in value.values())
+    if isinstance(value, list):
+        return sum(_content_chars(v) for v in value)
+    return 0
+
+
+def _level_cut(rec: dict[str, Any], max_bytes: int) -> None:
+    """Pass 1 of :func:`_cap_payload_record`: level the string leaves under :data:`_CAP_FIELDS`.
+
+    Property guaranteed: every string longer than a level ``L`` is cut to ``L``
+    and suffixed with ``…[truncated N chars]``; strings at or below ``L`` are
+    untouched; ``L`` is the LARGEST level at which the whole record serializes
+    within ``max_bytes`` (found by bisection on the actual serialized size, so
+    bytes-per-character and marker overhead are accounted for exactly). Hence
+    the record loses only the overage plus the bookkeeping that records it
+    (the ``truncated`` / ``truncated_chars`` keys and one marker per cut
+    string, ~70 bytes), taken from its longest strings first: a record one
+    byte over loses ~70 characters, never a fixed fraction. If even
+    ``L = _CAP_MIN_KEEP_CHARS`` does not fit, that level is applied and the
+    structural passes that follow do the rest.
+    """
+    leaves: list[tuple[Any, Any, str]] = []
+    for field in _CAP_FIELDS:
+        if field in rec:
+            _string_leaves(rec[field], leaves, rec, field)
+    lengths = [len(s) for _, _, s in leaves if len(s) > _CAP_MIN_KEEP_CHARS]
+    if not lengths:
+        return
+
+    def apply(level: int) -> None:
+        for container, key, s in leaves:
+            container[key] = s[:level] + f"…[truncated {len(s) - level} chars]" if len(s) > level else s
+
+    def fits(level: int) -> bool:
+        apply(level)
+        return len(json.dumps(rec, ensure_ascii=False, default=str).encode("utf-8")) <= max_bytes
+
+    low, high = _CAP_MIN_KEEP_CHARS, max(lengths)  # the record is known not to fit at `high` (nothing cut)
+    if fits(low):
+        while high - low > 1:  # largest level that fits; fits() is monotone in the level
+            mid = (low + high) // 2
+            if fits(mid):
+                low = mid
+            else:
+                high = mid
+    apply(low)
+
+
 def _cap_payload_record(record: dict[str, Any], max_bytes: int = MAX_LLM_PROMPT_PAYLOAD_BYTES) -> dict[str, Any]:
     """Ensure record JSON serialization does not exceed max_bytes.
 
-    If the serialized record exceeds max_bytes, trims heavy string/list fields
-    (messages, content, reasoning_content) and adds ``truncated: True`` to the record (#1039).
+    If the serialized record exceeds max_bytes, shortens string values in place
+    under ``messages`` / ``content`` / ``reasoning_content`` -- never slicing
+    the JSON text, so the record stays parseable at every pass (#1039) -- and
+    adds ``truncated: True`` plus ``truncated_chars`` (characters of content
+    removed, markers excluded) so a reader learns how much was lost, not only
+    that something was (#1319). Pass 1 (:func:`_level_cut`) removes only the
+    overage, from the longest strings first; passes 2-5 are the structural
+    fallbacks, gentlest first, and fire only when levelling alone cannot fit
+    the record.
     """
     serialized = json.dumps(record, ensure_ascii=False, default=str)
     if len(serialized.encode("utf-8")) <= max_bytes:
         return record
 
     rec = dict(record)
+    for field in _CAP_FIELDS:
+        if field in rec:
+            rec[field] = copy.deepcopy(rec[field])  # the caller's live messages must not be shortened
     rec["truncated"] = True
+    # Placeholder as wide as any real count, so the fit below budgets for the key; the true value is shorter.
+    rec["truncated_chars"] = 999_999_999
 
-    # First pass: trim message content
-    messages = rec.get("messages")
-    if isinstance(messages, list):
-        trimmed_msgs = []
-        for msg in messages:
-            if isinstance(msg, dict):
-                m_copy = dict(msg)
-                m_content = m_copy.get("content")
-                if isinstance(m_content, str) and len(m_content) > 1000:
-                    m_copy["content"] = m_content[:1000] + "…[truncated]"
-                trimmed_msgs.append(m_copy)
-            else:
-                trimmed_msgs.append(msg)
-        rec["messages"] = trimmed_msgs
-
-    # Trim reasoning_content if large
-    reasoning = rec.get("reasoning_content")
-    if isinstance(reasoning, str) and len(reasoning) > 1000:
-        rec["reasoning_content"] = reasoning[:1000] + "…[truncated]"
-
-    # Trim content if large
-    content = rec.get("content")
-    if isinstance(content, str) and len(content) > 2000:
-        rec["content"] = content[:2000] + "…[truncated]"
+    # First pass: level the string content down to the budget (#1319)
+    _level_cut(rec, max_bytes)
 
     serialized = json.dumps(rec, ensure_ascii=False, default=str)
     if len(serialized.encode("utf-8")) <= max_bytes:
+        rec["truncated_chars"] = _content_chars(record) - _content_chars(rec)
         return rec
 
     # Second pass: aggressively trim intermediate messages
@@ -282,6 +353,7 @@ def _cap_payload_record(record: dict[str, Any], max_bytes: int = MAX_LLM_PROMPT_
                 elif isinstance(rec[k], (list, dict)):
                     rec[k] = "…[truncated]"
 
+    rec["truncated_chars"] = max(0, _content_chars(record) - _content_chars(rec))
     return rec
 
 

--- a/nanobot/observability/llm_telemetry.py
+++ b/nanobot/observability/llm_telemetry.py
@@ -214,7 +214,12 @@ MAX_LLM_PROMPT_PAYLOAD_BYTES = 32 * 1024  # 32KB per-record cap (#1039)
 # and now fire only when the record's structure alone (message count, keys)
 # exceeds the budget.
 _CAP_FIELDS = ("messages", "content", "reasoning_content")
-_CAP_MIN_KEEP_CHARS = 32  # a string levelled below this is noise; fall through to pass 2 instead
+# A string levelled below this is noise, so when even this level does not fit
+# the record takes BOTH losses on purpose: near-total levelling here, then the
+# structural passes drop messages. That only happens when the structure alone
+# (message count, keys) exceeds the budget; on 334 real over-cap records from
+# the 2026-08-25 archive it happened 0 times.
+_CAP_MIN_KEEP_CHARS = 32
 _CAP_MARKER_RE = re.compile(
     r"…\[truncated \d+ chars\]|…\[truncated\]|…\[intermediate messages omitted\]|…\[payload truncated to fit 32KB budget\]"
 )
@@ -258,6 +263,12 @@ def _level_cut(rec: dict[str, Any], max_bytes: int) -> None:
     byte over loses ~70 characters, never a fixed fraction. If even
     ``L = _CAP_MIN_KEEP_CHARS`` does not fit, that level is applied and the
     structural passes that follow do the rest.
+
+    Cost, measured on the host (i686, Python 3.11.2, 120 real pre-cap records
+    of median 102 KB): about 17 full serializations per record, p50 78 ms,
+    p90 124 ms, max 192 ms, against 12 ms for the old clamp -- once per LLM
+    call that itself waits seconds, on ~90% of executor calls. If that ever
+    matters, the lever is the number of probes, not the property.
     """
     leaves: list[tuple[Any, Any, str]] = []
     for field in _CAP_FIELDS:

--- a/nanobot/runtime/reflector.py
+++ b/nanobot/runtime/reflector.py
@@ -363,6 +363,8 @@ def _fit_transcript(record: Any, max_chars: int) -> tuple[Any, dict[str, Any]]:
         # fit must repeat it, or "complete" would be the wrong answer exactly on
         # the long cycles this issue is about.
         fit["recorder_truncated"] = True
+        if isinstance(out.get("truncated_chars"), int):
+            fit["recorder_truncated_chars"] = out["truncated_chars"]  # #1319: the recorder now says how much
     return out, fit
 
 
@@ -374,7 +376,11 @@ def _fit_note(fit: dict[str, Any], unit: str) -> str:
     if fit.get("fields_omitted"):
         parts.append(", ".join(fit["fields_omitted"]) + " omitted")
     if fit.get("recorder_truncated"):
-        parts.append("record already shortened by the prompt recorder's 32 KiB cap")
+        chars = fit.get("recorder_truncated_chars")
+        parts.append(
+            "record already shortened by the prompt recorder's 32 KiB cap"
+            + (f", {chars} chars removed" if isinstance(chars, int) else "")
+        )
     return f" ({'; '.join(parts)})" if parts else ""
 
 

--- a/tests/test_llm_prompt_cap_proportional.py
+++ b/tests/test_llm_prompt_cap_proportional.py
@@ -1,0 +1,110 @@
+"""#1319: the prompt recorder's cap removes about the overage, not a fixed 97% of the record."""
+from __future__ import annotations
+
+import json
+import re
+
+from nanobot.observability.llm_telemetry import MAX_LLM_PROMPT_PAYLOAD_BYTES, _cap_payload_record
+
+_MARKER_RE = re.compile(r"…\[truncated \d+ chars\]|…\[truncated\]|…\[intermediate messages omitted\]|…\[payload truncated to fit 32KB budget\]")
+
+
+def _bytes(record: dict) -> int:
+    return len(json.dumps(record, ensure_ascii=False, default=str).encode("utf-8"))
+
+
+def _chars(value) -> int:
+    """Sum of string-leaf lengths with marker text removed — the content a reader still has."""
+    if isinstance(value, str):
+        return len(_MARKER_RE.sub("", value))
+    if isinstance(value, dict):
+        return sum(_chars(v) for v in value.values())
+    if isinstance(value, list):
+        return sum(_chars(v) for v in value)
+    return 0
+
+
+def _record(messages: list[dict], content: str = "done") -> dict:
+    return {
+        "ts": "2026-09-05T12:00:00Z", "model": "m", "cycle_id": "cycle-0123456789ab", "component": "bridge", "seq": 7,
+        "prompt_tokens": 30000, "completion_tokens": 100, "finish_reason": "stop",
+        "messages": messages, "content": content, "reasoning_content": None,
+    }
+
+
+def test_record_well_over_the_cap_lands_near_the_cap_not_near_the_clamp():
+    """Two 20K messages (~40 KB): the result must use the budget, not collapse to 2 × 1,000 chars."""
+    record = _record([{"role": "user", "content": "u" * 20_000}, {"role": "assistant", "content": "a" * 20_000}])
+    assert _bytes(record) > MAX_LLM_PROMPT_PAYLOAD_BYTES
+    capped = _cap_payload_record(record)
+    size = _bytes(capped)
+    assert size <= MAX_LLM_PROMPT_PAYLOAD_BYTES
+    assert size >= MAX_LLM_PROMPT_PAYLOAD_BYTES - 2_048, size  # within 2 KiB of the cap, not ~2 KB total
+    assert capped["truncated"] is True
+    assert capped["truncated_chars"] == _chars(record) - _chars(capped)
+
+
+def test_record_one_byte_over_loses_about_one_byte():
+    record = _record([{"role": "user", "content": "u" * 20_000}, {"role": "tool", "content": "t" * 5_000}])
+    filler = MAX_LLM_PROMPT_PAYLOAD_BYTES + 1 - _bytes(record)
+    record["messages"][0]["content"] += "x" * filler
+    assert _bytes(record) == MAX_LLM_PROMPT_PAYLOAD_BYTES + 1
+    capped = _cap_payload_record(record)
+    assert _bytes(capped) <= MAX_LLM_PROMPT_PAYLOAD_BYTES
+    # Loses the one byte plus the bookkeeping that records the loss: the `truncated` and
+    # `truncated_chars` keys and one "…[truncated N chars]" marker, ~70 bytes together. Not 19,000.
+    assert 1 <= capped["truncated_chars"] <= 96, capped["truncated_chars"]
+    assert capped["messages"][1]["content"] == "t" * 5_000  # the shorter string is never touched
+
+
+def test_overage_is_taken_from_the_longest_strings_and_short_ones_stay_whole():
+    record = _record(
+        [
+            {"role": "system", "content": "s" * 30_000},
+            {"role": "user", "content": "task " * 100},
+            {"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "read_file", "arguments": json.dumps({"path": "a.py"})}}]},
+            {"role": "tool", "content": "r" * 8_000},
+        ],
+        content="final answer " * 20,
+    )
+    capped = _cap_payload_record(record)
+    assert _bytes(capped) <= MAX_LLM_PROMPT_PAYLOAD_BYTES
+    assert capped["messages"][1] == record["messages"][1]
+    assert capped["messages"][2] == record["messages"][2]
+    assert capped["content"] == record["content"]
+    assert len(capped["messages"][0]["content"]) < 30_000 and capped["messages"][0]["content"].endswith(" chars]")
+    # the pool is levelled: the 8K tool result is only cut once the 30K system message is down to its size
+    assert len(capped["messages"][3]["content"]) >= min(8_000, len(_MARKER_RE.sub("", capped["messages"][0]["content"])))
+    assert capped["truncated_chars"] == _chars(record) - _chars(capped)
+    # every message is still present -- the recorder's copy is the only durable one
+    assert [m["role"] for m in capped["messages"]] == ["system", "user", "assistant", "tool"]
+
+
+def test_multibyte_content_still_fits_and_still_uses_most_of_the_budget():
+    record = _record([{"role": "user", "content": "ж" * 30_000}, {"role": "assistant", "content": "д" * 30_000}])
+    capped = _cap_payload_record(record)
+    size = _bytes(capped)
+    assert size <= MAX_LLM_PROMPT_PAYLOAD_BYTES
+    assert size >= MAX_LLM_PROMPT_PAYLOAD_BYTES // 2  # bytes-per-char 2 => at most 2x over-trim, never 97%
+
+
+def test_structural_overhead_beyond_the_budget_falls_through_to_the_old_passes():
+    """Thousands of tiny messages: no level can fit, so the later passes fire; the bound and the count still hold."""
+    record = _record([{"role": "tool", "content": f"r{i:04d}"} for i in range(3_000)])
+    capped = _cap_payload_record(record)
+    assert _bytes(capped) <= MAX_LLM_PROMPT_PAYLOAD_BYTES
+    assert capped["truncated"] is True
+    assert capped["truncated_chars"] == _chars(record) - _chars(capped) > 0
+
+
+def test_caller_messages_are_not_mutated():
+    messages = [{"role": "assistant", "content": "", "tool_calls": [{"function": {"name": "write_file", "arguments": "x" * 60_000}}]}]
+    before = json.dumps(messages)
+    _cap_payload_record(_record(messages))
+    assert json.dumps(messages) == before
+
+
+def test_under_the_cap_is_returned_untouched():
+    record = _record([{"role": "user", "content": "small"}])
+    assert _cap_payload_record(record) is record
+    assert "truncated_chars" not in record

--- a/tests/test_llm_prompt_recording.py
+++ b/tests/test_llm_prompt_recording.py
@@ -364,7 +364,8 @@ def test_record_llm_prompt_payload_cap_truncates_oversized_payload(tmp_path, mon
 
     record = json.loads(raw)
     assert record.get("truncated") is True
-    assert "[truncated]" in raw
+    assert "…[truncated " in raw  # #1319: the marker now carries the count, "…[truncated N chars]"
+    assert isinstance(record.get("truncated_chars"), int) and record["truncated_chars"] > 0
 
 
 def test_record_llm_prompt_payload_cap_guarantees_budget_with_huge_cycle_id_and_redaction(tmp_path, monkeypatch):

--- a/tests/test_reflector_input_fit.py
+++ b/tests/test_reflector_input_fit.py
@@ -91,6 +91,18 @@ def test_recorder_truncated_record_is_reported_as_lost_content():
     assert fit["status"] == "complete" and "recorder_truncated" not in fit["transcript"]
 
 
+def test_recorder_truncated_chars_are_carried_into_the_fit():
+    """#1319: once the recorder says how much it removed, the reflector row and the label repeat the number."""
+    record = _record(turns=2, chars=10)
+    record["truncated"] = True
+    record["truncated_chars"] = 123_456
+    messages, fit = reflector._build_prompt("c1", record, _ledger(1, 10), [])
+    assert fit["status"] == "truncated"
+    assert fit["transcript"]["recorder_truncated"] is True
+    assert fit["transcript"]["recorder_truncated_chars"] == 123_456
+    assert "123456 chars removed" in _header_lines(messages)[0]
+
+
 def test_ledger_over_budget_keeps_proposed_and_outcome_rows():
     ledger = _ledger(rows=40, chars=500)  # ~21K chars against 12K
     messages = reflector._messages("c1", _record(1, 10), ledger, [])


### PR DESCRIPTION
Closes #1319.

## Measurement first — the live row is the rule, not an outlier

Read-only on the host as `eeepc-agent`, 2026-09-05, every retained prompt record since the cap existed (2026-08-28 → 2026-09-05, 9 days, 13,924 records):

| what | truncated | share |
|---|---|---|
| all prompt records | 12,566 / 13,924 | **90.2%** |
| `bridge` (executor) records | 12,539 / 12,721 | 98.6% |
| `proposer` records | 0 / 1,168 | 0% |
| **latest record per cycle — what the reflector reads** | **581 / 582** | **99.8%** |

Per day the executor share never dipped below 84% (2026-08-28: 1,860/2,122 … 2026-09-05: 560/661); latest-per-cycle was 100% on eight of nine days and 20/21 on the ninth. Which pass fired: 7,917 records stopped at pass 1 (every message clamped to 1,000 chars), 4,649 (37%) fell through to pass 2 (first + last message only). Size after the cap across those 12,566 records: min 1,532, **median 6,652**, max 32,760 bytes — a median of 20% of the budget. `prompt_tokens` (the only pre-cap figure the record keeps; 4.27 B/token on clean records) puts the median executor record at ~140 KB before the cap, p95 ~300 KB.

Then the before/after comparison the issue asked for, on real pre-cap records: the 2026-08-25 archive predates the cap, so its records are originals. First 354 of them (349 bridge, 5 proposer; pre-cap median 173,404 bytes, max 311,076; 334 over the cap), run through the old and the new `_cap_payload_record` locally:

```
                      old (main)                 new (this PR)
after cap, p50        2,738 bytes  (8% of cap)   32,757 bytes  (100% of cap)
after cap, p10 / p90  1,623 / 24,669             32,697 / 32,764
messages kept, p50    3                          49
whole messages dropped (pass 2+)   —             0 of 334
truncated_chars, p50  (not recorded)             138,152
```

So the record that the issue's live row describes — arriving at the reflector as 2,495 chars with everything kept and nothing dropped by #1314's bound — is what **every** executor cycle has looked like since 2026-08-28. The reflector has been analysing ~2–7 KB of a ~140 KB transcript on 99.8% of cycles. The `prompt_tokens` estimate also corrects the issue's framing in one respect: records are not typically "one byte over", they are typically 4× over. The defect is the same (a constant where a fit was needed) and the fix is the same, but the median record needs to lose 75% of its content no matter how well the cap is met — the proportional trim raises what survives from 8% of the budget to 100% of it, not to 100% of the transcript.

## The fix (`nanobot/observability/llm_telemetry.py`)

**Property, stated where it is implemented (`_level_cut` docstring):** every string leaf under `messages` / `content` / `reasoning_content` longer than a level `L` is cut to `L` and suffixed `…[truncated N chars]`; strings at or below `L` are untouched; `L` is the **largest** level at which the whole record serializes within the cap, found by bisection on the actual serialized size (so bytes-per-character and marker overhead are exact). The record therefore loses only the overage plus the ~70 bytes of bookkeeping that records the loss, taken from its longest strings first. A record one byte over loses ~70 characters, not 97% of its content. If even `L = 32` does not fit, that level is applied and the structural passes do the rest.

- The 32 KiB bound is unchanged. In-place shortening + re-serialize is unchanged (the record stays parseable at every pass). Passes 2–5 are unchanged in order and text; they now fire only when the *structure* alone exceeds the budget (thousands of tiny messages), which happened on 0 of 334 real records.
- The first pass covers every string leaf under the three fields, so a 60 KB `tool_calls[].function.arguments` (a `write_file` body) is levelled with the rest instead of forcing pass 2. The old first pass only saw `content`.
- `messages` / `content` / `reasoning_content` are deep-copied before shortening. The old code shallow-copied each message dict; a nested `tool_calls` list was shared with the executor's live conversation. Nothing was mutated before because only `content` was rewritten, but levelling reaches inside, so the copy is now required and tested.
- **The record carries a number:** `truncated_chars` (content characters removed, marker text excluded) beside the unchanged `truncated: true`. Computed exactly as content-chars-before minus content-chars-after, whichever passes fired. A placeholder as wide as any real count is set before the fit so the key is budgeted for.
- Marker text changes from `…[truncated]` to `…[truncated N chars]`; the one existing assertion on it is updated.

**`nanobot/runtime/reflector.py`:** `_fit_transcript` copies `truncated_chars` into `input_fit.transcript.recorder_truncated_chars` and the label line adds `, N chars removed` — the loop #1315 opened is closed: the row says how much the recorder took, not only that it took.

**Cost, measured on the host** (review question). Production interpreter (`/opt/eeepc-agent/venv/bin/python`, 3.11.2, i686), 120 real pre-cap records from the 2026-08-25 archive, median 101,579 bytes, old and new implementation timed on the same records:

```
one json.dumps + utf-8 encode of the record   p50  9.2 ms   max  32.7 ms
old cap (1,000-char clamp) per record         p50 12.0 ms   p90  22.6   max  47.7 ms
new cap (bisection) per record                p50 77.9 ms   p90 123.6   max 192.3 ms
added per truncated record                    p50 65.8 ms
```

About 17 serializations per record, as the bisection predicts. It is paid once per LLM call, inside `record_llm_prompt`, on ~90% of executor calls; the call it follows waits seconds on the gateway, so this is on the order of 1–3% of call latency. Recorded here and in the `_level_cut` docstring so the next reader does not re-derive it. Not mitigated, deliberately: the measurement says it does not matter yet, and the cheap lever if it ever does is the number of probes, not the property. (Dev machine for comparison: 15.6 ms per record.)

**Double loss at the floor, intentional.** When even `L = _CAP_MIN_KEEP_CHARS = 32` does not fit, the record takes both losses: near-total levelling, then the structural passes drop messages. That happens only when the structure alone exceeds the budget (thousands of tiny messages); on the 334 real over-cap records it happened 0 times. Stated in the constant's comment.

### Rejected arms, recorded

- **Raise the cap.** No — #1039's reason (a runaway printer bounded only by `MemoryMax`) has not changed.
- **Scale every string by the same ratio.** Rejected: it cuts short tool results and role text proportionally with the big ones, so small messages lose their meaning while the large one still dominates. Levelling protects everything below `L` entirely and takes only from the longest — the reflector needs to see *every* step, and steps are mostly small.
- **Drop whole oldest messages** (the reflector's own #1314 rule). Rejected for the recorder: it is the only durable copy of the conversation, and "every message present, long ones shortened" is the better archival property than "some messages missing". Pass 2 already exists for the emergency and now fires on 0 of 334 real records.
- **Estimate the level from character counts instead of bisecting on bytes.** Tried first; multibyte text and marker overhead made the estimate collapse to the floor and fall through to pass 2 on the test data. Replaced with exact bisection.

## Tests — fail on `main`, verified

`tests/test_llm_prompt_cap_proportional.py` (7): run against the unmodified module first —

```
FAILED test_record_well_over_the_cap_lands_near_the_cap_not_near_the_clamp   assert 2364 >= (32768 - 2048)
FAILED test_record_one_byte_over_loses_about_one_byte                        KeyError: 'truncated_chars'
FAILED test_overage_is_taken_from_the_longest_strings_and_short_ones_stay_whole   endswith(' chars]') False
FAILED test_multibyte_content_still_fits_and_still_uses_most_of_the_budget   assert 4364 >= (32768 // 2)
FAILED test_structural_overhead_beyond_the_budget_falls_through_to_the_old_passes  KeyError: 'truncated_chars'
5 failed, 2 passed
```

The two that pass on `main` are guard tests and are labelled as such: the caller's messages are not mutated (true before, must stay true now that levelling reaches nested lists) and an under-cap record is returned untouched.

- two 20 K messages → lands within 2 KiB of the cap, not at 2 × 1,000; `truncated_chars` equals content-before minus content-after
- exactly one byte over → loses 1–96 chars (the ~70 of bookkeeping), the shorter message untouched
- 30 K system + short task + small `tool_calls` + 8 K tool result → short ones byte-identical, all four roles present, pool levelled
- Cyrillic (2 B/char) → fits and uses ≥ half the budget (was 4,364 bytes)
- 3,000 tiny messages → structure alone exceeds the cap → falls through to the old passes, bound and count hold
- `tests/test_reflector_input_fit.py` +1: `recorder_truncated_chars` carried into the fit and the label

`tests/test_llm_prompt_recording.py` / `test_llm_telemetry.py` / `test_reflector*.py`: 73 passed together. Ruff clean on the changed files.

Full Windows suite at `002c1a32` (on `9a67951e`); the follow-up `72d597dc` is comment-only (13 lines):

```
4 failed, 3114 passed, 17 skipped, 11 warnings in 1370.00s (0:22:50)
FAILED tests/test_bridge_cycle_tags.py::TestBridgeCycleTagIntegration::test_fail_open_tag_failure_never_breaks_a_green_cycle
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_acquires_when_free
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_second_acquire_in_same_process_is_contended
FAILED tests/test_bridge_locking.py::TestAcquireBridgeLock::test_contended_lock_via_monkeypatched_flock
```

Exactly the four Windows-baseline failures, matched by name.

## Not done, on purpose

- **`prompt_tokens` × 4.27 as the pre-cap size.** It is a proxy; the pre-cap byte size is not recorded and adding it would be a second number on the record for a one-time measurement. The 2026-08-25 archive gave real originals instead.
- **Reflector telemetry blindness** (`component: reflector` in `llm_calls`): untouched, separate defect.
- `nanobot/agent/context.py`, `gate.py`, `state_paths.py`, `validator_harness.py`, `scripts/eeebot_dashboard.py`: untouched.

## Live check owed after deploy

First reflector run after the deploy: `input_fit.transcript.chars` on new `reflections.jsonl` rows should sit near 32,000 (was 2,495 on the three pre-fix rows), `recorder_truncated: true` with `recorder_truncated_chars` in the ~100,000 range on a normal executor cycle. A row with `chars` in the low thousands and `recorder_truncated_chars` absent means the deployed release predates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
